### PR TITLE
[WIP] Onboarding follow artists

### DIFF
--- a/src/components/__stories__/collector_intent_page.story.tsx
+++ b/src/components/__stories__/collector_intent_page.story.tsx
@@ -1,0 +1,87 @@
+import { storiesOf } from "@storybook/react"
+import * as React from "react"
+import styled from "styled-components"
+
+import * as fonts from "../../assets/fonts"
+import Button from "../buttons/ghost"
+import Icon from "../icon"
+import Title from "../title"
+
+const IconContainer = styled.div`
+width: 15px;
+height: 15px;
+background-color: black;
+display: none;
+border-radius: 50%;
+float: right;
+margin-right: 15px;
+`
+
+const Link = styled.a`
+  display: block;
+  font-size: 14px;
+  color: black;
+  text-decoration: none;
+  text-transform: uppercase;
+  font-family: ${fonts.primary.fontFamily};
+  padding: 30px 0 30px 15px;
+  border-top: 1px solid #e5e5e5;
+  &:hover {
+    background-color: #f8f8f8;
+  }
+  &:hover .collector-intent-checked {
+    display: inline;
+  }
+`
+
+storiesOf("Onboarding", module).add("Collector Intent", () => {
+  return (
+    <div>
+      <div style={{ textAlign: "center", marginBottom: "100px" }}>
+        <Title titleSize="xlarge">Get started on Artsy, what are you most interested in doing?</Title>
+        <Title titleSize="xlarge" style={{ color: "#999999" }}>Select all that apply</Title>
+      </div>
+      <div style={{ width: "450px", margin: "0 auto 100px" }}>
+        <Link href="#">
+          Buy Art & Design
+          <IconContainer className="collector-intent-checked">
+            <Icon name="check" color="white" fontSize="8px" />
+          </IconContainer>
+        </Link>
+        <Link href="#">
+          Sell Art & Design
+          <IconContainer className="collector-intent-checked">
+            <Icon name="check" color="white" fontSize="8px" />
+          </IconContainer>
+        </Link>
+        <Link href="#">
+          Research Art Prices
+          <IconContainer className="collector-intent-checked">
+            <Icon name="check" color="white" fontSize="8px" />
+          </IconContainer>
+        </Link>
+        <Link href="#">
+          Learn About Art
+          <IconContainer className="collector-intent-checked">
+            <Icon name="check" color="white" fontSize="8px" />
+          </IconContainer>
+        </Link>
+        <Link href="#">
+          Find Out About New Exhibitions
+          <IconContainer className="collector-intent-checked">
+            <Icon name="check" color="white" fontSize="8px" />
+          </IconContainer>
+        </Link>
+        <Link href="#" style={{ borderBottom: "1px solid #e5e5e5", marginBottom: "100px" }}>
+          Read Art Market News
+          <IconContainer className="collector-intent-checked">
+            <Icon name="check" color="white" fontSize="8px" />
+          </IconContainer>
+        </Link>
+      </div>
+      <div style={{ textAlign: "center" }}>
+        <Button>Next</Button>
+      </div>
+    </div>
+  )
+})

--- a/src/components/__stories__/collector_intent_page.story.tsx
+++ b/src/components/__stories__/collector_intent_page.story.tsx
@@ -1,11 +1,11 @@
-import { storiesOf } from "@storybook/react"
-import * as React from "react"
-import styled from "styled-components"
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import styled from 'styled-components';
 
