### PR TITLE
@kanaabe => Header updates for Writer

### DIFF
--- a/src/components/publishing/__stories__/header.story.tsx
+++ b/src/components/publishing/__stories__/header.story.tsx
@@ -10,14 +10,14 @@ import { HeroSections } from "../fixtures/components"
 storiesOf("Publishing/Headers", module)
   .add("Classic Header", () => {
     return (
-      <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
+      <div style={{ width: "100%", height: "100vh", position: "relative" }}>
         <Header article={ClassicArticle} />
       </div>
     )
   })
   .add("Standard Header", () => {
     return (
-      <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
+      <div style={{ width: "100%", height: "100vh", position: "relative" }}>
         <Header article={StandardArticle} />
       </div>
     )
@@ -27,10 +27,10 @@ storiesOf("Publishing/Headers", module)
     const article2 = _.extend({}, FeatureArticle, { hero_section: HeroSections[5] })
     return (
       <div>
-        <div style={{ width: "100vw", position: "relative" }}>
+        <div style={{ width: "100%", position: "relative" }}>
           <Header article={article} />
         </div>
-        <div style={{ width: "100vw", position: "relative" }}>
+        <div style={{ width: "100%", position: "relative" }}>
           <Header article={article2} />
         </div>
       </div>
@@ -41,10 +41,10 @@ storiesOf("Publishing/Headers", module)
     const article2 = _.extend({}, FeatureArticle, { hero_section: HeroSections[3] })
     return (
       <div>
-        <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
+        <div style={{ width: "100%", height: "100vh", position: "relative" }}>
           <Header article={article} />
         </div>
-        <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
+        <div style={{ width: "100%", height: "100vh", position: "relative" }}>
           <Header article={article2} />
         </div>
       </div>
@@ -55,10 +55,10 @@ storiesOf("Publishing/Headers", module)
     const article2 = _.extend({}, FeatureArticle, { hero_section: HeroSections[4] })
     return (
       <div>
-        <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
+        <div style={{ width: "100%", height: "100vh", position: "relative" }}>
           <Header article={article} />
         </div>
-        <div style={{ width: "100vw", height: "100vh", position: "relative" }}>
+        <div style={{ width: "100%", height: "100vh", position: "relative" }}>
           <Header article={article2} />
         </div>
       </div>

--- a/src/components/publishing/__stories__/typography.story.tsx
+++ b/src/components/publishing/__stories__/typography.story.tsx
@@ -27,15 +27,15 @@ storiesOf("Publishing/Typography", module)
         </div>
         <div style={{ width: 50 }}>
           <IconLayoutSplit />
-          <p>Layout: Split</p>
+          <p>Layout Split</p>
         </div>
         <div style={{ width: 50 }}>
           <IconLayoutText />
-          <p>Layout: Text</p>
+          <p>Layout Text</p>
         </div>
         <div style={{ width: 50 }}>
           <IconLayoutFullscreen />
-          <p>Layout: Fullscreen</p>
+          <p>Layout Fullscreen</p>
         </div>
       </div>
     )

--- a/src/components/publishing/__stories__/typography.story.tsx
+++ b/src/components/publishing/__stories__/typography.story.tsx
@@ -3,6 +3,9 @@ import * as React from "react"
 
 import IconExpand from "../icon/expand"
 import IconImageSet from "../icon/image_set"
+import IconLayoutFullscreen from "../icon/layout_fullscreen"
+import IconLayoutSplit from "../icon/layout_split"
+import IconLayoutText from "../icon/layout_text"
 import IconRemove from "../icon/remove"
 import Typography from "./typography_examples"
 
@@ -21,6 +24,18 @@ storiesOf("Publishing/Typography", module)
         <div style={{ width: 50 }}>
           <IconExpand />
           <p>Expand</p>
+        </div>
+        <div style={{ width: 50 }}>
+          <IconLayoutSplit />
+          <p>Layout: Split</p>
+        </div>
+        <div style={{ width: 50 }}>
+          <IconLayoutText />
+          <p>Layout: Text</p>
+        </div>
+        <div style={{ width: 50 }}>
+          <IconLayoutFullscreen />
+          <p>Layout: Fullscreen</p>
         </div>
       </div>
     )

--- a/src/components/publishing/fixtures/articles.ts
+++ b/src/components/publishing/fixtures/articles.ts
@@ -40,7 +40,8 @@ export const ClassicArticle: ArticleData = {
   keywords: ["Joanne Artman Gallery"],
   updated_at: "2017-07-28T20:38:05.709Z",
   title: "New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple",
-  lead_paragraph: "<p></p>",
+  lead_paragraph:
+    "<p>Critics were skeptical of Bambi when it was first released in 1942—what was the point, they wondered, of a cartoon that ignored fantasy in favor of naturalistic forest landscapes?</p>",
   id: "597b9f652d35b80017a2a6a7",
   slug: "joanne-artman-gallery-poetry-naturerefinement-form",
   scheduled_publish_at: null,

--- a/src/components/publishing/header/__test__/__snapshots__/header.test.tsx.snap
+++ b/src/components/publishing/header/__test__/__snapshots__/header.test.tsx.snap
@@ -325,6 +325,20 @@ exports[`Classic Header renders classic header properly 1`] = `
   text-align: center;
 }
 
+.c0 p,
+.c0 > p {
+  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+  line-height: 1.35em;
+  -webkit-text-align: left;
+  text-align: left;
+  max-width: 580px;
+  margin: 0 auto;
+  padding-bottom: 30px;
+}
+
 .c1 {
   font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
   -webkit-font-smoothing: antialiased;
@@ -343,6 +357,15 @@ exports[`Classic Header renders classic header properly 1`] = `
   .c0 {
     -webkit-text-align: left;
     text-align: left;
+  }
+
+  .c0 p,
+  .c0 > p {
+    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 17px;
+    line-height: 1.1em;
+    line-height: 1.35em;
   }
 }
 
@@ -363,6 +386,13 @@ exports[`Classic Header renders classic header properly 1`] = `
   >
     New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple
   </div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p>Critics were skeptical of Bambi when it was first released in 1942—what was the point, they wondered, of a cartoon that ignored fantasy in favor of naturalistic forest landscapes?</p>",
+      }
+    }
+  />
   <div
     className="c2"
   >
@@ -662,7 +692,7 @@ exports[`feature renders feature full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-e04565-2 {
+.c0[data-type='split'] .file__FeatureVideo-q9b5i4-2 {
   width: 50vw;
 }
 
@@ -761,7 +791,7 @@ exports[`feature renders feature full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-e04565-2 {
+  .c0[data-type='split'] .file__FeatureVideo-q9b5i4-2 {
     width: 100%;
   }
 }
@@ -1000,7 +1030,7 @@ exports[`feature renders feature split header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-e04565-2 {
+.c0[data-type='split'] .file__FeatureVideo-q9b5i4-2 {
   width: 50vw;
 }
 
@@ -1099,7 +1129,7 @@ exports[`feature renders feature split header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-e04565-2 {
+  .c0[data-type='split'] .file__FeatureVideo-q9b5i4-2 {
     width: 100%;
   }
 }
@@ -1265,7 +1295,7 @@ exports[`feature renders feature text header properly 1`] = `
 }
 
 .c11 {
-  width: calc(100% - 40px);
+  width: 100%;
   padding: 20px;
 }
 
@@ -1331,7 +1361,7 @@ exports[`feature renders feature text header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-e04565-2 {
+.c0[data-type='split'] .file__FeatureVideo-q9b5i4-2 {
   width: 50vw;
 }
 
@@ -1430,7 +1460,7 @@ exports[`feature renders feature text header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-e04565-2 {
+  .c0[data-type='split'] .file__FeatureVideo-q9b5i4-2 {
     width: 100%;
   }
 }

--- a/src/components/publishing/header/classic_header.tsx
+++ b/src/components/publishing/header/classic_header.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import styled from "styled-components"
 import { pMedia } from "../../helpers"
+import Fonts from "../fonts"
 import AuthorDateClassic from "./author_date_classic"
 
 interface ClassicHeaderProps {
@@ -25,11 +26,23 @@ const ClassicHeaderContainer = styled.div`
   margin: 40px auto;
   box-sizing: border-box;
   text-align: center;
+  p, > p {
+    ${Fonts.garamond("s19")}
+    line-height: 1.35em;
+    text-align: left;
+    max-width: 580px;
+    margin: 0 auto;
+    padding-bottom: 30px;
+  }
   ${pMedia.lg`
     padding: 0 20px;
   `}
   ${pMedia.xs`
     text-align: left;
+    p, > p {
+      ${Fonts.garamond("s17")}
+      line-height: 1.35em;
+    }
   `}
 `
 

--- a/src/components/publishing/header/feature_header.tsx
+++ b/src/components/publishing/header/feature_header.tsx
@@ -39,7 +39,7 @@ function renderAsset(url, title, children) {
       </FeatureVideoContainer>
     )
   } else {
-    const src = resize(url, { width: 1200 })
+    const src = url.length && resize(url, { width: 1200 })
     const alt = url.length ? title : ""
     return (
       <FeatureImage src={src} alt={alt}>
@@ -60,11 +60,12 @@ function renderTextLayoutAsset(url, layout, title, children) {
       )
     } else {
       const alt = url.length ? title : ""
-      const src = resize(url, { width: 1200 })
+      const src = url.length && resize(url, { width: 1200 })
+      const image = <Image src={src} alt={alt} />
       return (
         <TextAsset>
           {children[2]}
-          <Image src={src} alt={alt} />
+          {url.length && image}
         </TextAsset>
       )
     }
@@ -88,12 +89,13 @@ const FeatureHeader: React.SFC<FeatureHeaderProps> = props => {
   const { article, size, children } = props
   const hero = article.hero_section
   const isMobile = size.width && size.width < 600 ? true : false
+  const vertical = article.vertical.name ? article.vertical.name : false
   return (
     <FeatureHeaderContainer data-type={hero.type}>
       {renderFeatureAsset(hero.url, hero.type, isMobile, article.title, children)}
       <HeaderTextContainer>
         <HeaderText>
-          <Vertical>{article.vertical.name}</Vertical>
+          <Vertical>{vertical}</Vertical>
           {children[0]}
           {renderMobileSplitAsset(hero.url, hero.type, isMobile, article.title, children)}
           <SubHeader>
@@ -173,7 +175,7 @@ const Video = styled.video`
   width: 100%;
 `
 const TextAsset = styled.div`
-  width: calc(100% - 40px);
+  width: 100%;
   padding: 20px;
 `
 const SubHeader = styled.div`

--- a/src/components/publishing/header/header.tsx
+++ b/src/components/publishing/header/header.tsx
@@ -20,7 +20,7 @@ const Header: React.SFC<HeaderProps> = props => {
         <FeatureTitle className="feature__title">
           {props.children ? props.children[0] : article.title}
         </FeatureTitle>
-        {props.children && props.children[1] ? <div className="feature__deck">props.children[1]</div> : deck}
+        {props.children && props.children[1] ? <div className="feature__deck">{props.children[1]}</div> : deck}
         {props.children && props.children[2]}
       </FeatureHeader>
     )
@@ -33,11 +33,15 @@ const Header: React.SFC<HeaderProps> = props => {
       </StandardHeader>
     )
   } else if (article.layout === "classic") {
+    const leadParagraph = article.lead_paragraph
+      ? <div dangerouslySetInnerHTML={{ __html: article.lead_paragraph }} />
+      : false
     return (
       <ClassicHeader article={article}>
         <ClassicTitle>
-          {props.children ? props.children : article.title}
+          {props.children ? props.children[0] : article.title}
         </ClassicTitle>
+        {props.children ? props.children[1] : leadParagraph}
       </ClassicHeader>
     )
   }

--- a/src/components/publishing/header/standard_header.tsx
+++ b/src/components/publishing/header/standard_header.tsx
@@ -10,9 +10,10 @@ interface StandardHeaderProps {
 
 const StandardHeader: React.SFC<StandardHeaderProps> = props => {
   const { article } = props
+  const vertical = article.vertical.name ? article.vertical.name : false
   return (
     <StandardHeaderContainer>
-      <Vertical>{article.vertical.name}</Vertical>
+      <Vertical>{vertical}</Vertical>
       {props.children}
       <AuthorDate authors={article.contributing_authors} date={article.published_at} layout="standard" />
     </StandardHeaderContainer>

--- a/src/components/publishing/icon/layout_fullscreen.tsx
+++ b/src/components/publishing/icon/layout_fullscreen.tsx
@@ -1,0 +1,16 @@
+import React, { Component } from "react"
+
+class IconLayoutFullscreen extends Component<any, null> {
+  render() {
+    return (
+      <svg id="layout-fullscreen" width="45px" height="30px" viewBox="0 0 45 30" xmlns="http://www.w3.org/2000/svg">
+        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <g id="group" fill={this.props.fill ? this.props.fill : "#000"}>
+            <path d="M0,0 L45,0 L45,30 L0,30 L0,0 Z M3,22 L37,22 L37,20 L3,20 L3,22 Z M3,27 L29,27 L29,25 L3,25 L3,27 Z" />
+          </g>
+        </g>
+      </svg>
+    )
+  }
+}
+export default IconLayoutFullscreen

--- a/src/components/publishing/icon/layout_split.tsx
+++ b/src/components/publishing/icon/layout_split.tsx
@@ -1,0 +1,21 @@
+import React, { Component } from "react"
+
+class IconLayoutSplit extends Component<any, null> {
+  render() {
+    return (
+      <svg id="layout-split" width="45px" height="30px" viewBox="0 0 45 30" xmlns="http://www.w3.org/2000/svg">
+        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <g id="group" fill={this.props.fill ? this.props.fill : "#000"}>
+            <g>
+              <polyline points="0 2 20 2 20 0 0 0" />
+              <polyline points="0 7 20 7 20 5 0 5" />
+              <polyline points="0 12 16 12 16 10 0 10" />
+              <rect x="25" y="0" width="20" height="30" />
+            </g>
+          </g>
+        </g>
+      </svg>
+    )
+  }
+}
+export default IconLayoutSplit

--- a/src/components/publishing/icon/layout_text.tsx
+++ b/src/components/publishing/icon/layout_text.tsx
@@ -1,0 +1,18 @@
+import React, { Component } from "react"
+
+class IconLayoutText extends Component<any, null> {
+  render() {
+    return (
+      <svg id="layout-text" width="45px" height="30px" viewBox="0 0 45 30" xmlns="http://www.w3.org/2000/svg">
+        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <g id="group" fill={this.props.fill ? this.props.fill : "#000"}>
+            <polyline points="0 2 34 2 34 0 0 0" />
+            <polyline points="0 7 26 7 26 5 0 5" />
+            <rect x="0" y="10" width="45" height="20" />
+          </g>
+        </g>
+      </svg>
+    )
+  }
+}
+export default IconLayoutText

--- a/src/components/publishing/index.tsx
+++ b/src/components/publishing/index.tsx
@@ -1,5 +1,4 @@
 import Article from "./article"
-import FeatureHeader from "./header/feature_header"
 import Header from "./header/header"
 import Artwork from "./sections/artwork"
 import Authors from "./sections/authors"
@@ -15,6 +14,9 @@ import Video from "./sections/video"
 
 // Icon SVGs
 import ImageSet from "./icon/image_set"
+import LayoutFullscreen from "./icon/layout_fullscreen"
+import LayoutSplit from "./icon/layout_split"
+import LayoutText from "./icon/layout_text"
 import Remove from "./icon/remove"
 
 export default {
@@ -23,7 +25,6 @@ export default {
   Authors,
   Embed,
   Caption,
-  FeatureHeader,
   FullscreenViewer,
   Header,
   Image,
@@ -34,6 +35,9 @@ export default {
   Video,
   Icon: {
     ImageSet,
+    LayoutFullscreen,
+    LayoutSplit,
+    LayoutText,
     Remove,
   },
 }


### PR DESCRIPTION
A few more changes to the headers for use in writer:
- Adds lead paragraph to classic header and fixtures
- Adds icons for feature header layouts
- Doesn't resize images if url is empty
- Doesn't render image if url is empty
- Vertical name is not required