### PR TITLE
@alloy => Remove unnecessary storybook webpack config

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -53,10 +53,4 @@ module.exports = {
     ],
   },
   plugins: plugins,
-  node: {
-    console: true,
-    fs: "empty",
-    net: "empty",
-    tls: "empty",
-  },
 }


### PR DESCRIPTION
When I first implemented the email component (https://github.com/artsy/reaction/pull/246), I needed to add this bit of Webpack config to get the `request` package working in storybooks. Issue detailed here: https://github.com/request/request/issues/1529. Now that we're using `superagent`, this is no longer necessary. 