-import * as fonts from "../../assets/fonts"
-import Button from "../buttons/ghost"
-import Icon from "../icon"
-import Title from "../title"
+import * as fonts from '../../assets/fonts';
+import Button from '../buttons/ghost';
+import Icon from '../icon';
+import Title from '../title';
 
 const IconContainer = styled.div`
 width: 15px;
@@ -34,7 +34,7 @@ const Link = styled.a`
   }
 `
 
-storiesOf("Onboarding", module).add("Collector Intent", () => {
+storiesOf("Onboarding").add("Collector Intent", () => {
   return (
     <div>
       <div style={{ textAlign: "center", marginBottom: "100px" }}>

--- a/src/components/artwork_filter/dropdown.tsx
+++ b/src/components/artwork_filter/dropdown.tsx
@@ -102,7 +102,12 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         <Button style={{ backgroundColor: buttonColor, color: buttonTextColor }}>
           {superLabelText && <SuperLabel style={{ color: superLabelColor }}>{superLabelText}</SuperLabel>}
           {labelText}
-          <Icon name="arrow-down" fontSize="9px" color={buttonTextColor} style={{ position: "absolute", right: 15, lineHeight: "inherit" }} />
+          <Icon
+            name="arrow-down"
+            fontSize="9px"
+            color={buttonTextColor}
+            style={{ position: "absolute", right: 15, lineHeight: "inherit" }}
+          />
         </Button>
         <Nav style={navStyle}>
           {navItems}

--- a/src/components/onboarding/__stories__/selectable_link.story.tsx
+++ b/src/components/onboarding/__stories__/selectable_link.story.tsx
@@ -1,11 +1,12 @@
-import { storiesOf } from "@storybook/react"
-import * as React from "react"
-import SelectableLink from "../selectable_link"
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+
+import SelectableLink from '../selectable_link';
 
 storiesOf("Onboarding", module).add("SelectableLink", () => {
   return (
     <div style={{ width: "400px" }}>
-      <SelectableLink href="#" text="Buy Art & Design" />
+      <SelectableLink href="#" text="Buy Art & Design" onSelect={(select) => console.log(select)} />
     </div>
   )
 })

--- a/src/components/onboarding/__stories__/selectable_link.story.tsx
+++ b/src/components/onboarding/__stories__/selectable_link.story.tsx
@@ -6,7 +6,7 @@ import SelectableLink from '../selectable_link';
 storiesOf("Onboarding", module).add("SelectableLink", () => {
   return (
     <div style={{ width: "400px" }}>
-      <SelectableLink href="#" text="Buy Art & Design" onSelect={(select) => console.log(select)} />
+      <SelectableLink text="Buy Art & Design" onSelect={this.onSelect} />
     </div>
   )
 })

--- a/src/components/onboarding/__stories__/selectable_link.story.tsx
+++ b/src/components/onboarding/__stories__/selectable_link.story.tsx
@@ -1,0 +1,11 @@
+import { storiesOf } from "@storybook/react"
+import * as React from "react"
+import SelectableLink from "../selectable_link"
+
+storiesOf("Onboarding", module).add("SelectableLink", () => {
+  return (
+    <div style={{ width: "400px" }}>
+      <SelectableLink href="#" text="Buy Art & Design" />
+    </div>
+  )
+})

--- a/src/components/onboarding/__stories__/wizard.story.tsx
+++ b/src/components/onboarding/__stories__/wizard.story.tsx
@@ -1,14 +1,22 @@
-import { storiesOf } from "@storybook/react"
-import * as React from "react"
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
 
-import Artists from "../steps/artists"
-import CollectorIntent from "../steps/collector_intent"
-import Wizard from "../wizard"
+import { ContextProvider } from '../../artsy';
+import Artists from '../steps/artists';
+import CollectorIntent from '../steps/collector_intent';
+import Wizard from '../wizard';
 
-storiesOf("Onboarding", module).add("Wizard", () => {
+storiesOf("Onboarding").add("Wizard", () => {
+  const currentUser = {
+    accessToken: "blah",
+    id: "my_id",
+    name: "Joe",
+  }
   return (
     <div>
-      <Wizard stepComponents={[CollectorIntent, Artists]} />
+      <ContextProvider currentUser={currentUser}>
+        <Wizard stepComponents={[CollectorIntent, Artists]} />
+      </ContextProvider>
     </div>
   )
 })

--- a/src/components/onboarding/__stories__/wizard.story.tsx
+++ b/src/components/onboarding/__stories__/wizard.story.tsx
@@ -1,0 +1,14 @@
+import { storiesOf } from "@storybook/react"
+import * as React from "react"
+
+import Artists from "../steps/artists"
+import CollectorIntent from "../steps/collector_intent"
+import Wizard from "../wizard"
+
+storiesOf("Onboarding", module).add("Wizard", () => {
+  return (
+    <div>
+      <Wizard stepComponents={[CollectorIntent, Artists]} />
+    </div>
+  )
+})

--- a/src/components/onboarding/index.tsx
+++ b/src/components/onboarding/index.tsx
@@ -1,0 +1,10 @@
+import * as React from "react"
+
+import Wizard from "./wizard"
+
+import Artists from "./steps/artists"
+import CollectorIntent from "./steps/collector_intent"
+
+export default () => {
+  return <Wizard stepComponents={[CollectorIntent, Artists]} />
+}

--- a/src/components/onboarding/popular_artist_list.tsx
+++ b/src/components/onboarding/popular_artist_list.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import * as Relay from 'react-relay';
+
+import { artsyNetworkLayer } from '../../relay/config';
+import PopularArtistQueryConfig from '../../relay/queries/popular_artist';
+import SelectableLink from './selectable_link';
+
+class PopularArtist extends React.Component<RelayProps, null> {
+  followArtist() {
+    console.log("hi")
+  }
+
+  render() {
+    const artists = this.props.artists.edges
+    const popularArtists = artists.map(artist => {
+      ;<SelectableLink onSelect={this.followArtist.bind(this)} text={artist.node.name} />
+    })
+    return (
+      <div>
+        {popularArtists}
+      </div>
+    )
+  }
+}
+
+const PopularArtistsContainer = Relay.createContainer(PopularArtist, {
+  fragments: {
+    artists: () => Relay.QL`
+      popular_artists() {
+        name
+      }
+    `,
+  },
+})
+
+function PopularArtistExample(props: { artistID: string }) {
+  Relay.injectNetworkLayer(artsyNetworkLayer())
+  return <Relay.RootContainer Component={PopularArtistsContainer} route={new PopularArtistQueryConfig()} />
+}
+
+interface RelayProps {
+  artists: {
+    edges: Array<{
+      node: any
+    } | null> | null
+  }
+}
+
+export default PopularArtistExample

--- a/src/components/onboarding/selectable_link.tsx
+++ b/src/components/onboarding/selectable_link.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import styled from "styled-components"
+import * as React from 'react';
+import styled from 'styled-components';
 
-import * as fonts from "../../assets/fonts"
-import Icon from "../icon"
+import * as fonts from '../../assets/fonts';
+import Icon from '../icon';
 
 interface SelectableLinkProps {
   href?: string
@@ -53,7 +53,7 @@ class SelectableLink extends React.Component<SelectableLinkProps, LinkState> {
     this.onSelect = this.onSelect.bind(this)
   }
 
-  onSelect(): any {
+  onSelect() {
     const state = !this.state.selected
     this.setState({ selected: state })
     if (this.props.onSelect) {
@@ -61,8 +61,7 @@ class SelectableLink extends React.Component<SelectableLinkProps, LinkState> {
     }
   }
 
-  render(): JSX.Element {
-    console.log(this.state.selected)
+  render() {
     return (
       <div>
         <Link href={this.props.href} onClick={() => this.onSelect()}>

--- a/src/components/onboarding/selectable_link.tsx
+++ b/src/components/onboarding/selectable_link.tsx
@@ -1,0 +1,80 @@
+import * as React from "react"
+import styled from "styled-components"
+
+import * as fonts from "../../assets/fonts"
+import Icon from "../icon"
+
+interface SelectableLinkProps {
+  href?: string
+  text?: string
+  onSelect: (selected: boolean) => void
+}
+
+interface LinkState {
+  selected: boolean
+}
+
+const IconContainer = styled.div`
+width: 15px;
+height: 15px;
+background-color: black;
+display: none;
+border-radius: 50%;
+float: right;
+margin-right: 15px;
+`
+
+const Link = styled.a`
+display: block;
+font-size: 14px;
+color: black;
+text-decoration: none;
+text-transform: uppercase;
+font-family: ${fonts.primary.fontFamily};
+padding: 30px 0 30px 15px;
+border-top: 1px solid #e5e5e5;
+&:hover {
+  background-color: #f8f8f8;
+}
+&:hover .collector-intent-checked {
+  display: inline;
+}
+& .collector-intent-checked.is-selected {
+  display: inline;
+}
+`
+
+class SelectableLink extends React.Component<SelectableLinkProps, LinkState> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      selected: false,
+    }
+    this.onSelect = this.onSelect.bind(this)
+  }
+
+  onSelect(): any {
+    const state = !this.state.selected
+    this.setState({ selected: state })
+    if (this.props.onSelect) {
+      this.props.onSelect(state)
+    }
+  }
+
+  render(): JSX.Element {
+    console.log(this.state.selected)
+    return (
+      <div>
+        <Link href={this.props.href} onClick={() => this.onSelect()}>
+          {this.props.text}
+
+          <IconContainer className={`collector-intent-checked ${this.state.selected ? "is-selected" : ""}`}>
+            <Icon name="check" color="white" fontSize="8px" />
+          </IconContainer>
+        </Link>
+      </div>
+    )
+  }
+}
+
+export default SelectableLink

--- a/src/components/onboarding/steps/artists.tsx
+++ b/src/components/onboarding/steps/artists.tsx
@@ -1,8 +1,9 @@
-import * as React from "react"
-import Input from "../../input"
-import Step, { StepProps } from "./step"
+import * as React from 'react';
 
-export default class Artists extends React.Component<StepProps, any> {
+import Input from '../../input';
+import Step, { StepProps } from './step';
+
+export default class Artists extends React.Component<StepProps, null> {
   onInputChange = e => {
     this.props.onStateChange({ nextButtonEnabled: true })
   }

--- a/src/components/onboarding/steps/artists.tsx
+++ b/src/components/onboarding/steps/artists.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import Input from "../../input"
+import Step, { StepProps } from "./step"
+
+export default class Artists extends React.Component<StepProps, any> {
+  onInputChange = e => {
+    this.props.onStateChange({ nextButtonEnabled: true })
+  }
+
+  render() {
+    return (
+      <Step
+        title="Follow a few artists that interest you most"
+        subtitle="Follow one or more"
+        onStateChange={this.props.onStateChange}
+      >
+        <div>
+          <Input onChange={this.onInputChange} />
+        </div>
+      </Step>
+    )
+  }
+}

--- a/src/components/onboarding/steps/artists.tsx
+++ b/src/components/onboarding/steps/artists.tsx
@@ -1,24 +1,25 @@
 import * as React from 'react';
 
 import Input from '../../input';
-import Step, { StepProps } from './step';
+import { StepProps } from '../types';
+import { Layout } from './layout';
 
 export default class Artists extends React.Component<StepProps, null> {
   onInputChange = e => {
-    this.props.onStateChange({ nextButtonEnabled: true })
+    // this.props.onStateChange({ nextButtonEnabled: true })
   }
 
   render() {
     return (
-      <Step
+      <Layout
         title="Follow a few artists that interest you most"
         subtitle="Follow one or more"
-        onStateChange={this.props.onStateChange}
+        onNextButtonPressed={null}
       >
         <div>
           <Input onChange={this.onInputChange} />
         </div>
-      </Step>
+      </Layout>
     )
   }
 }

--- a/src/components/onboarding/steps/collector_intent.tsx
+++ b/src/components/onboarding/steps/collector_intent.tsx
@@ -1,0 +1,72 @@
+import * as React from "react"
+import styled from "styled-components"
+
+import Title from "../../title"
+import SelectableLink from "../selectable_link"
+import Step, { StepProps } from "./step"
+
+const OptionsContainer = styled.div`
+  width: 450px;
+  margin: 0 auto 100px;
+`
+
+interface State {
+  selectedOptions: { [option: string]: boolean }
+  selectedCount: number
+}
+
+class CollectorIntent extends React.Component<StepProps, State> {
+  options = [
+    "Buy Art & Design",
+    "Sell Art & Design",
+    "Research Art Prices",
+    "Learn About Art",
+    "Find Out About New Exhibitions",
+    "Read Art Market News",
+  ]
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      selectedOptions: {},
+      selectedCount: 0,
+    }
+  }
+
+  onOptionSelected = (index, selected) => {
+    const option = this.options[index]
+
+    let selectedOptions = this.state.selectedOptions
+    selectedOptions[option] = selected
+
+    let count = 0
+    for (let key in selectedOptions) {
+      if (selectedOptions[key]) count++
+    }
+
+    this.setState({ selectedOptions, selectedCount: count })
+    this.props.onStateChange({ nextButtonEnabled: count > 0 })
+  }
+
+  submit() {}
+
+  render(): JSX.Element {
+    const options = this.options.map((text, index) =>
+      <SelectableLink key={index} href="#" text={text} onSelect={this.onOptionSelected.bind(this, index)} />
+    )
+    return (
+      <Step
+        title="Get started on Artsy, what are you most interested in doing?"
+        subtitle="Select all that apply"
+        onStateChange={this.props.onStateChange}
+      >
+        <OptionsContainer>
+          {options}
+        </OptionsContainer>
+      </Step>
+    )
+  }
+}
+
+export default CollectorIntent

--- a/src/components/onboarding/steps/collector_intent.tsx
+++ b/src/components/onboarding/steps/collector_intent.tsx
@@ -1,21 +1,28 @@
-import * as React from "react"
-import styled from "styled-components"
+import * as React from 'react';
+import styled from 'styled-components';
 
-import Title from "../../title"
-import SelectableLink from "../selectable_link"
-import Step, { StepProps } from "./step"
+import { ContextConsumer, ContextProps } from '../../artsy';
+import SelectableLink from '../selectable_link';
+import { StepProps } from '../types';
+import { Layout } from './layout';
 
 const OptionsContainer = styled.div`
   width: 450px;
   margin: 0 auto 100px;
