### PR TITLE
Add storybook for animations

### DIFF
--- a/src/Assets/Animations.tsx
+++ b/src/Assets/Animations.tsx
@@ -1,5 +1,6 @@
 import { css, keyframes } from "styled-components"
 
+// Fade effects
 export const fadeOut = css`
   animation: ${keyframes`
     from {
@@ -20,6 +21,60 @@ export const fadeIn = css`
 
     to {
       opacity: 1;
+    }
+  `} 0.5s both;
+`
+
+// Sliding effects
+
+export const slideInDown = css`
+  animation: ${keyframes`
+    from {
+      transform: translate3d(0, -100%, 0);
+      visibility: visible;
+    }
+
+    to {
+      transform: translate3d(0, 0, 0);
+    }
+  `} 0.5s both;
+`
+
+export const slideInLeft = css`
+  animation: ${keyframes`
+    from {
+      transform: translate3d(-100%, 0, 0);
+      visibility: visible;
+    }
+
+    to {
+      transform: translate3d(0, 0, 0);
+    }
+  `} 0.5s both;
+`
+
+export const slideInRight = css`
+  animation: ${keyframes`
+    from {
+      transform: translate3d(100%, 0, 0);
+      visibility: visible;
+    }
+
+    to {
+      transform: translate3d(0, 0, 0);
+    }
+  `} 0.5s both;
+`
+
+export const slideInUp = css`
+  animation: ${keyframes`
+    from {
+      transform: translate3d(0, 100%, 0);
+      visibility: visible;
+    }
+
+    to {
+      transform: translate3d(0, 0, 0);
     }
   `} 0.5s both;
 `

--- a/src/Components/__stories__/Animations.story.tsx
+++ b/src/Components/__stories__/Animations.story.tsx
@@ -1,0 +1,87 @@
+import { storiesOf } from "@storybook/react"
+import * as React from "react"
+
+import styled from "styled-components"
+import {fadeIn, fadeOut, slideInDown, slideInLeft, slideInUp, slideInRight} from "../../Assets/Animations"
+import Button from "../Buttons/Default"
+import { Col, Row } from "../Grid"
+import Icon from "../Icon"
+
+interface AnimationExampleProps {
+  button: string
+}
+
+interface VisibilityState {
+  show: boolean
+}
+
+class AnimationExample extends React.Component<AnimationExampleProps, VisibilityState> {
+  constructor(props) {
+    super(props)
+    this.state = { show: true }
+  }
+
+  onClick() {
+    this.setState({ show: false })
+
+    // setTimeout is used just for the sake of demo and shouldn't be used in production.
+    setTimeout((() => this.setState({ show: true })).bind(this), 100)
+  }
+
+  render() {
+    return (
+      <Row style={{ marginBottom: "20px" }}>
+        <Col xs={3} sm={3} md={3} lg={3}>
+          <Button onClick={this.onClick.bind(this)}>{this.props.button}</Button>
+        </Col>
+        <Col xs sm md lg>
+          {this.state.show && this.props.children}
+        </Col>
+      </Row>
+    )
+  }
+}
+
+const FadeIn = styled.div`${fadeIn}`
+const FadeOut = styled.div`${fadeOut}`
+const SlideInDown = styled.div`${slideInDown}`
+const SlideInLeft = styled.div`${slideInLeft}`
+const SlideInRight = styled.div`${slideInRight}`
+const SlideInUp = styled.div`${slideInUp}`
+
+storiesOf("Components/Animations", module).add("All Animations", () => {
+  return (
+    <div style={{ margin: "40px" }}>
+      <AnimationExample button='Fade in'>
+        <FadeIn>
+          <Icon name='logotype' fontSize="60px" color="black" />
+        </FadeIn>
+      </AnimationExample>
+      <AnimationExample button='Fade out'>
+        <FadeOut>
+          <Icon name='logotype' fontSize="60px" color="black" />
+        </FadeOut>
+      </AnimationExample>
+      <AnimationExample button='Slide in down'>
+        <SlideInDown>
+          <Icon name='logotype' fontSize="60px" color="black" />
+        </SlideInDown>
+      </AnimationExample>
+      <AnimationExample button='Slide in left'>
+        <SlideInLeft>
+          <Icon name='logotype' fontSize="60px" color="black" />
+        </SlideInLeft>
+      </AnimationExample>
+      <AnimationExample button='Slide in right'>
+        <SlideInRight>
+          <Icon name='logotype' fontSize="60px" color="black" />
+        </SlideInRight>
+      </AnimationExample>
+      <AnimationExample button='Slide in up'>
+        <SlideInUp>
+          <Icon name='logotype' fontSize="60px" color="black" />
+        </SlideInUp>
+      </AnimationExample>
+    </div>
+  )
+})


### PR DESCRIPTION
This adds a new storybook for animations.

Most popular animation libraries are based on [the `animation` property](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) and [the `@keyframes` at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes). [animate.css](https://github.com/daneden/animate.css) has a good set of animations and provides low-level CSS definitions. I also looked at [react-animation](https://github.com/FormidableLabs/react-animations), but it's just a thin layer that encapsulates animate.css, so I just decided to take some animations from animate.css, make them compatible with styled-component, and build our own components. In the future, we may want to depend on animate.css, but for now we can maintain the animations since we only need a few at this point.

![oct 11 2017 1-37 pm](https://user-images.githubusercontent.com/386234/31422705-8a00033c-ae8a-11e7-9168-7aeea4dd866e.gif)

