### PR TITLE
@alloy => Caption editable updates

### DIFF
--- a/src/components/publishing/__test__/__snapshots__/caption.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/caption.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a long caption properly 1`] = `
-.c3 {
+exports[`renders a child even if a caption is provided 1`] = `
+.c2 {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -18,7 +18,7 @@ exports[`renders a long caption properly 1`] = `
   align-self: flex-start;
 }
 
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -30,9 +30,9 @@ exports[`renders a long caption properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c2 > p,
-.c2 p,
-.c2 .public-DraftEditorPlaceholder-root {
+.c1 > p,
+.c1 p,
+.c1 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -41,52 +41,32 @@ exports[`renders a long caption properly 1`] = `
   margin: 0;
 }
 
-.c0 {
-  display: block;
-}
-
 @media (max-width: 600px) {
-  .c1 {
+  .c0 {
     padding: 0px 10px;
   }
 }
 
 <div
-  className="article-image"
+  className="c0"
 >
-  <img
-    alt="Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum."
-    className="c0"
-    height="auto"
-    src="https://d32dm0rphc51dk.cloudfront.net/CpHY-DRr7KW0HGXLslCXHw/larger.jpg"
-    width="100%"
-  />
-   // strip caption html
   <div
     className="c1"
   >
-    <div
-      className="c2"
-    >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum.</p>",
-          }
-        }
-      />
+    <div>
+      Here is a passed child
     </div>
-    <div
-      className="c3"
-    >
-      View Fullscreen
-    </div>
+  </div>
+  <div
+    className="c2"
+  >
+    View Fullscreen
   </div>
 </div>
 `;
 
-exports[`renders properly 1`] = `
-.c3 {
+exports[`renders a saved caption properly 1`] = `
+.c2 {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -103,7 +83,7 @@ exports[`renders properly 1`] = `
   align-self: flex-start;
 }
 
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -115,9 +95,9 @@ exports[`renders properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c2 > p,
-.c2 p,
-.c2 .public-DraftEditorPlaceholder-root {
+.c1 > p,
+.c1 p,
+.c1 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -126,46 +106,30 @@ exports[`renders properly 1`] = `
   margin: 0;
 }
 
-.c0 {
-  display: block;
-}
-
 @media (max-width: 600px) {
-  .c1 {
+  .c0 {
     padding: 0px 10px;
   }
 }
 
 <div
-  className="article-image"
+  className="c0"
 >
-  <img
-    alt="Photo by Adam Kuehl for Artsy."
-    className="c0"
-    height="auto"
-    src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
-    width="100%"
-  />
-   // strip caption html
   <div
     className="c1"
   >
     <div
-      className="c2"
-    >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>Photo by Adam Kuehl for Artsy.</p>",
-          }
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>This is a saved caption</p>",
         }
-      />
-    </div>
-    <div
-      className="c3"
-    >
-      View Fullscreen
-    </div>
+      }
+    />
+  </div>
+  <div
+    className="c2"
+  >
+    View Fullscreen
   </div>
 </div>
 `;

--- a/src/components/publishing/__test__/__snapshots__/image_collection.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/image_collection.test.tsx.snap
@@ -243,7 +243,8 @@ exports[`renders properly 1`] = `
 }
 
 .c11 > p,
-.c11 p {
+.c11 p,
+.c11 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;

--- a/src/components/publishing/__test__/__snapshots__/sections.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/sections.test.tsx.snap
@@ -36,7 +36,8 @@ exports[`renders properly 1`] = `
 }
 
 .c9 > p,
-.c9 p {
+.c9 p,
+.c9 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;

--- a/src/components/publishing/__test__/__snapshots__/video.test.tsx.snap
+++ b/src/components/publishing/__test__/__snapshots__/video.test.tsx.snap
@@ -14,7 +14,8 @@ exports[`renders properly 1`] = `
 }
 
 .c6 > p,
-.c6 p {
+.c6 p,
+.c6 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;

--- a/src/components/publishing/__test__/caption.test.tsx
+++ b/src/components/publishing/__test__/caption.test.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+import * as renderer from "react-test-renderer"
+
+import "jest-styled-components"
+
+import Caption from "../sections/caption"
+
+it("renders a saved caption properly", () => {
+  const embed = renderer.create(<Caption caption="<p>This is a saved caption</p>" />).toJSON()
+  expect(embed).toMatchSnapshot()
+})
+
+it("renders a child even if a caption is provided", () => {
+  const embed = renderer
+    .create(<Caption caption="<p>This is a saved caption</p>"><div>Here is a passed child</div></Caption>)
+    .toJSON()
+  expect(embed).toMatchSnapshot()
+})

--- a/src/components/publishing/sections/caption.tsx
+++ b/src/components/publishing/sections/caption.tsx
@@ -17,6 +17,7 @@ interface FigcaptionProps {
   layout: string
 }
 const div: StyledFunction<FigcaptionProps & React.HTMLProps<HTMLDivElement>> = styled.div
+// includes draft placeholder class for editable text in Writer
 const Figcaption = div`
   & > p, p, .public-DraftEditorPlaceholder-root {
     ${props => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium"))}
@@ -32,8 +33,8 @@ interface CaptionProps {
 }
 
 const Caption: React.SFC<CaptionProps> = props => {
-  const { layout, caption, viewFullscreen } = props
-  const child = props.children ? props.children : <div dangerouslySetInnerHTML={{ __html: caption }} />
+  const { layout, caption, viewFullscreen, children } = props
+  const child = children ? children : <div dangerouslySetInnerHTML={{ __html: caption }} />
   return (
     <CaptionContainer>
       <Figcaption layout={layout}>

--- a/src/components/publishing/sections/caption.tsx
+++ b/src/components/publishing/sections/caption.tsx
@@ -18,7 +18,7 @@ interface FigcaptionProps {
 }
 const div: StyledFunction<FigcaptionProps & React.HTMLProps<HTMLDivElement>> = styled.div
 const Figcaption = div`
-  & > p, p {
+  & > p, p, .public-DraftEditorPlaceholder-root {
     ${props => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14", "medium"))}
     color: ${props => (props.layout === "classic" ? "#666" : "#999")};
     margin: 0;
@@ -33,7 +33,7 @@ interface CaptionProps {
 
 const Caption: React.SFC<CaptionProps> = props => {
   const { layout, caption, viewFullscreen } = props
-  const child = caption ? <div dangerouslySetInnerHTML={{ __html: caption }} /> : props.children
+  const child = props.children ? props.children : <div dangerouslySetInnerHTML={{ __html: caption }} />
   return (
     <CaptionContainer>
       <Figcaption layout={layout}>


### PR DESCRIPTION
Minor updates: 
- Adds our text-editor's generic placeholder class to caption component (not ideal to include a vendor class, but it saves a lot of css on the other side).

- Flips weighting in Caption for displaying children vs section html (will display a child if it has one)