### PR TITLE
[Onboarding] use circle checkbox for icon

### DIFF
--- a/src/components/onboarding/__stories__/selectable_link.story.tsx
+++ b/src/components/onboarding/__stories__/selectable_link.story.tsx
@@ -1,12 +1,12 @@
-import { storiesOf } from "@storybook/react"
-import * as React from "react"
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
 
-import SelectableLink from "../selectable_link"
+import SelectableLink from '../selectable_link';
 
 storiesOf("Onboarding", module).add("SelectableLink", () => {
   return (
     <div style={{ width: "400px" }}>
-      <SelectableLink text="Buy Art & Design" onSelect={this.onSelect} />
+      <SelectableLink text="Buy Art & Design" onSelect={selected => selected} />
     </div>
   )
 })

--- a/src/components/onboarding/selectable_link.tsx
+++ b/src/components/onboarding/selectable_link.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import styled from "styled-components"
+import * as React from 'react';
+import styled from 'styled-components';
 
-import * as fonts from "../../assets/fonts"
-import Icon from "../icon"
+import * as fonts from '../../assets/fonts';
+import Icon from '../icon';
 
 interface SelectableLinkProps {
   href?: string
@@ -15,8 +15,8 @@ interface LinkState {
 }
 
 const IconContainer = styled.div`
-width: 15px;
-height: 15px;
+width: 18px;
+height: 18px;
 background-color: black;
 display: none;
 border-radius: 50%;
@@ -37,10 +37,12 @@ border-top: 1px solid #e5e5e5;
   background-color: #f8f8f8;
 }
 &:hover .collector-intent-checked {
-  display: inline;
+  display: inline-flex;
+  justify-content: center;
 }
 & .collector-intent-checked.is-selected {
-  display: inline;
+  display: inline-flex;
+  justify-content: center;
 }
 `
 
@@ -68,7 +70,7 @@ class SelectableLink extends React.Component<SelectableLinkProps, LinkState> {
           {this.props.text}
 
           <IconContainer className={`collector-intent-checked ${this.state.selected ? "is-selected" : ""}`}>
-            <Icon name="check" color="white" fontSize="8px" />
+            <Icon name="follow-circle.is-following" color="white" fontSize="39px" style={{ alignSelf: "center" }} />
           </IconContainer>
         </Link>
       </div>


### PR DESCRIPTION
This cleans up the icon in the Selectable Link component. This should allow use to move the collector intent view to do.

<img width="628" alt="screen shot 2017-10-09 at 5 40 17 pm" src="https://user-images.githubusercontent.com/5201004/31359912-0837e502-ad1a-11e7-9701-cc7f745d3de1.png">

_side note:_ @alloy you mentioned using dynamic styling based on props in the Budget component PR. I gave it a stab but couldn't quite get it to work. Could you help me to refactor this to use that?