### PR TITLE
@eessex => [Publishing] Refactor Artwork and Image components and support "classic"

### DIFF
--- a/src/components/publishing/__stories__/publishing.tsx
+++ b/src/components/publishing/__stories__/publishing.tsx
@@ -17,12 +17,12 @@ storiesOf("Publishing", Artwork)
     return (
       <div>
         <div style={{ width: 800 }}>
-          <Artwork linked artwork={Artworks[0]} />
+          <Artwork artwork={Artworks[0]} />
         </div>
         <hr />
         <p>Multiple Artists: </p>
         <div style={{ width: 800 }}>
-          <Artwork linked artwork={Artworks[1]} />
+          <Artwork artwork={Artworks[1]} />
         </div>
         <hr />
         <p>Unlinked: </p>
@@ -32,12 +32,12 @@ storiesOf("Publishing", Artwork)
         <hr />
         <p>Small: </p>
         <div style={{ width: 400 }}>
-          <Artwork linked artwork={Artworks[1]} />
+          <Artwork artwork={Artworks[1]} />
         </div>
         <hr />
         <p>Classic: </p>
         <div style={{ width: 800 }}>
-          <Artwork linked artwork={Artworks[0]} layout="classic" />
+          <Artwork artwork={Artworks[0]} layout="classic" />
         </div>
       </div>
     )

--- a/src/components/publishing/__stories__/publishing.tsx
+++ b/src/components/publishing/__stories__/publishing.tsx
@@ -15,8 +15,15 @@ import Typography from "./typography"
 storiesOf("Publishing", Artwork)
   .add("Artwork", () => {
     return (
-      <div style={{ width: 400 }}>
-        <Artwork linked artwork={Images[0]} />
+      <div>
+        <div style={{ width: 400 }}>
+          <Artwork linked artwork={Images[0]} />
+        </div>
+        <hr />
+        <p>Classic: </p>
+        <div style={{ width: 400 }}>
+          <Artwork linked artwork={Images[0]} layout="classic" />
+        </div>
       </div>
     )
   })
