### PR TITLE
Popular artist container

### DIFF
--- a/src/assets/animations.tsx
+++ b/src/assets/animations.tsx
@@ -1,0 +1,25 @@
+import { css, keyframes } from "styled-components"
+
+export const fadeOut = css`
+  animation: ${keyframes`
+    from {
+      opacity: 1;
+    }
+
+    to {
+      opacity: 0;
+    }
+  `} 0.5s both;
+`
+
+export const fadeIn = css`
+  animation: ${keyframes`
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  `} 0.5s both;
+`

--- a/src/components/onboarding/__stories__/artists.story.tsx
+++ b/src/components/onboarding/__stories__/artists.story.tsx
@@ -1,0 +1,6 @@
+import { storiesOf } from "@storybook/react"
+import * as React from "react"
+
+import Artists from "../steps/artists"
+
+storiesOf("Onboarding").add("Artist Selector", () => <Artists onNextButtonPressed={() => null} />)

--- a/src/components/onboarding/selectable_item_container.tsx
+++ b/src/components/onboarding/selectable_item_container.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import styled from 'styled-components'
+import styled, { StyledFunction } from 'styled-components'
 
+import { fadeIn, fadeOut } from "../../assets/animations"
 import colors from "../../assets/colors"
 import * as fonts from '../../assets/fonts'
 
@@ -19,7 +20,13 @@ interface SelectableItemProps {
   }>
 }
 
-const Link = styled.a`
+interface ClickableLinkState {
+  fadeIn?: boolean
+  fadeOut?: boolean
+}
+
+const anchor: StyledFunction<ClickableLinkState & React.HTMLProps<HTMLInputElement>> = styled.a
+const Link = anchor`
   display: flex;
   font-size: 14px;
   color: black;
@@ -30,6 +37,8 @@ const Link = styled.a`
   &:hover {
     background-color: #f8f8f8;
   }
+  ${props => props.fadeIn ? fadeIn : null}
+  ${props => props.fadeOut ? fadeOut : null}
 `
 
 const Avatar = styled.img`
@@ -53,10 +62,32 @@ const OnboardingSearchBox = styled.div`
   border-bottom: 1px solid #e5e5e5;
 `
 
+class ItemLink extends React.Component<React.HTMLProps<HTMLAnchorElement>, ClickableLinkState> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      fadeIn: false,
+      fadeOut: false,
+    }
+  }
+
+  onClick() {
+    this.setState({ fadeOut: true })
+  }
+
+  render() {
+    return (
+      <Link onClick={this.onClick.bind(this)} fadeIn={this.state.fadeIn} fadeOut={this.state.fadeOut}>
+        {this.props.children}
+      </Link>
+    )
+  }
+}
+
 export default class SelectableItemContainer extends React.Component<SelectableItemProps, null> {
   render() {
     const items = this.props.items.map(item =>
-      <Link href="#">
+      <ItemLink href="#">
         <Col>
           <Avatar src={item.image.cropped.url} width={50} height={50} />
         </Col>
@@ -66,7 +97,7 @@ export default class SelectableItemContainer extends React.Component<SelectableI
         <Col>
           <Icon name="follow-circle" color="black" fontSize="39px" />
         </Col>
-      </Link>
+      </ItemLink>
     )
 
     return (

--- a/src/components/onboarding/selectable_item_container.tsx
+++ b/src/components/onboarding/selectable_item_container.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import styled from 'styled-components'
+
+import colors from "../../assets/colors"
+import * as fonts from '../../assets/fonts'
+
+import Icon from "../icon"
+import Input from '../input'
+
+interface SelectableItemProps {
+  placeholder?: string,
+  items: Array<{
+    name: string,
+    image: {
+      cropped: {
+        url: string
+      }
+    }
+  }>
+}
+
+const Link = styled.a`
+  display: flex;
+  font-size: 14px;
+  color: black;
+  text-decoration: none;
+  text-transform: uppercase;
+  font-family: ${fonts.primary.fontFamily};
+  border-top: 1px solid #e5e5e5;
+  &:hover {
+    background-color: #f8f8f8;
+  }
+`
+
+const Avatar = styled.img`
+  padding: 10px 15px 10px 10px;
+`
+
+const FullWidthCol = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+`
+
+const Col = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const OnboardingSearchBox = styled.div`
+  width: 450px;
+  margin: 0 auto 100px;
+  border-bottom: 1px solid #e5e5e5;
+`
+
+export default class SelectableItemContainer extends React.Component<SelectableItemProps, null> {
+  render() {
+    const items = this.props.items.map(item =>
+      <Link href="#">
+        <Col>
+          <Avatar src={item.image.cropped.url} width={50} height={50} />
+        </Col>
+        <FullWidthCol>
+          {item.name}
+        </FullWidthCol>
+        <Col>
+          <Icon name="follow-circle" color="black" fontSize="39px" />
+        </Col>
+      </Link>
+    )
+
+    return (
+      <OnboardingSearchBox>
+        <div style={{ marginBottom: "35px" }}>
+          <Input placeholder={this.props.placeholder} leftView={<Icon name="search" color={colors.graySemibold} />} block />
+        </div>
+
+        {items}
+      </OnboardingSearchBox>
+    )
+  }
+}