+  &:last-child {
+    border-bottom: 1px solid #e5e5e5;
+  }
 `
+
+type Props = StepProps & ContextProps
 
 interface State {
   selectedOptions: { [option: string]: boolean }
   selectedCount: number
+  error?: string
 }
 
-class CollectorIntent extends React.Component<StepProps, State> {
+class CollectorIntent extends React.Component<Props, State> {
   options = [
     "Buy Art & Design",
     "Sell Art & Design",
@@ -46,27 +53,73 @@ class CollectorIntent extends React.Component<StepProps, State> {
     }
 
     this.setState({ selectedOptions, selectedCount: count })
-    this.props.onStateChange({ nextButtonEnabled: count > 0 })
   }
 
-  submit() {}
+  submit() {
+    const keys = Object.keys(this.state.selectedOptions)
+    const intents = keys.filter(key => {
+      return this.state.selectedOptions[key]
+    })
 
-  render(): JSX.Element {
+    console.log("intents:", intents)
+
+    // const options: RequestInit = {
+    //   method: "PUT",
+    //   credentials: "same-origin",
+    //   headers: {
+    //     "Content-Type": "application/json",
+    //     Accept: "application/json",
+    //     "X-Requested-With": "XMLHttpRequest",
+    //     "X-Access-Token": this.props.currentUser.accessToken,
+    //   },
+    //   body: JSON.stringify({
+    //     intents: JSON.stringify(intents),
+    //   }),
+    // }
+
+    // This should eventually be the collector id that is available on the props.
+    // I'm thinking the endpoint should also move into some sort of sd object.
+    // fetch(`https://api.artsy.net/api/v1/collector_profile/${this.props.currentUser.id}`, options)
+    //   .then(res => {
+    //     if (res.status >= 500) {
+    //       throw new Error(`Failed with status ${res.status}`)
+    //     } else if (res.status === 200) {
+    //       window.analytics.track("Completed collector intent question")
+    //       this.props.onNextButtonPressed()
+    //     } else {
+    //       // I'm also thinking the we should also handle the error differently, but
+    //       // I'm not super clear what the error behavior should be yet.
+    //       this.setState({
+    //         error: "Invalid email or password",
+    //       })
+    //     }
+    //   })
+    //   .catch(err => {
+    //     if (process.env.NODE_ENV !== "test") {
+    //       console.error(err)
+    //     }
+    //     this.setState({
+    //       error: "Internal Error. Please contact support@artsy.net",
+    //     })
+    //   })
+  }
+
+  render() {
     const options = this.options.map((text, index) =>
-      <SelectableLink key={index} href="#" text={text} onSelect={this.onOptionSelected.bind(this, index)} />
+      <SelectableLink key={index} text={text} onSelect={this.onOptionSelected.bind(this, index)} />
     )
     return (
-      <Step
+      <Layout
         title="Get started on Artsy, what are you most interested in doing?"
         subtitle="Select all that apply"
-        onStateChange={this.props.onStateChange}
+        onNextButtonPressed={this.state.selectedCount > 0 && this.submit.bind(this)}
       >
         <OptionsContainer>
           {options}
         </OptionsContainer>
-      </Step>
+      </Layout>
     )
   }
 }
 
