### PR TITLE
@orta => Unlock yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   ],
   "engines": {
     "node": "8.4.x",
-    "npm": "5.4.x",
-    "yarn": "1.x"
+    "npm": "5.4.x"
   },
   "scripts": {
     "start": "node verify-node-version.js && ts-babel-node index.js",


### PR DESCRIPTION
Follow up from https://github.com/artsy/force/pull/1818. CircleCI doesn't support yarn@1.x yet so we can't install Reaction in Force atm. Following @damassi's suggestion, we probably don't need to specify this anyway. We might be missing something tho, so please lmk! 