--- a/src/components/onboarding/steps/artists.tsx
+++ b/src/components/onboarding/steps/artists.tsx
@@ -1,13 +1,57 @@
 import * as React from "react"
+import * as Relay from 'react-relay'
 
-import Input from "../../input"
+import { artsyNetworkLayer } from "../../../relay/config"
+import PopularArtistQueryConfig from "../../../relay/queries/popular_artist"
+import SelectableItemContainer from "../selectable_item_container"
 import { StepProps } from "../types"
 import { Layout } from "./layout"
 
-export default class Artists extends React.Component<StepProps, null> {
-  onInputChange = e => {
-    // this.props.onStateChange({ nextButtonEnabled: true })
+export interface RelayProps {
+  popular_artists: {
+    artists: Array<{
+      name: string,
+      image: {
+        cropped: {
+          url: string
+        }
+      }
+    }>,
+  },
+}
+
+export class SelectableArtistContainer extends React.Component<RelayProps, null> {
+  render() {
+    return <SelectableItemContainer items={this.props.popular_artists.artists} />
   }
+}
+
+export const PopularArtistSelector = Relay.createContainer(SelectableArtistContainer, {
+  fragments: {
+    popular_artists: () => Relay.QL`
+      fragment on PopularArtists {
+        artists {
+          name
+          image {
+            cropped(width: 100, height: 100) {
+              url
+            }
+          }
+        }
+      }
+    `,
+  },
+})
+
+function ConnectedPopularArtistSelector() {
+  Relay.injectNetworkLayer(artsyNetworkLayer())
+  return <Relay.RootContainer Component={PopularArtistSelector} route={new PopularArtistQueryConfig()} />
+}
+
+export default class Artists extends React.Component<StepProps, null> {
+  // onInputChange = e => {
+  //   this.props.onStateChange({ nextButtonEnabled: true })
+  // }
 
   render() {
     return (
@@ -16,9 +60,7 @@ export default class Artists extends React.Component<StepProps, null> {
         subtitle="Follow one or more"
         onNextButtonPressed={null}
       >
-        <div>
-          <Input onChange={this.onInputChange} />
-        </div>
+        <ConnectedPopularArtistSelector />
       </Layout>
     )
   }

--- a/src/relay/queries/popular_artist.ts
+++ b/src/relay/queries/popular_artist.ts
@@ -1,0 +1,17 @@
+import * as Relay from 'react-relay';
+
+class PopularArtistQueryConfig extends Relay.Route {
+  public static queries = {
+    popular_artists: (component, params) => Relay.QL`
+      query {
+        popular_artists {
+          ${component.getFragment("popular_artists", params)}
+        }
+      }
+    `,
+  }
+
+  public static routeName = "PopularQueryConfig"
+}
+
+export default PopularArtistQueryConfig


### PR DESCRIPTION
This (partially) implements https://github.com/artsy/collector-experience/issues/505

Right now typing in the search bar doesn't update the list. Also, a click event for each individual artist is not hooked up. But as we discussed we should get this merged before we hook up the data layer with all the components.

![screencapture-localhost-9001-1507448346326](https://user-images.githubusercontent.com/386234/31314924-426d5906-ac47-11e7-912b-2e88d1046a70.png)

 * [ ] Use the right icon for (+)
 * [x] after clicking an artist row should fade out
 * [ ] a new similar artist should fade in after following an artist
 * [ ] Actually use [the related artist endpoint](https://github.com/artsy/gravity/blob/d3eaf52632221d0a9cc95877accb8082375e26f8/app/api/v1/related_endpoint.rb#L7) to show a similar artist
 * [ ] Search and show new results as you type
 * [ ] Show "No results found" when there's no result
 * [ ] Clicking the `x` should clear out the search bar
 * [ ] The search result view should be scrollable when there are many results
 * [ ] Tweak the paddings/margins to match what's specified in the mockup
 * [ ] Change the title/subtitle size/margin/padding on mobile (could be done separately)
 * [ ] The "next" button should stay at the bottom on mobile (could be done separately)