-export default CollectorIntent
+export default ContextConsumer(CollectorIntent)

--- a/src/components/onboarding/steps/collector_intent.tsx
+++ b/src/components/onboarding/steps/collector_intent.tsx
@@ -56,13 +56,11 @@ class CollectorIntent extends React.Component<Props, State> {
   }
 
   submit() {
-    const keys = Object.keys(this.state.selectedOptions)
-    const intents = keys.filter(key => {
-      return this.state.selectedOptions[key]
-    })
-
-    console.log("intents:", intents)
-
+    // const keys = Object.keys(this.state.selectedOptions)
+    // const intents = keys.filter(key => {
+    //   return this.state.selectedOptions[key]
+    // })
+    // console.log("intents:", intents)
     // const options: RequestInit = {
     //   method: "PUT",
     //   credentials: "same-origin",
@@ -76,7 +74,6 @@ class CollectorIntent extends React.Component<Props, State> {
     //     intents: JSON.stringify(intents),
     //   }),
     // }
-
     // This should eventually be the collector id that is available on the props.
     // I'm thinking the endpoint should also move into some sort of sd object.
     // fetch(`https://api.artsy.net/api/v1/collector_profile/${this.props.currentUser.id}`, options)

--- a/src/components/onboarding/steps/layout.tsx
+++ b/src/components/onboarding/steps/layout.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
+import Button from '../../buttons/ghost';
 import Title from '../../title';
 
-export interface StepProps {
-  onStateChange: ({ nextButtonEnabled }) => void
+interface Props {
   title: string
   subtitle: string
+  onNextButtonPressed?: () => void
 }
 
 const Container = styled.div`
@@ -15,22 +16,32 @@ const Container = styled.div`
   margin-right: auto;
 `
 
-const MainTitle = styled(Title) `
+const MainTitle = styled(Title)`
   text-align: center;
 `
-const Subtitle = styled(Title) `
+const Subtitle = styled(Title)`
   color: #999;
   margin-bottom: 100px;
   text-align: center;
 `
 
-export default class Step extends React.Component<StepProps, any> {
+const ButtonContainer = styled(Button)`
+  margin: 0 auto 50px;
+  display: block;
+  width: 250px;
+`
+
+export class Layout extends React.Component<Props, null> {
   render() {
+    const disabled = !this.props.onNextButtonPressed
     return (
       <Container>
         <MainTitle titleSize="xlarge">{this.props.title} </MainTitle>
         <Subtitle titleSize="xlarge">{this.props.subtitle}</Subtitle>
         <div>{this.props.children}</div>
+        <ButtonContainer disabled={disabled} onClick={this.props.onNextButtonPressed}>
+          Next
+        </ButtonContainer>
       </Container>
     )
   }

--- a/src/components/onboarding/steps/step.tsx
+++ b/src/components/onboarding/steps/step.tsx
@@ -1,8 +1,7 @@
-import * as React from "react"
+import * as React from 'react';
+import styled from 'styled-components';
 
-import styled from "styled-components"
-
-import Title from "../../title"
+import Title from '../../title';
 
 export interface StepProps {
   onStateChange: ({ nextButtonEnabled }) => void
@@ -11,16 +10,25 @@ export interface StepProps {
 }
 
 const Container = styled.div`
+  max-width: 930px;
+  margin-left: auto;
+  margin-right: auto;
 `
-const Subtitle = styled(Title)`
+
+const MainTitle = styled(Title) `
+  text-align: center;
+`
+const Subtitle = styled(Title) `
   color: #999;
+  margin-bottom: 100px;
+  text-align: center;
 `
 
 export default class Step extends React.Component<StepProps, any> {
   render() {
     return (
       <Container>
-        <Title titleSize="xlarge">{this.props.title}</Title>
+        <MainTitle titleSize="xlarge">{this.props.title} </MainTitle>
         <Subtitle titleSize="xlarge">{this.props.subtitle}</Subtitle>
         <div>{this.props.children}</div>
       </Container>

--- a/src/components/onboarding/steps/step.tsx
+++ b/src/components/onboarding/steps/step.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+
+import styled from "styled-components"
+
+import Title from "../../title"
+
+export interface StepProps {
+  onStateChange: ({ nextButtonEnabled }) => void
+  title: string
+  subtitle: string
+}
+
+const Container = styled.div`
+`
+const Subtitle = styled(Title)`
+  color: #999;
+`
+
+export default class Step extends React.Component<StepProps, any> {
+  render() {
+    return (
+      <Container>
+        <Title titleSize="xlarge">{this.props.title}</Title>
+        <Subtitle titleSize="xlarge">{this.props.subtitle}</Subtitle>
+        <div>{this.props.children}</div>
+      </Container>
+    )
+  }
+}

--- a/src/components/onboarding/types.ts
+++ b/src/components/onboarding/types.ts
@@ -1,0 +1,6 @@
+/**
+ * The props interface that the step needs to implement for the wizard.
+ */
+export interface StepProps {
+  onNextButtonPressed: () => void
+}

--- a/src/components/onboarding/wizard.tsx
+++ b/src/components/onboarding/wizard.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+import Button from "../buttons/default"
+
+interface Props {
+  stepComponents: Array<React.ComponentClass<any>>
+}
+
+interface State {
+  currentStep: number
+  nextButtonEnabled: boolean
+}
+
+class Wizard extends React.Component<Props, State> {
+  currentStepComponent: any
+
+  constructor(props, state) {
+    super(props, state)
+
+    this.state = {
+      currentStep: 0,
+      nextButtonEnabled: false,
+    }
+  }
+
+  getCurrentStep(): JSX.Element | null {
+    const currentStep = this.state.currentStep
+    if (currentStep > this.props.stepComponents.length - 1) {
+      return null
+    }
+
+    const Step = this.props.stepComponents[currentStep]
+    return <Step onStateChange={this.onStepStateChanged.bind(this)} ref={step => (this.currentStepComponent = step)} />
+  }
+
+  onStepStateChanged(state: boolean) {
+    this.setState({
+      nextButtonEnabled: state,
+    })
+  }
+
+  onNextButtonPressed() {
+    if (this.props.stepComponents.length <= this.state.currentStep) {
+      return
+    }
+
+    this.currentStepComponent.submit()
+
+    const stepIndex = this.state.currentStep + 1
+    this.setState({ currentStep: stepIndex })
+  }
+
+  render() {
+    const step = this.getCurrentStep()
+    return (
+      <div>
+        {step}
+        <Button disabled={!this.state.nextButtonEnabled} onClick={this.onNextButtonPressed.bind(this)}>
+          Next
+        </Button>
+      </div>
+    )
+  }
+}
+
+export default Wizard

--- a/src/components/onboarding/wizard.tsx
+++ b/src/components/onboarding/wizard.tsx
@@ -1,17 +1,9 @@
 import * as React from 'react';
-import styled from 'styled-components';
 
-import Button from '../buttons/default';
-
-const ButtonContainer = styled(Button) `
-  margin: 0 auto 50px;
-  display: block;
-  width: 250px;
-
-`
+import { StepProps } from './types';
 
 interface Props {
-  stepComponents: Array<React.ComponentClass<any>>
+  stepComponents: Array<React.ComponentClass<StepProps>>
 }
 
 interface State {
@@ -20,8 +12,6 @@ interface State {
 }
 
 class Wizard extends React.Component<Props, State> {
-  currentStepComponent: any
-
   constructor(props, state) {
     super(props, state)
 
@@ -37,22 +27,14 @@ class Wizard extends React.Component<Props, State> {
       return null
     }
 
-    const Step = this.props.stepComponents[currentStep]
-    return <Step onStateChange={this.onStepStateChanged.bind(this)} ref={step => (this.currentStepComponent = step)} />
+    const CurrentStep = this.props.stepComponents[currentStep]
+    return <CurrentStep onNextButtonPressed={this.onNextButtonPressed.bind(this)} />
   }
 
-  onStepStateChanged(state: boolean) {
-    this.setState({
-      nextButtonEnabled: state,
-    })
-  }
-
-  onNextButtonPressed(e) {
+  onNextButtonPressed() {
     if (this.props.stepComponents.length <= this.state.currentStep) {
       return
     }
-
-    this.currentStepComponent.submit(e)
 
     const stepIndex = this.state.currentStep + 1
     this.setState({ currentStep: stepIndex })
@@ -63,9 +45,6 @@ class Wizard extends React.Component<Props, State> {
     return (
       <div>
         {step}
-        <ButtonContainer disabled={!this.state.nextButtonEnabled} onClick={this.onNextButtonPressed.bind(this)}>
-          Next
-        </ButtonContainer>
       </div>
     )
   }

--- a/src/components/onboarding/wizard.tsx
+++ b/src/components/onboarding/wizard.tsx
@@ -1,5 +1,14 @@
-import * as React from "react"
-import Button from "../buttons/default"
+import * as React from 'react';
+import styled from 'styled-components';
+
+import Button from '../buttons/default';
+
+const ButtonContainer = styled(Button) `
+  margin: 0 auto 50px;
+  display: block;
+  width: 250px;
+
+`
 
 interface Props {
   stepComponents: Array<React.ComponentClass<any>>
@@ -38,12 +47,12 @@ class Wizard extends React.Component<Props, State> {
     })
   }
 
-  onNextButtonPressed() {
+  onNextButtonPressed(e) {
     if (this.props.stepComponents.length <= this.state.currentStep) {
       return
     }
 
-    this.currentStepComponent.submit()
+    this.currentStepComponent.submit(e)
 
     const stepIndex = this.state.currentStep + 1
     this.setState({ currentStep: stepIndex })
@@ -54,9 +63,9 @@ class Wizard extends React.Component<Props, State> {
     return (
       <div>
         {step}
-        <Button disabled={!this.state.nextButtonEnabled} onClick={this.onNextButtonPressed.bind(this)}>
+        <ButtonContainer disabled={!this.state.nextButtonEnabled} onClick={this.onNextButtonPressed.bind(this)}>
           Next
-        </Button>
+        </ButtonContainer>
       </div>
     )
   }

--- a/src/relay/queries/popular_artist.ts
+++ b/src/relay/queries/popular_artist.ts
@@ -1,0 +1,15 @@
+import * as Relay from 'react-relay';
+
+class PopularArtistQueryConfig extends Relay.Route {
+  public static queries = {
+    artists: (component, params) => Relay.QL`
+      query {
+        ${component.getFragment("artists", params)}
+      }
+    `,
+  }
+
+  public static routeName = "PopularQueryConfig"
+}
+
+export default PopularArtistQueryConfig


### PR DESCRIPTION
For what it's worth this is probably throw away code but is an example of how we might want to approach fetching popular artists from metaphysics. @orta and I paired on [adding popular artists to metaphysics](https://github.com/artsy/metaphysics/pull/770), but it's not yet been merged so I can't see if this actually works yet. If it's still now merged by the time you start work tomorrow perhaps you could use fixture data to build out the UI.

If anything, I'm hoping this unblocks Yuki to be able to continue work on the Artist Follow view of the onboarding flow with this as a sudo example and the popular artists data in flight in metaphysics. 