### PR TITLE
Update prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,10 +12,5 @@
   },
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
-  "prettier.singleQuote": false,
-  "prettier.trailingComma": "es5",
-  "prettier.typescriptEnable": ["typescript", "typescriptreact"],
-  "prettier.semi": false,
-  "prettier.printWidth": 120,
   "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,7 @@
   "repository": "https://github.com/artsy/reaction-force.git",
   "author": "Eloy Durán <eloy.de.enige@gmail.com>",
   "license": "MIT",
-  "files": [
-    "dist",
-    "assets",
-    "data",
-    "docs"
-  ],
+  "files": ["dist", "assets", "data", "docs"],
   "scripts": {
     "start": "node verify-node-version.js && ts-babel-node index.js",
     "start:dist": "npm run compile && node index.js ./dist",
@@ -19,8 +14,10 @@
     "storybook": "node verify-node-version.js && start-storybook -p 9001",
     "deploy-storybook": "NODE_ENV=production storybook-to-ghpages",
     "relay2ts": "relay2ts src/components/*.tsx --update",
-    "sync-schema": "cd externals/metaphysics && git fetch && git checkout origin/master && yarn install && npm run dump-schema -- ../../data",
-    "sync-colors": "cd externals/elan && git fetch && git checkout origin/master && cp components/lib/variables/colors.json ../../data",
+    "sync-schema":
+      "cd externals/metaphysics && git fetch && git checkout origin/master && yarn install && npm run dump-schema -- ../../data",
+    "sync-colors":
+      "cd externals/elan && git fetch && git checkout origin/master && cp components/lib/variables/colors.json ../../data",
     "lint": "tslint -c tslint.json --project tsconfig.json",
     "type-check": "tsc --noEmit --pretty",
     "compile:server": "gulp compile-server",
@@ -30,8 +27,15 @@
     "precommit": "lint-staged",
     "prepush": "npm run type-check",
     "prettier": "prettier",
-    "prettier-write": "npm run prettier -- --parser typescript --no-semi --trailing-comma es5 --write --print-width 120",
+    "prettier-write": "npm run prettier --write",
     "prettier-project": "npm run prettier-write -- 'src/**/*.{ts,tsx}'"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "semi": false,
+    "singleQuote": false,
+    "trailingComma": "es5",
+    "bracketSpacing": true
   },
   "devDependencies": {
     "@storybook/storybook-deployer": "^2.0.0",
@@ -78,7 +82,7 @@
     "lint-staged": "^4.0.0",
     "longjohn": "^0.2.12",
     "morgan": "^1.8.1",
-    "prettier": "^1.4.4",
+    "prettier": "^1.7.4",
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",
     "react-hot-loader": "^1.3.1",
@@ -139,17 +143,10 @@
       ".(ts|tsx)": "typescript-babel-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js"]
   },
   "lint-staged": {
-    "*.@(ts|tsx)": [
-      "tslint --fix",
-      "npm run prettier-write --",
-      "git add"
-    ]
+    "*.@(ts|tsx)": ["tslint --fix", "npm run prettier-write --", "git add"],
+    "*.json": ["npm run prettier-write --"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   "author": "Eloy Durán <eloy.de.enige@gmail.com>",
   "license": "MIT",
   "files": ["dist", "assets", "data", "docs"],
+  "engines": {
+    "node": "8.4.x",
+    "npm": "5.4.x",
+    "yarn": "1.x"
+  },
   "scripts": {
     "start": "node verify-node-version.js && ts-babel-node index.js",
     "start:dist": "npm run compile && node index.js ./dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7006,9 +7006,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.4.4.tgz#a8d1447b14c9bf67e6d420dcadd10fb9a4fad65a"
+prettier@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
 pretty-format@^20.0.3:
   version "20.0.3"


### PR DESCRIPTION
I didn't run prettier across the whole project, because there are 8 open PRs and it'd likely force a bunch of merge conflicts.

The update moves the settings to be inside prettier, instead of inside vscode.