### PR TITLE
Fix the position of arrow in DropDown

### DIFF
--- a/src/components/artwork_filter/dropdown.tsx
+++ b/src/components/artwork_filter/dropdown.tsx
@@ -102,7 +102,7 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         <Button style={{ backgroundColor: buttonColor, color: buttonTextColor }}>
           {superLabelText && <SuperLabel style={{ color: superLabelColor }}>{superLabelText}</SuperLabel>}
           {labelText}
-          <Icon name="arrow-down" fontSize="9px" color={buttonTextColor} style={{ position: "absolute", right: 15 }} />
+          <Icon name="arrow-down" fontSize="9px" color={buttonTextColor} style={{ position: "absolute", right: 15, lineHeight: "inherit" }} />
         </Button>
         <Nav style={navStyle}>
           {navItems}


### PR DESCRIPTION
This fixes a style issue in Force.

### Before:

![screen shot 2017-07-13 at 11 56 01 am](https://user-images.githubusercontent.com/386234/28175517-792e502c-67c2-11e7-8cff-8b8dd9cd238f.png)

### After:

![screen shot 2017-07-13 at 11 54 15 am](https://user-images.githubusercontent.com/386234/28175521-7b7f8fbc-67c2-11e7-981e-27a922b8fac0.png)
