### PR TITLE
Add ability to set leftView to input

### DIFF
--- a/src/apps/loyalty/containers/forgot_password/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/forgot_password/__tests__/__snapshots__/index.tsx.snap
@@ -24,7 +24,7 @@ exports[`<ForgotPassword /> renders the snapshot 1`] = `
   </div>
   <input
     autoFocus={true}
-    className="file__StyledInput-s1up4l80-1 koOAAW file__StyledInput-s2fklig-0 ffQmtI"
+    className="file__StyledInput-s1up4l80-1 koOAAW file__StyledInput-s14cczvx-0 kELuxT"
     name="email"
     onChange={[Function]}
     placeholder="Email"

--- a/src/apps/loyalty/containers/login/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/login/__tests__/__snapshots__/index.tsx.snap
@@ -24,20 +24,20 @@ exports[`login renders the snapshot 1`] = `
   >
     <input
       autoFocus={true}
-      className="file__StyledInput-s1d01h8e-1 qmhxa file__StyledInput-s2fklig-0 ffQmtI"
+      className="file__StyledInput-s1d01h8e-1 qmhxa file__StyledInput-s14cczvx-0 kELuxT"
       name="email"
       onChange={[Function]}
       placeholder="Email"
       value=""
     />
     <div
-      className="file__StyledDiv-s2fklig-2 gnqeba"
+      className="file__StyledDiv-s14cczvx-2 eKNcia"
     >
       <div
         className="border-container"
       />
       <input
-        className="file__BorderlessInput-s2fklig-1 fbjzqZ"
+        className="file__BorderlessInput-s14cczvx-1 bxtRHC"
         name="password"
         onBlur={[Function]}
         onChange={[Function]}

--- a/src/components/__stories__/input.story.tsx
+++ b/src/components/__stories__/input.story.tsx
@@ -1,16 +1,26 @@
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
 
+import colors from "../../assets/colors"
 import Button from "../buttons/inverted"
+import Icon from "../icon"
 import Input from "../input"
 import TextArea from "../text_area"
 
 storiesOf("Components/Input", module)
   .add("Inputs", () =>
-    <div>
+    <div style={{ padding: 10 }}>
       <Input placeholder="First Name" />
       <Input placeholder="First Name" error />
       <Input placeholder="First Name" disabled />
+
+      <div style={{ paddingTop: 10 }}>
+        <Input placeholder="Search" leftView={<Icon name="search" color={colors.graySemibold} />} />
+      </div>
+
+      <div style={{ paddingTop: 10 }}>
+        <Input placeholder="Email" rightView={<Icon name="check" color={colors.greenRegular} />} />
+      </div>
     </div>
   )
   .add("Text Areas", () =>

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -7,6 +7,7 @@ import { border, borderedInput } from "./mixins"
 export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   error?: boolean
   block?: boolean
+  leftView?: JSX.Element
   rightView?: JSX.Element
 }
 
@@ -88,6 +89,17 @@ class Input extends React.Component<InputProps, InputState> {
           {this.props.rightView}
         </StyledDiv>
       )
+    } else if (this.props.leftView) {
+        const newProps: any = { ...this.props }
+        delete newProps.className
+
+        return (
+          <StyledDiv>
+            <div className={this.state.borderClasses}/>
+            {this.props.leftView}
+            <BorderlessInput {...newProps} onFocus={this.onFocus.bind(this)} onBlur={this.onBlur.bind(this)}/>
+          </StyledDiv>
+        )
     }
 
     return <StyledInput {...this.props} />


### PR DESCRIPTION
Similar to the `rightView` option for `Input`, but this adds the ability to assign a view to the left of the input. I need this in order to implement: https://app.zeplin.io/project/59b2e6a22224266545e2aea2/screen/59b2e7a8968341983ee82a9b

<img width="625" alt="screen shot 2017-10-04 at 16 13 36" src="https://user-images.githubusercontent.com/386234/31163783-09cc3b1a-a91f-11e7-85ef-6ca843a575a8.png">


I also added two examples of an `Input` with `leftView`/`rightView` options.