### PR TITLE
@orta => Fix deploy-storybook command related to NODE_ENV in Circle

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -11,14 +11,14 @@ const { CheckerPlugin } = require("awesome-typescript-loader")
  * Write out a file that stubs the data that’s normally shared with the client through the `sharify` module. This file
  * is then replaced in the product of webpack where normally the actual `sharify` module would be loaded.
  */
-const { METAPHYSICS_ENDPOINT, NODE_ENV } = env.config().parsed
+const { METAPHYSICS_ENDPOINT } = env.config().parsed
 const sharifyPath = sharify({ METAPHYSICS_ENDPOINT })
 
 /**
  * Only use HMR plugin in dev mode
  */
 let plugins = [new CheckerPlugin()]
-if (NODE_ENV === "development") {
+if (process.env.NODE_ENV === "development") {
   plugins.push(new webpack.HotModuleReplacementPlugin())
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:dist": "npm run compile && node index.js ./dist",
     "test": "node verify-node-version.js && jest",
     "storybook": "node verify-node-version.js && start-storybook -p 9001 -c .storybook -s ./assets ",
-    "deploy-storybook": "storybook-to-ghpages",
+    "deploy-storybook": "NODE_ENV=production storybook-to-ghpages",
     "relay2ts": "relay2ts src/components/*.tsx --update",
     "sync-schema": "cd externals/metaphysics && git fetch && git checkout origin/master && yarn install && npm run dump-schema -- ../../data",
     "sync-colors": "cd externals/elan && git fetch && git checkout origin/master && cp components/lib/variables/colors.json ../../data",


### PR DESCRIPTION
The deploy is still failing because we're copying the env.oss file to .env which contains `NODE_ENV=development`.

There are a few ways to solve this, but I just switched to using `process.env.NODE_ENV` and passed in the configuration on the `yarn deploy-storybook` command. 

![image](https://user-images.githubusercontent.com/2236794/29141258-73982b74-7d1b-11e7-94e7-f10d1da2f78a.png)
