### PR TITLE
@kanaabe: Added tracking for publishing components

### DIFF
--- a/src/__stories__/config.js
+++ b/src/__stories__/config.js
@@ -1,4 +1,5 @@
 const { configure } = require("@storybook/react")
+const Events = require("../utils/events").default
 
 const req = require.context("../", true, /\.story\.tsx$/)
 
@@ -16,3 +17,5 @@ setOptions({
   showDownPanel: false,
   sortStoriesByKind: true,
 })
+
+Events.onEvent(data => console.log("Tracked event", data))

--- a/src/components/publishing/__test__/article_tracking.test.tsx
+++ b/src/components/publishing/__test__/article_tracking.test.tsx
@@ -14,10 +14,10 @@ jest.mock("react-sizeme", () => jest.fn(c => d => d))
 it("emits analytics events to an event emitter", done => {
   const article = mount(<Article article={StandardArticle} />)
   Events.onEvent(data => {
-    expect(data.action).toEqual("share article")
+    expect(data.action).toEqual("Article share")
     done()
   })
   const shareUrl = `http://www.artsy.net/article/${StandardArticle.slug}`
   const fbURL = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`
-  article.find(`[href='${fbURL}']`).simulate("click")
+  article.find(`[href='${fbURL}']`).first().simulate("click")
 })

--- a/src/components/publishing/article.tsx
+++ b/src/components/publishing/article.tsx
@@ -34,7 +34,7 @@ interface ArticleState {
   isTruncated: boolean
 }
 
-@track({}, { dispatch: data => Events.postEvent(data) })
+@track({ page: "Article" }, { dispatch: data => Events.postEvent(data) })
 class Article extends React.Component<ArticleProps, ArticleState> {
   static childContextTypes = {
     onViewFullscreen: PropTypes.func,
@@ -51,6 +51,18 @@ class Article extends React.Component<ArticleProps, ArticleState> {
       isTruncated: props.isTruncated || false,
     }
   }
+
+  @track((props, [e]) => ({
+    action: "Article Impression",
+    article_id: props.article.id,
+    destination_path: window.location.pathname,
+    // TODO: What do we put here? According to analytics there are the valid types
+    // [newsletter signup, toc, artist follow, image set, article callout, social, related article]
+    impression_type: "related_article",
+    context_type: "article_fixed",
+  }))
+  // tslint:disable-next-line:no-empty
+  componentDidMount() {}
 
   getChildContext() {
     return { onViewFullscreen: this.openViewer }

--- a/src/components/publishing/article.tsx
+++ b/src/components/publishing/article.tsx
@@ -52,18 +52,6 @@ class Article extends React.Component<ArticleProps, ArticleState> {
     }
   }
 
-  @track((props, [e]) => ({
-    action: "Article Impression",
-    article_id: props.article.id,
-    destination_path: window.location.pathname,
-    // TODO: What do we put here? According to analytics there are the valid types
-    // [newsletter signup, toc, artist follow, image set, article callout, social, related article]
-    impression_type: "related_article",
-    context_type: "article_fixed",
-  }))
-  // tslint:disable-next-line:no-empty
-  componentDidMount() {}
-
   getChildContext() {
     return { onViewFullscreen: this.openViewer }
   }

--- a/src/components/publishing/byline/share.tsx
+++ b/src/components/publishing/byline/share.tsx
@@ -8,6 +8,7 @@ import IconSocialTwitter from "../icon/social_twitter"
 interface ShareProps extends React.HTMLProps<HTMLDivElement> {
   url: string
   title: string
+  articleId?: string
   color?: string
 }
 
@@ -23,7 +24,17 @@ class Share extends React.Component<ShareProps, null> {
     this.trackShare = this.trackShare.bind(this)
   }
 
-  @track(props => ({ action: "share article", url: props.url }))
+  @track((props, [e]) => ({
+    action: "Article share",
+    article_id: props.articleId,
+    context_type: "article_fixed",
+    service: (() => {
+      const href = e.currentTarget.attributes.href.value
+      if (href.match("facebook")) return "facebook"
+      if (href.match("twitter")) return "twitter"
+      if (href.match("mailto")) return "email"
+    })(),
+  }))
   trackShare(e) {
     e.preventDefault()
     window.open(e.currentTarget.attributes.href.value, "Share", "width = 600,height = 300")

--- a/src/components/publishing/related_articles/__test__/__snapshots__/related_articles_canvas.test.tsx.snap
+++ b/src/components/publishing/related_articles/__test__/__snapshots__/related_articles_canvas.test.tsx.snap
@@ -83,6 +83,9 @@ exports[`renders the related articles canvas 1`] = `
   flex-direction: column;
   max-width: 278px;
   margin-right: 30px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: black;
 }
 
 .c7 {
@@ -222,10 +225,11 @@ exports[`renders the related articles canvas 1`] = `
   >
     <div
       className="c4"
-      href="https://artsy.net/article/artsy-editorial-15-top-art-schools-united-states"
     >
       <a
         className="c5"
+        href="https://artsy.net/article/artsy-editorial-15-top-art-schools-united-states"
+        onClick={[Function]}
       >
         <img
           alt="The 15 Top Art Schools in the United States"
@@ -256,10 +260,11 @@ exports[`renders the related articles canvas 1`] = `
     </div>
     <div
       className="c4"
-      href="https://artsy.net/article/artsy-editorial-four-years-walter-de-marias-death-final-work-complete"
     >
       <a
         className="c5"
+        href="https://artsy.net/article/artsy-editorial-four-years-walter-de-marias-death-final-work-complete"
+        onClick={[Function]}
       >
         <img
           alt="Four Years after Walter De Maria’s Death, His Final Work Is Complete"
@@ -290,10 +295,11 @@ exports[`renders the related articles canvas 1`] = `
     </div>
     <div
       className="c4"
-      href="https://artsy.net/article/artsy-editorial-french-art-history-in-a-nutshell"
     >
       <a
         className="c5"
+        href="https://artsy.net/article/artsy-editorial-french-art-history-in-a-nutshell"
+        onClick={[Function]}
       >
         <img
           alt="French Art History in a Nutshell"
@@ -324,10 +330,11 @@ exports[`renders the related articles canvas 1`] = `
     </div>
     <div
       className="c4"
-      href="https://artsy.net/article/artsy-editorial-miami-artists-museums-brace-hurricane-irma"
     >
       <a
         className="c5"
+        href="https://artsy.net/article/artsy-editorial-miami-artists-museums-brace-hurricane-irma"
+        onClick={[Function]}
       >
         <img
           alt="Miami Artists and Museums Brace for Hurricane Irma"

--- a/src/components/publishing/related_articles/related_article_figure.tsx
+++ b/src/components/publishing/related_articles/related_article_figure.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 import { crop } from "../../../utils/resizer"
+import { track } from "../../../utils/track"
 import { pMedia } from "../../helpers"
 import Byline from "../byline/byline"
 import { articleHref } from "../constants"
@@ -16,17 +17,37 @@ interface RelatedArticleFigureProps extends React.HTMLProps<HTMLDivElement> {
   }
 }
 
-const RelatedArticleFigure: React.SFC<RelatedArticleFigureProps> = props => {
-  const { article } = props
-  return (
-    <ArticleFigure href={articleHref(article.slug)}>
-      <ImageTitle>
-        <BlockImage src={crop(article.thumbnail_image, { width: 510, height: 340 })} alt={article.thumbnail_title} />
-        <ArticleTitle>{article.thumbnail_title}</ArticleTitle>
-      </ImageTitle>
-      <Byline article={article} layout="condensed" />
-    </ArticleFigure>
-  )
+@track()
+class RelatedArticleFigure extends React.Component<RelatedArticleFigureProps, void> {
+  constructor(props) {
+    super()
+    this.onClick = this.onClick.bind(this)
+  }
+
+  @track((props, [e]) => ({
+    action: "Clicked article impression",
+    article_id: props.article.id,
+    destination_path: e.currentTarget.attributes.href.value,
+    // TODO: What do we put here? According to analytics there are the valid types
+    // [newsletter signup, toc, artist follow, image set, article callout, social, related article]
+    impression_type: "related_article",
+    context_type: "article_fixed",
+  }))
+  // tslint:disable-next-line:no-empty
+  onClick(e) {}
+
+  render() {
+    const { article } = this.props
+    return (
+      <ArticleFigure>
+        <ImageTitle href={articleHref(article.slug)} onClick={this.onClick}>
+          <BlockImage src={crop(article.thumbnail_image, { width: 510, height: 340 })} alt={article.thumbnail_title} />
+          <ArticleTitle>{article.thumbnail_title}</ArticleTitle>
+        </ImageTitle>
+        <Byline article={article} layout="condensed" />
+      </ArticleFigure>
+    )
+  }
 }
 
 const ImageTitle = styled.a`
@@ -44,6 +65,8 @@ const ArticleFigure = styled.div`
   flex-direction: column;
   max-width: 278px;
   margin-right: 30px;
+  text-decoration: none;
+  color: black;
 `
 const ArticleTitle = styled.div`
   ${Fonts.unica("s16")}

--- a/src/components/publishing/related_articles/related_article_figure.tsx
+++ b/src/components/publishing/related_articles/related_article_figure.tsx
@@ -28,9 +28,7 @@ class RelatedArticleFigure extends React.Component<RelatedArticleFigureProps, vo
     action: "Clicked article impression",
     article_id: props.article.id,
     destination_path: e.currentTarget.attributes.href.value,
-    // TODO: What do we put here? According to analytics there are the valid types
-    // [newsletter signup, toc, artist follow, image set, article callout, social, related article]
-    impression_type: "related_article",
+    impression_type: "related_articles_canvas",
     context_type: "article_fixed",
   }))
   // tslint:disable-next-line:no-empty

