### PR TITLE
[Onboarding] Budget screen views

### DIFF
--- a/src/components/onboarding/__stories__/budget.story.tsx
+++ b/src/components/onboarding/__stories__/budget.story.tsx
@@ -1,0 +1,21 @@
+import { storiesOf } from "@storybook/react"
+import * as React from "react"
+
+import { ContextProvider } from "../../artsy"
+import Budget from "../steps/budget"
+
+storiesOf("Onboarding").add("Budget", () => {
+  const currentUser = {
+    accessToken: "blah",
+    id: "my_id",
+    name: "Joe",
+  }
+  return (
+    <div>
+      <ContextProvider currentUser={currentUser}>
+        {/* tbc */}
+        <Budget onNextButtonPressed={null} />
+      </ContextProvider>
+    </div>
+  )
+})

--- a/src/components/onboarding/__stories__/selectable_link.story.tsx
+++ b/src/components/onboarding/__stories__/selectable_link.story.tsx
@@ -1,12 +1,17 @@
-import { storiesOf } from '@storybook/react';
-import * as React from 'react';
+import { storiesOf } from "@storybook/react"
+import * as React from "react"
 
-import SelectableLink from '../selectable_link';
+import SelectableLink from "../selectable_link"
 
 storiesOf("Onboarding", module).add("SelectableLink", () => {
   return (
     <div style={{ width: "400px" }}>
-      <SelectableLink text="Buy Art & Design" onSelect={this.onSelect} />
+      <SelectableLink
+        text="Buy Art & Design"
+        onSelect={select => {
+          return select
+        }}
+      />
     </div>
   )
 })

--- a/src/components/onboarding/selectable_toggle.tsx
+++ b/src/components/onboarding/selectable_toggle.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import styled from "styled-components"
+
+import * as fonts from "../../assets/fonts"
+import Icon from "../icon"
+
+interface SelectableToggleProps {
+  href?: string
+  text?: string
+  onSelect: (selected: boolean) => void
+  selected: boolean
+}
+
+const IconContainer = styled.div`
+width: 15px;
+height: 15px;
+background-color: black;
+display: none;
+border-radius: 50%;
+float: right;
+margin-right: 15px;
+`
+
+const Link = styled.a`
+display: block;
+font-size: 14px;
+color: black;
+text-decoration: none;
+text-transform: uppercase;
+font-family: ${fonts.primary.fontFamily};
+padding: 30px 0 30px 15px;
+border-top: 1px solid #e5e5e5;
+&:hover {
+  background-color: #f8f8f8;
+}
+&:hover .collector-intent-checked {
+  display: inline;
+}
+& .collector-intent-checked.is-selected {
+  display: inline;
+}
+`
+
+class SelectableToggle extends React.Component<SelectableToggleProps, null> {
+  constructor(props) {
+    super(props)
+    this.onSelect = this.onSelect.bind(this)
+  }
+
+  onSelect() {
+    if (this.props.onSelect) {
+      this.props.onSelect(this.props.selected)
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <Link href={this.props.href} onClick={() => this.onSelect()}>
+          {this.props.text}
+
+          <IconContainer className={`collector-intent-checked ${this.props.selected ? "is-selected" : ""}`}>
+            <Icon name="check" color="white" fontSize="8px" />
+          </IconContainer>
+        </Link>
+      </div>
+    )
+  }
+}
+
+export default SelectableToggle

--- a/src/components/onboarding/steps/budget.tsx
+++ b/src/components/onboarding/steps/budget.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import styled from "styled-components"
+
+import SelectableLink from "../selectable_link"
+import { StepProps } from "../types"
+import { Layout } from "./layout"
+
+const OptionsContainer = styled.div`
+width: 450px;
+margin: 0 auto 100px;
+&:last-child {
+  border-bottom: 1px solid #e5e5e5;
+}
+`
+
+export default class Budget extends React.Component<StepProps, null> {
+  options = [
+    "UNDER $500",
+    "UNDER $2,500",
+    "UNDER $5,000",
+    "UNDER $10,000",
+    "UNDER $25,000",
+    "UNDER $50,000",
+    "NO BUDGET IN MIND",
+  ]
+
+  onOptionSelected = () => {
+    // to be continued
+    null
+  }
+
+  render() {
+    const options = this.options.map((text, index) =>
+      <SelectableLink key={index} text={text} onSelect={this.onOptionSelected.bind(this, index)} />
+    )
+
+    return (
+      <Layout title="What's your budget?" subtitle="Select one" onNextButtonPressed={null}>
+        <OptionsContainer>
+          {options}
+        </OptionsContainer>
+      </Layout>
+    )
+  }
+}

--- a/src/components/onboarding/steps/budget.tsx
+++ b/src/components/onboarding/steps/budget.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import styled from "styled-components"
 
-import SelectableLink from "../selectable_link"
+import SelectableToggle from "../selectable_toggle"
 import { StepProps } from "../types"
 import { Layout } from "./layout"
 
@@ -13,7 +13,11 @@ margin: 0 auto 100px;
 }
 `
 
-export default class Budget extends React.Component<StepProps, null> {
+interface State {
+  selection: string
+}
+
+export default class Budget extends React.Component<StepProps, State> {
   options = [
     "UNDER $500",
     "UNDER $2,500",
@@ -24,18 +28,39 @@ export default class Budget extends React.Component<StepProps, null> {
     "NO BUDGET IN MIND",
   ]
 
-  onOptionSelected = () => {
-    // to be continued
-    null
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      selection: "",
+    }
+  }
+
+  onOptionSelected = (index: number) => {
+    let selection = { selection: this.options[index] }
+    this.setState(selection)
+  }
+
+  submit() {
+    null // coming soooon
   }
 
   render() {
     const options = this.options.map((text, index) =>
-      <SelectableLink key={index} text={text} onSelect={this.onOptionSelected.bind(this, index)} />
+      <SelectableToggle
+        key={index}
+        text={text}
+        onSelect={this.onOptionSelected.bind(this, index)}
+        selected={this.state.selection === text}
+      />
     )
 
     return (
-      <Layout title="What's your budget?" subtitle="Select one" onNextButtonPressed={null}>
+      <Layout
+        title="What's your budget?"
+        subtitle="Select one"
+        onNextButtonPressed={this.state.selection !== "" && this.submit.bind(this)}
+      >
         <OptionsContainer>
           {options}
         </OptionsContainer>


### PR DESCRIPTION
Made with the 🎉 @xtina-starr 

Issue [here](https://github.com/artsy/collector-experience/issues/507). 

Currently looks like:

<img width="1434" alt="screen shot 2017-10-09 at 18 13 19" src="https://user-images.githubusercontent.com/373860/31350064-9b7a499c-ad1d-11e7-8c41-00a32866afab.png">

Still needs:
- [ ] Icon
- [ ] Potential refactor / cleanup? Some overlap code with `selectable_link.tsx`

We've just added a few reviewers just for some extra eyes 😄 