@@ -34,11 +41,17 @@ storiesOf("Publishing", Artwork)
   .add("Image", () => {
     return (
       <div>
+        <p>Standard:</p>
         <div style={{ width: 400 }}>
           <Image image={Images[1]} />
         </div>
+        <p>Long Caption:</p>
         <div style={{ width: 400 }}>
           <Image image={Images[2]} />
+        </div>
+        <p>Classic:</p>
+        <div style={{ width: 400 }}>
+          <Image layout="classic" image={Images[2]} />
         </div>
       </div>
     )

--- a/src/components/publishing/__stories__/publishing.tsx
+++ b/src/components/publishing/__stories__/publishing.tsx
@@ -16,12 +16,12 @@ storiesOf("Publishing", Artwork)
   .add("Artwork", () => {
     return (
       <div>
-        <div style={{ width: 400 }}>
+        <div style={{ width: 800 }}>
           <Artwork linked artwork={Images[0]} />
         </div>
         <hr />
         <p>Classic: </p>
-        <div style={{ width: 400 }}>
+        <div style={{ width: 800 }}>
           <Artwork linked artwork={Images[0]} layout="classic" />
         </div>
       </div>

--- a/src/components/publishing/__stories__/publishing.tsx
+++ b/src/components/publishing/__stories__/publishing.tsx
@@ -17,7 +17,7 @@ storiesOf("Publishing", Artwork)
     return (
       <div>
         <div style={{ width: 800 }}>
-          <Artwork linked artwork={Images[0]} />
+          <Artwork linked artwork={Artworks[0]} />
         </div>
         <hr />
         <p>Multiple Artists: </p>
@@ -37,7 +37,7 @@ storiesOf("Publishing", Artwork)
         <hr />
         <p>Classic: </p>
         <div style={{ width: 800 }}>
-          <Artwork linked artwork={Images[0]} layout="classic" />
+          <Artwork linked artwork={Artworks[0]} layout="classic" />
         </div>
       </div>
     )

--- a/src/components/publishing/__stories__/publishing.tsx
+++ b/src/components/publishing/__stories__/publishing.tsx
@@ -8,7 +8,7 @@ import Image from "../image"
 import ImageCollection from "../image_collection"
 import ImagesetPreview from "../imageset_preview"
 
-import { FeatureHeaders, Images } from "../__test__/fixtures"
+import { Artworks, FeatureHeaders, Images } from "../__test__/fixtures"
 
 import Typography from "./typography"
 
@@ -18,6 +18,21 @@ storiesOf("Publishing", Artwork)
       <div>
         <div style={{ width: 800 }}>
           <Artwork linked artwork={Images[0]} />
+        </div>
+        <hr />
+        <p>Multiple Artists: </p>
+        <div style={{ width: 800 }}>
+          <Artwork linked artwork={Artworks[1]} />
+        </div>
+        <hr />
+        <p>Unlinked: </p>
+        <div style={{ width: 800 }}>
+          <Artwork linked={false} artwork={Artworks[1]} />
+        </div>
+        <hr />
+        <p>Small: </p>
+        <div style={{ width: 400 }}>
+          <Artwork linked artwork={Artworks[1]} />
         </div>
         <hr />
         <p>Classic: </p>

--- a/src/components/publishing/__test__/__snapshots__/artwork.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/artwork.test.tsx.snap
@@ -4,11 +4,16 @@ exports[`renders properly 1`] = `
 <div
   className="display-artwork"
 >
-  <img
-    className="display-artwork__image file__BlockImage-s1b0ss2l-1 BjLdn"
-    src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-    width="100%"
-  />
+  <a
+    className="file__ArtworkImageLink-puphad-0 dOeRCh"
+    href="/artwork/fernando-botero-nude-on-the-beach"
+  >
+    <img
+      className="display-artwork__image file__BlockImage-puphad-1 fJSmLl"
+      src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+      width="100%"
+    />
+  </a>
   <div
     className="display-artwork__caption sc-bdVaJa bLvhbP"
   >
@@ -21,15 +26,23 @@ exports[`renders properly 1`] = `
         <span
           className="name"
         >
-          Fernando Botero
+          <a
+            className="file__StyledTextLink-s18afosz-0 hOUyga"
+            href="/artist/fernando-botero"
+          >
+            Fernando Botero
+          </a>
         </span>
       </span>
       <span
         className="title"
       >
-        <em>
+        <a
+          className="file__StyledTextLink-s18afosz-0 hOUyga"
+          href="/artwork/fernando-botero-nude-on-the-beach"
+        >
           Nude on the Beach
-        </em>
+        </a>
       </span>
       <span
         className="comma"
@@ -46,7 +59,12 @@ exports[`renders properly 1`] = `
       >
         , 
       </span>
-      Gary Nader
+      <a
+        className="file__StyledTextLink-s18afosz-0 hOUyga"
+        href="/partner/gary-nader"
+      >
+        Gary Nader
+      </a>
     </div>
     <div
       className="file__ViewFullscreenLink-s1bkkgtk-0 gQyVOi"

--- a/src/components/publishing/__test__/__snapshots__/artwork.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/artwork.test.tsx.snap
@@ -4,49 +4,61 @@ exports[`renders properly 1`] = `
 <div
   className="display-artwork"
 >
-  <img
-    className="display-artwork__image"
-    src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-    width="100%"
-  />
+  <a
+    className="file__ArtworkImageLink-s1wdol0a-0 hZsObq"
+    href="/artwork/fernando-botero-nude-on-the-beach"
+  >
+    <img
+      className="display-artwork__image"
+      src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+      width="100%"
+    />
+  </a>
   <div
-    className="display-artwork__caption"
+    className="display-artwork__caption sc-bdVaJa doqzCy"
   >
     <div
-      className="file__TruncatedLine-s1fags0c-0 cAwELk"
-    >
-      <strong>
-        <span>
-          Fernando Botero
-          
-        </span>
-      </strong>
-    </div>
-    <div
-      className="file__TruncatedLine-s1fags0c-0 cAwELk"
+      className="file__TruncatedLine-s1uu86vb-0 keVTMa"
     >
       <span
-        className="title"
+        className="artist-name"
       >
-        <em>
-          Nude on the Beach
-        </em>
+        <span
+          className="name"
+        >
+          Fernando Botero
+        </span>
+      </span>
+      <span>
+        <span
+          className="title"
+        >
+          <em>
+            Nude on the Beach
+          </em>
+        </span>
+        <span
+          className="comma"
+        >
+          , 
+        </span>
+        <span
+          className="date"
+        >
+          2000
+        </span>
       </span>
       <span
-        className="spacer"
+        className="comma"
       >
         , 
       </span>
-      <span
-        className="date"
-      >
-        2000
-      </span>
+      Gary Nader
     </div>
     <div
-      className="file__TruncatedLine-s1fags0c-0 cAwELk"
+      className="file__ViewFullscreenLink-s1bkkgtk-0 gQyVOi"
     >
-      Gary Nader
+      View Fullscreen
     </div>
   </div>
 </div>

--- a/src/components/publishing/__test__/__snapshots__/artwork.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/artwork.test.tsx.snap
@@ -4,21 +4,16 @@ exports[`renders properly 1`] = `
 <div
   className="display-artwork"
 >
-  <a
-    className="file__ArtworkImageLink-s1wdol0a-0 hZsObq"
-    href="/artwork/fernando-botero-nude-on-the-beach"
-  >
-    <img
-      className="display-artwork__image"
-      src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-      width="100%"
-    />
-  </a>
+  <img
+    className="display-artwork__image file__BlockImage-s1b0ss2l-1 BjLdn"
+    src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+    width="100%"
+  />
   <div
-    className="display-artwork__caption sc-bdVaJa doqzCy"
+    className="display-artwork__caption sc-bdVaJa bLvhbP"
   >
     <div
-      className="file__TruncatedLine-s1uu86vb-0 keVTMa"
+      className="file__TruncatedLine-s1g06yg0-0 jLJrz"
     >
       <span
         className="artist-name"
@@ -29,24 +24,22 @@ exports[`renders properly 1`] = `
           Fernando Botero
         </span>
       </span>
-      <span>
-        <span
-          className="title"
-        >
-          <em>
-            Nude on the Beach
-          </em>
-        </span>
-        <span
-          className="comma"
-        >
-          , 
-        </span>
-        <span
-          className="date"
-        >
-          2000
-        </span>
+      <span
+        className="title"
+      >
+        <em>
+          Nude on the Beach
+        </em>
+      </span>
+      <span
+        className="comma"
+      >
+        , 
+      </span>
+      <span
+        className="date"
+      >
+        2000
       </span>
       <span
         className="comma"

--- a/src/components/publishing/__test__/__snapshots__/image.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/image.test.tsx.snap
@@ -5,15 +5,15 @@ exports[`renders a long caption properly 1`] = `
   className="article-image"
 >
   <img
-    className="file__BlockImage-mvwcj2-3 WFCj"
+    className="file__BlockImage-s186ra47-0 cutMiz"
     src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
     width="100%"
   />
   <div
-    className="file__CaptionContainer-mvwcj2-2 dqVbIF"
+    className="file__CaptionContainer-s6d7sbx-0 ghxIfb"
   >
     <div
-      className="file__Figcaption-mvwcj2-0 frYyrr"
+      className="sc-bdVaJa bGfehm"
       dangerouslySetInnerHTML={
         Object {
           "__html": "<p>Photo by Adam Kuehl for Artsy.</p>",
@@ -21,7 +21,7 @@ exports[`renders a long caption properly 1`] = `
       }
     />
     <div
-      className="file__CaptionLink-mvwcj2-1 bmAGxU"
+      className="file__ViewFullscreenLink-s1bkkgtk-0 gQyVOi"
     >
       View Fullscreen
     </div>
@@ -34,15 +34,15 @@ exports[`renders properly 1`] = `
   className="article-image"
 >
   <img
-    className="file__BlockImage-mvwcj2-3 WFCj"
+    className="file__BlockImage-s186ra47-0 cutMiz"
     src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
     width="100%"
   />
   <div
-    className="file__CaptionContainer-mvwcj2-2 dqVbIF"
+    className="file__CaptionContainer-s6d7sbx-0 ghxIfb"
   >
     <div
-      className="file__Figcaption-mvwcj2-0 frYyrr"
+      className="sc-bdVaJa bGfehm"
       dangerouslySetInnerHTML={
         Object {
           "__html": "<p>Photo by Adam Kuehl for Artsy.</p>",
@@ -50,7 +50,7 @@ exports[`renders properly 1`] = `
       }
     />
     <div
-      className="file__CaptionLink-mvwcj2-1 bmAGxU"
+      className="file__ViewFullscreenLink-s1bkkgtk-0 gQyVOi"
     >
       View Fullscreen
     </div>

--- a/src/components/publishing/__test__/__snapshots__/image_collection.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/image_collection.test.tsx.snap
@@ -12,11 +12,16 @@ exports[`renders properly 1`] = `
     <div
       className="display-artwork"
     >
-      <img
-        className="display-artwork__image file__BlockImage-s1b0ss2l-1 BjLdn"
-        src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-        width="100%"
-      />
+      <a
+        className="file__ArtworkImageLink-puphad-0 dOeRCh"
+        href="/artwork/fernando-botero-nude-on-the-beach"
+      >
+        <img
+          className="display-artwork__image file__BlockImage-puphad-1 fJSmLl"
+          src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+          width="100%"
+        />
+      </a>
       <div
         className="display-artwork__caption sc-bdVaJa bLvhbP"
       >
@@ -29,15 +34,23 @@ exports[`renders properly 1`] = `
             <span
               className="name"
             >
-              Fernando Botero
+              <a
+                className="file__StyledTextLink-s18afosz-0 hOUyga"
+                href="/artist/fernando-botero"
+              >
+                Fernando Botero
+              </a>
             </span>
           </span>
           <span
             className="title"
           >
-            <em>
+            <a
+              className="file__StyledTextLink-s18afosz-0 hOUyga"
+              href="/artwork/fernando-botero-nude-on-the-beach"
+            >
               Nude on the Beach
-            </em>
+            </a>
           </span>
           <span
             className="comma"
@@ -54,7 +67,12 @@ exports[`renders properly 1`] = `
           >
             , 
           </span>
-          Gary Nader
+          <a
+            className="file__StyledTextLink-s18afosz-0 hOUyga"
+            href="/partner/gary-nader"
+          >
+            Gary Nader
+          </a>
         </div>
         <div
           className="file__ViewFullscreenLink-s1bkkgtk-0 gQyVOi"

--- a/src/components/publishing/__test__/__snapshots__/image_collection.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/image_collection.test.tsx.snap
@@ -12,21 +12,16 @@ exports[`renders properly 1`] = `
     <div
       className="display-artwork"
     >
-      <a
-        className="file__ArtworkImageLink-s1wdol0a-0 hZsObq"
-        href="/artwork/fernando-botero-nude-on-the-beach"
-      >
-        <img
-          className="display-artwork__image"
-          src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-          width="100%"
-        />
-      </a>
+      <img
+        className="display-artwork__image file__BlockImage-s1b0ss2l-1 BjLdn"
+        src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+        width="100%"
+      />
       <div
-        className="display-artwork__caption sc-bdVaJa doqzCy"
+        className="display-artwork__caption sc-bdVaJa bLvhbP"
       >
         <div
-          className="file__TruncatedLine-s1uu86vb-0 keVTMa"
+          className="file__TruncatedLine-s1g06yg0-0 jLJrz"
         >
           <span
             className="artist-name"
@@ -37,24 +32,22 @@ exports[`renders properly 1`] = `
               Fernando Botero
             </span>
           </span>
-          <span>
-            <span
-              className="title"
-            >
-              <em>
-                Nude on the Beach
-              </em>
-            </span>
-            <span
-              className="comma"
-            >
-              , 
-            </span>
-            <span
-              className="date"
-            >
-              2000
-            </span>
+          <span
+            className="title"
+          >
+            <em>
+              Nude on the Beach
+            </em>
+          </span>
+          <span
+            className="comma"
+          >
+            , 
+          </span>
+          <span
+            className="date"
+          >
+            2000
           </span>
           <span
             className="comma"

--- a/src/components/publishing/__test__/__snapshots__/image_collection.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/image_collection.test.tsx.snap
@@ -5,86 +5,66 @@ exports[`renders properly 1`] = `
   className="file__ImageCollectionContainer-s19j8h0e-0 jFhFbf"
 >
   <div
-    className="sc-bdVaJa dmDgFe"
+    className="sc-htpNat grTzba"
     height={298}
     width={415}
   >
     <div
       className="display-artwork"
     >
-      <img
-        className="display-artwork__image"
-        src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-        width="100%"
-      />
+      <a
+        className="file__ArtworkImageLink-s1wdol0a-0 hZsObq"
+        href="/artwork/fernando-botero-nude-on-the-beach"
+      >
+        <img
+          className="display-artwork__image"
+          src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+          width="100%"
+        />
+      </a>
       <div
-        className="display-artwork__caption"
+        className="display-artwork__caption sc-bdVaJa doqzCy"
       >
         <div
-          className="file__TruncatedLine-s1fags0c-0 cAwELk"
-        >
-          <strong>
-            <span>
-              Fernando Botero
-              
-            </span>
-          </strong>
-        </div>
-        <div
-          className="file__TruncatedLine-s1fags0c-0 cAwELk"
+          className="file__TruncatedLine-s1uu86vb-0 keVTMa"
         >
           <span
-            className="title"
+            className="artist-name"
           >
-            <em>
-              Nude on the Beach
-            </em>
+            <span
+              className="name"
+            >
+              Fernando Botero
+            </span>
+          </span>
+          <span>
+            <span
+              className="title"
+            >
+              <em>
+                Nude on the Beach
+              </em>
+            </span>
+            <span
+              className="comma"
+            >
+              , 
+            </span>
+            <span
+              className="date"
+            >
+              2000
+            </span>
           </span>
           <span
-            className="spacer"
+            className="comma"
           >
             , 
           </span>
-          <span
-            className="date"
-          >
-            2000
-          </span>
-        </div>
-        <div
-          className="file__TruncatedLine-s1fags0c-0 cAwELk"
-        >
           Gary Nader
         </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className="sc-bdVaJa gGBma"
-    height={299}
-    width={224}
-  >
-    <div
-      className="article-image"
-    >
-      <img
-        className="file__BlockImage-mvwcj2-3 WFCj"
-        src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
-        width="100%"
-      />
-      <div
-        className="file__CaptionContainer-mvwcj2-2 dqVbIF"
-      >
         <div
-          className="file__Figcaption-mvwcj2-0 frYyrr"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>Photo by Adam Kuehl for Artsy.</p>",
-            }
-          }
-        />
-        <div
-          className="file__CaptionLink-mvwcj2-1 bmAGxU"
+          className="file__ViewFullscreenLink-s1bkkgtk-0 gQyVOi"
         >
           View Fullscreen
         </div>
@@ -92,7 +72,39 @@ exports[`renders properly 1`] = `
     </div>
   </div>
   <div
-    className="sc-bdVaJa iKUmlK"
+    className="sc-htpNat gdGBhL"
+    height={299}
+    width={224}
+  >
+    <div
+      className="article-image"
+    >
+      <img
+        className="file__BlockImage-s186ra47-0 cutMiz"
+        src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
+        width="100%"
+      />
+      <div
+        className="file__CaptionContainer-s6d7sbx-0 ghxIfb"
+      >
+        <div
+          className="sc-bwzfXH gpZhql"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>Photo by Adam Kuehl for Artsy.</p>",
+            }
+          }
+        />
+        <div
+          className="file__ViewFullscreenLink-s1bkkgtk-0 gQyVOi"
+        >
+          View Fullscreen
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="sc-htpNat hAWKir"
     height={299}
     width={238}
   >
@@ -100,15 +112,15 @@ exports[`renders properly 1`] = `
       className="article-image"
     >
       <img
-        className="file__BlockImage-mvwcj2-3 WFCj"
+        className="file__BlockImage-s186ra47-0 cutMiz"
         src="https://d32dm0rphc51dk.cloudfront.net/CpHY-DRr7KW0HGXLslCXHw/larger.jpg"
         width="100%"
       />
       <div
-        className="file__CaptionContainer-mvwcj2-2 dqVbIF"
+        className="file__CaptionContainer-s6d7sbx-0 ghxIfb"
       >
         <div
-          className="file__Figcaption-mvwcj2-0 frYyrr"
+          className="sc-bwzfXH gpZhql"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<p>Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum.</p>",
@@ -116,7 +128,7 @@ exports[`renders properly 1`] = `
           }
         />
         <div
-          className="file__CaptionLink-mvwcj2-1 bmAGxU"
+          className="file__ViewFullscreenLink-s1bkkgtk-0 gQyVOi"
         >
           View Fullscreen
         </div>

--- a/src/components/publishing/__test__/fixtures.tsx
+++ b/src/components/publishing/__test__/fixtures.tsx
@@ -39,6 +39,49 @@ export const Images = [
   },
 ]
 
+export const Artworks = [
+  {
+    type: "artwork",
+    id: "589a6291275b2410d1beb6a5",
+    slug: "fernando-botero-nude-on-the-beach",
+    date: "2000",
+    title: "Nude on the Beach",
+    image: "https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg",
+    partner: {
+      name: "Gary Nader",
+    },
+    artist: {
+      name: "Fernando Botero",
+    },
+    width: 1152,
+    height: 826,
+  },
+  {
+    type: "artwork",
+    id: "589a6291275b2410d1beb6a5",
+    slug: "fernando-botero-nude-on-the-beach",
+    date: "2000",
+    title: "Nude on the Beach",
+    image: "https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg",
+    partner: {
+      name: "Gary Nader",
+      slug: "gary-nader",
+    },
+    artists: [
+      {
+        name: "Fernando Botero",
+        slug: "fernando-botero",
+      },
+      {
+        name: "Frida Kahlo",
+        slug: "frida-kahlo",
+      },
+    ],
+    width: 1152,
+    height: 826,
+  },
+]
+
 export const FeatureHeaders = [
   {
     layout: "text",

--- a/src/components/publishing/artwork.tsx
+++ b/src/components/publishing/artwork.tsx
@@ -28,6 +28,7 @@ const ArtworkImage: React.SFC<ArtworkImageProps> = props => {
 interface ArtworkProps {
   artwork?: any
   layout?: string
+  linked?: boolean
 }
 
 const Artwork: React.SFC<ArtworkProps> = props => {

--- a/src/components/publishing/artwork.tsx
+++ b/src/components/publishing/artwork.tsx
@@ -5,16 +5,19 @@ import ArtworkCaption from "./artwork_caption"
 const ArtworkImageLink = styled.a`
   text-underline: none;
 `
+const BlockImage = styled.img`
+  display: block;
+`
 
-interface ArtworkImageProps {
+interface ArtworkProps {
   artwork: any
-  linked?: boolean
   layout?: string
+  linked?: boolean
 }
 
-const ArtworkImage: React.SFC<ArtworkImageProps> = props => {
+const ArtworkImage: React.SFC<ArtworkProps> = props => {
   const { artwork, linked } = props
-  const image = <img src={artwork.image} className="display-artwork__image" width={"100%"} />
+  const image = <BlockImage src={artwork.image} className="display-artwork__image" width="100%" />
   if (linked) {
     return (
       <ArtworkImageLink href={"/artwork/" + artwork.slug}>
@@ -25,18 +28,12 @@ const ArtworkImage: React.SFC<ArtworkImageProps> = props => {
     return image
   }
 }
-interface ArtworkProps {
-  artwork?: any
-  layout?: string
-  linked?: boolean
-}
 
 const Artwork: React.SFC<ArtworkProps> = props => {
-  const { artwork, layout } = props
   return (
     <div className="display-artwork">
-      <ArtworkImage linked artwork={artwork} />
-      <ArtworkCaption artwork={artwork} layout={layout} />
+      <ArtworkImage {...props} />
+      <ArtworkCaption {...props} />
     </div>
   )
 }

--- a/src/components/publishing/artwork.tsx
+++ b/src/components/publishing/artwork.tsx
@@ -1,114 +1,36 @@
-import React, { Component } from "react"
-import styled from "styled-components"
+import React from "react"
 import TextLink from "../text_link"
-import Fonts from "./fonts"
+import ArtworkCaption from "./artwork_caption"
 
-const TruncatedLine = styled.div`
-  ${Fonts.garamond("s15")}
-  display: block;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  color: #666;
-`
+interface ArtworkImageProps {
+  artwork: any
+  linked?: boolean
+  layout?: string
+}
 
-class Artwork extends Component<any, null> {
-  renderImage(artwork) {
-    const image = <img src={artwork.image} className="display-artwork__image" width={"100%"} />
-    if (this.props.linked) {
-      return <TextLink href={"/artwork/" + artwork.slug} color="#666">{image}</TextLink>
-    } else {
-      return image
-    }
-  }
-
-  renderArtists(artwork) {
-    if (artwork.artists != null ? artwork.artists[0] : undefined) {
-      let names = artwork.artists.map((artist, i) => {
-        return this.renderArtistName(artist, i)
-      })
-      return names
-    } else {
-      return artwork.artist != null ? artwork.artist.name : undefined
-    }
-  }
-
-  renderArtistName(artist, i) {
-    const spacer = i < this.props.artwork.artists.length - 1 ? this.renderSpacer() : ""
-    if (this.props.linked && artist.slug) {
-      return (
-        <span key={"artist-" + i}>
-          <TextLink href={"/artist/" + artist.slug} color="#666">{artist.name}</TextLink>
-          {spacer}
-        </span>
-      )
-    } else {
-      return <span>{artist.name}{spacer}</span>
-    }
-  }
-
-  renderTitleDate(artwork) {
-    if (artwork.title && artwork.date) {
-      return (
-        <TruncatedLine>
-          {this.renderTitle(artwork)}
-          {this.renderSpacer()}
-          {this.renderDate(artwork)}
-        </TruncatedLine>
-      )
-    } else {
-      return <TruncatedLine>{this.renderTitle(artwork)}</TruncatedLine>
-    }
-  }
-
-  renderTitle(artwork) {
-    if (artwork.title) {
-      if (this.props.linked) {
-        return (
-          <span className="title">
-            <TextLink href={"/artwork/" + artwork.slug} color={"#666"}>
-              <em>{artwork.title}</em>
-            </TextLink>
-          </span>
-        )
-      } else {
-        return <span className="title"><em>{artwork.title}</em></span>
-      }
-    }
-  }
-
-  renderDate(artwork) {
-    if (artwork.date) {
-      return <span className="date">{artwork.date}</span>
-    }
-  }
-  renderSpacer() {
-    return <span className="spacer">, </span>
-  }
-
-  renderPartner(artwork) {
-    if (artwork.partner.name) {
-      if (this.props.linked && artwork.partner.slug) {
-        return <TextLink href={"/" + artwork.partner.slug} color="#666">{artwork.partner.name}</TextLink>
-      } else {
-        return artwork.partner.name
-      }
-    }
-    return false
-  }
-
-  render() {
-    const { artwork } = this.props
-    return (
-      <div className="display-artwork">
-        {this.renderImage(artwork)}
-        <div className="display-artwork__caption">
-          <TruncatedLine><strong>{this.renderArtists(artwork)}</strong></TruncatedLine>
-          {this.renderTitleDate(artwork)}
-          <TruncatedLine>{this.renderPartner(artwork)}</TruncatedLine>
-        </div>
-      </div>
-    )
+const ArtworkImage: React.SFC<ArtworkImageProps> = props => {
+  const { artwork, linked, layout } = props
+  const image = <img src={artwork.image} className="display-artwork__image" width={"100%"} />
+  if (linked) {
+    const color = layout === "classic" ? "#666" : "#999"
+    return <TextLink href={"/artwork/" + artwork.slug} color={color}>{image}</TextLink>
+  } else {
+    return image
   }
 }
+interface ArtworkProps {
+  artwork?: any
+  layout?: string
+}
+
+const Artwork: React.SFC<ArtworkProps> = props => {
+  const { artwork, layout } = props
+  return (
+    <div className="display-artwork">
+      <ArtworkImage linked artwork={artwork} />
+      <ArtworkCaption artwork={artwork} layout={layout} />
+    </div>
+  )
+}
+
 export default Artwork

--- a/src/components/publishing/artwork.tsx
+++ b/src/components/publishing/artwork.tsx
@@ -38,4 +38,8 @@ const Artwork: React.SFC<ArtworkProps> = props => {
   )
 }
 
+Artwork.defaultProps = {
+  linked: true,
+}
+
 export default Artwork

--- a/src/components/publishing/artwork.tsx
+++ b/src/components/publishing/artwork.tsx
@@ -1,6 +1,10 @@
 import React from "react"
-import TextLink from "../text_link"
+import styled from "styled-components"
 import ArtworkCaption from "./artwork_caption"
+
+const ArtworkImageLink = styled.a`
+  text-underline: none;
+`
 
 interface ArtworkImageProps {
   artwork: any
@@ -9,11 +13,14 @@ interface ArtworkImageProps {
 }
 
 const ArtworkImage: React.SFC<ArtworkImageProps> = props => {
-  const { artwork, linked, layout } = props
+  const { artwork, linked } = props
   const image = <img src={artwork.image} className="display-artwork__image" width={"100%"} />
   if (linked) {
-    const color = layout === "classic" ? "#666" : "#999"
-    return <TextLink href={"/artwork/" + artwork.slug} color={color}>{image}</TextLink>
+    return (
+      <ArtworkImageLink href={"/artwork/" + artwork.slug}>
+        {image}
+      </ArtworkImageLink>
+    )
   } else {
     return image
   }

--- a/src/components/publishing/artwork_caption.tsx
+++ b/src/components/publishing/artwork_caption.tsx
@@ -4,12 +4,21 @@ import TextLink from "../text_link"
 import Fonts from "./fonts"
 
 const TruncatedLine = styled.div`
+  color: #999;
   display: block;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  ${Fonts.unica("s14", "medium")}
-  color: #999;
+`
+
+interface StyledArtworkCaptionProps {
+  layout?: string
+}
+
+const StyledArtworkCaption = styled.div`
+  ${(props: StyledArtworkCaptionProps) =>
+    props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium")}
+  display: ${(props: StyledArtworkCaptionProps) => (props.layout === "classic" ? "block" : "flex")}
 `
 
 interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
@@ -104,17 +113,19 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
     const { artwork, layout } = this.props
     if (layout === "classic") {
       return (
-        <div className="display-artwork__caption">
-          <strong>
-            {this.renderArtists(artwork)}
-          </strong>
-          {this.renderTitleDate(artwork)}
-          {this.renderPartner(artwork)}
-        </div>
+        <StyledArtworkCaption layout={layout} className="display-artwork__caption">
+          <TruncatedLine>
+            <strong>
+              {this.renderArtists(artwork)}
+            </strong>
+            {this.renderTitleDate(artwork)}
+            {this.renderPartner(artwork)}
+          </TruncatedLine>
+        </StyledArtworkCaption>
       )
     } else {
       return (
-        <div className="display-artwork__caption">
+        <StyledArtworkCaption layout={layout} className="display-artwork__caption">
           <TruncatedLine>
             <strong>
               {this.renderArtists(artwork)}
@@ -124,7 +135,7 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
           <TruncatedLine>
             {this.renderPartner(artwork)}
           </TruncatedLine>
-        </div>
+        </StyledArtworkCaption>
       )
     }
   }

--- a/src/components/publishing/artwork_caption.tsx
+++ b/src/components/publishing/artwork_caption.tsx
@@ -1,15 +1,20 @@
 import * as React from "react"
 import styled, { StyledFunction } from "styled-components"
+// import { joinChildren } from "../../utils/index"
 import TextLink from "../text_link"
 import Fonts from "./fonts"
 import ViewFullscreen from "./view_fullscreen"
 
 const TruncatedLine = styled.div`
   color: #999;
-  display: flex;
+  display: block;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  width: 100%;
+  .artist-name {
+    margin-right: 30px;
+  }
 `
 
 interface StyledArtworkCaptionProps {
@@ -19,8 +24,9 @@ interface StyledArtworkCaptionProps {
 const div: StyledFunction<StyledArtworkCaptionProps & React.HTMLProps<HTMLDivElement>> = styled.div
 
 const StyledArtworkCaption = div`
+  display: ${props => (props.layout === "classic" ? "block" : "flex")};
   ${props => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium"))}
-  display: ${props => (props.layout === "classic" ? "block" : "flex")}
+
 `
 
 interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
@@ -30,52 +36,57 @@ interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
-  renderArtists(artwork) {
-    if (artwork.artists != null ? artwork.artists[0] : undefined) {
-      let names = artwork.artists.map((artist, i) => {
+  renderArtists() {
+    const artwork = this.props.artwork
+    if (artwork.artists && artwork.artists.length > 0) {
+      const names = artwork.artists.map((artist, i) => {
         return this.renderArtistName(artist, i)
       })
       return names
+    } else if (artwork.artist) {
+      return this.renderArtistName(artwork.artist, 0)
     } else {
-      return artwork.artist != null ? artwork.artist.name : undefined
+      return false
     }
   }
 
   renderArtistName(artist, i) {
-    const spacer = i < this.props.artwork.artists.length - 1 ? this.renderSpacer() : false
+    const comma = i < this.props.artwork.artists.length - 1 ? this.renderComma() : false
     if (this.props.linked && artist.slug) {
       return (
-        <span key={"artist-" + i}>
+        <span key={"artist-" + i} className="name">
           <TextLink href={"/artist/" + artist.slug} color="#666">{artist.name}</TextLink>
-          {spacer}
+          {comma}
         </span>
       )
     } else {
-      return <span>{artist.name}{spacer}</span>
+      return <span className="name">{artist.name}{comma}</span>
     }
   }
 
-  renderTitleDate(artwork) {
+  renderTitleDate() {
+    const artwork = this.props.artwork
     if (artwork.title && artwork.date) {
       return (
-        <div>
-          {this.renderTitle(artwork)}
-          {this.renderSpacer()}
-          {this.renderDate(artwork)}
-        </div>
+        <span>
+          {this.renderTitle()}
+          {this.renderComma()}
+          {this.renderDate()}
+        </span>
       )
     } else {
-      return this.renderTitle(artwork)
+      return this.renderTitle()
     }
   }
 
-  renderTitle(artwork) {
+  renderTitle() {
+    const artwork = this.props.artwork
     if (artwork.title) {
       if (this.props.linked) {
         return (
           <span className="title">
             <TextLink href={"/artwork/" + artwork.slug} color={"#666"}>
-              <em>{artwork.title}</em>
+              {artwork.title}
             </TextLink>
           </span>
         )
@@ -85,13 +96,15 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
     }
   }
 
-  renderDate(artwork) {
+  renderDate() {
+    const artwork = this.props.artwork
     if (artwork.date) {
       return <span className="date">{artwork.date}</span>
     }
   }
 
-  renderPartner(artwork) {
+  renderPartner() {
+    const artwork = this.props.artwork
     if (artwork.partner.name) {
       if (this.props.linked && artwork.partner.slug) {
         const color = this.props.layout === "classic" ? "#666" : "#999"
@@ -107,25 +120,25 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
     return false
   }
 
-  renderSpacer() {
-    return <span className="spacer">, </span>
+  renderComma() {
+    return <span className="comma">, </span>
   }
 
   render() {
-    const { artwork, layout } = this.props
+    const { layout } = this.props
     if (layout === "classic") {
       return (
         <StyledArtworkCaption layout={layout} className="display-artwork__caption">
           <TruncatedLine>
             <strong>
-              {this.renderArtists(artwork)}
+              {this.renderArtists()}
             </strong>
           </TruncatedLine>
           <TruncatedLine>
-            {this.renderTitleDate(artwork)}
+            {this.renderTitleDate()}
           </TruncatedLine>
           <TruncatedLine>
-            {this.renderPartner(artwork)}
+            {this.renderPartner()}
           </TruncatedLine>
         </StyledArtworkCaption>
       )
@@ -133,12 +146,12 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
       return (
         <StyledArtworkCaption layout={layout} className="display-artwork__caption">
           <TruncatedLine>
-            <strong>
-              {this.renderArtists(artwork)}
-            </strong>
-            <span className="spacer" />
-            {this.renderTitleDate(artwork)}
-            {this.renderPartner(artwork)}
+            <span className="artist-name">
+              {this.renderArtists()}
+            </span>
+            {this.renderTitleDate()}
+            {this.renderComma()}
+            {this.renderPartner()}
           </TruncatedLine>
           <ViewFullscreen />
         </StyledArtworkCaption>

--- a/src/components/publishing/artwork_caption.tsx
+++ b/src/components/publishing/artwork_caption.tsx
@@ -1,0 +1,133 @@
+import * as React from "react"
+import styled from "styled-components"
+import TextLink from "../text_link"
+import Fonts from "./fonts"
+
+const TruncatedLine = styled.div`
+  display: block;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  ${Fonts.unica("s14", "medium")}
+  color: #999;
+`
+
+interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
+  layout?: string
+  artwork?: any
+  linked?: boolean
+}
+
+class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
+  renderArtists(artwork) {
+    if (artwork.artists != null ? artwork.artists[0] : undefined) {
+      let names = artwork.artists.map((artist, i) => {
+        return this.renderArtistName(artist, i)
+      })
+      return names
+    } else {
+      return artwork.artist != null ? artwork.artist.name : undefined
+    }
+  }
+
+  renderArtistName(artist, i) {
+    const spacer = i < this.props.artwork.artists.length - 1 ? this.renderSpacer() : false
+    if (this.props.linked && artist.slug) {
+      return (
+        <span key={"artist-" + i}>
+          <TextLink href={"/artist/" + artist.slug} color="#666">{artist.name}</TextLink>
+          {spacer}
+        </span>
+      )
+    } else {
+      return <span>{artist.name}{spacer}</span>
+    }
+  }
+
+  renderTitleDate(artwork) {
+    if (artwork.title && artwork.date) {
+      return (
+        <TruncatedLine>
+          {this.renderTitle(artwork)}
+          {this.renderSpacer()}
+          {this.renderDate(artwork)}
+        </TruncatedLine>
+      )
+    } else {
+      return (
+        <TruncatedLine>
+          {this.renderTitle(artwork)}
+        </TruncatedLine>
+      )
+    }
+  }
+
+  renderTitle(artwork) {
+    if (artwork.title) {
+      if (this.props.linked) {
+        return (
+          <span className="title">
+            <TextLink href={"/artwork/" + artwork.slug} color={"#666"}>
+              <em>{artwork.title}</em>
+            </TextLink>
+          </span>
+        )
+      } else {
+        return <span className="title"><em>{artwork.title}</em></span>
+      }
+    }
+  }
+
+  renderDate(artwork) {
+    if (artwork.date) {
+      return <span className="date">{artwork.date}</span>
+    }
+  }
+
+  renderPartner(artwork) {
+    if (artwork.partner.name) {
+      if (this.props.linked && artwork.partner.slug) {
+        const color = this.props.layout === "classic" ? "#666" : "#999"
+        return <TextLink href={"/partner/" + artwork.partner.slug} color={color}>{artwork.partner.name}</TextLink>
+      } else {
+        return artwork.partner.name
+      }
+    }
+    return false
+  }
+
+  renderSpacer() {
+    return <span className="spacer">, </span>
+  }
+
+  render() {
+    const { artwork, layout } = this.props
+    if (layout === "classic") {
+      return (
+        <div className="display-artwork__caption">
+          <strong>
+            {this.renderArtists(artwork)}
+          </strong>
+          {this.renderTitleDate(artwork)}
+          {this.renderPartner(artwork)}
+        </div>
+      )
+    } else {
+      return (
+        <div className="display-artwork__caption">
+          <TruncatedLine>
+            <strong>
+              {this.renderArtists(artwork)}
+            </strong>
+          </TruncatedLine>
+          {this.renderTitleDate(artwork)}
+          <TruncatedLine>
+            {this.renderPartner(artwork)}
+          </TruncatedLine>
+        </div>
+      )
+    }
+  }
+}
+
+export default ArtworkCaption

--- a/src/components/publishing/artwork_caption.tsx
+++ b/src/components/publishing/artwork_caption.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import styled, { StyledFunction } from "styled-components"
-// import { joinChildren } from "../../utils/index"
 import TextLink from "../text_link"
 import Fonts from "./fonts"
 import ViewFullscreen from "./view_fullscreen"
@@ -24,59 +23,51 @@ interface StyledArtworkCaptionProps {
 const div: StyledFunction<StyledArtworkCaptionProps & React.HTMLProps<HTMLDivElement>> = styled.div
 
 const StyledArtworkCaption = div`
+  margin-top: 10px;
   display: ${props => (props.layout === "classic" ? "block" : "flex")};
   ${props => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium"))}
-
 `
 
 interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
+  artwork: any
   layout?: string
-  artwork?: any
   linked?: boolean
 }
 
-class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
+class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
+  joinChildren(children) {
+    const joined = children.reduce((prev, curr) => {
+      return [prev, this.renderComma(), curr]
+    })
+    return joined
+  }
   renderArtists() {
     const artwork = this.props.artwork
     if (artwork.artists && artwork.artists.length > 0) {
       const names = artwork.artists.map((artist, i) => {
         return this.renderArtistName(artist, i)
       })
-      return names
+      return this.joinChildren(names)
     } else if (artwork.artist) {
       return this.renderArtistName(artwork.artist, 0)
-    } else {
-      return false
     }
   }
 
   renderArtistName(artist, i) {
-    const comma = i < this.props.artwork.artists.length - 1 ? this.renderComma() : false
     if (this.props.linked && artist.slug) {
       return (
         <span key={"artist-" + i} className="name">
-          <TextLink href={"/artist/" + artist.slug} color="#666">{artist.name}</TextLink>
-          {comma}
+          <TextLink href={"/artist/" + artist.slug} color="#999">{artist.name}</TextLink>
         </span>
       )
     } else {
-      return <span className="name">{artist.name}{comma}</span>
+      return <span className="name">{artist.name}</span>
     }
   }
 
   renderTitleDate() {
-    const artwork = this.props.artwork
-    if (artwork.title && artwork.date) {
-      return (
-        <span>
-          {this.renderTitle()}
-          {this.renderComma()}
-          {this.renderDate()}
-        </span>
-      )
-    } else {
-      return this.renderTitle()
-    }
+    const children = [this.renderTitle(), this.renderDate()]
+    return this.joinChildren(children)
   }
 
   renderTitle() {
@@ -85,7 +76,7 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
       if (this.props.linked) {
         return (
           <span className="title">
-            <TextLink href={"/artwork/" + artwork.slug} color={"#666"}>
+            <TextLink href={"/artwork/" + artwork.slug} color="#999">
               {artwork.title}
             </TextLink>
           </span>
@@ -107,9 +98,8 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
     const artwork = this.props.artwork
     if (artwork.partner.name) {
       if (this.props.linked && artwork.partner.slug) {
-        const color = this.props.layout === "classic" ? "#666" : "#999"
         return (
-          <TextLink href={"/partner/" + artwork.partner.slug} color={color}>
+          <TextLink href={"/partner/" + artwork.partner.slug} color="#999">
             {artwork.partner.name}
           </TextLink>
         )
@@ -117,11 +107,15 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
         return artwork.partner.name
       }
     }
-    return false
   }
 
   renderComma() {
     return <span className="comma">, </span>
+  }
+
+  renderTitleDatePartner() {
+    const children = [this.renderTitle(), this.renderDate(), this.renderPartner()]
+    return this.joinChildren(children)
   }
 
   render() {
@@ -149,9 +143,7 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
             <span className="artist-name">
               {this.renderArtists()}
             </span>
-            {this.renderTitleDate()}
-            {this.renderComma()}
-            {this.renderPartner()}
+            {this.renderTitleDatePartner()}
           </TruncatedLine>
           <ViewFullscreen />
         </StyledArtworkCaption>

--- a/src/components/publishing/artwork_caption.tsx
+++ b/src/components/publishing/artwork_caption.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
-import styled from "styled-components"
+import styled, { StyledFunction } from "styled-components"
 import TextLink from "../text_link"
 import Fonts from "./fonts"
+import ViewFullscreen from "./view_fullscreen"
 
 const TruncatedLine = styled.div`
   color: #999;
-  display: block;
+  display: flex;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -15,10 +16,11 @@ interface StyledArtworkCaptionProps {
   layout?: string
 }
 
-const StyledArtworkCaption = styled.div`
-  ${(props: StyledArtworkCaptionProps) =>
-    props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium")}
-  display: ${(props: StyledArtworkCaptionProps) => (props.layout === "classic" ? "block" : "flex")}
+const div: StyledFunction<StyledArtworkCaptionProps & React.HTMLProps<HTMLDivElement>> = styled.div
+
+const StyledArtworkCaption = div`
+  ${props => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium"))}
+  display: ${props => (props.layout === "classic" ? "block" : "flex")}
 `
 
 interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
@@ -27,7 +29,7 @@ interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
   linked?: boolean
 }
 
-class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
+class ArtworkCaption extends React.Component<ArtworkCaptionProps, void> {
   renderArtists(artwork) {
     if (artwork.artists != null ? artwork.artists[0] : undefined) {
       let names = artwork.artists.map((artist, i) => {
@@ -56,18 +58,14 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
   renderTitleDate(artwork) {
     if (artwork.title && artwork.date) {
       return (
-        <TruncatedLine>
+        <div>
           {this.renderTitle(artwork)}
           {this.renderSpacer()}
           {this.renderDate(artwork)}
-        </TruncatedLine>
+        </div>
       )
     } else {
-      return (
-        <TruncatedLine>
-          {this.renderTitle(artwork)}
-        </TruncatedLine>
-      )
+      return this.renderTitle(artwork)
     }
   }
 
@@ -97,7 +95,11 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
     if (artwork.partner.name) {
       if (this.props.linked && artwork.partner.slug) {
         const color = this.props.layout === "classic" ? "#666" : "#999"
-        return <TextLink href={"/partner/" + artwork.partner.slug} color={color}>{artwork.partner.name}</TextLink>
+        return (
+          <TextLink href={"/partner/" + artwork.partner.slug} color={color}>
+            {artwork.partner.name}
+          </TextLink>
+        )
       } else {
         return artwork.partner.name
       }
@@ -118,7 +120,11 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
             <strong>
               {this.renderArtists(artwork)}
             </strong>
+          </TruncatedLine>
+          <TruncatedLine>
             {this.renderTitleDate(artwork)}
+          </TruncatedLine>
+          <TruncatedLine>
             {this.renderPartner(artwork)}
           </TruncatedLine>
         </StyledArtworkCaption>
@@ -130,11 +136,11 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
             <strong>
               {this.renderArtists(artwork)}
             </strong>
-          </TruncatedLine>
-          {this.renderTitleDate(artwork)}
-          <TruncatedLine>
+            <span className="spacer" />
+            {this.renderTitleDate(artwork)}
             {this.renderPartner(artwork)}
           </TruncatedLine>
+          <ViewFullscreen />
         </StyledArtworkCaption>
       )
     }

--- a/src/components/publishing/image.tsx
+++ b/src/components/publishing/image.tsx
@@ -1,46 +1,22 @@
 import React from "react"
 import styled from "styled-components"
-import Fonts from "./fonts"
-
-const Figcaption = styled.div`
-  & > p {
-    ${Fonts.unica("s14", "medium")}
-    margin: 0;
-    color: #999;
-  }
-`
-
-const CaptionLink = styled.div`
-  ${Fonts.unica("s14", "medium")}
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  align-self: flex-start;
-`
-
-const CaptionContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin: 10px 0 10px 0;
-`
+import ImageCaption from "./image_caption"
 
 const BlockImage = styled.img`
   display: block;
 `
 
-function Image(props) {
-  const { image } = props
+interface ImageProps extends React.HTMLProps<HTMLDivElement> {
+  image?: any
+  layout?: string
+}
+
+const Image: React.SFC<ImageProps> = props => {
+  const { image, layout } = props
   return (
     <div className="article-image">
       <BlockImage src={image.url} width="100%" />
-      <CaptionContainer>
-        <Figcaption dangerouslySetInnerHTML={{ __html: image.caption }} />
-        <CaptionLink>View Fullscreen</CaptionLink>
-      </CaptionContainer>
+      <ImageCaption image={image} layout={layout} />
     </div>
   )
 }

--- a/src/components/publishing/image_caption.tsx
+++ b/src/components/publishing/image_caption.tsx
@@ -1,0 +1,50 @@
+import React from "react"
+import styled from "styled-components"
+import Fonts from "./fonts"
+
+const CaptionLink = styled.div`
+  ${Fonts.unica("s14", "medium")}
+  margin: 0;
+  margin-left: 10px;
+  border-bottom: 1px solid black;
+  cursor: pointer;
+  display: inline-block;
+  min-width: 7.1em;
+  align-self: flex-start;
+`
+
+const CaptionContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 10px 0 10px 0;
+`
+
+// Caption
+interface FigcaptionProps extends React.HTMLProps<HTMLDivElement> {
+  layout: string
+}
+const Figcaption = styled.div`
+  & > p {
+    ${(props: FigcaptionProps) => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium"))}
+    color: ${(props: FigcaptionProps) => (props.layout === "classic" ? "#666" : "#999")};
+    margin: 0;
+  }
+`
+interface CaptionProps {
+  image: any
+  layout?: string
+}
+
+const Caption: React.SFC<CaptionProps> = props => {
+  const { layout, image } = props
+  const viewFullscreen = layout !== "classic" ? <CaptionLink>View Fullscreen</CaptionLink> : false
+
+  return (
+    <CaptionContainer>
+      <Figcaption dangerouslySetInnerHTML={{ __html: image.caption }} layout={layout} />
+      {viewFullscreen}
+    </CaptionContainer>
+  )
+}
+
+export default Caption

--- a/src/components/publishing/image_caption.tsx
+++ b/src/components/publishing/image_caption.tsx
@@ -1,17 +1,7 @@
 import React from "react"
-import styled from "styled-components"
+import styled, { StyledFunction } from "styled-components"
 import Fonts from "./fonts"
-
-const CaptionLink = styled.div`
-  ${Fonts.unica("s14", "medium")}
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  align-self: flex-start;
-`
+import ViewFullscreen from "./view_fullscreen"
 
 const CaptionContainer = styled.div`
   display: flex;
@@ -19,25 +9,25 @@ const CaptionContainer = styled.div`
   margin: 10px 0 10px 0;
 `
 
-// Caption
-interface FigcaptionProps extends React.HTMLProps<HTMLDivElement> {
+interface FigcaptionProps {
   layout: string
 }
-const Figcaption = styled.div`
+const div: StyledFunction<FigcaptionProps & React.HTMLProps<HTMLDivElement>> = styled.div
+const Figcaption = div`
   & > p {
-    ${(props: FigcaptionProps) => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium"))}
-    color: ${(props: FigcaptionProps) => (props.layout === "classic" ? "#666" : "#999")};
+    ${props => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium"))}
+    color: ${props => (props.layout === "classic" ? "#666" : "#999")};
     margin: 0;
   }
 `
+
 interface CaptionProps {
   image: any
   layout?: string
 }
-
 const Caption: React.SFC<CaptionProps> = props => {
   const { layout, image } = props
-  const viewFullscreen = layout !== "classic" ? <CaptionLink>View Fullscreen</CaptionLink> : false
+  const viewFullscreen = layout !== "classic" ? <ViewFullscreen /> : false
 
   return (
     <CaptionContainer>

--- a/src/components/publishing/view_fullscreen.tsx
+++ b/src/components/publishing/view_fullscreen.tsx
@@ -10,6 +10,7 @@ const ViewFullscreenLink = styled.div`
   cursor: pointer;
   display: inline-block;
   min-width: 7.1em;
+  white-space: nowrap;
   align-self: flex-start;
 `
 

--- a/src/components/publishing/view_fullscreen.tsx
+++ b/src/components/publishing/view_fullscreen.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import styled from "styled-components"
+import Fonts from "./fonts"
+
+const ViewFullscreenLink = styled.div`
+  ${Fonts.unica("s14", "medium")}
+  margin: 0;
+  margin-left: 10px;
+  border-bottom: 1px solid black;
+  cursor: pointer;
+  display: inline-block;
+  min-width: 7.1em;
+  align-self: flex-start;
+`
+
+function ViewFullscreen() {
+  return <ViewFullscreenLink>View Fullscreen</ViewFullscreenLink>
+}
+
+export default ViewFullscreen

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
-import fillwidth from "./fillwidth"
+import fillwidthDimensions from "./fillwidth"
 
 export default {
-  fillwidth,
+  fillwidthDimensions,
 }


### PR DESCRIPTION
Refactors the Artwork and Image components to be more Typescript-friendly and adds in support for the "classic" views.  


![imageartwork](https://user-images.githubusercontent.com/2236794/28292288-63e9c004-6b1c-11e7-9eec-098354968014.gif)
