### PR TITLE
@kanaabe => Header children

### DIFF
--- a/src/components/publishing/header/__test__/__snapshots__/header.test.tsx.snap
+++ b/src/components/publishing/header/__test__/__snapshots__/header.test.tsx.snap
@@ -626,7 +626,7 @@ exports[`feature renders feature full header properly 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
 }
 
@@ -662,7 +662,7 @@ exports[`feature renders feature full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-s170ibci-2 {
+.c0[data-type='split'] .file__FeatureVideo-ipgsgz-2 {
   width: 50vw;
 }
 
@@ -761,8 +761,8 @@ exports[`feature renders feature full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-s170ibci-2 {
-    width: 100vw;
+  .c0[data-type='split'] .file__FeatureVideo-ipgsgz-2 {
+    width: 100%;
   }
 }
 
@@ -964,7 +964,7 @@ exports[`feature renders feature split header properly 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
 }
 
@@ -1000,7 +1000,7 @@ exports[`feature renders feature split header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-s170ibci-2 {
+.c0[data-type='split'] .file__FeatureVideo-ipgsgz-2 {
   width: 50vw;
 }
 
@@ -1099,8 +1099,8 @@ exports[`feature renders feature split header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-s170ibci-2 {
-    width: 100vw;
+  .c0[data-type='split'] .file__FeatureVideo-ipgsgz-2 {
+    width: 100%;
   }
 }
 
@@ -1258,11 +1258,15 @@ exports[`feature renders feature text header properly 1`] = `
   justify-content: flex-start;
 }
 
-.c11 {
+.c12 {
   width: 100%;
   height: auto;
-  padding: 20px;
   box-sizing: border-box;
+}
+
+.c11 {
+  width: calc(100% - 40px);
+  padding: 20px;
 }
 
 .c7 {
@@ -1291,7 +1295,7 @@ exports[`feature renders feature text header properly 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
 }
 
@@ -1327,7 +1331,7 @@ exports[`feature renders feature text header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-s170ibci-2 {
+.c0[data-type='split'] .file__FeatureVideo-ipgsgz-2 {
   width: 50vw;
 }
 
@@ -1426,8 +1430,8 @@ exports[`feature renders feature text header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-s170ibci-2 {
-    width: 100vw;
+  .c0[data-type='split'] .file__FeatureVideo-ipgsgz-2 {
+    width: 100%;
   }
 }
 
@@ -1510,11 +1514,15 @@ exports[`feature renders feature text header properly 1`] = `
         </div>
       </div>
     </div>
-    <img
-      alt="What’s the Path to Winning an Art Prize?"
+    <div
       className="c11"
-      src="https://artsy-media-uploads.s3.amazonaws.com/YqTtwB7AWqKD95NGItwjJg%2FRachel_Rossin_portrait_2.jpg"
-    />
+    >
+      <img
+        alt="What’s the Path to Winning an Art Prize?"
+        className="c12"
+        src="https://artsy-media-uploads.s3.amazonaws.com/YqTtwB7AWqKD95NGItwjJg%2FRachel_Rossin_portrait_2.jpg"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/src/components/publishing/header/feature_header.tsx
+++ b/src/components/publishing/header/feature_header.tsx
@@ -37,8 +37,9 @@ function renderAsset(url, title, children) {
       </FeatureVideoContainer>
     )
   } else {
+    const alt = url.length ? title : ""
     return (
-      <FeatureImage src={url} alt={title}>
+      <FeatureImage src={url} alt={alt}>
         {children[2]}
       </FeatureImage>
     )
@@ -55,10 +56,11 @@ function renderTextLayoutAsset(url, layout, title, children) {
         </TextAsset>
       )
     } else {
+      const alt = url.length ? title : ""
       return (
         <TextAsset>
           {children[2]}
-          <Image src={url} alt={title} />
+          <Image src={url} alt={alt} />
         </TextAsset>
       )
     }

--- a/src/components/publishing/header/feature_header.tsx
+++ b/src/components/publishing/header/feature_header.tsx
@@ -5,47 +5,62 @@ import { pMedia } from "../../helpers"
 import Fonts from "../fonts"
 import AuthorDate from "./author_date"
 
-function renderFeatureAsset(url, layout, isMobile, title) {
+function renderFeatureAsset(url, layout, isMobile, title, children) {
   if (layout === "fullscreen") {
     return (
       <div>
-        {renderAsset(url, title)}
+        {renderAsset(url, title, children)}
         <Overlay />
       </div>
     )
   } else if (layout === "split" && !isMobile) {
-    return renderAsset(url, title)
+    return renderAsset(url, title, children)
   } else {
     return false
   }
 }
 
-function renderMobileSplitAsset(url, layout, isMobile, title) {
+function renderMobileSplitAsset(url, layout, isMobile, title, children) {
   if (layout === "split" && isMobile) {
-    return renderAsset(url, title)
+    return renderAsset(url, title, children)
   } else {
     return false
   }
 }
 
-function renderAsset(url, title) {
+function renderAsset(url, title, children) {
   if (isVideo(url)) {
     return (
       <FeatureVideoContainer>
+        {children[2]}
         <FeatureVideo src={url} autoPlay controls={false} loop muted playsInline />
       </FeatureVideoContainer>
     )
   } else {
-    return <FeatureImage src={url} alt={title} />
+    return (
+      <FeatureImage src={url} alt={title}>
+        {children[2]}
+      </FeatureImage>
+    )
   }
 }
 
-function renderTextLayoutAsset(url, layout, title) {
+function renderTextLayoutAsset(url, layout, title, children) {
   if (layout === "text") {
     if (isVideo(url)) {
-      return <Video src={url} autoPlay controls={false} loop muted playsInline />
+      return (
+        <TextAsset>
+          {children[2]}
+          <Video src={url} autoPlay controls={false} loop muted playsInline />
+        </TextAsset>
+      )
     } else {
-      return <Image src={url} alt={title} />
+      return (
+        <TextAsset>
+          {children[2]}
+          <Image src={url} alt={title} />
+        </TextAsset>
+      )
     }
   } else {
     return false
@@ -64,23 +79,23 @@ interface FeatureHeaderProps {
 }
 
 const FeatureHeader: React.SFC<FeatureHeaderProps> = props => {
-  const { article, size } = props
+  const { article, size, children } = props
   const hero = article.hero_section
   const isMobile = size.width && size.width < 600 ? true : false
   return (
     <FeatureHeaderContainer data-type={hero.type}>
-      {renderFeatureAsset(hero.url, hero.type, isMobile, article.title)}
+      {renderFeatureAsset(hero.url, hero.type, isMobile, article.title, children)}
       <HeaderTextContainer>
         <HeaderText>
           <Vertical>{article.vertical.name}</Vertical>
-          {props.children[0]}
-          {renderMobileSplitAsset(hero.url, hero.type, isMobile, article.title)}
+          {children[0]}
+          {renderMobileSplitAsset(hero.url, hero.type, isMobile, article.title, children)}
           <SubHeader>
-            {props.children[1]}
+            {children[1]}
             <AuthorDate layout={hero.type} authors={article.contributing_authors} date={article.published_at} />
           </SubHeader>
         </HeaderText>
-        {renderTextLayoutAsset(hero.url, hero.type, article.title)}
+        {renderTextLayoutAsset(hero.url, hero.type, article.title, children)}
       </HeaderTextContainer>
     </FeatureHeaderContainer>
   )
@@ -132,7 +147,7 @@ const FeatureImage = Div.extend`
   width: 100%;
 `
 const FeatureVideo = styled.video`
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   object-fit: cover;
 `
@@ -146,11 +161,14 @@ const FeatureVideoContainer = Div.extend`
 const Image = styled.img`
   width: 100%;
   height: auto;
-  padding: 20px;
   box-sizing: border-box;
 `
 const Video = styled.video`
-  width: 100vw;
+  width: 100%;
+`
+const TextAsset = styled.div`
+  width: calc(100% - 40px);
+  padding: 20px;
 `
 const SubHeader = styled.div`
   ${Fonts.unica("s19", "medium")}
@@ -164,7 +182,7 @@ const SubHeader = styled.div`
   `}
 `
 const FeatureHeaderContainer = Div.extend`
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   &[data-type='text'] {
     height: auto;
@@ -220,7 +238,7 @@ const FeatureHeaderContainer = Div.extend`
         margin-bottom: 30px;
       }
       ${FeatureVideo} {
-        width: 100vw;
+        width: 100%;
       }
     `}
   }

--- a/src/components/publishing/header/header.tsx
+++ b/src/components/publishing/header/header.tsx
@@ -20,14 +20,15 @@ const Header: React.SFC<HeaderProps> = props => {
         <FeatureTitle className="feature__title">
           {props.children ? props.children[0] : article.title}
         </FeatureTitle>
-        {props.children ? props.children[1] : deck}
+        {props.children && props.children[1] ? <div className="feature__deck">props.children[1]</div> : deck}
+        {props.children && props.children[2]}
       </FeatureHeader>
     )
   } else if (article.layout === "standard") {
     return (
       <StandardHeader article={article}>
         <StandardTitle>
-          {props.children ? props.children[0] : article.title}
+          {props.children ? props.children : article.title}
         </StandardTitle>
       </StandardHeader>
     )
@@ -35,7 +36,7 @@ const Header: React.SFC<HeaderProps> = props => {
     return (
       <ClassicHeader article={article}>
         <ClassicTitle>
-          {props.children ? props.children[0] : article.title}
+          {props.children ? props.children : article.title}
         </ClassicTitle>
       </ClassicHeader>
     )


### PR DESCRIPTION
Updates to header to accommodate children in Writer
- Adds support for a third child to feature header (for image asset UI)
- Changes css `width: 100vw` to `100%` for accommodating Writer's sidebar
- Adds deck class to child as deck