### PR TITLE
Add ability to set a custom color for the Title tag

### DIFF
--- a/src/apps/loyalty/containers/3w_thank_you/__tests__/__snapshots__/index.ts.snap
+++ b/src/apps/loyalty/containers/3w_thank_you/__tests__/__snapshots__/index.ts.snap
@@ -29,7 +29,8 @@ exports[`3-way Handshake Thank You renders the snapshot 1`] = `
     className="file__TitleSection-apq9gn-1 fdjVYi"
   >
     <div
-      className="file__StyledTitle-s3pz4jh-0 izQygJ"
+      className="file__StyledTitle-s11cvek3-0 icFPpY"
+      color="inherit"
     >
       Thank you, 
       Percy

--- a/src/apps/loyalty/containers/acb_thank_you/__tests__/__snapshots__/index.ts.snap
+++ b/src/apps/loyalty/containers/acb_thank_you/__tests__/__snapshots__/index.ts.snap
@@ -35,7 +35,8 @@ exports[`ACB Thank You renders the snapshot 1`] = `
     </p>
   </div>
   <div
-    className="file__StyledTitle-s3pz4jh-0 izQygJ"
+    className="file__StyledTitle-s11cvek3-0 icFPpY"
+    color="inherit"
   >
     Artsy Collector Loyalty Program
   </div>

--- a/src/apps/loyalty/containers/inquiries/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/inquiries/__tests__/__snapshots__/index.tsx.snap
@@ -29,7 +29,8 @@ exports[`inquiries renders the inquiries listing 1`] = `
     className="file__Header-cpd21h-2 gEkXMR"
   >
     <div
-      className="header-title file__StyledTitle-s3pz4jh-0 jziesf"
+      className="header-title file__StyledTitle-s11cvek3-0 icqqDF"
+      color="inherit"
     >
       Please select all works you purchased
     </div>

--- a/src/apps/loyalty/containers/repeat_visitor/__tests__/__snapshots__/index.ts.snap
+++ b/src/apps/loyalty/containers/repeat_visitor/__tests__/__snapshots__/index.ts.snap
@@ -26,7 +26,8 @@ exports[`RepeatVisitor renders the snapshot 1`] = `
     </a>
   </div>
   <div
-    className="file__StyledTitle-s3pz4jh-0 izQygJ"
+    className="file__StyledTitle-s11cvek3-0 icFPpY"
+    color="inherit"
   >
     Your purchases are being reviewed
   </div>

--- a/src/components/__stories__/typography.story.tsx
+++ b/src/components/__stories__/typography.story.tsx
@@ -61,6 +61,10 @@ storiesOf("Typography", module)
         Text Color
       </Title>
 
+      <Title color={colors.graySemibold}>
+        Contact Us
+      </Title>
+
       <Text align="center" color={colors.graySemibold}>
         Have questions? Get in touch:&nbsp;
         <TextLink href="#">youremail@example.com</TextLink>

--- a/src/components/title.tsx
+++ b/src/components/title.tsx
@@ -7,6 +7,7 @@ type TitleSize = "small" | "medium" | "large" | "xlarge" | "xxlarge"
 
 interface TitleProps extends React.HTMLProps<HTMLDivElement> {
   titleSize?: TitleSize
+  color?: string
 }
 
 const titleSizes = {
@@ -30,6 +31,7 @@ const Title: React.SFC<TitleProps> = props => {
 
 const StyledTitle = styled(Title)`
   font-size: ${props => titleSizes[props.titleSize]};
+  color: ${props => props.color};
   margin: 20px 0;
   ${fonts.secondary.style}
 
@@ -40,6 +42,7 @@ const StyledTitle = styled(Title)`
 
 StyledTitle.defaultProps = {
   titleSize: "medium",
+  color: "inherit",
 }
 
 export default StyledTitle


### PR DESCRIPTION
In order to implement https://github.com/artsy/collector-experience/issues/505 we need to be able to change the color of a title.

<img width="584" alt="screen shot 2017-10-04 at 15 18 35" src="https://user-images.githubusercontent.com/386234/31162263-66f158aa-a917-11e7-8cdc-1666b0b8309a.png">