--- a/src/components/publishing/sections/view_fullscreen.tsx
+++ b/src/components/publishing/sections/view_fullscreen.tsx
@@ -1,28 +1,39 @@
 import * as PropTypes from "prop-types"
 import * as React from "react"
 import styled from "styled-components"
+import { track } from "../../../utils/track"
 import IconExpand from "../icon/expand"
 
 interface ViewFullscreenProps extends React.HTMLProps<HTMLDivElement> {
   index?: number
 }
 
-const ViewFullscreen: React.SFC<ViewFullscreenProps> = (props, context) => {
-  const onClick = e => {
+@track()
+class ViewFullscreen extends React.Component<ViewFullscreenProps, void> {
+  static childContextTypes = {
+    onViewFullscreen: PropTypes.func,
+  }
+
+  constructor(props) {
+    super()
+    this.onClick = this.onClick.bind(this)
+  }
+
+  @track({ action: "Clicked article impression" })
+  onClick(e) {
     e.preventDefault()
-    if (context.onViewFullscreen) {
-      context.onViewFullscreen(props.index)
+    if (this.context.onViewFullscreen) {
+      this.context.onViewFullscreen(this.props.index)
     }
   }
-  return (
-    <ViewFullscreenLink onClick={onClick}>
-      <IconExpand />
-    </ViewFullscreenLink>
-  )
-}
 
-ViewFullscreen.contextTypes = {
-  onViewFullscreen: PropTypes.func,
+  render() {
+    return (
+      <ViewFullscreenLink onClick={this.onClick}>
+        <IconExpand />
+      </ViewFullscreenLink>
+    )
+  }
 }
 
 const ViewFullscreenLink = styled.div`

--- a/src/typings/react-tracking.d.ts
+++ b/src/typings/react-tracking.d.ts
@@ -10,8 +10,8 @@ declare module "react-tracking" {
     trackEvent: ({}) => any
 
     /**
-       * This method returns all of the contextual tracking data up until this point in the component hierarchy.
-       */
+     * This method returns all of the contextual tracking data up until this point in the component hierarchy.
+     */
     getTrackingData: () => {}
   }
 
@@ -19,38 +19,38 @@ declare module "react-tracking" {
 
   interface Options<T> {
     /**
-       * By default, data tracking objects are pushed to `window.dataLayer[]`. This is a good default if you use Google
-       * Tag Manager. You can override this by passing in a dispatch function as a second parameter to the tracking
-       * decorator `{ dispatch: fn() }` on some top-level component high up in your app (typically some root-level
-       * component that wraps your entire app).
-       */
+     * By default, data tracking objects are pushed to `window.dataLayer[]`. This is a good default if you use Google
+     * Tag Manager. You can override this by passing in a dispatch function as a second parameter to the tracking
+     * decorator `{ dispatch: fn() }` on some top-level component high up in your app (typically some root-level
+     * component that wraps your entire app).
+     */
     dispatch?: (data: T) => any
 
     /**
-       * To dispatch tracking data when a component mounts, you can pass in `{ dispatchOnMount: true }` as the second
-       * parameter to `@track()`. This is useful for dispatching tracking data on "Page" components.
-       *
-       * If you pass in a function, the function will be called with all of the tracking data from the app's context when
-       * the component mounts. The return value of this function will be dispatched in `componentDidMount()`. The object
-       * returned from this function call will be merged with the context data and then dispatched. A use case for this
-       * would be that you want to provide extra tracking data without adding it to the context.
-       */
+     * To dispatch tracking data when a component mounts, you can pass in `{ dispatchOnMount: true }` as the second
+     * parameter to `@track()`. This is useful for dispatching tracking data on "Page" components.
+     *
+     * If you pass in a function, the function will be called with all of the tracking data from the app's context when
+     * the component mounts. The return value of this function will be dispatched in `componentDidMount()`. The object
+     * returned from this function call will be merged with the context data and then dispatched. A use case for this
+     * would be that you want to provide extra tracking data without adding it to the context.
+     */
     dispatchOnMount?: boolean | ((contextData: T) => T)
 
     /**
-       * When there's a need to implicitly dispatch an event with some data for every component, you can define an
-       * `options.process` function. This function should be declared once, at some top-level component. It will get
-       * called with each component's tracking data as the only argument. The returned object from this function will be
-       * merged with all the tracking context data and dispatched in `componentDidMount()`. If a falsy value is returned
-       * (`false`, `null`, `undefined`, ...), nothing will be dispatched.
-       *
-       * A common use case for this is to dispatch a `pageview` event for every component in the application that has a
-       * `page` property on its `trackingData`.
-       */
+     * When there's a need to implicitly dispatch an event with some data for every component, you can define an
+     * `options.process` function. This function should be declared once, at some top-level component. It will get
+     * called with each component's tracking data as the only argument. The returned object from this function will be
+     * merged with all the tracking context data and dispatched in `componentDidMount()`. If a falsy value is returned
+     * (`false`, `null`, `undefined`, ...), nothing will be dispatched.
+     *
+     * A common use case for this is to dispatch a `pageview` event for every component in the application that has a
+     * `page` property on its `trackingData`.
+     */
     process?: (ownTrackingData: T) => T | Falsy
   }
 
-  export type TrackingInfo<T, P> = T | ((props: P) => T)
+  export type TrackingInfo<T, P> = T | ((props: P, args: any[]) => T)
 
   // Duplicated from ES6 lib to remove the `void` typing, otherwise `track` can’t be used as a HOC function that passes
   // through a JSX component that be used wihtout casting.


### PR DESCRIPTION
This attempts to fill out the tracking calls for publishing components for https://github.com/artsy/publishing/issues/50

There were a handful of tracking calls that I couldn't find homes for in the Reaction components.

Specified in the [analytics spreadsheet](https://docs.google.com/spreadsheets/d/17oqFli15x1SmNBu_-fPZhFifMw2BNSPJe9VdOgs1aKs/edit#gid=1499052602):
1. `Sign up for editorial email` 
2. `Clicked partner logo` (Venice 360)
3. `Video play` (Venice 360)
4. `Video duration` (Venice 360)

Seems the last three are irrelevant right now, but #1 I'm curious if we need to re-implement that component?

These events I saw in our current analytics code but didn't find homes for them, nor did I see them in the analytics doc

- `Clicked primary partner logo` (Super article)
- `Clicked secondary partner logo`  (Super article)
- `Clicked partner cta link` (Super article)
- `Clicked partner cta link in footer blurb` (Super article)
- `Clicked Read More`
- `Sign up for gallery insights email`
- `Dismiss editorial signup`
- `Clicked Venice 2017 Banner link`

So this is probably incomplete, but it should be a good starting point and maybe I can sync up with @wrgoldstein on ensuring we have our bases covered.