### PR TITLE
@alloy => FullscreenViewer QA

### DIFF
--- a/src/components/publishing/__stories__/article.story.tsx
+++ b/src/components/publishing/__stories__/article.story.tsx
@@ -2,12 +2,12 @@ import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
 import Article from "../article"
-import Articles from "../fixtures/articles"
+import { FeatureArticle, StandardArticle } from "../fixtures/articles"
 
 storiesOf("Publishing/Articles", module)
   .add("Standard", () => {
-    return <Article article={Articles[1]} />
+    return <Article article={StandardArticle} />
   })
   .add("Feature", () => {
-    return <Article article={Articles[2]} />
+    return <Article article={FeatureArticle} />
   })

--- a/src/components/publishing/__stories__/header.story.tsx
+++ b/src/components/publishing/__stories__/header.story.tsx
@@ -4,27 +4,27 @@ import * as React from "react"
 
 import Header from "../header/header"
 
-import Articles from "../fixtures/articles"
+import { ClassicArticle, FeatureArticle, StandardArticle } from "../fixtures/articles"
 import { HeroSections } from "../fixtures/components"
 
 storiesOf("Publishing/Headers", module)
   .add("Classic Header", () => {
     return (
       <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
-        <Header article={Articles[0]} />
+        <Header article={ClassicArticle} />
       </div>
     )
   })
   .add("Standard Header", () => {
     return (
       <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
-        <Header article={Articles[1]} />
+        <Header article={StandardArticle} />
       </div>
     )
   })
   .add("Feature Header - Text", () => {
-    const article = _.extend({}, Articles[2], { hero_section: HeroSections[0] })
-    const article2 = _.extend({}, Articles[2], { hero_section: HeroSections[5] })
+    const article = _.extend({}, FeatureArticle, { hero_section: HeroSections[0] })
+    const article2 = _.extend({}, FeatureArticle, { hero_section: HeroSections[5] })
     return (
       <div>
         <div style={{ width: "100vw", position: "relative" }}>
@@ -37,8 +37,8 @@ storiesOf("Publishing/Headers", module)
     )
   })
   .add("Feature Header - Split", () => {
-    const article = _.extend({}, Articles[2], { hero_section: HeroSections[1] })
-    const article2 = _.extend({}, Articles[2], { hero_section: HeroSections[3] })
+    const article = _.extend({}, FeatureArticle, { hero_section: HeroSections[1] })
+    const article2 = _.extend({}, FeatureArticle, { hero_section: HeroSections[3] })
     return (
       <div>
         <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
@@ -51,8 +51,8 @@ storiesOf("Publishing/Headers", module)
     )
   })
   .add("Feature Header - Full", () => {
-    const article = _.extend({}, Articles[2], { hero_section: HeroSections[2] })
-    const article2 = _.extend({}, Articles[2], { hero_section: HeroSections[4] })
+    const article = _.extend({}, FeatureArticle, { hero_section: HeroSections[2] })
+    const article2 = _.extend({}, FeatureArticle, { hero_section: HeroSections[4] })
     return (
       <div>
         <div style={{ width: "100vw", height: "100vh", position: "relative" }}>

--- a/src/components/publishing/__stories__/typography.story.tsx
+++ b/src/components/publishing/__stories__/typography.story.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
+import IconExpand from "../icon/expand"
 import IconImageSet from "../icon/image_set"
 import IconRemove from "../icon/remove"
 import Typography from "./typography_examples"
@@ -16,6 +17,10 @@ storiesOf("Publishing/Typography", module)
         <div style={{ width: 50 }}>
           <IconRemove />
           <p>Remove</p>
+        </div>
+        <div style={{ width: 50 }}>
+          <IconExpand />
+          <p>Expand</p>
         </div>
       </div>
     )

--- a/src/components/publishing/__test__/article.test.tsx
+++ b/src/components/publishing/__test__/article.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from "enzyme"
 import "jest-styled-components"
 import * as React from "react"
 import Article from "../article"
-import Articles from "../fixtures/articles"
+import { StandardArticle } from "../fixtures/articles"
 
 jest.mock("react-slick", () => {
   const React = require("react")
@@ -11,7 +11,7 @@ jest.mock("react-slick", () => {
 jest.mock("react-sizeme", () => jest.fn(c => d => d))
 
 it("indexes and titles images", () => {
-  const article = shallow(<Article article={Articles[1]} />)
+  const article = shallow(<Article article={StandardArticle} />)
   expect(article.state("article").sections[4].images[0].setTitle).toBe("A World Without Capitalism")
   expect(article.state("article").sections[4].images[0].index).toBe(0)
   expect(article.state("article").sections[4].images[1].index).toBe(1)

--- a/src/components/publishing/article.tsx
+++ b/src/components/publishing/article.tsx
@@ -6,9 +6,13 @@ import FeatureLayout from "./layouts/feature_layout"
 import StandardLayout from "./layouts/standard_layout"
 import FullscreenViewer from "./sections/fullscreen_viewer/fullscreen_viewer"
 import Sections from "./sections/sections"
+import { Layout } from "./typings"
 
-interface ArticleProps {
-  article: any
+export interface ArticleProps {
+  article: {
+    layout: Layout
+    [x: string]: any
+  }
 }
 interface ArticleState {
   viewerIsOpen: boolean

--- a/src/components/publishing/article.tsx
+++ b/src/components/publishing/article.tsx
@@ -6,13 +6,10 @@ import FeatureLayout from "./layouts/feature_layout"
 import StandardLayout from "./layouts/standard_layout"
 import FullscreenViewer from "./sections/fullscreen_viewer/fullscreen_viewer"
 import Sections from "./sections/sections"
-import { Layout } from "./typings"
+import { ArticleData } from "./typings"
 
 export interface ArticleProps {
-  article: {
-    layout: Layout
-    [x: string]: any
-  }
+  article: ArticleData
 }
 interface ArticleState {
   viewerIsOpen: boolean

--- a/src/components/publishing/fixtures/articles.ts
+++ b/src/components/publishing/fixtures/articles.ts
@@ -1,6 +1,6 @@
-import { ArticleProps } from "../article"
+import { ArticleData } from "../typings"
 
-export const ClassicArticle: ArticleProps["article"] = {
+export const ClassicArticle: ArticleData = {
   _id: "597b9f652d35b80017a2a6a7",
   author_id: "4f85e1b55ca0370001000072",
   partner_channel_id: "52d99185cd530e581300006c",
@@ -132,7 +132,7 @@ export const ClassicArticle: ArticleProps["article"] = {
   ],
 }
 
-export const StandardArticle: ArticleProps["article"] = {
+export const StandardArticle: ArticleData = {
   title: "New York's Next Art District",
   contributing_authors: [],
   published_at: "2017-05-19T13:09:18.567Z",
@@ -372,7 +372,7 @@ export const StandardArticle: ArticleProps["article"] = {
   ],
 }
 
-export const FeatureArticle: ArticleProps["article"] = {
+export const FeatureArticle: ArticleData = {
   _id: "594a7e2254c37f00177c0ea9",
   keywords: ["Inspiration", "Casey Lesser"],
   author_id: "57b5fc6acd530e65f8000406",

--- a/src/components/publishing/fixtures/articles.ts
+++ b/src/components/publishing/fixtures/articles.ts
@@ -1,545 +1,542 @@
-const Articles = [
-  {
-    _id: "597b9f652d35b80017a2a6a7",
-    author_id: "4f85e1b55ca0370001000072",
-    partner_channel_id: "52d99185cd530e581300006c",
-    partner_ids: ["52d99185cd530e581300006c"],
-    author: {
-      id: "4f85e1b55ca0370001000072",
-      name: "Joanne Artman Gallery",
-    },
-    layout: "classic",
-    hero_section: null,
-    thumbnail_title: "New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple",
-    email_metadata: {
-      image_url:
-        "https://artsy-media-uploads.s3.amazonaws.com/wHFgQlrTrHav5O6bQRJ0dg%2FUntitled+Suspended_30x67x33+%282%29_sm+cropped.jpg",
-      author: "Joanne Artman Gallery",
-      headline: "New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple",
-    },
-    send_body: false,
-    tier: 2,
-    tags: [],
-    tracking_tags: [],
-    published: true,
-    fair_ids: [],
-    fair_programming_ids: [],
-    fair_artsy_ids: [],
-    fair_about_ids: [],
-    auction_ids: [],
-    section_ids: [],
-    featured: false,
-    exclude_google_news: false,
-    indexable: true,
-    contributing_authors: [],
-    is_super_article: false,
-    channel_id: null,
-    daily_email: false,
-    weekly_email: false,
-    keywords: ["Joanne Artman Gallery"],
-    updated_at: "2017-07-28T20:38:05.709Z",
-    title: "New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple",
-    lead_paragraph: "<p></p>",
-    id: "597b9f652d35b80017a2a6a7",
-    slug: "joanne-artman-gallery-poetry-naturerefinement-form",
-    scheduled_publish_at: null,
-    thumbnail_image:
-      "https://artsy-media-uploads.s3.amazonaws.com/wHFgQlrTrHav5O6bQRJ0dg%2FUntitled+Suspended_30x67x33+%282%29_sm+cropped.jpg",
-    published_at: "2017-07-28T20:38:05.709Z",
-    description:
-      " The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist on ev...",
-    sections: [
-      {
-        type: "text",
-        body:
-          "<p>The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist on every level in nature. Along with fractals, chaos theory is one of the essential, universal influences on patterns in nature. In essence, the theory shows how systems of chaotic, apparent randomness have an underlying pattern, or repetition.</p><p>The work of sculptor Matt Devine echoes the natural world, as the artist creates wonderfully complex works that resonate with both chaos and order. Perhaps this is why we can’t stop looking at Devine’s <em>Brass Tax</em>. Elevated by the use of a metallic finish, the piece is a minimalist refinement of nature, form and sequence.</p>",
-      },
-      {
-        type: "image_collection",
-        layout: "overflow_fillwidth",
-        images: [
-          {
-            type: "artwork",
-            id: "596aa2851a1e864d5eea6681",
-            slug: "matt-devine-brass-tax",
-            date: "",
-            title: "Brass Tax",
-            image: "https://d32dm0rphc51dk.cloudfront.net/lSBz0tsfvOAm2qKdWwgxLw/larger.jpg",
-            partner: {
-              name: "Joanne Artman Gallery",
-              slug: "joanne-artman-gallery",
-            },
-            artists: [
-              {
-                name: "Matt Devine",
-                slug: "matt-devine",
-              },
-            ],
-            artist: {
-              name: "Matt Devine",
-              slug: "matt-devine",
-            },
-            width: 1500,
-            height: 2000,
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          "<p>Long before chaos theory, scientists have hypothesized on the apparent beauty of the “irregular” in nature. In the 1841 edition of the American Repertory of Arts, Sciences and Manufactures (Volume 3), James Jay Mapes pens a deftly, eloquently written ode to the irregularities of our world, the stars, the oceans, the mountains and deserts. Mapes describes how our perceptions of beauty are built upon such irregularities - poignant breaks from any visible pattern, that are then captured and described in works of art. &nbsp;</p><p>“…the relative distances of the planets, their magnitudes, and the number of their satellites, conform to no known numerical law. The fixed stars exhibit no regular arrangement, either in their magnitudes, distances, or positions, but appear scattered at random across the sky. To descend to our own earth, no symmetry is traceable in the forms of island or continents, the courses of rivers, or the directions of mountain chains… In the “human face divine,” portrait painters affirm that the two sides never correspond; and even when the external form of an animal exhibits an appearance of bilateral or radiate symmetry, nature departs from it in her arrangement of the internal structure. In short, variety is a great and a most beautiful law of nature: it is that which distinguishes her productions from those of art, and it is that which man often exerts his highest efforts…to imitate.”</p><p>In a recent text, <em>Aesthetics of Ugliness: A Critical Edition</em> by Karl Rosenkranz, the author stipulates, that although “free multiplicity” is indeed beautiful, “regularity tires through its stereotypical sameness, which presents to us difference always in the same manner, so that we long to get out of its uniformity and into freedom, even if <em>in extremis</em> it is a chaotic freedom.”</p>",
-      },
-      {
-        type: "image_collection",
-        layout: "overflow_fillwidth",
-        images: [
-          {
-            type: "artwork",
-            id: "57dc83ce139b212bd7000172",
-            slug: "matt-devine-untitled-suspended",
-            date: "",
-            title: "Untitled Suspended",
-            image: "https://d32dm0rphc51dk.cloudfront.net/jDXiwSBgNP2eml1YkMIitg/larger.jpg",
-            partner: {
-              name: "Joanne Artman Gallery",
-              slug: "joanne-artman-gallery",
-            },
-            artists: [
-              {
-                name: "Matt Devine",
-                slug: "matt-devine",
-              },
-            ],
-            artist: {
-              name: "Matt Devine",
-              slug: "matt-devine",
-            },
-            width: 3134,
-            height: 2062,
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          "<p>In both<em>Brass Tax</em>as well as<em>Untitled Suspended</em>, the words of Mapes and Rosenkranz can be seen to find their home, both pieces exhibiting a poetic, chaotic freedom, their beauty centered in their adherence to no prescriptive, formal pattern. The works seem entirely organic despite their true nature.</p>",
-      },
-      {
-        type: "text",
-        body: "Hello World",
-      },
-    ],
-  },
-  {
-    title: "New York's Next Art District",
-    contributing_authors: [],
-    published_at: "2017-05-19T13:09:18.567Z",
-    layout: "standard",
-    vertical: {
-      name: "Art Market",
-      id: "12345",
-    },
-    sections: [
-      {
-        type: "text",
-        body:
-          "<p>What would Antoine Court de Gébelin think of the Happy Squirrel? </p><p>De Gébelin was a Protestant minister born in the 18th century. He authored the multi-volume tome <em>Le Monde primitif</em>, which insisted that the tarot deck contained secrets of the ancient Egyptians, whose priests had distilled their occult wisdom into the cards’ illustrations, imbuing them with great mystical power. Before that point, tarot was primarily a card game—meant for fun, not prophecy.</p><p>It was a bold and somewhat absurd assertion, given that de Gébelin could not read Egyptian hieroglyphics (no one could at the time, since they weren’t deciphered until the 19th century). Despite a total lack of historical evidence to back his claim, the theory stuck: Tarot decks, once a novelty, became popular tools for divination after the publication of de Gébelin’s book.</p><p>Which brings us back to the Happy Squirrel, a relatively recent addition to the tarot’s Major Arcana, and one whose provenance is less hazy: it originated on season six of <em>The Simpsons</em>. Lisa visits a fortune teller who is unconcerned when Lisa picks Death, but gasps in horror when the next card she draws is the Happy Squirrel. (When Lisa asks if the fuzzy rodent is a bad sign, the fortune teller demurs, saying that “the cards are vague and mysterious.”) Although it began as a cartoon joke, the Happy Squirrel card has made its way into over a dozen commercially available tarot decks. </p><p>So what would de Gébelin’s reaction be? The answer depends on whether tarot is a collection of timeless, mystical wisdom—or a flexible framework that has endured by changing with the times. Although tarot imagery employs supposedly universal archetypes, new decks are constantly being invented, and old decks altered. The art of tarot cards can never fully transcend its milieu. Which begs a second question: How do the cards’ art and design relate to the social changes, technological advances, and aesthetic sensibilities of their particular eras?</p>",
-      },
-      {
-        type: "text",
-        body:
-          "<h3><strong>Galleries Section, Booth 10221</strong></h3><h2>neugerriemschneider</h2><h3>With works by Franz Ackermann, Ai Weiwei, Pawel Althamer, Billy Childish, Keith Edmier, Olafur Eliasson, Andreas Eriksson, Noa Eshkol, Mario García Torres, Renata Lucas, Michel Majerus, Mike Nelson, Jorge Pardo, Elizabeth Peyton, Tobias Rehberger, Thaddeus Strode, Rirkrit Tiravanija, Pae White</h3><p>The resultant work allows Salley the chance to recount her experiences of the aftermath of her scandal in her own words. In the film, Fujiwara and Salley are shown meeting professionals from public relations, advertising, and fashion companies as they seek to construct a new public image for her. Alongside the film, light boxes display fashion photographer Andreas Larsson’s pictures of Salley, which were taken as part of the project to rebuild her profile. While the show tackles public identity, female iconography, and Salley’s voice as an artist, the pair’s close working relationship—one in which the conventional power relationship has been overturned—no doubt aided their collaboration.</p>",
-      },
-      {
-        type: "text",
-        layout: "blockquote",
-        body:
-          "<blockquote>The fixed stars exhibit no regular arrangement, either in their magnitudes, distances, or positions.</blockquote>",
-      },
-      {
-        type: "text",
-        body: "<h2>A Wealthy Family’s Trick-Taking Game</h2>",
-      },
-      {
-        type: "image_collection",
-        layout: "overflow_fillwidth",
-        title: "A World Without Capitalism",
-        images: [
-          {
-            url: "https://artsy-media-uploads.s3.amazonaws.com/5ZP7vKuVPqiynVU0jpFewQ%2Funnamed.png",
-            type: "image",
-            width: 600,
-            height: 1067,
-            caption:
-              "<p>John Elisle, <em>The Star</em>, from the reimagined female Tarot cards. Courtesy of the artist. </p>",
-          },
-          {
-            url: "https://artsy-media-uploads.s3.amazonaws.com/PcvH_rh89gRGxRXgCyGGng%2Funnamed-5.png",
-            type: "image",
-            width: 600,
-            height: 1067,
-            caption:
-              "<p>John Elisle, <em>The Magician</em>, from the reimagined female Tarot cards. Courtesy of the artist. </p>",
-          },
-          {
-            type: "artwork",
-            id: "596aa2851a1e864d5eea6681",
-            slug: "matt-devine-brass-tax",
-            date: "",
-            title: "Brass Tax",
-            image: "https://d32dm0rphc51dk.cloudfront.net/lSBz0tsfvOAm2qKdWwgxLw/larger.jpg",
-            partner: {
-              name: "Joanne Artman Gallery",
-              slug: "joanne-artman-gallery",
-            },
-            artists: [
-              {
-                name: "Matt Devine",
-                slug: "matt-devine",
-              },
-            ],
-            artist: {
-              name: "Matt Devine",
-              slug: "matt-devine",
-            },
-            width: 1500,
-            height: 2000,
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          '<p>Despite their aura of mystery, medieval tarot cards were not used for divination, and were probably <em>not</em> created by ancient Egyptian magicians. The earliest surviving tarot decks—now preserved in various museum collections—are Italian, and were commissioned by wealthy patrons, the same way one might have hired an artist to paint a portrait or illuminated prayerbook. </p><p>The Visconti-Sforza Tarot is a collection of decks, none complete, commissioned by the Visconti and Sforza families from the workshop of Milanese court painter Bonifacio Bembo. Cards such as Death, who rides a horse and swings a giant scythe like a player in the world’s most high-stakes polo match, will seem familiar to contemporary enthusiasts. So will the Pope, who sits on a golden throne; and the Lovers, who hold hands beneath a string of heraldic flags. Rather than looking to these cards for mystic guidance, the Visconti and Sforza families would have used them to play a trick-taking card game similar to modern-day Bridge. (Although it’s unlikely—given the good condition of the decks—that they were ever handled with much frequency).</p><p>The cards each have intricately tooled gold backgrounds that glow like the luxury items that they were. Bembo is believed to have included portraits of the families in many of the cards, as well as adding the Visconti family motto here and there for good measure. Akin to the work of <a href="https://www.artsy.net/artist/fra-angelico">Fra Angelico</a> and other early-Renaissance artists, the cards are opulent but pictorially flat, although the bodies appear in naturalistic perspective and their clothing billows around them, suggesting volume and form. </p><p><br></p><h2>The 18th-Century Conver Classic</h2>',
-      },
-      {
-        type: "image_collection",
-        layout: "overflow_fillwidth",
-        images: [
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/GwIVCQftjauWBCQie9oQ-A%2FTarot_de_Marseille_major21_world.jpg",
-            type: "image",
-            width: 320,
-            height: 620,
-            caption: "<p>Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
-          },
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/UaNPuL9iz-X7Xm-SNtat7Q%2FTarot_de_Marseille_clubs13_queen.jpg",
-            type: "image",
-            width: 320,
-            height: 620,
-            caption:
-              "<p>Nicolas Conver, <em>Queen of Clubs</em>. Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
-          },
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/x5EcmVNBKoUJqQa8BQgqJA%2FTarot_de_Marseille_major06_lovers.jpg",
-            type: "image",
-            width: 320,
-            height: 620,
-            caption: "<p>Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          '<p>Produced in 1760, French engraver Nicolas Conver’s deck of delicate woodcuts, the Tarot de Marseille, is the template on which many contemporary decks are based. Like the Visconti-Sforza Tarot, the deck’s design likely originated in 15th-century Italy before traveling north to France. It’s a favorite of many tarot enthusiasts, most notably the cult film director Alejandro Jodorowsky, who <a href="http://www.nytimes.com/2011/11/13/fashion/alejandro-jodorowsky-and-his-tarot-de-marseille.html?mcubz=1">designed his own deck</a> based on the style. While the Conver deck wasn’t the first to be called the Tarot de Marseille, it’s highly prized by collectors for its delicate color palette of sky blues and minty greens. The graphic black outlines and blunt shading of the prints give the cards a simple and rough-hewn appearance, which adds to the ambience of ancient wisdom. The popularity of the tarot grew due to advances in printing technology and via the writings of 19th-century French occultists such as Éliphas Lévi and Etteilla, which popularized the use of tarot as a method of fortune-telling and assigned additional divinatory meaning to the cards.</p><p><br></p><h2>The New Mystics</h2>',
-      },
-      {
-        type: "image_collection",
-        layout: "overflow_fillwidth",
-        images: [
-          {
-            url: "https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg",
-            type: "image",
-            width: 1152,
-            height: 826,
-            caption:
-              "<p>Pamela Colman Smith, <em>The Empress</em>, c. 1937. Courtesy of the Beinecke Rare Book &amp; Manuscript Library at Yale University.</p>",
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          '<p>The Rider-Waite Smith deck, which debuted in 1909, remains the most recognizable and popular today. Designed by artist Pamela Colman Smith under the direction of the mystic A.E. Waite, it was the first to be mass-produced in English, and was intended for divination rather than gameplay. Smith and Waite were both active members of the Order of the Golden Dawn, a secretive organization devoted to the exploration of the paranormal and occult (allegedly Bram Stoker, Aleister Crowley, and Sir Arthur Conan Doyle were also members). </p><p>In addition to Smith’s occult bonafides, she was also an accomplished artist, championed by <a href="https://www.artsy.net/artist/alfred-stieglitz">Alfred Stieglitz</a>, who collected her work and showed it at his gallery. Smith created fully-realized illustrations of all 78 cards that made the deck a treasure-trove for cartomancers, who now had a much richer store of images to work with. (Previously, only the 22 Major Arcana cards such as the Fool, the Magician, and the Lovers had been elaborately illustrated—traditionally, the Minor Arcana cards, which are roughly analogous to the suits in a deck of modern playing cards, were not.) The Major Arcana were based on the Tarot de Marseille drawings, but rendered in an illustrative <a href="https://www.artsy.net/gene/art-nouveau">Art Nouveau</a> style rich with patterns. Even the Fool looks debonaire; he carelessly approaches the cliff, a feather in his cap and a blooming rose in his elegant fingers, wearing a floral tunic that looks straight out of <a href="https://www.artsy.net/artist/william-morris">William Morris</a>’s workshop.</p><p><br></p><h2>An Occultist’s Pure Geometry</h2>',
-      },
-      {
-        mobile_height: 1300,
-        height: 1000,
-        url: "http://files.artsy.net/documents/1parrasch.html",
-        layout: "overflow_fillwidth",
-        type: "embed",
-      },
-      {
-        type: "text",
-        body:
-          '<p>The Thoth deck, named for the Ibis-faced Egyptian god more commonly known as Horus, was painted by the artist Frieda Harris based on direction from the infamous occultist-about-town Aleister Crowley. Completed in the early 1940s, but not widely available until 1969, it features <a href="https://www.artsy.net/gene/art-deco">Art Deco</a> borders resembling the pattern of a butterfly wing. </p><p>The deck is an aesthetic departure from the Rider-Waite’s homey <a href="https://www.artsy.net/gene/arts-and-crafts-movement">Arts and Crafts</a> aesthetic. Shaped by Harris’s interest in pure geometry, the cards are reminiscent of the work of Swedish painter <a href="https://www.artsy.net/artist/hilma-af-klint">Hilma af Klint</a> (a visionary artist who shared Harris’s interest in spiritualism and the writings of Austrian philosopher Rudolf Steiner, both popular subjects of study among the middle and upper classes in the early 20th century). Harris’s shaded orbs and compass-inscribed curves that fill the background of each card bear more than a passing resemblance to Klint’s highly-saturated geometries. Klint, considered by some to be Europe’s first abstract painter, believed that her luminous compositions were the created under the influence of spirits. (The same could easily be said of Harris because she was taking direction from Crowley, who was believed to be a medium, able to channel ancient and magical forces.) </p><p>It’s no coincidence that Klint’s paintings and Harris’s Thoth illustrations were shown in the same pavilion at the 2013 Venice Biennale, which was intended to amplify voices that had previously been excluded and “cover 100 years of dreams and visions,” <a href="http://www.nytimes.com/2013/05/26/arts/design/massimiliano-gioni-of-venice-biennale.html">according</a> to curator Massimiliano Gioni.</p><p><br></p><h2>Sex &amp; Self-Help, ’70s Style</h2>',
-      },
-      {
-        type: "image_collection",
-        layout: "overflow_fillwidth",
-        images: [
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/jmrvzuo7VfRidule-4zWNA%2F07272017170054-0001+%28dragged%29+copy.jpg",
-            type: "image",
-            width: 405,
-            height: 723,
-            caption: "<p>Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. </p>",
-          },
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/66XOTGwZQzAAa0igYKSNTQ%2F07272017170207-0001+%28dragged%29.jpg",
-            type: "image",
-            width: 407,
-            height: 719,
-            caption: "<p>Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. </p>",
-          },
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/l0Qu946mLja0Dbv4ME4MHg%2F07272017170259-0001+%28dragged%29.jpg",
-            type: "image",
-            width: 413,
-            height: 721,
-            caption: "<p>Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. </p>",
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          '<p>Created by the artist Bill Greer under the direction of Lloyd Morgan, the Morgan-Greer deck is, like the 1970s themselves, both opulent and optimistic. The Magician sports a mustache that would make Tom Selleck blush, and the naked and embracing Lovers would fit right in with the hirsute and curvaceous illustrations in the original 1972 edition of <em>The Joy of Sex</em>.</p><p>The ‘70s enthusiasm for all things New Age created a renewed interest in tarot as a tool for self-discovery, and the Morgan Greer deck was there to greet it. The cards’ colors are lush and the lines are fluid. Greer chose to crop his figures tightly and removed the borders, allowing the illustrations to extend to the edges. The effect is fresh and personal. Formally, the Morgan-Greer illustrations have more in common with Jefferson Starship’s <em>Spitfire</em> (1976) album cover than with contemporary painting of the same period—the pendulum had swung away from figuration and would take a few years longer to swing back—but it’s possible to find a resonance between this deck’s art and a work like <a href="https://www.artsy.net/artist/judy-chicago">Judy </a><a href="https://www.artsy.net/artist/judy-chicago">Chicago</a>’s <em>Dinner Party </em>(1979), with its powerful goddess and blooming flowers. Greer’s strong women and frank sexuality make the deck very much of its time.</p><p><br></p><h2>Minimalism &amp; Identity in the Present Day</h2>',
-      },
-      {
-        type: "image_set",
-        layout: "full",
-        title: "The Work of Bruce M. Sherman",
-        images: [
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/CzofaZln2q-XhtXFqIio5A%2F07272017133815-0001+%28dragged%29+copy.jpg",
-            type: "image",
-            width: 396,
-            height: 719,
-            caption: "<p>King Khan, card from the Black Power Tarot. </p>",
-          },
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/z7BUiIKCStBxlcXh53t0Xg%2F07272017133730-0001+%28dragged%29+copy.jpg",
-            type: "image",
-            width: 396,
-            height: 728,
-            caption: "<p>King Khan, card from the Black Power Tarot. </p>",
-          },
-          {
-            url: "https://artsy-media-uploads.s3.amazonaws.com/T9g-NNJcmy8ej6qV6UQ-fA%2F07272017133839-0001.jpg",
-            type: "image",
-            width: 392,
-            height: 718,
-            caption: "<p>King Khan, card from the Black Power Tarot. </p>",
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          "<p>Created by graphic designer Kati Forner for a Los Angeles-based fashion retailer, the Dreslyn tarot is the epitome of techno-minimalism. Although the deck is lovingly printed with high-gloss embossing, its illustrations are simple enough to be mistaken for the icon of an elegant iPhone app. It’s a radical departure from the historical approach, where each card is full to bursting with details, signs, and symbols—instead, each card has been paired down the bare minimum. The Dreslyn’s Lovers image is just two slender circles bisecting a line; its Eight of Wands is simply eight diagonal rules. The deck’s aesthetic mirrors the contemporary fear of clutter, as well as the increasing simplicity of the interfaces we use every day.</p><p>Tarot decks have also increasingly become more personal, and occasionally political, while reflecting a greater diversity. Illustrator John Elisle, in a commission for Missy Magazine, created seven all-women tarot cards, a chic sci-fi universe that includes a dominatrix Devil and a psychedelic High Priestess.</p>",
-      },
-      {
-        type: "image_collection",
-        layout: "column_width",
-        images: [
-          {
-            url: "https://artsy-media-uploads.s3.amazonaws.com/Gk95i1tUaDJKeqQ-jcq6Cw%2FIMG_2142.jpg",
-            type: "image",
-            width: 5184,
-            height: 3456,
-            caption: "<p>Designed by Kati Forner for The Dreslyn, courtesy of the artist. </p>",
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          "<p>The Black Power Tarot was conceived by musician King Khan in consultation with Alejandro Jodorowsky, and designed by illustrator Michael Eaton in 2015. The deck celebrates the strength and achievements of Black musicians, artists, and activists while staying faithful to the imagery and composition of the classic Tarot de Marseilles. The familiar faces of Malcolm X, James Brown, Tina Turner, Howlin’ Wolf, Sister Rosetta Tharpe, and others emerge from the Major Arcana. Sun Ra is there too, appropriately imagined as the Sun card. At a time when Black Americans are at a high risk of being the victims of state-sponsored violence, the Black Power Tarot feels especially urgent. By situating these figures within a centuries-old framework of esoteric wisdom, Khan affirms their value and influence, the importance of their legacy. By placing them on cards used for fortune-telling, he extends their power into the future. <span class='content-end'></span></p><p> &nbsp;—Ariela Gittlen</p>",
-      },
-    ],
-  },
-  {
-    _id: "594a7e2254c37f00177c0ea9",
-    keywords: ["Inspiration", "Casey Lesser"],
-    author_id: "57b5fc6acd530e65f8000406",
-    author: {
-      id: "50f4367051e7956b6e00045d",
-      name: "Artsy Editorial",
-    },
-    thumbnail_title: "What’s the Path to Winning an Art Prize?",
-    vertical: {
-      name: "Creativity",
-      id: "591eaa6bfaef6a3a8e7fe1b1",
-    },
-    hero_section: {
-      type: "fullscreen",
-      title: "What’s the Path to Winning an Art Prize?",
-      url: "https://artsy-media-uploads.s3.amazonaws.com/z9w_n6UxxoZ_u1lzt4vwrw%2FHero+Loop+02.mp4",
-    },
-    contributing_authors: [
-      {
-        id: "523783258b3b815f7100055a",
-        name: "Casey Lesser",
-      },
-    ],
-    authors: [
-      {
-        id: "523783258b3b815f7100055a",
-        name: "Casey Lesser",
-        bio: "[Casey Lesser](http://artsy.net) is a well-known author and a long-time baker.",
-        twitter_handle: "caseylesser",
-      },
-    ],
-    channel_id: "5759e3efb5989e6f98f77993",
-    description:
-      "Applying for art prizes can be daunting, but doing so is a pathway to exhibitions, influential contacts, and a way to gain valuable feedback about your work.",
-    tier: 1,
-    tags: ["Inspiration"],
-    tracking_tags: ["sponsored"],
-    layout: "feature",
-    published: true,
-    featured: true,
-    updated_at: "2017-07-19T17:19:55.909Z",
-    title: "What’s the Path to Winning an Art Prize?",
-    lead_paragraph: "",
-    sections: [
-      {
-        type: "text",
-        body:
-          "<p><span class='content-start'>A</span>round two years ago, a collector encouraged New York-based ceramic artist <a href='https://www.artsy.net/artist/jennie-jieun-lee'>Jennie Jieun Lee</a> to apply for an art prize. “I was a little bit scared. I’d applied to a few things in the past and been rejected, so I was bummed by that,” she admits. “I entered not thinking that I was going to win, but that it would be a good exercise to go through the process.” &nbsp;</p><p>It paid off. She was among several artists in 2015 who won an Artadia Award—an unrestricted, merit-based prize of up to $10,000, which is given to visual artists working in certain U.S. cities. The winnings, as well as the experience, helped Lee push her career forward. </p><p>“That money enabled me to move into a bigger studio and buy a larger kiln,” she explains. “With that movement, I was able to make my career.” And the momentum continued: More recently, she won a Pollock-Krasner grant that she used to move cross-country and fund a residency in the ceramic department at California State University, Long Beach. </p><p>Lee is by no means alone. While we’ve all heard of the boldfaced awards, like the Turner Prize or the Hugo Boss Prize, which tend to anoint artists when they’re already well known to the art world, a wealth of awards are available for lesser-known and emerging artists. </p>",
-      },
-      {
-        type: "text",
-        layout: "blockquote",
-        body:
-          "<blockquote>Land exhibitions, make influential contacts, and gain valuable feedback about your work.</blockquote>",
-      },
-      {
-        type: "image_collection",
-        layout: "overflow_fillwidth",
-        images: [
-          {
-            type: "artwork",
-            id: "57dc83ce139b212bd7000172",
-            slug: "matt-devine-untitled-suspended",
-            date: "",
-            title: "Untitled Suspended",
-            image: "https://d32dm0rphc51dk.cloudfront.net/jDXiwSBgNP2eml1YkMIitg/larger.jpg",
-            partner: {
-              name: "Joanne Artman Gallery",
-              slug: "joanne-artman-gallery",
-            },
-            artists: [
-              {
-                name: "Matt Devine",
-                slug: "matt-devine",
-              },
-            ],
-            artist: {
-              name: "Matt Devine",
-              slug: "matt-devine",
-            },
-            width: 3134,
-            height: 2062,
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          "<p>While applying for these opportunities can be daunting and time-consuming, it’s rewarding in more ways than one (even if you don’t end up winning). Artist prizes can be a path to prestige and profits, as well as a way to land exhibitions, make influential contacts, and gain valuable feedback about your work.</p><p>Based on conversations with artists who have won several different prizes, we share guidance below on how to go about applying for these opportunities, navigating the process, and benefiting from the positive outcomes they can offer.</p><p><br></p><h2>Finding the Prize That’s Right for You</h2><p>Artists should seek out opportunities based on their eligibility and the kind of work they make. “Don’t change to accommodate prizes,” advises London artist <a href='https://www.artsy.net/artist/ally-mcintyre'>Allyson McIntyre</a>, who won the 2015 HIX Award, which gives artists £10,000 to go towards a solo show at the London gallery HIX ART. “Be authentic to your practice and find the prizes that work for what you do.”</p><p>It’s important to recognize the distinction between prizes and awards—which are generally given in recognition of past work—and grants, which typically serve to facilitate future projects. Many artists note that they apply to both types of opportunities based on recommendations by word-of-mouth; they find that peers, former teachers, or other art-world contacts can share valuable input. New Orleans-based artist <a href='https://www.artsy.net/artist/aron-belka'>Aron Belka</a>, who won the BOMBAY SAPPHIRE® Artisan Series in 2015, advises artists to search for opportunities locally, through art schools, regional arts councils, art centers, and museums. &nbsp;</p><p>For those who perhaps do not have a tight-knit network of artist peers, there are several open-call websites and listservs that aggregate information on prizes, grants, and juried exhibitions. These include <a href='https://www.submittable.com/'>Submittable</a> and <a href='https://www.callforentry.org/'>Call for Entry</a>. On the latter, artists can create a profile, upload artwork images, and browse opportunities.</p>",
-      },
-      {
-        type: "image_collection",
-        layout: "overflow_fillwidth",
-        images: [
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/7lsxxsw0qPAuKl37jEYitw%2Farticle+asset+1-hig+res+copy.jpg",
-            type: "image",
-            width: 1200,
-            height: 750,
-            caption: "<p>Illustration by Tomi Um for Artsy.</p>",
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          "<h1>Section Header</h1><p>Enthusiastically grow high-payoff infomediaries for virtual methodologies. Competently maximize reliable scenarios whereas magnetic e-services. Completely formulate sticky schemas rather than strategic technologies. Phosfluorescently disseminate long-term high-impact e-services vis-a-vis effective collaboration and idea-sharing. Credibly provide access to technically sound services through plug-and-play niches.</p>",
-      },
-      {
-        type: "video",
-        url: "https://vimeo.com/191988155",
-        caption:
-          "<p>2016 was a memorable year for the world, and art along with it. Powered by data culled from Artsy as well as UBS’s Planet Art app, “The Year in Art 2016” will explore how the creative community responded to the cultural shifts and tribulations this year has seen—from the destruction of Palmyra to the proliferation of Virtual Reality to the U.S. election.</p>",
-        cover_image_url:
-          "https://artsy-media-uploads.s3.amazonaws.com/ditbyaUgdcl6mHin07TfKA%2FMassimilianoGioni_0581.jpg",
-        layout: "overflow_fillwidth",
-      },
-      {
-        type: "text",
-        body:
-          '<p><br></p><h2>The Application Process</h2><p>Most awards will require several images of your work, as well as a written artist statement to provide some context. With higher-stakes prizes, artists may be asked to submit recommendation letters from peers or professionals. </p><p>A somewhat obvious, though easily botched, element of the application process is following directions. “You have to be careful not to get lazy with how you submit, as it may lead to you being disqualified, which is just a waste of your time,” McIntyre explains. Be sure to read the fine print and adhere to all particulars regarding preparing, labeling, and submitting application materials.</p><p>Organizations administering prizes will allow artists to submit several—typically three to eight—images. They are generally interested in seeing recent work, created over the past two or three years. Some prizes may specify that artists create a new, original work to submit. Artists should be sure to send high-quality photographs; if resources allow, hire a photographer (or recruit a qualified friend) to have works shot professionally.</p><p>For those artists who work across mediums—perhaps printmaking one day, performance the next—know that it might not be advisable to try to include the full breadth of your practice in a single application. “Try to hone in on a single idea, or a couple of ideas,” says artist <a href="https://www.artsy.net/artist/alex-podesta">Alex Podesta</a>, who won the BOMBAY SAPPHIRE® Artisan Series in 2013, and has also served as a juror for other awards. “I’ve been on the other side of this a number of times, and when you’re reviewing applications it’s confusing and not helpful to have an artist submitting sculpture, painting, <em>and</em> a video piece. Focus on one aspect of your work.” </p><p>In addition to images, a written artist’s statement that explains and contextualizes the artist’s work is important, too. Artists should get in the habit of updating their statements regularly, adapting their texts to accurately reflect their current practices. Artist <a href="https://www.artsy.net/artist/yevgeniya-baras">Yevgeniya Baras</a>, who won an Artadia Award in New York in 2015, notes that she rewrites or edits her artist statement every two years. &nbsp;</p><p>For certain awards, artists may need to be able to speak about their work with jurors in person. If this is the case, be prepared to take full advantage of the opportunity. Baras notes that for Artadia, the panel of jurors visited her studio; she was careful to delve deeper into elements of her work that don’t come across through two-dimensional images or her online application. For the Meurice Prize for contemporary art, artists must give an oral presentation of their work. “While we don’t judge the artist on their ability to conduct a perfect verbal presentation of the work, we are of course interested to hear the artist speak of their work in a very intimate way, and that can actually be the decisive sector,” says Jennifer Flay, director of the art fair FIAC, and a juror for the Meurice Prize.</p><p><br></p><h2>Application Fees</h2><p>While it’s free to apply for some awards, it’s not uncommon to pay a fee in the range of $20 to $75—which can make a difference for artists looking to apply to multiple opportunites. Belka notes that if the stakes are high, an application fee may be worth it, but he advises that artists do their research before submitting said fees to avoid scams. </p><p>McIntyre recalls that she once applied to a competition that promised winners a show in Venice. “I was accepted, but they asked for an outrageous artist fee of €500,” she says. Later she learned that fellow artists had fallen for the scam and lost their money—and the works they had submitted. “Have discretion and awareness that your money may amount to nothing,” she counsels.</p><p><br></p><h2>Set Expectations and Be Persistent</h2><p>No one wins every award; there’s often a trail of rejections on the way to any prize. Baras, who landed the Rema Hort Mann Foundation Emerging Artist Grant in 2014 and the Artadia Award thereafter, notes that there’s been plenty of failure mixed in with those successes. (She estimates that she submits around 10 award or grant applications per year.) </p><p>“Assume that for nine out of every 10 applications that you send in, it’s not going to be the work they’re looking for,” Podesta says. “Younger artists, especially, shouldn’t get daunted. Remember that the work just isn’t resonating with the [specific] people reviewing it.”</p><p>It helps to go into the application process with an open mind, and reasonable hopes. “I went into it not expecting it to make my career, but rather for it to be an addition to it,” says <a href="https://www.artsy.net/artist/kristine-mays">Kristine Mays</a>, who won the BOMBAY SAPPHIRE® Artisan Series in 2014. Artists, she adds, should simply stay true to their craft, and keep working away.</p><p>Remember that rejection, while disappointing, can be a learning experience. “Without this kind of risk, you can’t really put yourself out there,” Baras says. “Most applications, for many amazing awards, just take a few days. It’s a way to see a new community, to seek new eyes, and I think that’s a necessary and healthy risk for an artist to take.”</p><p>Lee advises fellow artists to cast a wide net and apply to as many opportunities as possible, developing a thick skin as they do. “If you get rejected one year, apply again the next,” she says, simply. “It’s about being persistent and not taking anything personally.”</p><p><br></p>',
-      },
-      {
-        type: "image_collection",
-        layout: "fillwidth",
-        images: [
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/MGjCex4gkN4ofE_qOj_DPQ%2Farticle+asset+2-hig+res+copy.jpg",
-            type: "image",
-            width: 1200,
-            height: 750,
-            caption: "<p>Illustration by Tomi Um for Artsy</p>",
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          "<p>Enthusiastically grow high-payoff infomediaries for virtual methodologies. Competently maximize reliable scenarios whereas magnetic e-services. Completely formulate sticky schemas rather than strategic technologies. Phosfluorescently disseminate long-term high-impact e-services vis-a-vis effective collaboration and idea-sharing. Credibly provide access to technically sound services through plug-and-play niches.</p>",
-      },
-      {
-        type: "image_set",
-        layout: "mini",
-        images: [
-          {
-            url:
-              "https://artsy-media-uploads.s3.amazonaws.com/MGjCex4gkN4ofE_qOj_DPQ%2Farticle+asset+2-hig+res+copy.jpg",
-            type: "image",
-            width: 1200,
-            height: 750,
-            caption: "<p>Illustration by Tomi Um for Artsy</p>",
-          },
-        ],
-      },
-      {
-        type: "text",
-        body:
-          "<p><br></p><h2>Make the Most of Winning</h2><p>Depending on the prize, artists may be awarded a stipend to create new work for a show or unrestricted funds to further their careers. In both cases, artists report that these funds have gone towards keeping their art practices up and running, be it through realizing new works and shows or for subsidizing rent, bills, and the costs of production and supplies. &nbsp;</p><p>For example, the Meurice Prize, which supports artists under the age of 45 who show with French galleries, awards €20,000, which is split between the artist and their gallery. This year, the BOMBAY SAPPHIRE® Artisan Series (which is only open to entrants from North America) awards a grand prize winner a stipend of $10,000 to create a public artwork. </p><p>In some cases, like Lee’s, a sizable prize could help an artist move into a bigger studio, relocate to another city, or participate in a residency. “Before, I never even thought about moving out of New York,” she says. “The Pollock-Krasner grant gave me the freedom to possibly move cross-country to explore this residency. I feel like it’s completely changed my life, and now I’m not sure when I’m coming back.”</p><p><br></p><h2>It’s More Than Just Money </h2><p>Baras notes that even if she hadn’t won the Artadia Award it would’ve been a rewarding experience due to the panel of jurors she encountered. “Whether you win or not, whoever’s on the panel remembers your work,” she says. “It’s beneficial regardless to put yourself out there because you really never know who might notice.” &nbsp; </p><p>Other prizes similarly award artists with the opportunity to exhibit their work to a new audience. The Daiwa Foundation Art Prize, awarded each year to a British artist, serves to give that artist a solo gallery exhibition in Japan. And the Luxembourg Art Prize gives finalists the opportunity to show their work in a group exhibition in Luxembourg; the winner is awarded €25,000 to produce new work for a solo presentation at Galerie Hervé Lancelin for an exhibition the following year. </p><p>For Belka and Mays, who both won the chance to show their work at the Scope Art Fair in New York through the BOMBAY SAPPHIRE® Artisan Series, winning led to important exposure and networking opportunities. “Overall, the most positive outcome was being able to put myself in arenas I’d never been in before,” Mays says of her experience. She saw it as a “jump start” for her career; she’s been busy making and showing her work steadily since her Scope debut.</p><p>“I made a point of greeting and speaking to everyone that came to the space,” Mays adds. Both artists recommend being prepared with business cards and following up with the contacts you make via email. Belka notes that he made an important collector contact that he maintains today. “Come prepared to talk about your work, have cards, spread your name, and get yourself out there,” says Belka.</p><p>Mays was also inspired by the feedback she received from viewers of her work. “Many times we overlook the value of feedback from people, the ideas that can come out of conversation with people,” she says. </p><p><br></p><h2>Building Confidence </h2><p>Most artists agree that one of the most impactful parts of winning a prize is the vote of confidence that it provides. Formal recognition can be a sign of assurance that they were right to pursue a career as an artist, and can inspire them to get back in the studio. &nbsp;</p><p>“It’s a nice confirmation to know that you can communicate to people you don’t even know, and just continue along the path of making your work,” Baras muses. “I see it as a kind of hug. Generally, you’re sort of hugging yourself as an artist—but once in awhile, you get an acknowledgment from the outside world.”<span class='content-end'></span></p>",
-      },
-    ],
-    postscript: "<p>Header animation: Illustration by Tomi Um for Artsy. Animation by Ale Pixel Studio.</p>",
-    id: "594a7e2254c37f00177c0ea9",
-    scheduled_publish_at: null,
-    thumbnail_image: "https://artsy-media-uploads.s3.amazonaws.com/gejssmXDiO3G1pE73phZ3Q%2FArtboard+2%402xef-100.jpg",
-    social_image: "https://artsy-media-uploads.s3.amazonaws.com/wU7ase6M0zWv6MLcC8-L5A%2Fd7hftxdivxxvm.cloudfront.jpg",
-    published_at: "2017-06-29T15:00:00.000Z",
-    slug: "artsy-editorial-path-winning-art-prize",
-  },
-]
+import { ArticleProps } from "../article"
 
-export default Articles
+export const ClassicArticle: ArticleProps["article"] = {
+  _id: "597b9f652d35b80017a2a6a7",
+  author_id: "4f85e1b55ca0370001000072",
+  partner_channel_id: "52d99185cd530e581300006c",
+  partner_ids: ["52d99185cd530e581300006c"],
+  author: {
+    id: "4f85e1b55ca0370001000072",
+    name: "Joanne Artman Gallery",
+  },
+  layout: "classic",
+  hero_section: null,
+  thumbnail_title: "New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple",
+  email_metadata: {
+    image_url:
+      "https://artsy-media-uploads.s3.amazonaws.com/wHFgQlrTrHav5O6bQRJ0dg%2FUntitled+Suspended_30x67x33+%282%29_sm+cropped.jpg",
+    author: "Joanne Artman Gallery",
+    headline: "New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple",
+  },
+  send_body: false,
+  tier: 2,
+  tags: [],
+  tracking_tags: [],
+  published: true,
+  fair_ids: [],
+  fair_programming_ids: [],
+  fair_artsy_ids: [],
+  fair_about_ids: [],
+  auction_ids: [],
+  section_ids: [],
+  featured: false,
+  exclude_google_news: false,
+  indexable: true,
+  contributing_authors: [],
+  is_super_article: false,
+  channel_id: null,
+  daily_email: false,
+  weekly_email: false,
+  keywords: ["Joanne Artman Gallery"],
+  updated_at: "2017-07-28T20:38:05.709Z",
+  title: "New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple",
+  lead_paragraph: "<p></p>",
+  id: "597b9f652d35b80017a2a6a7",
+  slug: "joanne-artman-gallery-poetry-naturerefinement-form",
+  scheduled_publish_at: null,
+  thumbnail_image:
+    "https://artsy-media-uploads.s3.amazonaws.com/wHFgQlrTrHav5O6bQRJ0dg%2FUntitled+Suspended_30x67x33+%282%29_sm+cropped.jpg",
+  published_at: "2017-07-28T20:38:05.709Z",
+  description:
+    " The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist on ev...",
+  sections: [
+    {
+      type: "text",
+      body:
+        "<p>The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist on every level in nature. Along with fractals, chaos theory is one of the essential, universal influences on patterns in nature. In essence, the theory shows how systems of chaotic, apparent randomness have an underlying pattern, or repetition.</p><p>The work of sculptor Matt Devine echoes the natural world, as the artist creates wonderfully complex works that resonate with both chaos and order. Perhaps this is why we can’t stop looking at Devine’s <em>Brass Tax</em>. Elevated by the use of a metallic finish, the piece is a minimalist refinement of nature, form and sequence.</p>",
+    },
+    {
+      type: "image_collection",
+      layout: "overflow_fillwidth",
+      images: [
+        {
+          type: "artwork",
+          id: "596aa2851a1e864d5eea6681",
+          slug: "matt-devine-brass-tax",
+          date: "",
+          title: "Brass Tax",
+          image: "https://d32dm0rphc51dk.cloudfront.net/lSBz0tsfvOAm2qKdWwgxLw/larger.jpg",
+          partner: {
+            name: "Joanne Artman Gallery",
+            slug: "joanne-artman-gallery",
+          },
+          artists: [
+            {
+              name: "Matt Devine",
+              slug: "matt-devine",
+            },
+          ],
+          artist: {
+            name: "Matt Devine",
+            slug: "matt-devine",
+          },
+          width: 1500,
+          height: 2000,
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        "<p>Long before chaos theory, scientists have hypothesized on the apparent beauty of the “irregular” in nature. In the 1841 edition of the American Repertory of Arts, Sciences and Manufactures (Volume 3), James Jay Mapes pens a deftly, eloquently written ode to the irregularities of our world, the stars, the oceans, the mountains and deserts. Mapes describes how our perceptions of beauty are built upon such irregularities - poignant breaks from any visible pattern, that are then captured and described in works of art. &nbsp;</p><p>“…the relative distances of the planets, their magnitudes, and the number of their satellites, conform to no known numerical law. The fixed stars exhibit no regular arrangement, either in their magnitudes, distances, or positions, but appear scattered at random across the sky. To descend to our own earth, no symmetry is traceable in the forms of island or continents, the courses of rivers, or the directions of mountain chains… In the “human face divine,” portrait painters affirm that the two sides never correspond; and even when the external form of an animal exhibits an appearance of bilateral or radiate symmetry, nature departs from it in her arrangement of the internal structure. In short, variety is a great and a most beautiful law of nature: it is that which distinguishes her productions from those of art, and it is that which man often exerts his highest efforts…to imitate.”</p><p>In a recent text, <em>Aesthetics of Ugliness: A Critical Edition</em> by Karl Rosenkranz, the author stipulates, that although “free multiplicity” is indeed beautiful, “regularity tires through its stereotypical sameness, which presents to us difference always in the same manner, so that we long to get out of its uniformity and into freedom, even if <em>in extremis</em> it is a chaotic freedom.”</p>",
+    },
+    {
+      type: "image_collection",
+      layout: "overflow_fillwidth",
+      images: [
+        {
+          type: "artwork",
+          id: "57dc83ce139b212bd7000172",
+          slug: "matt-devine-untitled-suspended",
+          date: "",
+          title: "Untitled Suspended",
+          image: "https://d32dm0rphc51dk.cloudfront.net/jDXiwSBgNP2eml1YkMIitg/larger.jpg",
+          partner: {
+            name: "Joanne Artman Gallery",
+            slug: "joanne-artman-gallery",
+          },
+          artists: [
+            {
+              name: "Matt Devine",
+              slug: "matt-devine",
+            },
+          ],
+          artist: {
+            name: "Matt Devine",
+            slug: "matt-devine",
+          },
+          width: 3134,
+          height: 2062,
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        "<p>In both<em>Brass Tax</em>as well as<em>Untitled Suspended</em>, the words of Mapes and Rosenkranz can be seen to find their home, both pieces exhibiting a poetic, chaotic freedom, their beauty centered in their adherence to no prescriptive, formal pattern. The works seem entirely organic despite their true nature.</p>",
+    },
+    {
+      type: "text",
+      body: "Hello World",
+    },
+  ],
+}
+
+export const StandardArticle: ArticleProps["article"] = {
+  title: "New York's Next Art District",
+  contributing_authors: [],
+  published_at: "2017-05-19T13:09:18.567Z",
+  layout: "standard",
+  vertical: {
+    name: "Art Market",
+    id: "12345",
+  },
+  sections: [
+    {
+      type: "text",
+      body:
+        "<p>What would Antoine Court de Gébelin think of the Happy Squirrel? </p><p>De Gébelin was a Protestant minister born in the 18th century. He authored the multi-volume tome <em>Le Monde primitif</em>, which insisted that the tarot deck contained secrets of the ancient Egyptians, whose priests had distilled their occult wisdom into the cards’ illustrations, imbuing them with great mystical power. Before that point, tarot was primarily a card game—meant for fun, not prophecy.</p><p>It was a bold and somewhat absurd assertion, given that de Gébelin could not read Egyptian hieroglyphics (no one could at the time, since they weren’t deciphered until the 19th century). Despite a total lack of historical evidence to back his claim, the theory stuck: Tarot decks, once a novelty, became popular tools for divination after the publication of de Gébelin’s book.</p><p>Which brings us back to the Happy Squirrel, a relatively recent addition to the tarot’s Major Arcana, and one whose provenance is less hazy: it originated on season six of <em>The Simpsons</em>. Lisa visits a fortune teller who is unconcerned when Lisa picks Death, but gasps in horror when the next card she draws is the Happy Squirrel. (When Lisa asks if the fuzzy rodent is a bad sign, the fortune teller demurs, saying that “the cards are vague and mysterious.”) Although it began as a cartoon joke, the Happy Squirrel card has made its way into over a dozen commercially available tarot decks. </p><p>So what would de Gébelin’s reaction be? The answer depends on whether tarot is a collection of timeless, mystical wisdom—or a flexible framework that has endured by changing with the times. Although tarot imagery employs supposedly universal archetypes, new decks are constantly being invented, and old decks altered. The art of tarot cards can never fully transcend its milieu. Which begs a second question: How do the cards’ art and design relate to the social changes, technological advances, and aesthetic sensibilities of their particular eras?</p>",
+    },
+    {
+      type: "text",
+      body:
+        "<h3><strong>Galleries Section, Booth 10221</strong></h3><h2>neugerriemschneider</h2><h3>With works by Franz Ackermann, Ai Weiwei, Pawel Althamer, Billy Childish, Keith Edmier, Olafur Eliasson, Andreas Eriksson, Noa Eshkol, Mario García Torres, Renata Lucas, Michel Majerus, Mike Nelson, Jorge Pardo, Elizabeth Peyton, Tobias Rehberger, Thaddeus Strode, Rirkrit Tiravanija, Pae White</h3><p>The resultant work allows Salley the chance to recount her experiences of the aftermath of her scandal in her own words. In the film, Fujiwara and Salley are shown meeting professionals from public relations, advertising, and fashion companies as they seek to construct a new public image for her. Alongside the film, light boxes display fashion photographer Andreas Larsson’s pictures of Salley, which were taken as part of the project to rebuild her profile. While the show tackles public identity, female iconography, and Salley’s voice as an artist, the pair’s close working relationship—one in which the conventional power relationship has been overturned—no doubt aided their collaboration.</p>",
+    },
+    {
+      type: "text",
+      layout: "blockquote",
+      body:
+        "<blockquote>The fixed stars exhibit no regular arrangement, either in their magnitudes, distances, or positions.</blockquote>",
+    },
+    {
+      type: "text",
+      body: "<h2>A Wealthy Family’s Trick-Taking Game</h2>",
+    },
+    {
+      type: "image_collection",
+      layout: "overflow_fillwidth",
+      title: "A World Without Capitalism",
+      images: [
+        {
+          url: "https://artsy-media-uploads.s3.amazonaws.com/5ZP7vKuVPqiynVU0jpFewQ%2Funnamed.png",
+          type: "image",
+          width: 600,
+          height: 1067,
+          caption:
+            "<p>John Elisle, <em>The Star</em>, from the reimagined female Tarot cards. Courtesy of the artist. </p>",
+        },
+        {
+          url: "https://artsy-media-uploads.s3.amazonaws.com/PcvH_rh89gRGxRXgCyGGng%2Funnamed-5.png",
+          type: "image",
+          width: 600,
+          height: 1067,
+          caption:
+            "<p>John Elisle, <em>The Magician</em>, from the reimagined female Tarot cards. Courtesy of the artist. </p>",
+        },
+        {
+          type: "artwork",
+          id: "596aa2851a1e864d5eea6681",
+          slug: "matt-devine-brass-tax",
+          date: "",
+          title: "Brass Tax",
+          image: "https://d32dm0rphc51dk.cloudfront.net/lSBz0tsfvOAm2qKdWwgxLw/larger.jpg",
+          partner: {
+            name: "Joanne Artman Gallery",
+            slug: "joanne-artman-gallery",
+          },
+          artists: [
+            {
+              name: "Matt Devine",
+              slug: "matt-devine",
+            },
+          ],
+          artist: {
+            name: "Matt Devine",
+            slug: "matt-devine",
+          },
+          width: 1500,
+          height: 2000,
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        '<p>Despite their aura of mystery, medieval tarot cards were not used for divination, and were probably <em>not</em> created by ancient Egyptian magicians. The earliest surviving tarot decks—now preserved in various museum collections—are Italian, and were commissioned by wealthy patrons, the same way one might have hired an artist to paint a portrait or illuminated prayerbook. </p><p>The Visconti-Sforza Tarot is a collection of decks, none complete, commissioned by the Visconti and Sforza families from the workshop of Milanese court painter Bonifacio Bembo. Cards such as Death, who rides a horse and swings a giant scythe like a player in the world’s most high-stakes polo match, will seem familiar to contemporary enthusiasts. So will the Pope, who sits on a golden throne; and the Lovers, who hold hands beneath a string of heraldic flags. Rather than looking to these cards for mystic guidance, the Visconti and Sforza families would have used them to play a trick-taking card game similar to modern-day Bridge. (Although it’s unlikely—given the good condition of the decks—that they were ever handled with much frequency).</p><p>The cards each have intricately tooled gold backgrounds that glow like the luxury items that they were. Bembo is believed to have included portraits of the families in many of the cards, as well as adding the Visconti family motto here and there for good measure. Akin to the work of <a href="https://www.artsy.net/artist/fra-angelico">Fra Angelico</a> and other early-Renaissance artists, the cards are opulent but pictorially flat, although the bodies appear in naturalistic perspective and their clothing billows around them, suggesting volume and form. </p><p><br></p><h2>The 18th-Century Conver Classic</h2>',
+    },
+    {
+      type: "image_collection",
+      layout: "overflow_fillwidth",
+      images: [
+        {
+          url:
+            "https://artsy-media-uploads.s3.amazonaws.com/GwIVCQftjauWBCQie9oQ-A%2FTarot_de_Marseille_major21_world.jpg",
+          type: "image",
+          width: 320,
+          height: 620,
+          caption: "<p>Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
+        },
+        {
+          url:
+            "https://artsy-media-uploads.s3.amazonaws.com/UaNPuL9iz-X7Xm-SNtat7Q%2FTarot_de_Marseille_clubs13_queen.jpg",
+          type: "image",
+          width: 320,
+          height: 620,
+          caption:
+            "<p>Nicolas Conver, <em>Queen of Clubs</em>. Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
+        },
+        {
+          url:
+            "https://artsy-media-uploads.s3.amazonaws.com/x5EcmVNBKoUJqQa8BQgqJA%2FTarot_de_Marseille_major06_lovers.jpg",
+          type: "image",
+          width: 320,
+          height: 620,
+          caption: "<p>Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        '<p>Produced in 1760, French engraver Nicolas Conver’s deck of delicate woodcuts, the Tarot de Marseille, is the template on which many contemporary decks are based. Like the Visconti-Sforza Tarot, the deck’s design likely originated in 15th-century Italy before traveling north to France. It’s a favorite of many tarot enthusiasts, most notably the cult film director Alejandro Jodorowsky, who <a href="http://www.nytimes.com/2011/11/13/fashion/alejandro-jodorowsky-and-his-tarot-de-marseille.html?mcubz=1">designed his own deck</a> based on the style. While the Conver deck wasn’t the first to be called the Tarot de Marseille, it’s highly prized by collectors for its delicate color palette of sky blues and minty greens. The graphic black outlines and blunt shading of the prints give the cards a simple and rough-hewn appearance, which adds to the ambience of ancient wisdom. The popularity of the tarot grew due to advances in printing technology and via the writings of 19th-century French occultists such as Éliphas Lévi and Etteilla, which popularized the use of tarot as a method of fortune-telling and assigned additional divinatory meaning to the cards.</p><p><br></p><h2>The New Mystics</h2>',
+    },
+    {
+      type: "image_collection",
+      layout: "overflow_fillwidth",
+      images: [
+        {
+          url: "https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg",
+          type: "image",
+          width: 1152,
+          height: 826,
+          caption:
+            "<p>Pamela Colman Smith, <em>The Empress</em>, c. 1937. Courtesy of the Beinecke Rare Book &amp; Manuscript Library at Yale University.</p>",
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        '<p>The Rider-Waite Smith deck, which debuted in 1909, remains the most recognizable and popular today. Designed by artist Pamela Colman Smith under the direction of the mystic A.E. Waite, it was the first to be mass-produced in English, and was intended for divination rather than gameplay. Smith and Waite were both active members of the Order of the Golden Dawn, a secretive organization devoted to the exploration of the paranormal and occult (allegedly Bram Stoker, Aleister Crowley, and Sir Arthur Conan Doyle were also members). </p><p>In addition to Smith’s occult bonafides, she was also an accomplished artist, championed by <a href="https://www.artsy.net/artist/alfred-stieglitz">Alfred Stieglitz</a>, who collected her work and showed it at his gallery. Smith created fully-realized illustrations of all 78 cards that made the deck a treasure-trove for cartomancers, who now had a much richer store of images to work with. (Previously, only the 22 Major Arcana cards such as the Fool, the Magician, and the Lovers had been elaborately illustrated—traditionally, the Minor Arcana cards, which are roughly analogous to the suits in a deck of modern playing cards, were not.) The Major Arcana were based on the Tarot de Marseille drawings, but rendered in an illustrative <a href="https://www.artsy.net/gene/art-nouveau">Art Nouveau</a> style rich with patterns. Even the Fool looks debonaire; he carelessly approaches the cliff, a feather in his cap and a blooming rose in his elegant fingers, wearing a floral tunic that looks straight out of <a href="https://www.artsy.net/artist/william-morris">William Morris</a>’s workshop.</p><p><br></p><h2>An Occultist’s Pure Geometry</h2>',
+    },
+    {
+      mobile_height: 1300,
+      height: 1000,
+      url: "http://files.artsy.net/documents/1parrasch.html",
+      layout: "overflow_fillwidth",
+      type: "embed",
+    },
+    {
+      type: "text",
+      body:
+        '<p>The Thoth deck, named for the Ibis-faced Egyptian god more commonly known as Horus, was painted by the artist Frieda Harris based on direction from the infamous occultist-about-town Aleister Crowley. Completed in the early 1940s, but not widely available until 1969, it features <a href="https://www.artsy.net/gene/art-deco">Art Deco</a> borders resembling the pattern of a butterfly wing. </p><p>The deck is an aesthetic departure from the Rider-Waite’s homey <a href="https://www.artsy.net/gene/arts-and-crafts-movement">Arts and Crafts</a> aesthetic. Shaped by Harris’s interest in pure geometry, the cards are reminiscent of the work of Swedish painter <a href="https://www.artsy.net/artist/hilma-af-klint">Hilma af Klint</a> (a visionary artist who shared Harris’s interest in spiritualism and the writings of Austrian philosopher Rudolf Steiner, both popular subjects of study among the middle and upper classes in the early 20th century). Harris’s shaded orbs and compass-inscribed curves that fill the background of each card bear more than a passing resemblance to Klint’s highly-saturated geometries. Klint, considered by some to be Europe’s first abstract painter, believed that her luminous compositions were the created under the influence of spirits. (The same could easily be said of Harris because she was taking direction from Crowley, who was believed to be a medium, able to channel ancient and magical forces.) </p><p>It’s no coincidence that Klint’s paintings and Harris’s Thoth illustrations were shown in the same pavilion at the 2013 Venice Biennale, which was intended to amplify voices that had previously been excluded and “cover 100 years of dreams and visions,” <a href="http://www.nytimes.com/2013/05/26/arts/design/massimiliano-gioni-of-venice-biennale.html">according</a> to curator Massimiliano Gioni.</p><p><br></p><h2>Sex &amp; Self-Help, ’70s Style</h2>',
+    },
+    {
+      type: "image_collection",
+      layout: "overflow_fillwidth",
+      images: [
+        {
+          url:
+            "https://artsy-media-uploads.s3.amazonaws.com/jmrvzuo7VfRidule-4zWNA%2F07272017170054-0001+%28dragged%29+copy.jpg",
+          type: "image",
+          width: 405,
+          height: 723,
+          caption: "<p>Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. </p>",
+        },
+        {
+          url:
+            "https://artsy-media-uploads.s3.amazonaws.com/66XOTGwZQzAAa0igYKSNTQ%2F07272017170207-0001+%28dragged%29.jpg",
+          type: "image",
+          width: 407,
+          height: 719,
+          caption: "<p>Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. </p>",
+        },
+        {
+          url:
+            "https://artsy-media-uploads.s3.amazonaws.com/l0Qu946mLja0Dbv4ME4MHg%2F07272017170259-0001+%28dragged%29.jpg",
+          type: "image",
+          width: 413,
+          height: 721,
+          caption: "<p>Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. </p>",
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        '<p>Created by the artist Bill Greer under the direction of Lloyd Morgan, the Morgan-Greer deck is, like the 1970s themselves, both opulent and optimistic. The Magician sports a mustache that would make Tom Selleck blush, and the naked and embracing Lovers would fit right in with the hirsute and curvaceous illustrations in the original 1972 edition of <em>The Joy of Sex</em>.</p><p>The ‘70s enthusiasm for all things New Age created a renewed interest in tarot as a tool for self-discovery, and the Morgan Greer deck was there to greet it. The cards’ colors are lush and the lines are fluid. Greer chose to crop his figures tightly and removed the borders, allowing the illustrations to extend to the edges. The effect is fresh and personal. Formally, the Morgan-Greer illustrations have more in common with Jefferson Starship’s <em>Spitfire</em> (1976) album cover than with contemporary painting of the same period—the pendulum had swung away from figuration and would take a few years longer to swing back—but it’s possible to find a resonance between this deck’s art and a work like <a href="https://www.artsy.net/artist/judy-chicago">Judy </a><a href="https://www.artsy.net/artist/judy-chicago">Chicago</a>’s <em>Dinner Party </em>(1979), with its powerful goddess and blooming flowers. Greer’s strong women and frank sexuality make the deck very much of its time.</p><p><br></p><h2>Minimalism &amp; Identity in the Present Day</h2>',
+    },
+    {
+      type: "image_set",
+      layout: "full",
+      title: "The Work of Bruce M. Sherman",
+      images: [
+        {
+          url:
+            "https://artsy-media-uploads.s3.amazonaws.com/CzofaZln2q-XhtXFqIio5A%2F07272017133815-0001+%28dragged%29+copy.jpg",
+          type: "image",
+          width: 396,
+          height: 719,
+          caption: "<p>King Khan, card from the Black Power Tarot. </p>",
+        },
+        {
+          url:
+            "https://artsy-media-uploads.s3.amazonaws.com/z7BUiIKCStBxlcXh53t0Xg%2F07272017133730-0001+%28dragged%29+copy.jpg",
+          type: "image",
+          width: 396,
+          height: 728,
+          caption: "<p>King Khan, card from the Black Power Tarot. </p>",
+        },
+        {
+          url: "https://artsy-media-uploads.s3.amazonaws.com/T9g-NNJcmy8ej6qV6UQ-fA%2F07272017133839-0001.jpg",
+          type: "image",
+          width: 392,
+          height: 718,
+          caption: "<p>King Khan, card from the Black Power Tarot. </p>",
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        "<p>Created by graphic designer Kati Forner for a Los Angeles-based fashion retailer, the Dreslyn tarot is the epitome of techno-minimalism. Although the deck is lovingly printed with high-gloss embossing, its illustrations are simple enough to be mistaken for the icon of an elegant iPhone app. It’s a radical departure from the historical approach, where each card is full to bursting with details, signs, and symbols—instead, each card has been paired down the bare minimum. The Dreslyn’s Lovers image is just two slender circles bisecting a line; its Eight of Wands is simply eight diagonal rules. The deck’s aesthetic mirrors the contemporary fear of clutter, as well as the increasing simplicity of the interfaces we use every day.</p><p>Tarot decks have also increasingly become more personal, and occasionally political, while reflecting a greater diversity. Illustrator John Elisle, in a commission for Missy Magazine, created seven all-women tarot cards, a chic sci-fi universe that includes a dominatrix Devil and a psychedelic High Priestess.</p>",
+    },
+    {
+      type: "image_collection",
+      layout: "column_width",
+      images: [
+        {
+          url: "https://artsy-media-uploads.s3.amazonaws.com/Gk95i1tUaDJKeqQ-jcq6Cw%2FIMG_2142.jpg",
+          type: "image",
+          width: 5184,
+          height: 3456,
+          caption: "<p>Designed by Kati Forner for The Dreslyn, courtesy of the artist. </p>",
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        "<p>The Black Power Tarot was conceived by musician King Khan in consultation with Alejandro Jodorowsky, and designed by illustrator Michael Eaton in 2015. The deck celebrates the strength and achievements of Black musicians, artists, and activists while staying faithful to the imagery and composition of the classic Tarot de Marseilles. The familiar faces of Malcolm X, James Brown, Tina Turner, Howlin’ Wolf, Sister Rosetta Tharpe, and others emerge from the Major Arcana. Sun Ra is there too, appropriately imagined as the Sun card. At a time when Black Americans are at a high risk of being the victims of state-sponsored violence, the Black Power Tarot feels especially urgent. By situating these figures within a centuries-old framework of esoteric wisdom, Khan affirms their value and influence, the importance of their legacy. By placing them on cards used for fortune-telling, he extends their power into the future. <span class='content-end'></span></p><p> &nbsp;—Ariela Gittlen</p>",
+    },
+  ],
+}
+
+export const FeatureArticle: ArticleProps["article"] = {
+  _id: "594a7e2254c37f00177c0ea9",
+  keywords: ["Inspiration", "Casey Lesser"],
+  author_id: "57b5fc6acd530e65f8000406",
+  author: {
+    id: "50f4367051e7956b6e00045d",
+    name: "Artsy Editorial",
+  },
+  thumbnail_title: "What’s the Path to Winning an Art Prize?",
+  vertical: {
+    name: "Creativity",
+    id: "591eaa6bfaef6a3a8e7fe1b1",
+  },
+  hero_section: {
+    type: "fullscreen",
+    title: "What’s the Path to Winning an Art Prize?",
+    url: "https://artsy-media-uploads.s3.amazonaws.com/z9w_n6UxxoZ_u1lzt4vwrw%2FHero+Loop+02.mp4",
+  },
+  contributing_authors: [
+    {
+      id: "523783258b3b815f7100055a",
+      name: "Casey Lesser",
+    },
+  ],
+  authors: [
+    {
+      id: "523783258b3b815f7100055a",
+      name: "Casey Lesser",
+      bio: "[Casey Lesser](http://artsy.net) is a well-known author and a long-time baker.",
+      twitter_handle: "caseylesser",
+    },
+  ],
+  channel_id: "5759e3efb5989e6f98f77993",
+  description:
+    "Applying for art prizes can be daunting, but doing so is a pathway to exhibitions, influential contacts, and a way to gain valuable feedback about your work.",
+  tier: 1,
+  tags: ["Inspiration"],
+  tracking_tags: ["sponsored"],
+  layout: "feature",
+  published: true,
+  featured: true,
+  updated_at: "2017-07-19T17:19:55.909Z",
+  title: "What’s the Path to Winning an Art Prize?",
+  lead_paragraph: "",
+  sections: [
+    {
+      type: "text",
+      body:
+        "<p><span class='content-start'>A</span>round two years ago, a collector encouraged New York-based ceramic artist <a href='https://www.artsy.net/artist/jennie-jieun-lee'>Jennie Jieun Lee</a> to apply for an art prize. “I was a little bit scared. I’d applied to a few things in the past and been rejected, so I was bummed by that,” she admits. “I entered not thinking that I was going to win, but that it would be a good exercise to go through the process.” &nbsp;</p><p>It paid off. She was among several artists in 2015 who won an Artadia Award—an unrestricted, merit-based prize of up to $10,000, which is given to visual artists working in certain U.S. cities. The winnings, as well as the experience, helped Lee push her career forward. </p><p>“That money enabled me to move into a bigger studio and buy a larger kiln,” she explains. “With that movement, I was able to make my career.” And the momentum continued: More recently, she won a Pollock-Krasner grant that she used to move cross-country and fund a residency in the ceramic department at California State University, Long Beach. </p><p>Lee is by no means alone. While we’ve all heard of the boldfaced awards, like the Turner Prize or the Hugo Boss Prize, which tend to anoint artists when they’re already well known to the art world, a wealth of awards are available for lesser-known and emerging artists. </p>",
+    },
+    {
+      type: "text",
+      layout: "blockquote",
+      body:
+        "<blockquote>Land exhibitions, make influential contacts, and gain valuable feedback about your work.</blockquote>",
+    },
+    {
+      type: "image_collection",
+      layout: "overflow_fillwidth",
+      images: [
+        {
+          type: "artwork",
+          id: "57dc83ce139b212bd7000172",
+          slug: "matt-devine-untitled-suspended",
+          date: "",
+          title: "Untitled Suspended",
+          image: "https://d32dm0rphc51dk.cloudfront.net/jDXiwSBgNP2eml1YkMIitg/larger.jpg",
+          partner: {
+            name: "Joanne Artman Gallery",
+            slug: "joanne-artman-gallery",
+          },
+          artists: [
+            {
+              name: "Matt Devine",
+              slug: "matt-devine",
+            },
+          ],
+          artist: {
+            name: "Matt Devine",
+            slug: "matt-devine",
+          },
+          width: 3134,
+          height: 2062,
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        "<p>While applying for these opportunities can be daunting and time-consuming, it’s rewarding in more ways than one (even if you don’t end up winning). Artist prizes can be a path to prestige and profits, as well as a way to land exhibitions, make influential contacts, and gain valuable feedback about your work.</p><p>Based on conversations with artists who have won several different prizes, we share guidance below on how to go about applying for these opportunities, navigating the process, and benefiting from the positive outcomes they can offer.</p><p><br></p><h2>Finding the Prize That’s Right for You</h2><p>Artists should seek out opportunities based on their eligibility and the kind of work they make. “Don’t change to accommodate prizes,” advises London artist <a href='https://www.artsy.net/artist/ally-mcintyre'>Allyson McIntyre</a>, who won the 2015 HIX Award, which gives artists £10,000 to go towards a solo show at the London gallery HIX ART. “Be authentic to your practice and find the prizes that work for what you do.”</p><p>It’s important to recognize the distinction between prizes and awards—which are generally given in recognition of past work—and grants, which typically serve to facilitate future projects. Many artists note that they apply to both types of opportunities based on recommendations by word-of-mouth; they find that peers, former teachers, or other art-world contacts can share valuable input. New Orleans-based artist <a href='https://www.artsy.net/artist/aron-belka'>Aron Belka</a>, who won the BOMBAY SAPPHIRE® Artisan Series in 2015, advises artists to search for opportunities locally, through art schools, regional arts councils, art centers, and museums. &nbsp;</p><p>For those who perhaps do not have a tight-knit network of artist peers, there are several open-call websites and listservs that aggregate information on prizes, grants, and juried exhibitions. These include <a href='https://www.submittable.com/'>Submittable</a> and <a href='https://www.callforentry.org/'>Call for Entry</a>. On the latter, artists can create a profile, upload artwork images, and browse opportunities.</p>",
+    },
+    {
+      type: "image_collection",
+      layout: "overflow_fillwidth",
+      images: [
+        {
+          url: "https://artsy-media-uploads.s3.amazonaws.com/7lsxxsw0qPAuKl37jEYitw%2Farticle+asset+1-hig+res+copy.jpg",
+          type: "image",
+          width: 1200,
+          height: 750,
+          caption: "<p>Illustration by Tomi Um for Artsy.</p>",
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        "<h1>Section Header</h1><p>Enthusiastically grow high-payoff infomediaries for virtual methodologies. Competently maximize reliable scenarios whereas magnetic e-services. Completely formulate sticky schemas rather than strategic technologies. Phosfluorescently disseminate long-term high-impact e-services vis-a-vis effective collaboration and idea-sharing. Credibly provide access to technically sound services through plug-and-play niches.</p>",
+    },
+    {
+      type: "video",
+      url: "https://vimeo.com/191988155",
+      caption:
+        "<p>2016 was a memorable year for the world, and art along with it. Powered by data culled from Artsy as well as UBS’s Planet Art app, “The Year in Art 2016” will explore how the creative community responded to the cultural shifts and tribulations this year has seen—from the destruction of Palmyra to the proliferation of Virtual Reality to the U.S. election.</p>",
+      cover_image_url:
+        "https://artsy-media-uploads.s3.amazonaws.com/ditbyaUgdcl6mHin07TfKA%2FMassimilianoGioni_0581.jpg",
+      layout: "overflow_fillwidth",
+    },
+    {
+      type: "text",
+      body:
+        '<p><br></p><h2>The Application Process</h2><p>Most awards will require several images of your work, as well as a written artist statement to provide some context. With higher-stakes prizes, artists may be asked to submit recommendation letters from peers or professionals. </p><p>A somewhat obvious, though easily botched, element of the application process is following directions. “You have to be careful not to get lazy with how you submit, as it may lead to you being disqualified, which is just a waste of your time,” McIntyre explains. Be sure to read the fine print and adhere to all particulars regarding preparing, labeling, and submitting application materials.</p><p>Organizations administering prizes will allow artists to submit several—typically three to eight—images. They are generally interested in seeing recent work, created over the past two or three years. Some prizes may specify that artists create a new, original work to submit. Artists should be sure to send high-quality photographs; if resources allow, hire a photographer (or recruit a qualified friend) to have works shot professionally.</p><p>For those artists who work across mediums—perhaps printmaking one day, performance the next—know that it might not be advisable to try to include the full breadth of your practice in a single application. “Try to hone in on a single idea, or a couple of ideas,” says artist <a href="https://www.artsy.net/artist/alex-podesta">Alex Podesta</a>, who won the BOMBAY SAPPHIRE® Artisan Series in 2013, and has also served as a juror for other awards. “I’ve been on the other side of this a number of times, and when you’re reviewing applications it’s confusing and not helpful to have an artist submitting sculpture, painting, <em>and</em> a video piece. Focus on one aspect of your work.” </p><p>In addition to images, a written artist’s statement that explains and contextualizes the artist’s work is important, too. Artists should get in the habit of updating their statements regularly, adapting their texts to accurately reflect their current practices. Artist <a href="https://www.artsy.net/artist/yevgeniya-baras">Yevgeniya Baras</a>, who won an Artadia Award in New York in 2015, notes that she rewrites or edits her artist statement every two years. &nbsp;</p><p>For certain awards, artists may need to be able to speak about their work with jurors in person. If this is the case, be prepared to take full advantage of the opportunity. Baras notes that for Artadia, the panel of jurors visited her studio; she was careful to delve deeper into elements of her work that don’t come across through two-dimensional images or her online application. For the Meurice Prize for contemporary art, artists must give an oral presentation of their work. “While we don’t judge the artist on their ability to conduct a perfect verbal presentation of the work, we are of course interested to hear the artist speak of their work in a very intimate way, and that can actually be the decisive sector,” says Jennifer Flay, director of the art fair FIAC, and a juror for the Meurice Prize.</p><p><br></p><h2>Application Fees</h2><p>While it’s free to apply for some awards, it’s not uncommon to pay a fee in the range of $20 to $75—which can make a difference for artists looking to apply to multiple opportunites. Belka notes that if the stakes are high, an application fee may be worth it, but he advises that artists do their research before submitting said fees to avoid scams. </p><p>McIntyre recalls that she once applied to a competition that promised winners a show in Venice. “I was accepted, but they asked for an outrageous artist fee of €500,” she says. Later she learned that fellow artists had fallen for the scam and lost their money—and the works they had submitted. “Have discretion and awareness that your money may amount to nothing,” she counsels.</p><p><br></p><h2>Set Expectations and Be Persistent</h2><p>No one wins every award; there’s often a trail of rejections on the way to any prize. Baras, who landed the Rema Hort Mann Foundation Emerging Artist Grant in 2014 and the Artadia Award thereafter, notes that there’s been plenty of failure mixed in with those successes. (She estimates that she submits around 10 award or grant applications per year.) </p><p>“Assume that for nine out of every 10 applications that you send in, it’s not going to be the work they’re looking for,” Podesta says. “Younger artists, especially, shouldn’t get daunted. Remember that the work just isn’t resonating with the [specific] people reviewing it.”</p><p>It helps to go into the application process with an open mind, and reasonable hopes. “I went into it not expecting it to make my career, but rather for it to be an addition to it,” says <a href="https://www.artsy.net/artist/kristine-mays">Kristine Mays</a>, who won the BOMBAY SAPPHIRE® Artisan Series in 2014. Artists, she adds, should simply stay true to their craft, and keep working away.</p><p>Remember that rejection, while disappointing, can be a learning experience. “Without this kind of risk, you can’t really put yourself out there,” Baras says. “Most applications, for many amazing awards, just take a few days. It’s a way to see a new community, to seek new eyes, and I think that’s a necessary and healthy risk for an artist to take.”</p><p>Lee advises fellow artists to cast a wide net and apply to as many opportunities as possible, developing a thick skin as they do. “If you get rejected one year, apply again the next,” she says, simply. “It’s about being persistent and not taking anything personally.”</p><p><br></p>',
+    },
+    {
+      type: "image_collection",
+      layout: "fillwidth",
+      images: [
+        {
+          url: "https://artsy-media-uploads.s3.amazonaws.com/MGjCex4gkN4ofE_qOj_DPQ%2Farticle+asset+2-hig+res+copy.jpg",
+          type: "image",
+          width: 1200,
+          height: 750,
+          caption: "<p>Illustration by Tomi Um for Artsy</p>",
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        "<p>Enthusiastically grow high-payoff infomediaries for virtual methodologies. Competently maximize reliable scenarios whereas magnetic e-services. Completely formulate sticky schemas rather than strategic technologies. Phosfluorescently disseminate long-term high-impact e-services vis-a-vis effective collaboration and idea-sharing. Credibly provide access to technically sound services through plug-and-play niches.</p>",
+    },
+    {
+      type: "image_set",
+      layout: "mini",
+      images: [
+        {
+          url: "https://artsy-media-uploads.s3.amazonaws.com/MGjCex4gkN4ofE_qOj_DPQ%2Farticle+asset+2-hig+res+copy.jpg",
+          type: "image",
+          width: 1200,
+          height: 750,
+          caption: "<p>Illustration by Tomi Um for Artsy</p>",
+        },
+      ],
+    },
+    {
+      type: "text",
+      body:
+        "<p><br></p><h2>Make the Most of Winning</h2><p>Depending on the prize, artists may be awarded a stipend to create new work for a show or unrestricted funds to further their careers. In both cases, artists report that these funds have gone towards keeping their art practices up and running, be it through realizing new works and shows or for subsidizing rent, bills, and the costs of production and supplies. &nbsp;</p><p>For example, the Meurice Prize, which supports artists under the age of 45 who show with French galleries, awards €20,000, which is split between the artist and their gallery. This year, the BOMBAY SAPPHIRE® Artisan Series (which is only open to entrants from North America) awards a grand prize winner a stipend of $10,000 to create a public artwork. </p><p>In some cases, like Lee’s, a sizable prize could help an artist move into a bigger studio, relocate to another city, or participate in a residency. “Before, I never even thought about moving out of New York,” she says. “The Pollock-Krasner grant gave me the freedom to possibly move cross-country to explore this residency. I feel like it’s completely changed my life, and now I’m not sure when I’m coming back.”</p><p><br></p><h2>It’s More Than Just Money </h2><p>Baras notes that even if she hadn’t won the Artadia Award it would’ve been a rewarding experience due to the panel of jurors she encountered. “Whether you win or not, whoever’s on the panel remembers your work,” she says. “It’s beneficial regardless to put yourself out there because you really never know who might notice.” &nbsp; </p><p>Other prizes similarly award artists with the opportunity to exhibit their work to a new audience. The Daiwa Foundation Art Prize, awarded each year to a British artist, serves to give that artist a solo gallery exhibition in Japan. And the Luxembourg Art Prize gives finalists the opportunity to show their work in a group exhibition in Luxembourg; the winner is awarded €25,000 to produce new work for a solo presentation at Galerie Hervé Lancelin for an exhibition the following year. </p><p>For Belka and Mays, who both won the chance to show their work at the Scope Art Fair in New York through the BOMBAY SAPPHIRE® Artisan Series, winning led to important exposure and networking opportunities. “Overall, the most positive outcome was being able to put myself in arenas I’d never been in before,” Mays says of her experience. She saw it as a “jump start” for her career; she’s been busy making and showing her work steadily since her Scope debut.</p><p>“I made a point of greeting and speaking to everyone that came to the space,” Mays adds. Both artists recommend being prepared with business cards and following up with the contacts you make via email. Belka notes that he made an important collector contact that he maintains today. “Come prepared to talk about your work, have cards, spread your name, and get yourself out there,” says Belka.</p><p>Mays was also inspired by the feedback she received from viewers of her work. “Many times we overlook the value of feedback from people, the ideas that can come out of conversation with people,” she says. </p><p><br></p><h2>Building Confidence </h2><p>Most artists agree that one of the most impactful parts of winning a prize is the vote of confidence that it provides. Formal recognition can be a sign of assurance that they were right to pursue a career as an artist, and can inspire them to get back in the studio. &nbsp;</p><p>“It’s a nice confirmation to know that you can communicate to people you don’t even know, and just continue along the path of making your work,” Baras muses. “I see it as a kind of hug. Generally, you’re sort of hugging yourself as an artist—but once in awhile, you get an acknowledgment from the outside world.”<span class='content-end'></span></p>",
+    },
+  ],
+  postscript: "<p>Header animation: Illustration by Tomi Um for Artsy. Animation by Ale Pixel Studio.</p>",
+  id: "594a7e2254c37f00177c0ea9",
+  scheduled_publish_at: null,
+  thumbnail_image: "https://artsy-media-uploads.s3.amazonaws.com/gejssmXDiO3G1pE73phZ3Q%2FArtboard+2%402xef-100.jpg",
+  social_image: "https://artsy-media-uploads.s3.amazonaws.com/wU7ase6M0zWv6MLcC8-L5A%2Fd7hftxdivxxvm.cloudfront.jpg",
+  published_at: "2017-06-29T15:00:00.000Z",
+  slug: "artsy-editorial-path-winning-art-prize",
+}

--- a/src/components/publishing/header/__test__/header.test.tsx
+++ b/src/components/publishing/header/__test__/header.test.tsx
@@ -4,7 +4,7 @@ import * as renderer from "react-test-renderer"
 import "jest-styled-components"
 import * as _ from "lodash"
 
-import Articles from "../../fixtures/articles"
+import { ClassicArticle, FeatureArticle, StandardArticle } from "../../fixtures/articles"
 import { HeroSections } from "../../fixtures/components"
 import AuthorDate from "../author_date"
 import AuthorDateClassic from "../author_date_classic"
@@ -14,19 +14,19 @@ jest.mock("react-sizeme", () => jest.fn(c => d => d))
 
 describe("feature", () => {
   it("renders feature text header properly", () => {
-    const article = _.extend({}, Articles[2], { hero_section: HeroSections[0] })
+    const article = _.extend({}, FeatureArticle, { hero_section: HeroSections[0] })
     const header = renderer.create(<Header article={article} />).toJSON()
     expect(header).toMatchSnapshot()
   })
 
   it("renders feature split header properly", () => {
-    const article = _.extend({}, Articles[2], { hero_section: HeroSections[1] })
+    const article = _.extend({}, FeatureArticle, { hero_section: HeroSections[1] })
     const header = renderer.create(<Header article={article} />).toJSON()
     expect(header).toMatchSnapshot()
   })
 
   it("renders feature full header properly", () => {
-    const article = _.extend({}, Articles[2], { hero_section: HeroSections[2] })
+    const article = _.extend({}, FeatureArticle, { hero_section: HeroSections[2] })
     const header = renderer.create(<Header article={article} />).toJSON()
     expect(header).toMatchSnapshot()
   })
@@ -34,7 +34,7 @@ describe("feature", () => {
 
 describe("Standard Header", () => {
   it("renders standard header properly", () => {
-    const header = renderer.create(<Header article={Articles[1]} />).toJSON()
+    const header = renderer.create(<Header article={StandardArticle} />).toJSON()
     expect(header).toMatchSnapshot()
   })
 })
@@ -59,7 +59,7 @@ describe("AuthorDate", () => {
 
 describe("Classic Header", () => {
   it("renders classic header properly", () => {
-    const header = renderer.create(<Header article={Articles[0]} />).toJSON()
+    const header = renderer.create(<Header article={ClassicArticle} />).toJSON()
     expect(header).toMatchSnapshot()
   })
 })

--- a/src/components/publishing/icon/expand.tsx
+++ b/src/components/publishing/icon/expand.tsx
@@ -1,0 +1,28 @@
+import React, { Component } from "react"
+
+class IconImageSet extends Component<any, null> {
+  render() {
+    return (
+      <svg viewBox="0 0 27 27" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+          <g>
+            <circle fill="#000000" fillRule="nonzero" opacity="0.6" cx="13.9575195" cy="13.0588379" r="13" />
+            <g transform="translate(8.000000, 7.000000)" stroke="#FFFFFF">
+              <g>
+                <g transform="translate(0.382532, 0.382532)">
+                  <polyline points="4.78165571 0 11.1571966 0 11.1571966 6.37554094" />
+                  <polyline
+                    transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                    points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                  />
+                  <path d="M10.360254,0.796942618 L0.796942618,10.360254" strokeLinecap="square" />
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    )
+  }
+}
+export default IconImageSet

--- a/src/components/publishing/icon/expand.tsx
+++ b/src/components/publishing/icon/expand.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react"
 
-class IconImageSet extends Component<any, null> {
+class IconExpand extends Component<any, null> {
   render() {
     return (
       <svg viewBox="0 0 27 27" version="1.1" xmlns="http://www.w3.org/2000/svg">
@@ -25,4 +25,4 @@ class IconImageSet extends Component<any, null> {
     )
   }
 }
-export default IconImageSet
+export default IconExpand

--- a/src/components/publishing/sections/__test__/__snapshots__/artwork.test.tsx.snap
+++ b/src/components/publishing/sections/__test__/__snapshots__/artwork.test.tsx.snap
@@ -1,30 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders properly 1`] = `
-.c4 {
+.c6 {
   color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c5 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
-.c2 {
+.c4 {
   margin-top: 10px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -36,7 +19,7 @@ exports[`renders properly 1`] = `
   line-height: 1.1em;
 }
 
-.c3 {
+.c5 {
   color: #999;
   display: block;
   -webkit-text-overflow: ellipsis;
@@ -46,17 +29,31 @@ exports[`renders properly 1`] = `
   width: 100%;
 }
 
-.c3 .artist-name {
+.c5 .artist-name {
   margin-right: 30px;
+}
+
+.c3 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin: 10px;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+}
+
+.c1 {
+  position: relative;
+}
+
+.c2 {
+  display: block;
 }
 
 .c0 {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c1 {
-  display: block;
 }
 
 <div
@@ -66,19 +63,73 @@ exports[`renders properly 1`] = `
     className="c0"
     href="/artwork/fernando-botero-nude-on-the-beach"
   >
-    <img
-      alt="Nude on the Beach"
-      className="display-artwork__image c1"
-      height="auto"
-      src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-      width="100%"
-    />
+    <div
+      className="c1"
+    >
+      <img
+        alt="Nude on the Beach"
+        className="display-artwork__image c2"
+        height="auto"
+        src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+        width="100%"
+      />
+      <div
+        className="c3"
+        onClick={[Function]}
+      >
+        <svg
+          version="1.1"
+          viewBox="0 0 27 27"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <g>
+              <circle
+                cx="13.9575195"
+                cy="13.0588379"
+                fill="#000000"
+                fillRule="nonzero"
+                opacity="0.6"
+                r="13"
+              />
+              <g
+                stroke="#FFFFFF"
+                transform="translate(8.000000, 7.000000)"
+              >
+                <g>
+                  <g
+                    transform="translate(0.382532, 0.382532)"
+                  >
+                    <polyline
+                      points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                    />
+                    <polyline
+                      points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                      transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                    />
+                    <path
+                      d="M10.360254,0.796942618 L0.796942618,10.360254"
+                      strokeLinecap="square"
+                    />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
   </a>
   <div
-    className="display-artwork__caption c2"
+    className="display-artwork__caption c4"
   >
     <div
-      className="c3"
+      className="c5"
     >
       <span
         className="artist-name"
@@ -87,7 +138,7 @@ exports[`renders properly 1`] = `
           className="name"
         >
           <a
-            className="c4"
+            className="c6"
             href="/artist/fernando-botero"
           >
             Fernando Botero
@@ -98,7 +149,7 @@ exports[`renders properly 1`] = `
         className="title"
       >
         <a
-          className="c4"
+          className="c6"
           href="/artwork/fernando-botero-nude-on-the-beach"
         >
           Nude on the Beach
@@ -120,17 +171,11 @@ exports[`renders properly 1`] = `
         , 
       </span>
       <a
-        className="c4"
+        className="c6"
         href="/partner/gary-nader"
       >
         Gary Nader
       </a>
-    </div>
-    <div
-      className="c5"
-      onClick={[Function]}
-    >
-      View Fullscreen
     </div>
   </div>
 </div>

--- a/src/components/publishing/sections/__test__/__snapshots__/caption.test.tsx.snap
+++ b/src/components/publishing/sections/__test__/__snapshots__/caption.test.tsx.snap
@@ -1,23 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a child even if a caption is provided 1`] = `
-.c2 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -57,33 +40,10 @@ exports[`renders a child even if a caption is provided 1`] = `
       Here is a passed child
     </div>
   </div>
-  <div
-    className="c2"
-    onClick={[Function]}
-  >
-    View Fullscreen
-  </div>
 </div>
 `;
 
 exports[`renders a saved caption properly 1`] = `
-.c2 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -126,12 +86,6 @@ exports[`renders a saved caption properly 1`] = `
         }
       }
     />
-  </div>
-  <div
-    className="c2"
-    onClick={[Function]}
-  >
-    View Fullscreen
   </div>
 </div>
 `;

--- a/src/components/publishing/sections/__test__/__snapshots__/image.test.tsx.snap
+++ b/src/components/publishing/sections/__test__/__snapshots__/image.test.tsx.snap
@@ -2,23 +2,6 @@
 
 exports[`renders a long caption properly 1`] = `
 .c3 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
-.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -30,9 +13,9 @@ exports[`renders a long caption properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c2 > p,
-.c2 p,
-.c2 .public-DraftEditorPlaceholder-root {
+.c4 > p,
+.c4 p,
+.c4 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -41,12 +24,26 @@ exports[`renders a long caption properly 1`] = `
   margin: 0;
 }
 
+.c2 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin: 10px;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+}
+
 .c0 {
+  position: relative;
+}
+
+.c1 {
   display: block;
 }
 
 @media (max-width: 600px) {
-  .c1 {
+  .c3 {
     padding: 0px 10px;
   }
 }
@@ -54,18 +51,72 @@ exports[`renders a long caption properly 1`] = `
 <div
   className="article-image"
 >
-  <img
-    alt="Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum."
-    className="c0"
-    height="auto"
-    src="https://d32dm0rphc51dk.cloudfront.net/CpHY-DRr7KW0HGXLslCXHw/larger.jpg"
-    width="100%"
-  />
   <div
-    className="c1"
+    className="c0"
   >
+    <img
+      alt="Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum."
+      className="c1"
+      height="auto"
+      src="https://d32dm0rphc51dk.cloudfront.net/CpHY-DRr7KW0HGXLslCXHw/larger.jpg"
+      width="100%"
+    />
     <div
       className="c2"
+      onClick={[Function]}
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 27 27"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <g>
+            <circle
+              cx="13.9575195"
+              cy="13.0588379"
+              fill="#000000"
+              fillRule="nonzero"
+              opacity="0.6"
+              r="13"
+            />
+            <g
+              stroke="#FFFFFF"
+              transform="translate(8.000000, 7.000000)"
+            >
+              <g>
+                <g
+                  transform="translate(0.382532, 0.382532)"
+                >
+                  <polyline
+                    points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                  />
+                  <polyline
+                    points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                    transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                  />
+                  <path
+                    d="M10.360254,0.796942618 L0.796942618,10.360254"
+                    strokeLinecap="square"
+                  />
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+  <div
+    className="c3"
+  >
+    <div
+      className="c4"
     >
       <div
         dangerouslySetInnerHTML={
@@ -75,35 +126,12 @@ exports[`renders a long caption properly 1`] = `
         }
       />
     </div>
-    <div
-      className="c3"
-      onClick={[Function]}
-    >
-      View Fullscreen
-    </div>
   </div>
 </div>
 `;
 
 exports[`renders a react child as caption properly 1`] = `
 .c3 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
-.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -115,9 +143,9 @@ exports[`renders a react child as caption properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c2 > p,
-.c2 p,
-.c2 .public-DraftEditorPlaceholder-root {
+.c4 > p,
+.c4 p,
+.c4 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -126,12 +154,26 @@ exports[`renders a react child as caption properly 1`] = `
   margin: 0;
 }
 
+.c2 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin: 10px;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+}
+
 .c0 {
+  position: relative;
+}
+
+.c1 {
   display: block;
 }
 
 @media (max-width: 600px) {
-  .c1 {
+  .c3 {
     padding: 0px 10px;
   }
 }
@@ -139,18 +181,72 @@ exports[`renders a react child as caption properly 1`] = `
 <div
   className="article-image"
 >
-  <img
-    alt="Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum."
-    className="c0"
-    height="auto"
-    src="https://d32dm0rphc51dk.cloudfront.net/CpHY-DRr7KW0HGXLslCXHw/larger.jpg"
-    width="100%"
-  />
   <div
-    className="c1"
+    className="c0"
   >
+    <img
+      alt="Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum."
+      className="c1"
+      height="auto"
+      src="https://d32dm0rphc51dk.cloudfront.net/CpHY-DRr7KW0HGXLslCXHw/larger.jpg"
+      width="100%"
+    />
     <div
       className="c2"
+      onClick={[Function]}
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 27 27"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <g>
+            <circle
+              cx="13.9575195"
+              cy="13.0588379"
+              fill="#000000"
+              fillRule="nonzero"
+              opacity="0.6"
+              r="13"
+            />
+            <g
+              stroke="#FFFFFF"
+              transform="translate(8.000000, 7.000000)"
+            >
+              <g>
+                <g
+                  transform="translate(0.382532, 0.382532)"
+                >
+                  <polyline
+                    points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                  />
+                  <polyline
+                    points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                    transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                  />
+                  <path
+                    d="M10.360254,0.796942618 L0.796942618,10.360254"
+                    strokeLinecap="square"
+                  />
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+  <div
+    className="c3"
+  >
+    <div
+      className="c4"
     >
       <div>
         <p>
@@ -158,35 +254,12 @@ exports[`renders a react child as caption properly 1`] = `
         </p>
       </div>
     </div>
-    <div
-      className="c3"
-      onClick={[Function]}
-    >
-      View Fullscreen
-    </div>
   </div>
 </div>
 `;
 
 exports[`renders properly 1`] = `
 .c3 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
-.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -198,9 +271,9 @@ exports[`renders properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c2 > p,
-.c2 p,
-.c2 .public-DraftEditorPlaceholder-root {
+.c4 > p,
+.c4 p,
+.c4 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -209,12 +282,26 @@ exports[`renders properly 1`] = `
   margin: 0;
 }
 
+.c2 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin: 10px;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+}
+
 .c0 {
+  position: relative;
+}
+
+.c1 {
   display: block;
 }
 
 @media (max-width: 600px) {
-  .c1 {
+  .c3 {
     padding: 0px 10px;
   }
 }
@@ -222,18 +309,72 @@ exports[`renders properly 1`] = `
 <div
   className="article-image"
 >
-  <img
-    alt="Photo by Adam Kuehl for Artsy."
-    className="c0"
-    height="auto"
-    src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
-    width="100%"
-  />
   <div
-    className="c1"
+    className="c0"
   >
+    <img
+      alt="Photo by Adam Kuehl for Artsy."
+      className="c1"
+      height="auto"
+      src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
+      width="100%"
+    />
     <div
       className="c2"
+      onClick={[Function]}
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 27 27"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <g>
+            <circle
+              cx="13.9575195"
+              cy="13.0588379"
+              fill="#000000"
+              fillRule="nonzero"
+              opacity="0.6"
+              r="13"
+            />
+            <g
+              stroke="#FFFFFF"
+              transform="translate(8.000000, 7.000000)"
+            >
+              <g>
+                <g
+                  transform="translate(0.382532, 0.382532)"
+                >
+                  <polyline
+                    points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                  />
+                  <polyline
+                    points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                    transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                  />
+                  <path
+                    d="M10.360254,0.796942618 L0.796942618,10.360254"
+                    strokeLinecap="square"
+                  />
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+  <div
+    className="c3"
+  >
+    <div
+      className="c4"
     >
       <div
         dangerouslySetInnerHTML={
@@ -242,12 +383,6 @@ exports[`renders properly 1`] = `
           }
         }
       />
-    </div>
-    <div
-      className="c3"
-      onClick={[Function]}
-    >
-      View Fullscreen
     </div>
   </div>
 </div>

--- a/src/components/publishing/sections/__test__/__snapshots__/image_collection.test.tsx.snap
+++ b/src/components/publishing/sections/__test__/__snapshots__/image_collection.test.tsx.snap
@@ -1,30 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a single image properly 1`] = `
-.c6 {
+.c8 {
   color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c7 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
-.c4 {
+.c6 {
   margin-top: 10px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -36,7 +19,7 @@ exports[`renders a single image properly 1`] = `
   line-height: 1.1em;
 }
 
-.c5 {
+.c7 {
   color: #999;
   display: block;
   -webkit-text-overflow: ellipsis;
@@ -46,17 +29,31 @@ exports[`renders a single image properly 1`] = `
   width: 100%;
 }
 
-.c5 .artist-name {
+.c7 .artist-name {
   margin-right: 30px;
+}
+
+.c5 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin: 10px;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+}
+
+.c3 {
+  position: relative;
+}
+
+.c4 {
+  display: block;
 }
 
 .c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c3 {
-  display: block;
 }
 
 .c1 {
@@ -100,19 +97,73 @@ exports[`renders a single image properly 1`] = `
         className="c2"
         href="/artwork/fernando-botero-nude-on-the-beach"
       >
-        <img
-          alt="Nude on the Beach"
-          className="display-artwork__image c3"
-          height="auto"
-          src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-          width="100%"
-        />
+        <div
+          className="c3"
+        >
+          <img
+            alt="Nude on the Beach"
+            className="display-artwork__image c4"
+            height="auto"
+            src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+            width="100%"
+          />
+          <div
+            className="c5"
+            onClick={[Function]}
+          >
+            <svg
+              version="1.1"
+              viewBox="0 0 27 27"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fillRule="evenodd"
+                stroke="none"
+                strokeWidth="1"
+              >
+                <g>
+                  <circle
+                    cx="13.9575195"
+                    cy="13.0588379"
+                    fill="#000000"
+                    fillRule="nonzero"
+                    opacity="0.6"
+                    r="13"
+                  />
+                  <g
+                    stroke="#FFFFFF"
+                    transform="translate(8.000000, 7.000000)"
+                  >
+                    <g>
+                      <g
+                        transform="translate(0.382532, 0.382532)"
+                      >
+                        <polyline
+                          points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                        />
+                        <polyline
+                          points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                          transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                        />
+                        <path
+                          d="M10.360254,0.796942618 L0.796942618,10.360254"
+                          strokeLinecap="square"
+                        />
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </svg>
+          </div>
+        </div>
       </a>
       <div
-        className="display-artwork__caption c4"
+        className="display-artwork__caption c6"
       >
         <div
-          className="c5"
+          className="c7"
         >
           <span
             className="artist-name"
@@ -121,7 +172,7 @@ exports[`renders a single image properly 1`] = `
               className="name"
             >
               <a
-                className="c6"
+                className="c8"
                 href="/artist/fernando-botero"
               >
                 Fernando Botero
@@ -132,7 +183,7 @@ exports[`renders a single image properly 1`] = `
             className="title"
           >
             <a
-              className="c6"
+              className="c8"
               href="/artwork/fernando-botero-nude-on-the-beach"
             >
               Nude on the Beach
@@ -154,17 +205,11 @@ exports[`renders a single image properly 1`] = `
             , 
           </span>
           <a
-            className="c6"
+            className="c8"
             href="/partner/gary-nader"
           >
             Gary Nader
           </a>
-        </div>
-        <div
-          className="c7"
-          onClick={[Function]}
-        >
-          View Fullscreen
         </div>
       </div>
     </div>
@@ -173,30 +218,13 @@ exports[`renders a single image properly 1`] = `
 `;
 
 exports[`renders properly 1`] = `
-.c6 {
+.c8 {
   color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c7 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
-.c4 {
+.c6 {
   margin-top: 10px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -208,7 +236,7 @@ exports[`renders properly 1`] = `
   line-height: 1.1em;
 }
 
-.c5 {
+.c7 {
   color: #999;
   display: block;
   -webkit-text-overflow: ellipsis;
@@ -218,17 +246,31 @@ exports[`renders properly 1`] = `
   width: 100%;
 }
 
-.c5 .artist-name {
+.c7 .artist-name {
   margin-right: 30px;
+}
+
+.c5 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin: 10px;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+}
+
+.c3 {
+  position: relative;
+}
+
+.c4 {
+  display: block;
 }
 
 .c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c3 {
-  display: block;
 }
 
 .c10 {
@@ -254,16 +296,12 @@ exports[`renders properly 1`] = `
   margin: 0;
 }
 
-.c9 {
-  display: block;
-}
-
 .c1 {
   margin-right: 10px;
   width: 312px;
 }
 
-.c8 {
+.c9 {
   margin-right: 10px;
   width: 168px;
 }
@@ -294,7 +332,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c8 {
+  .c9 {
     margin-bottom: 10px;
   }
 }
@@ -327,19 +365,73 @@ exports[`renders properly 1`] = `
         className="c2"
         href="/artwork/fernando-botero-nude-on-the-beach"
       >
-        <img
-          alt="Nude on the Beach"
-          className="display-artwork__image c3"
-          height={224}
-          src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-          width={312}
-        />
+        <div
+          className="c3"
+        >
+          <img
+            alt="Nude on the Beach"
+            className="display-artwork__image c4"
+            height={224}
+            src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+            width={312}
+          />
+          <div
+            className="c5"
+            onClick={[Function]}
+          >
+            <svg
+              version="1.1"
+              viewBox="0 0 27 27"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fillRule="evenodd"
+                stroke="none"
+                strokeWidth="1"
+              >
+                <g>
+                  <circle
+                    cx="13.9575195"
+                    cy="13.0588379"
+                    fill="#000000"
+                    fillRule="nonzero"
+                    opacity="0.6"
+                    r="13"
+                  />
+                  <g
+                    stroke="#FFFFFF"
+                    transform="translate(8.000000, 7.000000)"
+                  >
+                    <g>
+                      <g
+                        transform="translate(0.382532, 0.382532)"
+                      >
+                        <polyline
+                          points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                        />
+                        <polyline
+                          points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                          transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                        />
+                        <path
+                          d="M10.360254,0.796942618 L0.796942618,10.360254"
+                          strokeLinecap="square"
+                        />
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </svg>
+          </div>
+        </div>
       </a>
       <div
-        className="display-artwork__caption c4"
+        className="display-artwork__caption c6"
       >
         <div
-          className="c5"
+          className="c7"
         >
           <span
             className="artist-name"
@@ -348,7 +440,7 @@ exports[`renders properly 1`] = `
               className="name"
             >
               <a
-                className="c6"
+                className="c8"
                 href="/artist/fernando-botero"
               >
                 Fernando Botero
@@ -359,7 +451,7 @@ exports[`renders properly 1`] = `
             className="title"
           >
             <a
-              className="c6"
+              className="c8"
               href="/artwork/fernando-botero-nude-on-the-beach"
             >
               Nude on the Beach
@@ -381,35 +473,83 @@ exports[`renders properly 1`] = `
             , 
           </span>
           <a
-            className="c6"
+            className="c8"
             href="/partner/gary-nader"
           >
             Gary Nader
           </a>
         </div>
-        <div
-          className="c7"
-          onClick={[Function]}
-        >
-          View Fullscreen
-        </div>
       </div>
     </div>
   </div>
   <div
-    className="c8"
+    className="c9"
     width={168}
   >
     <div
       className="article-image"
     >
-      <img
-        alt="Photo by Adam Kuehl for Artsy."
-        className="c9"
-        height={224}
-        src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
-        width={168}
-      />
+      <div
+        className="c3"
+      >
+        <img
+          alt="Photo by Adam Kuehl for Artsy."
+          className="c4"
+          height={224}
+          src="https://artsy-media-uploads.s3.amazonaws.com/co8j2xq40ROMyBrJQm_4eQ%2FDafenOilPaintingVillage_AK03.jpg"
+          width={168}
+        />
+        <div
+          className="c5"
+          onClick={[Function]}
+        >
+          <svg
+            version="1.1"
+            viewBox="0 0 27 27"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <g>
+                <circle
+                  cx="13.9575195"
+                  cy="13.0588379"
+                  fill="#000000"
+                  fillRule="nonzero"
+                  opacity="0.6"
+                  r="13"
+                />
+                <g
+                  stroke="#FFFFFF"
+                  transform="translate(8.000000, 7.000000)"
+                >
+                  <g>
+                    <g
+                      transform="translate(0.382532, 0.382532)"
+                    >
+                      <polyline
+                        points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                      />
+                      <polyline
+                        points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                        transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                      />
+                      <path
+                        d="M10.360254,0.796942618 L0.796942618,10.360254"
+                        strokeLinecap="square"
+                      />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
       <div
         className="c10"
       >
@@ -424,12 +564,6 @@ exports[`renders properly 1`] = `
             }
           />
         </div>
-        <div
-          className="c7"
-          onClick={[Function]}
-        >
-          View Fullscreen
-        </div>
       </div>
     </div>
   </div>
@@ -440,13 +574,67 @@ exports[`renders properly 1`] = `
     <div
       className="article-image"
     >
-      <img
-        alt="Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum."
-        className="c9"
-        height={224}
-        src="https://d32dm0rphc51dk.cloudfront.net/CpHY-DRr7KW0HGXLslCXHw/larger.jpg"
-        width={178}
-      />
+      <div
+        className="c3"
+      >
+        <img
+          alt="Photo by Adam Kuehl for Artsy. Image courtesy of the Guggenheim Museum."
+          className="c4"
+          height={224}
+          src="https://d32dm0rphc51dk.cloudfront.net/CpHY-DRr7KW0HGXLslCXHw/larger.jpg"
+          width={178}
+        />
+        <div
+          className="c5"
+          onClick={[Function]}
+        >
+          <svg
+            version="1.1"
+            viewBox="0 0 27 27"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <g>
+                <circle
+                  cx="13.9575195"
+                  cy="13.0588379"
+                  fill="#000000"
+                  fillRule="nonzero"
+                  opacity="0.6"
+                  r="13"
+                />
+                <g
+                  stroke="#FFFFFF"
+                  transform="translate(8.000000, 7.000000)"
+                >
+                  <g>
+                    <g
+                      transform="translate(0.382532, 0.382532)"
+                    >
+                      <polyline
+                        points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                      />
+                      <polyline
+                        points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                        transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                      />
+                      <path
+                        d="M10.360254,0.796942618 L0.796942618,10.360254"
+                        strokeLinecap="square"
+                      />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
       <div
         className="c10"
       >
@@ -460,12 +648,6 @@ exports[`renders properly 1`] = `
               }
             }
           />
-        </div>
-        <div
-          className="c7"
-          onClick={[Function]}
-        >
-          View Fullscreen
         </div>
       </div>
     </div>

--- a/src/components/publishing/sections/__test__/__snapshots__/sections.test.tsx.snap
+++ b/src/components/publishing/sections/__test__/__snapshots__/sections.test.tsx.snap
@@ -12,23 +12,6 @@ exports[`renders properly 1`] = `
   text-decoration: none;
 }
 
-.c10 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.1em;
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
-  cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-}
-
 .c14 {
   margin-top: 10px;
   display: -webkit-box;
@@ -55,16 +38,30 @@ exports[`renders properly 1`] = `
   margin-right: 30px;
 }
 
-.c12 {
+.c9 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin: 10px;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+}
+
+.c7 {
+  position: relative;
+}
+
+.c8 {
+  display: block;
+}
+
+.c13 {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c13 {
-  display: block;
-}
-
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -76,9 +73,9 @@ exports[`renders properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c9 > p,
-.c9 p,
-.c9 .public-DraftEditorPlaceholder-root {
+.c11 > p,
+.c11 p,
+.c11 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -87,16 +84,12 @@ exports[`renders properly 1`] = `
   margin: 0;
 }
 
-.c7 {
-  display: block;
-}
-
 .c6 {
   margin-right: 10px;
   width: 197px;
 }
 
-.c11 {
+.c12 {
   margin-right: 0px;
   width: 264px;
 }
@@ -456,7 +449,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c8 {
+  .c10 {
     padding: 0px 10px;
   }
 }
@@ -468,7 +461,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c11 {
+  .c12 {
     margin-bottom: 10px;
   }
 }
@@ -723,18 +716,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="John Elisle, The Star, from the reimagined female Tarot cards. Courtesy of the artist. "
-            className="c7"
-            height={351}
-            src="https://artsy-media-uploads.s3.amazonaws.com/5ZP7vKuVPqiynVU0jpFewQ%2Funnamed.png"
-            width={197}
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="John Elisle, The Star, from the reimagined female Tarot cards. Courtesy of the artist. "
+              className="c8"
+              height={351}
+              src="https://artsy-media-uploads.s3.amazonaws.com/5ZP7vKuVPqiynVU0jpFewQ%2Funnamed.png"
+              width={197}
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -743,12 +790,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>
@@ -760,18 +801,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="John Elisle, The Magician, from the reimagined female Tarot cards. Courtesy of the artist. "
-            className="c7"
-            height={351}
-            src="https://artsy-media-uploads.s3.amazonaws.com/PcvH_rh89gRGxRXgCyGGng%2Funnamed-5.png"
-            width={197}
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="John Elisle, The Magician, from the reimagined female Tarot cards. Courtesy of the artist. "
+              className="c8"
+              height={351}
+              src="https://artsy-media-uploads.s3.amazonaws.com/PcvH_rh89gRGxRXgCyGGng%2Funnamed-5.png"
+              width={197}
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -781,33 +876,81 @@ exports[`renders properly 1`] = `
                 }
               />
             </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
-            </div>
           </div>
         </div>
       </div>
       <div
-        className="c11"
+        className="c12"
         width={264}
       >
         <div
           className="display-artwork"
         >
           <a
-            className="c12"
+            className="c13"
             href="/artwork/matt-devine-brass-tax"
           >
-            <img
-              alt="Brass Tax"
-              className="display-artwork__image c13"
-              height={352}
-              src="https://d32dm0rphc51dk.cloudfront.net/lSBz0tsfvOAm2qKdWwgxLw/larger.jpg"
-              width={264}
-            />
+            <div
+              className="c7"
+            >
+              <img
+                alt="Brass Tax"
+                className="display-artwork__image c8"
+                height={352}
+                src="https://d32dm0rphc51dk.cloudfront.net/lSBz0tsfvOAm2qKdWwgxLw/larger.jpg"
+                width={264}
+              />
+              <div
+                className="c9"
+                onClick={[Function]}
+              >
+                <svg
+                  version="1.1"
+                  viewBox="0 0 27 27"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    fill="none"
+                    fillRule="evenodd"
+                    stroke="none"
+                    strokeWidth="1"
+                  >
+                    <g>
+                      <circle
+                        cx="13.9575195"
+                        cy="13.0588379"
+                        fill="#000000"
+                        fillRule="nonzero"
+                        opacity="0.6"
+                        r="13"
+                      />
+                      <g
+                        stroke="#FFFFFF"
+                        transform="translate(8.000000, 7.000000)"
+                      >
+                        <g>
+                          <g
+                            transform="translate(0.382532, 0.382532)"
+                          >
+                            <polyline
+                              points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                            />
+                            <polyline
+                              points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                              transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                            />
+                            <path
+                              d="M10.360254,0.796942618 L0.796942618,10.360254"
+                              strokeLinecap="square"
+                            />
+                          </g>
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
           </a>
           <div
             className="display-artwork__caption c14"
@@ -851,12 +994,6 @@ exports[`renders properly 1`] = `
                 Joanne Artman Gallery
               </a>
             </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
-            </div>
           </div>
         </div>
       </div>
@@ -890,18 +1027,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
-            className="c7"
-            height={425}
-            src="https://artsy-media-uploads.s3.amazonaws.com/GwIVCQftjauWBCQie9oQ-A%2FTarot_de_Marseille_major21_world.jpg"
-            width={219}
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
+              className="c8"
+              height={425}
+              src="https://artsy-media-uploads.s3.amazonaws.com/GwIVCQftjauWBCQie9oQ-A%2FTarot_de_Marseille_major21_world.jpg"
+              width={219}
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -910,12 +1101,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>
@@ -927,18 +1112,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="Nicolas Conver, Queen of Clubs. Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
-            className="c7"
-            height={425}
-            src="https://artsy-media-uploads.s3.amazonaws.com/UaNPuL9iz-X7Xm-SNtat7Q%2FTarot_de_Marseille_clubs13_queen.jpg"
-            width={219}
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="Nicolas Conver, Queen of Clubs. Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
+              className="c8"
+              height={425}
+              src="https://artsy-media-uploads.s3.amazonaws.com/UaNPuL9iz-X7Xm-SNtat7Q%2FTarot_de_Marseille_clubs13_queen.jpg"
+              width={219}
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -947,12 +1186,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>
@@ -964,18 +1197,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
-            className="c7"
-            height={426}
-            src="https://artsy-media-uploads.s3.amazonaws.com/x5EcmVNBKoUJqQa8BQgqJA%2FTarot_de_Marseille_major06_lovers.jpg"
-            width={219}
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
+              className="c8"
+              height={426}
+              src="https://artsy-media-uploads.s3.amazonaws.com/x5EcmVNBKoUJqQa8BQgqJA%2FTarot_de_Marseille_major06_lovers.jpg"
+              width={219}
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -984,12 +1271,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>
@@ -1024,18 +1305,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="Pamela Colman Smith, The Empress, c. 1937. Courtesy of the Beinecke Rare Book &amp; Manuscript Library at Yale University."
-            className="c7"
-            height="auto"
-            src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
-            width="100%"
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="Pamela Colman Smith, The Empress, c. 1937. Courtesy of the Beinecke Rare Book &amp; Manuscript Library at Yale University."
+              className="c8"
+              height="auto"
+              src="https://d32dm0rphc51dk.cloudfront.net/0aRUvnVgQKbQk5dj8xcCAg/larger.jpg"
+              width="100%"
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1044,12 +1379,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>
@@ -1110,18 +1439,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. "
-            className="c7"
-            height={387}
-            src="https://artsy-media-uploads.s3.amazonaws.com/jmrvzuo7VfRidule-4zWNA%2F07272017170054-0001+%28dragged%29+copy.jpg"
-            width={216}
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. "
+              className="c8"
+              height={387}
+              src="https://artsy-media-uploads.s3.amazonaws.com/jmrvzuo7VfRidule-4zWNA%2F07272017170054-0001+%28dragged%29+copy.jpg"
+              width={216}
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1130,12 +1513,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>
@@ -1147,18 +1524,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. "
-            className="c7"
-            height={388}
-            src="https://artsy-media-uploads.s3.amazonaws.com/66XOTGwZQzAAa0igYKSNTQ%2F07272017170207-0001+%28dragged%29.jpg"
-            width={219}
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. "
+              className="c8"
+              height={388}
+              src="https://artsy-media-uploads.s3.amazonaws.com/66XOTGwZQzAAa0igYKSNTQ%2F07272017170207-0001+%28dragged%29.jpg"
+              width={219}
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1167,12 +1598,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>
@@ -1184,18 +1609,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. "
-            className="c7"
-            height={388}
-            src="https://artsy-media-uploads.s3.amazonaws.com/l0Qu946mLja0Dbv4ME4MHg%2F07272017170259-0001+%28dragged%29.jpg"
-            width={222}
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="Bill Greer and Lloyd Morgan, card from Morgan-Greer Tarot, 1979. "
+              className="c8"
+              height={388}
+              src="https://artsy-media-uploads.s3.amazonaws.com/l0Qu946mLja0Dbv4ME4MHg%2F07272017170259-0001+%28dragged%29.jpg"
+              width={222}
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1204,12 +1683,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>
@@ -1328,18 +1801,72 @@ exports[`renders properly 1`] = `
         <div
           className="article-image"
         >
-          <img
-            alt="Designed by Kati Forner for The Dreslyn, courtesy of the artist. "
-            className="c7"
-            height="auto"
-            src="https://artsy-media-uploads.s3.amazonaws.com/Gk95i1tUaDJKeqQ-jcq6Cw%2FIMG_2142.jpg"
-            width="100%"
-          />
           <div
-            className="c8"
+            className="c7"
           >
+            <img
+              alt="Designed by Kati Forner for The Dreslyn, courtesy of the artist. "
+              className="c8"
+              height="auto"
+              src="https://artsy-media-uploads.s3.amazonaws.com/Gk95i1tUaDJKeqQ-jcq6Cw%2FIMG_2142.jpg"
+              width="100%"
+            />
             <div
               className="c9"
+              onClick={[Function]}
+            >
+              <svg
+                version="1.1"
+                viewBox="0 0 27 27"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <g>
+                    <circle
+                      cx="13.9575195"
+                      cy="13.0588379"
+                      fill="#000000"
+                      fillRule="nonzero"
+                      opacity="0.6"
+                      r="13"
+                    />
+                    <g
+                      stroke="#FFFFFF"
+                      transform="translate(8.000000, 7.000000)"
+                    >
+                      <g>
+                        <g
+                          transform="translate(0.382532, 0.382532)"
+                        >
+                          <polyline
+                            points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                          />
+                          <polyline
+                            points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                            transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                          />
+                          <path
+                            d="M10.360254,0.796942618 L0.796942618,10.360254"
+                            strokeLinecap="square"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <div
+            className="c10"
+          >
+            <div
+              className="c11"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1348,12 +1875,6 @@ exports[`renders properly 1`] = `
                   }
                 }
               />
-            </div>
-            <div
-              className="c10"
-              onClick={[Function]}
-            >
-              View Fullscreen
             </div>
           </div>
         </div>

--- a/src/components/publishing/sections/__test__/sections.test.tsx
+++ b/src/components/publishing/sections/__test__/sections.test.tsx
@@ -3,12 +3,12 @@ import * as renderer from "react-test-renderer"
 
 import "jest-styled-components"
 
-import Articles from "../../fixtures/articles"
+import { StandardArticle } from "../../fixtures/articles"
 import Sections from "../sections"
 
 jest.mock("react-sizeme", () => jest.fn(c => d => d))
 
 it("renders properly", () => {
-  const sections = renderer.create(<Sections article={Articles[1]} />).toJSON()
+  const sections = renderer.create(<Sections article={StandardArticle} />).toJSON()
   expect(sections).toMatchSnapshot()
 })

--- a/src/components/publishing/sections/artwork.tsx
+++ b/src/components/publishing/sections/artwork.tsx
@@ -1,11 +1,12 @@
 import React from "react"
 import styled from "styled-components"
+import { Layout } from "../typings"
 import ArtworkCaption from "./artwork_caption"
 import ImageWrapper from "./image_wrapper"
 
 interface ArtworkProps {
   artwork: any
-  layout?: string
+  layout?: Layout
   linked?: boolean
   width?: string | number
   height?: string | number

--- a/src/components/publishing/sections/artwork.tsx
+++ b/src/components/publishing/sections/artwork.tsx
@@ -1,13 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 import ArtworkCaption from "./artwork_caption"
-
-const ArtworkImageLink = styled.a`
-  text-decoration: none;
-`
-const BlockImage = styled.img`
-  display: block;
-`
+import ImageWrapper from "./image_wrapper"
 
 interface ArtworkProps {
   artwork: any
@@ -18,14 +12,16 @@ interface ArtworkProps {
 }
 
 const ArtworkImage: React.SFC<ArtworkProps> = props => {
-  const { artwork, linked, height, width } = props
+  const { artwork, linked, height, width, layout } = props
   const image = (
-    <BlockImage
+    <ImageWrapper
+      layout={layout}
       src={artwork.image}
       className="display-artwork__image"
       width={width}
       height={height}
       alt={artwork.title}
+      index={artwork.index}
     />
   )
   if (linked) {
@@ -56,5 +52,9 @@ const Artwork: React.SFC<ArtworkProps> = props => {
 Artwork.defaultProps = {
   linked: true,
 }
+
+const ArtworkImageLink = styled.a`
+  text-decoration: none;
+`
 
 export default Artwork

--- a/src/components/publishing/sections/artwork_caption.tsx
+++ b/src/components/publishing/sections/artwork_caption.tsx
@@ -4,7 +4,6 @@ import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../helpers"
 import TextLink from "../../text_link"
 import Fonts from "../fonts"
-import ViewFullscreen from "./view_fullscreen"
 
 interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
   artwork: any
@@ -101,7 +100,7 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
   }
 
   render() {
-    const { layout, artwork } = this.props
+    const { layout } = this.props
     if (layout === "classic") {
       return (
         <StyledClassicCaption layout={layout} className="display-artwork__caption">
@@ -138,7 +137,6 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
             </span>
             {this.renderTitleDatePartner()}
           </TruncatedLine>
-          <ViewFullscreen index={artwork.index} />
         </StyledArtworkCaption>
       )
     }

--- a/src/components/publishing/sections/artwork_caption.tsx
+++ b/src/components/publishing/sections/artwork_caption.tsx
@@ -4,14 +4,16 @@ import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../helpers"
 import TextLink from "../../text_link"
 import Fonts from "../fonts"
+import { Layout } from "../typings"
 
 interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
   artwork: any
-  layout?: string
+  layout?: Layout
   linked?: boolean
+  isFullscreenCaption?: boolean
 }
 interface StyledArtworkCaptionProps {
-  layout?: string
+  layout?: Layout
 }
 
 class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
@@ -100,8 +102,19 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
   }
 
   render() {
-    const { layout } = this.props
-    if (layout === "classic") {
+    const { layout, isFullscreenCaption } = this.props
+    if (isFullscreenCaption) {
+      return (
+        <StyledFullscreenCaption layout={layout}>
+          <Line className="artist-name">
+            {this.renderArtists()}
+          </Line>
+          <Line>
+            {this.renderTitleDatePartner()}
+          </Line>
+        </StyledFullscreenCaption>
+      )
+    } else if (layout === "classic") {
       return (
         <StyledClassicCaption layout={layout} className="display-artwork__caption">
           <TruncatedLine>
@@ -116,17 +129,6 @@ class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
             {this.renderPartner()}
           </TruncatedLine>
         </StyledClassicCaption>
-      )
-    } else if (layout === "fullscreen") {
-      return (
-        <StyledFullscreenCaption layout={layout}>
-          <Line className="artist-name">
-            {this.renderArtists()}
-          </Line>
-          <Line>
-            {this.renderTitleDatePartner()}
-          </Line>
-        </StyledFullscreenCaption>
       )
     } else {
       return (

--- a/src/components/publishing/sections/caption.tsx
+++ b/src/components/publishing/sections/caption.tsx
@@ -2,14 +2,15 @@ import React from "react"
 import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../helpers"
 import Fonts from "../fonts"
+import { Layout } from "../typings"
 
 interface CaptionProps {
   caption: string
-  layout?: string
+  layout?: Layout
   index?: any
 }
 interface FigcaptionProps {
-  layout: string
+  layout: Layout
 }
 
 const Caption: React.SFC<CaptionProps> = props => {

--- a/src/components/publishing/sections/caption.tsx
+++ b/src/components/publishing/sections/caption.tsx
@@ -2,12 +2,10 @@ import React from "react"
 import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../helpers"
 import Fonts from "../fonts"
-import ViewFullscreen from "./view_fullscreen"
 
 interface CaptionProps {
   caption: string
   layout?: string
-  viewFullscreen?: boolean
   index?: any
 }
 interface FigcaptionProps {
@@ -15,19 +13,15 @@ interface FigcaptionProps {
 }
 
 const Caption: React.SFC<CaptionProps> = props => {
-  const { layout, caption, viewFullscreen, children, index } = props
+  const { layout, caption, children } = props
   const child = children ? children : <div dangerouslySetInnerHTML={{ __html: caption }} />
   return (
     <CaptionContainer>
       <Figcaption layout={layout}>
         {child}
       </Figcaption>
-      {viewFullscreen ? <ViewFullscreen index={index} /> : false}
     </CaptionContainer>
   )
-}
-Caption.defaultProps = {
-  viewFullscreen: true,
 }
 
 const CaptionContainer = styled.div`

--- a/src/components/publishing/sections/fullscreen_viewer/__test__/__snapshots__/fullscreen_viewer.test.tsx.snap
+++ b/src/components/publishing/sections/fullscreen_viewer/__test__/__snapshots__/fullscreen_viewer.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`renders properly 1`] = `
   height: 100vh;
   overflow: hidden;
   position: fixed;
-  z-index: 20;
+  z-index: 1070;
   top: 0;
   left: 0;
   background-color: white;

--- a/src/components/publishing/sections/fullscreen_viewer/caption.tsx
+++ b/src/components/publishing/sections/fullscreen_viewer/caption.tsx
@@ -15,7 +15,7 @@ interface FullscreenViewerCaptionProps extends React.HTMLProps<HTMLDivElement> {
 
 const FullscreenViewerCaption: React.SFC<FullscreenViewerCaptionProps> = props => {
   const caption = props.section.type === "artwork"
-    ? <ArtworkCaption layout="fullscreen" artwork={props.section} linked />
+    ? <ArtworkCaption isFullscreenCaption artwork={props.section} linked />
     : <div dangerouslySetInnerHTML={{ __html: props.section.caption }} />
   const indexText = `${props.index} of ${props.total}`
   return (

--- a/src/components/publishing/sections/fullscreen_viewer/fullscreen_viewer.tsx
+++ b/src/components/publishing/sections/fullscreen_viewer/fullscreen_viewer.tsx
@@ -23,9 +23,18 @@ class FullscreenViewer extends React.Component<FullscreenViewerProps, Fullscreen
     onToggleCaption: PropTypes.func,
   }
 
+  private slider: any
+
   constructor(props) {
     super(props)
     this.state = { isCaptionOpen: false }
+  }
+
+  componentDidUpdate() {
+    if (this.slider) {
+      this.slider.innerSlider.list.setAttribute("tabindex", 0)
+      this.slider.innerSlider.list.focus()
+    }
   }
 
   handleKeydown = e => {
@@ -73,7 +82,7 @@ class FullscreenViewer extends React.Component<FullscreenViewerProps, Fullscreen
     }
     return (
       <FullscreenViewerContainer onKeyDown={this.handleKeydown}>
-        <Slider {...sliderSettings}>
+        <Slider {...sliderSettings} ref={slider => (this.slider = slider)}>
           {this.renderImageComponents()}
         </Slider>
         <Close onClick={this.close}>
@@ -105,7 +114,7 @@ const FullscreenViewerContainer = styled.div`
   height: 100vh;
   overflow: hidden;
   position: fixed;
-  z-index: 20;
+  z-index: 1070;
   top: 0;
   left: 0;
   background-color: white;

--- a/src/components/publishing/sections/image.tsx
+++ b/src/components/publishing/sections/image.tsx
@@ -1,10 +1,11 @@
 import React from "react"
+import { Layout } from "../typings"
 import Caption from "./caption"
 import ImageWrapper from "./image_wrapper"
 
 interface ImageProps extends React.HTMLProps<HTMLDivElement> {
   image?: any
-  layout?: string
+  layout?: Layout
   width?: number | string
   height?: number | string
 }

--- a/src/components/publishing/sections/image.tsx
+++ b/src/components/publishing/sections/image.tsx
@@ -1,10 +1,6 @@
 import React from "react"
-import styled from "styled-components"
 import Caption from "./caption"
-
-const BlockImage = styled.img`
-  display: block;
-`
+import ImageWrapper from "./image_wrapper"
 
 interface ImageProps extends React.HTMLProps<HTMLDivElement> {
   image?: any
@@ -18,13 +14,15 @@ const Image: React.SFC<ImageProps> = props => {
   const child = children && children
   return (
     <div className="article-image">
-      <BlockImage
+      <ImageWrapper
+        layout={layout}
         src={image.url}
         width={width}
         height={height}
         alt={image.caption.replace(/<[^>]*>/g, "") /* strip caption html */}
+        index={image.index}
       />
-      <Caption caption={image.caption} layout={layout} viewFullscreen={layout !== "classic"} index={image.index}>
+      <Caption caption={image.caption} layout={layout}>
         {child}
       </Caption>
     </div>

--- a/src/components/publishing/sections/image_wrapper.tsx
+++ b/src/components/publishing/sections/image_wrapper.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import styled from "styled-components"
+import ViewFullscreen from "./view_fullscreen"
+
+interface ImageWrapperProps extends React.HTMLProps<HTMLDivElement> {
+  src: any
+  layout?: string
+  width?: string | number
+  height?: string | number
+  alt?: string
+  index?: number
+}
+
+const ImageWrapper: React.SFC<ImageWrapperProps> = props => {
+  const { layout, index } = props
+  const viewFullscreen = layout !== "classic" ? <ViewFullscreen index={index} /> : false
+  const newProps: any = { ...props }
+  delete newProps.layout
+  delete newProps.index
+
+  return (
+    <StyledImageWrapper>
+      <BlockImage {...newProps} />
+      {viewFullscreen}
+    </StyledImageWrapper>
+  )
+}
+
+const StyledImageWrapper = styled.div`
+  position: relative;
+`
+
+const BlockImage = styled.img`
+  display: block;
+`
+
+export default ImageWrapper

--- a/src/components/publishing/sections/image_wrapper.tsx
+++ b/src/components/publishing/sections/image_wrapper.tsx
@@ -1,10 +1,11 @@
 import React from "react"
 import styled from "styled-components"
+import { Layout } from "../typings"
 import ViewFullscreen from "./view_fullscreen"
 
-interface ImageWrapperProps extends React.HTMLProps<HTMLDivElement> {
+interface ImageWrapperProps extends React.HTMLProps<HTMLImageElement> {
   src: any
-  layout?: string
+  layout?: Layout
   width?: string | number
   height?: string | number
   alt?: string
@@ -12,15 +13,12 @@ interface ImageWrapperProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 const ImageWrapper: React.SFC<ImageWrapperProps> = props => {
-  const { layout, index } = props
+  const { layout, index, ...blockImageProps }: any = props
   const viewFullscreen = layout !== "classic" ? <ViewFullscreen index={index} /> : false
-  const newProps: any = { ...props }
-  delete newProps.layout
-  delete newProps.index
 
   return (
     <StyledImageWrapper>
-      <BlockImage {...newProps} />
+      <BlockImage {...blockImageProps} />
       {viewFullscreen}
     </StyledImageWrapper>
   )

--- a/src/components/publishing/sections/section_container.tsx
+++ b/src/components/publishing/sections/section_container.tsx
@@ -1,10 +1,11 @@
 import * as React from "react"
 import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../helpers"
+import { Layout } from "../typings"
 
 interface SectionContainerProps extends React.HTMLProps<HTMLDivElement> {
   layout?: string
-  articleLayout?: "classic" | "standard" | "feature"
+  articleLayout?: Layout
 }
 
 const Div: StyledFunction<SectionContainerProps> = styled.div

--- a/src/components/publishing/sections/sections.tsx
+++ b/src/components/publishing/sections/sections.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import styled, { StyledFunction } from "styled-components"
+import { Layout } from "../typings"
 import Authors from "./authors"
 import Embed from "./embed"
 import ImageCollection from "./image_collection"
@@ -10,7 +11,7 @@ import Video from "./video"
 
 interface SectionsProps {
   article: {
-    layout: string
+    layout: Layout
     authors?: any
     postscript?: string
   }

--- a/src/components/publishing/sections/styled_text.tsx
+++ b/src/components/publishing/sections/styled_text.tsx
@@ -2,9 +2,10 @@ import React from "react"
 import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../helpers"
 import Fonts from "../fonts"
+import { Layout } from "../typings"
 
 interface StyledTextProps {
-  layout: String
+  layout: Layout
   postscript?: Boolean
 }
 

--- a/src/components/publishing/sections/text.tsx
+++ b/src/components/publishing/sections/text.tsx
@@ -1,8 +1,9 @@
 import React from "react"
+import { Layout } from "../typings"
 import StyledText from "./styled_text"
 
 interface TextProps extends React.HTMLProps<HTMLDivElement> {
-  layout: "classic" | "feature" | "standard"
+  layout: Layout
   postscript?: boolean
   html?: string
 }

--- a/src/components/publishing/sections/video.tsx
+++ b/src/components/publishing/sections/video.tsx
@@ -75,7 +75,7 @@ class Video extends React.Component<VideoProps, VideoState> {
           <PlayButton><PlayButtonCaret /></PlayButton>
         </CoverImage>
         <IFrame src={this.state.src} frameBorder="0" allowFullScreen height={width * videoRatio} />
-        <Caption caption={caption} layout={this.props.layout} viewFullscreen={false}>
+        <Caption caption={caption} layout={this.props.layout}>
           {this.props.children}
         </Caption>
       </VideoContainer>

--- a/src/components/publishing/sections/video.tsx
+++ b/src/components/publishing/sections/video.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import sizeMe from "react-sizeme"
 import styled, { StyledFunction } from "styled-components"
 import urlParser from "url"
+import { Layout } from "../typings"
 import Caption from "./caption"
 
 const QUERYSTRING =
@@ -31,7 +32,7 @@ interface VideoProps {
     cover_image_url?: string
   }
   size?: any
-  layout?: string
+  layout?: Layout
 }
 
 interface VideoState {

--- a/src/components/publishing/sections/view_fullscreen.tsx
+++ b/src/components/publishing/sections/view_fullscreen.tsx
@@ -1,7 +1,7 @@
 import * as PropTypes from "prop-types"
 import * as React from "react"
 import styled from "styled-components"
-import Fonts from "../fonts"
+import IconExpand from "../icon/expand"
 
 interface ViewFullscreenProps extends React.HTMLProps<HTMLDivElement> {
   index?: number
@@ -9,11 +9,16 @@ interface ViewFullscreenProps extends React.HTMLProps<HTMLDivElement> {
 
 const ViewFullscreen: React.SFC<ViewFullscreenProps> = (props, context) => {
   const onClick = e => {
+    e.preventDefault()
     if (context.onViewFullscreen) {
       context.onViewFullscreen(props.index)
     }
   }
-  return <ViewFullscreenLink onClick={onClick}>View Fullscreen</ViewFullscreenLink>
+  return (
+    <ViewFullscreenLink onClick={onClick}>
+      <IconExpand />
+    </ViewFullscreenLink>
+  )
 }
 
 ViewFullscreen.contextTypes = {
@@ -21,15 +26,13 @@ ViewFullscreen.contextTypes = {
 }
 
 const ViewFullscreenLink = styled.div`
-  ${Fonts.unica("s14", "medium")}
-  margin: 0;
-  margin-left: 10px;
-  border-bottom: 1px solid black;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin: 10px;
+  width: 25px;
+  height: 25px;
   cursor: pointer;
-  display: inline-block;
-  min-width: 7.1em;
-  white-space: nowrap;
-  align-self: flex-start;
 `
 
 export default ViewFullscreen

--- a/src/components/publishing/typings.ts
+++ b/src/components/publishing/typings.ts
@@ -1,1 +1,6 @@
 export type Layout = "classic" | "standard" | "feature"
+
+export type ArticleData = {
+  layout: Layout
+  [x: string]: any
+}

--- a/src/components/publishing/typings.ts
+++ b/src/components/publishing/typings.ts
@@ -1,0 +1,1 @@
+export type Layout = "classic" | "standard" | "feature"


### PR DESCRIPTION
- New ImageWrapper component handles artwork/image + expand icon overlay to enter the fullscreen viewer
- Focus slider on component update to ensure that key commands work without clicking/focusing on component.

![image](https://user-images.githubusercontent.com/2236794/29945597-c2615a68-8e6f-11e7-9935-1d628abe7345.png)
