### PR TITLE
@kanaabe: Fix & refactor fullscreen slideshow 

### DIFF
--- a/src/Components/Publishing/ReadMore/__test__/ReadMore.test.tsx
+++ b/src/Components/Publishing/ReadMore/__test__/ReadMore.test.tsx
@@ -7,6 +7,10 @@ import Sections from "../../Sections/Sections"
 import ReadMoreWrapper from "../ReadMoreWrapper"
 
 jest.useFakeTimers()
+jest.mock("react-slick", () => {
+  const React = require("react")
+  return props => <div>{props.children}</div>
+})
 
 describe("ReadMore", () => {
   beforeEach(() => {

--- a/src/Components/Publishing/Sections/Artwork.tsx
+++ b/src/Components/Publishing/Sections/Artwork.tsx
@@ -12,6 +12,8 @@ interface ArtworkProps {
   linked?: boolean
   width?: string | number
   height?: string | number
+  images?: [object]
+  slideIndex?: number
 }
 
 const ArtworkImage: React.SFC<ArtworkProps> = props => {
@@ -19,6 +21,8 @@ const ArtworkImage: React.SFC<ArtworkProps> = props => {
   const src = resize(artwork.image, { width: 1200 })
   const image = (
     <ImageWrapper
+      images={props.images}
+      slideIndex={props.slideIndex}
       layout={layout}
       src={src}
       className="display-artwork__image"

--- a/src/Components/Publishing/Sections/FullscreenViewer/FullscreenViewer.tsx
+++ b/src/Components/Publishing/Sections/FullscreenViewer/FullscreenViewer.tsx
@@ -11,7 +11,7 @@ import Slide from "./Slide"
 interface FullscreenViewerProps extends React.HTMLProps<HTMLDivElement> {
   images: any
   show: boolean
-  onClose: () => void
+  onClose: (e?: object) => void
   slideIndex?: number
 }
 

--- a/src/Components/Publishing/Sections/Image.tsx
+++ b/src/Components/Publishing/Sections/Image.tsx
@@ -10,6 +10,8 @@ interface ImageProps extends React.HTMLProps<HTMLDivElement> {
   sectionLayout?: SectionLayout
   width?: number | string
   height?: number | string
+  images?: [object]
+  slideIndex?: number
 }
 
 const Image: React.SFC<ImageProps> = props => {
@@ -19,6 +21,8 @@ const Image: React.SFC<ImageProps> = props => {
   return (
     <div className="article-image">
       <ImageWrapper
+        images={props.images}
+        slideIndex={props.slideIndex}
         layout={layout}
         src={src}
         width={width}

--- a/src/Components/Publishing/Sections/ImageCollection.tsx
+++ b/src/Components/Publishing/Sections/ImageCollection.tsx
@@ -48,11 +48,25 @@ function renderImages(images, dimensions, gutter, sectionLayout, width) {
     let renderedImage
     if (image.type === "image") {
       renderedImage = (
-        <Image image={image} sectionLayout={sectionLayout} width={imageSize.width} height={imageSize.height} />
+        <Image
+          images={images}
+          slideIndex={i}
+          image={image}
+          sectionLayout={sectionLayout}
+          width={imageSize.width}
+          height={imageSize.height}
+        />
       )
     } else if (image.type === "artwork") {
       renderedImage = (
-        <Artwork artwork={image} sectionLayout={sectionLayout} width={imageSize.width} height={imageSize.height} />
+        <Artwork
+          images={images}
+          slideIndex={i}
+          artwork={image}
+          sectionLayout={sectionLayout}
+          width={imageSize.width}
+          height={imageSize.height}
+        />
       )
     } else {
       return false

--- a/src/Components/Publishing/Sections/ImageWrapper.tsx
+++ b/src/Components/Publishing/Sections/ImageWrapper.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import { pMedia } from "../../Helpers"
 import { Layout } from "../Typings"
-import ViewFullscreen from "./ViewFullscreen"
+import ViewFullscreen, { ViewFullscreenLink } from "./ViewFullscreen"
 
 interface ImageWrapperProps extends React.HTMLProps<HTMLImageElement> {
   src: string
@@ -11,11 +11,13 @@ interface ImageWrapperProps extends React.HTMLProps<HTMLImageElement> {
   height?: string | number
   alt?: string
   index?: number
+  images?: [object]
+  slideIndex?: number
 }
 
 const ImageWrapper: React.SFC<ImageWrapperProps> = props => {
   const { layout, index, ...blockImageProps }: any = props
-  const fullscreen = <Fullscreen><ViewFullscreen index={index} /></Fullscreen>
+  const fullscreen = <ViewFullscreen images={props.images} slideIndex={props.slideIndex} index={index} />
   const viewFullscreen = layout !== "classic" ? fullscreen : false
 
   return (
@@ -26,21 +28,16 @@ const ImageWrapper: React.SFC<ImageWrapperProps> = props => {
   )
 }
 
-const Fullscreen = styled.div`
-  opacity: 0;
-  transition: opacity .3s;
-`
-
 const StyledImageWrapper = styled.div`
   position: relative;
   &:hover {
-    ${Fullscreen} {
-      opacity: 1;
+    ${ViewFullscreenLink} {
+      opacity: 0.6;
     }
   }
   ${pMedia.sm`
-    ${Fullscreen} {
-      opacity: 1;
+    ${ViewFullscreenLink} {
+      opacity: 0.6;
     }
   `}
 `

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -53,7 +53,7 @@ const StyledText = div`
     padding-bottom: 0;
   }
   ul, ol {
-    padding-left: 1em;  
+    padding-left: 1em;
   }
   li {
     ${props => (props.layout === "classic" ? Fonts.garamond("s19") : Fonts.garamond("s23"))};
@@ -142,7 +142,7 @@ const StyledText = div`
   }
   ${props => pMedia.md`
     max-width: calc(100% - 40px);
-    margin: 0 auto;
+    margin: 0;
   `}
   ${props => pMedia.sm`
     max-width: 100%;

--- a/src/Components/Publishing/Sections/ViewFullscreen.tsx
+++ b/src/Components/Publishing/Sections/ViewFullscreen.tsx
@@ -3,40 +3,54 @@ import * as React from "react"
 import styled from "styled-components"
 import { track } from "../../../Utils/track"
 import IconExpand from "../Icon/Expand"
+import FullscreenViewer from "./FullscreenViewer/FullscreenViewer"
 
 interface ViewFullscreenProps extends React.HTMLProps<HTMLDivElement> {
   index?: number
+  images?: [object]
+  slideIndex?: number
 }
 
 @track()
-class ViewFullscreen extends React.Component<ViewFullscreenProps, void> {
+class ViewFullscreen extends React.Component<ViewFullscreenProps, any> {
   static childContextTypes = {
     onViewFullscreen: PropTypes.func,
   }
 
   constructor(props) {
     super()
-    this.onClick = this.onClick.bind(this)
+    this.openViewer = this.openViewer.bind(this)
+    this.state = { viewerIsOpen: false }
   }
 
   @track({ action: "Clicked article impression" })
-  onClick(e) {
+  openViewer(e) {
     e.preventDefault()
-    if (this.context.onViewFullscreen) {
-      this.context.onViewFullscreen(this.props.index)
-    }
+    this.setState({ viewerIsOpen: true })
+  }
+
+  closeViewer = e => {
+    this.setState({ viewerIsOpen: false })
   }
 
   render() {
     return (
-      <ViewFullscreenLink onClick={this.onClick}>
-        <IconExpand />
-      </ViewFullscreenLink>
+      <div>
+        <ViewFullscreenLink onClick={this.openViewer}>
+          <IconExpand />
+        </ViewFullscreenLink>
+        <FullscreenViewer
+          slideIndex={this.props.slideIndex}
+          onClose={this.closeViewer}
+          show={this.state.viewerIsOpen}
+          images={this.props.images}
+        />
+      </div>
     )
   }
 }
 
-const ViewFullscreenLink = styled.div`
+export const ViewFullscreenLink = styled.div`
   position: absolute;
   bottom: 0;
   right: 0;
@@ -44,11 +58,8 @@ const ViewFullscreenLink = styled.div`
   width: 25px;
   height: 25px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0;
   transition: opacity 0.3s;
-  &:hover {
-    opacity: 1;
-  }
 `
 
 export default ViewFullscreen

--- a/src/Components/Publishing/Sections/__test__/Artwork.test.tsx
+++ b/src/Components/Publishing/Sections/__test__/Artwork.test.tsx
@@ -6,6 +6,11 @@ import "jest-styled-components"
 import { Images } from "../../Fixtures/Components"
 import Artwork from "../Artwork"
 
+jest.mock("react-slick", () => {
+  const React = require("react")
+  return props => <div>{props.children}</div>
+})
+
 it("renders properly", () => {
   const artwork = renderer.create(<Artwork artwork={Images[0]} />).toJSON()
   expect(artwork).toMatchSnapshot()

--- a/src/Components/Publishing/Sections/__test__/Image.test.tsx
+++ b/src/Components/Publishing/Sections/__test__/Image.test.tsx
@@ -6,6 +6,11 @@ import "jest-styled-components"
 import { Images } from "../../Fixtures/Components"
 import Image from "../Image"
 
+jest.mock("react-slick", () => {
+  const React = require("react")
+  return props => <div>{props.children}</div>
+})
+
 it("renders properly", () => {
   const image = renderer.create(<Image image={Images[1]} />).toJSON()
   expect(image).toMatchSnapshot()

--- a/src/Components/Publishing/Sections/__test__/ImageCollection.test.tsx
+++ b/src/Components/Publishing/Sections/__test__/ImageCollection.test.tsx
@@ -7,6 +7,10 @@ import { Images } from "../../Fixtures/Components"
 import ImageCollection from "../ImageCollection"
 
 jest.mock("react-sizeme", () => jest.fn(c => d => d))
+jest.mock("react-slick", () => {
+  const React = require("react")
+  return props => <div>{props.children}</div>
+})
 
 it("renders properly", () => {
   const image = renderer.create(<ImageCollection images={Images} targetHeight={400} gutter={10} />).toJSON()

--- a/src/Components/Publishing/Sections/__test__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__test__/Sections.test.tsx
@@ -7,6 +7,10 @@ import { StandardArticle } from "../../Fixtures/Articles"
 import Sections from "../Sections"
 
 jest.mock("react-sizeme", () => jest.fn(c => d => d))
+jest.mock("react-slick", () => {
+  const React = require("react")
+  return props => <div>{props.children}</div>
+})
 
 it("renders properly", () => {
   const sections = renderer.create(<Sections article={StandardArticle} />).toJSON()

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Artwork.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Artwork.test.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders properly 1`] = `
-.c8 {
+.c7 {
   color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c6 {
+.c5 {
   padding: 0;
   margin-top: 10px;
   display: -webkit-box;
@@ -20,14 +20,14 @@ exports[`renders properly 1`] = `
   line-height: 1.4em;
 }
 
-.c6 .title {
+.c5 .title {
   font-family: Unica77LLWebItalic ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
-.c7 {
+.c6 {
   color: #999;
   display: block;
   -webkit-text-overflow: ellipsis;
@@ -37,11 +37,11 @@ exports[`renders properly 1`] = `
   width: 100%;
 }
 
-.c7 .artist-name {
+.c6 .artist-name {
   margin-right: 30px;
 }
 
-.c5 {
+.c4 {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -49,19 +49,9 @@ exports[`renders properly 1`] = `
   width: 25px;
   height: 25px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-}
-
-.c5:hover {
-  opacity: 1;
-}
-
-.c4 {
-  opacity: 0;
-  -webkit-transition: opacity .3s;
-  transition: opacity .3s;
 }
 
 .c1 {
@@ -69,7 +59,7 @@ exports[`renders properly 1`] = `
 }
 
 .c1:hover .c3 {
-  opacity: 1;
+  opacity: 0.6;
 }
 
 .c2 {
@@ -82,14 +72,14 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c6 {
+  .c5 {
     padding: 0 10px;
   }
 }
 
 @media (max-width: 720px) {
   .c1 .c3 {
-    opacity: 1;
+    opacity: 0.6;
   }
 }
 
@@ -110,11 +100,9 @@ exports[`renders properly 1`] = `
         src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0aRUvnVgQKbQk5dj8xcCAg%2Flarger.jpg&width=1200&quality=95"
         width="100%"
       />
-      <div
-        className="c3 c4"
-      >
+      <div>
         <div
-          className="c5"
+          className="c3 c4"
           onClick={[Function]}
         >
           <svg
@@ -167,10 +155,10 @@ exports[`renders properly 1`] = `
     </div>
   </a>
   <div
-    className="display-artwork__caption c6"
+    className="display-artwork__caption c5"
   >
     <div
-      className="c7"
+      className="c6"
     >
       <span
         className="artist-name"
@@ -179,7 +167,7 @@ exports[`renders properly 1`] = `
           className="name"
         >
           <a
-            className="c8"
+            className="c7"
             href="/artist/fernando-botero"
           >
             Fernando Botero
@@ -190,7 +178,7 @@ exports[`renders properly 1`] = `
         className="title"
       >
         <a
-          className="c8"
+          className="c7"
           href="/artwork/fernando-botero-nude-on-the-beach"
         >
           Nude on the Beach
@@ -212,7 +200,7 @@ exports[`renders properly 1`] = `
         , 
       </span>
       <a
-        className="c8"
+        className="c7"
         href="/partner/gary-nader"
       >
         Gary Nader

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Image.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Image.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a long caption properly 1`] = `
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13,15 +13,15 @@ exports[`renders a long caption properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c6 {
+.c5 {
   padding: 0;
   width: 100%;
   word-break: break-word;
 }
 
-.c6 > p,
-.c6 p,
-.c6 .public-DraftEditorPlaceholder-root {
+.c5 > p,
+.c5 p,
+.c5 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -30,17 +30,17 @@ exports[`renders a long caption properly 1`] = `
   margin: 0;
 }
 
-.c6 > a,
-.c6 a {
+.c5 > a,
+.c5 a {
   color: #999;
 }
 
-.c6 > a:hover,
-.c6 a:hover {
+.c5 > a:hover,
+.c5 a:hover {
   color: black;
 }
 
-.c4 {
+.c3 {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -48,19 +48,9 @@ exports[`renders a long caption properly 1`] = `
   width: 25px;
   height: 25px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-}
-
-.c4:hover {
-  opacity: 1;
-}
-
-.c3 {
-  opacity: 0;
-  -webkit-transition: opacity .3s;
-  transition: opacity .3s;
 }
 
 .c0 {
@@ -68,7 +58,7 @@ exports[`renders a long caption properly 1`] = `
 }
 
 .c0:hover .c2 {
-  opacity: 1;
+  opacity: 0.6;
 }
 
 .c1 {
@@ -76,20 +66,20 @@ exports[`renders a long caption properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c5 {
+  .c4 {
     padding: 0px 10px;
   }
 }
 
 @media (max-width: 600px) {
-  .c6 {
+  .c5 {
     padding: 0px;
   }
 }
 
 @media (max-width: 720px) {
   .c0 .c2 {
-    opacity: 1;
+    opacity: 0.6;
   }
 }
 
@@ -106,11 +96,9 @@ exports[`renders a long caption properly 1`] = `
       src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCpHY-DRr7KW0HGXLslCXHw%2Flarger.jpg&width=1200&quality=95"
       width="100%"
     />
-    <div
-      className="c2 c3"
-    >
+    <div>
       <div
-        className="c4"
+        className="c2 c3"
         onClick={[Function]}
       >
         <svg
@@ -162,10 +150,10 @@ exports[`renders a long caption properly 1`] = `
     </div>
   </div>
   <div
-    className="c5"
+    className="c4"
   >
     <div
-      className="c6"
+      className="c5"
     >
       <div
         dangerouslySetInnerHTML={
@@ -180,7 +168,7 @@ exports[`renders a long caption properly 1`] = `
 `;
 
 exports[`renders a react child as caption properly 1`] = `
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -192,15 +180,15 @@ exports[`renders a react child as caption properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c6 {
+.c5 {
   padding: 0;
   width: 100%;
   word-break: break-word;
 }
 
-.c6 > p,
-.c6 p,
-.c6 .public-DraftEditorPlaceholder-root {
+.c5 > p,
+.c5 p,
+.c5 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -209,17 +197,17 @@ exports[`renders a react child as caption properly 1`] = `
   margin: 0;
 }
 
-.c6 > a,
-.c6 a {
+.c5 > a,
+.c5 a {
   color: #999;
 }
 
-.c6 > a:hover,
-.c6 a:hover {
+.c5 > a:hover,
+.c5 a:hover {
   color: black;
 }
 
-.c4 {
+.c3 {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -227,19 +215,9 @@ exports[`renders a react child as caption properly 1`] = `
   width: 25px;
   height: 25px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-}
-
-.c4:hover {
-  opacity: 1;
-}
-
-.c3 {
-  opacity: 0;
-  -webkit-transition: opacity .3s;
-  transition: opacity .3s;
 }
 
 .c0 {
@@ -247,7 +225,7 @@ exports[`renders a react child as caption properly 1`] = `
 }
 
 .c0:hover .c2 {
-  opacity: 1;
+  opacity: 0.6;
 }
 
 .c1 {
@@ -255,20 +233,20 @@ exports[`renders a react child as caption properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c5 {
+  .c4 {
     padding: 0px 10px;
   }
 }
 
 @media (max-width: 600px) {
-  .c6 {
+  .c5 {
     padding: 0px;
   }
 }
 
 @media (max-width: 720px) {
   .c0 .c2 {
-    opacity: 1;
+    opacity: 0.6;
   }
 }
 
@@ -285,11 +263,9 @@ exports[`renders a react child as caption properly 1`] = `
       src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCpHY-DRr7KW0HGXLslCXHw%2Flarger.jpg&width=1200&quality=95"
       width="100%"
     />
-    <div
-      className="c2 c3"
-    >
+    <div>
       <div
-        className="c4"
+        className="c2 c3"
         onClick={[Function]}
       >
         <svg
@@ -341,10 +317,10 @@ exports[`renders a react child as caption properly 1`] = `
     </div>
   </div>
   <div
-    className="c5"
+    className="c4"
   >
     <div
-      className="c6"
+      className="c5"
     >
       <div>
         <p>
@@ -357,7 +333,7 @@ exports[`renders a react child as caption properly 1`] = `
 `;
 
 exports[`renders properly 1`] = `
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -369,15 +345,15 @@ exports[`renders properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c6 {
+.c5 {
   padding: 0;
   width: 100%;
   word-break: break-word;
 }
 
-.c6 > p,
-.c6 p,
-.c6 .public-DraftEditorPlaceholder-root {
+.c5 > p,
+.c5 p,
+.c5 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -386,17 +362,17 @@ exports[`renders properly 1`] = `
   margin: 0;
 }
 
-.c6 > a,
-.c6 a {
+.c5 > a,
+.c5 a {
   color: #999;
 }
 
-.c6 > a:hover,
-.c6 a:hover {
+.c5 > a:hover,
+.c5 a:hover {
   color: black;
 }
 
-.c4 {
+.c3 {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -404,19 +380,9 @@ exports[`renders properly 1`] = `
   width: 25px;
   height: 25px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-}
-
-.c4:hover {
-  opacity: 1;
-}
-
-.c3 {
-  opacity: 0;
-  -webkit-transition: opacity .3s;
-  transition: opacity .3s;
 }
 
 .c0 {
@@ -424,7 +390,7 @@ exports[`renders properly 1`] = `
 }
 
 .c0:hover .c2 {
-  opacity: 1;
+  opacity: 0.6;
 }
 
 .c1 {
@@ -432,20 +398,20 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c5 {
+  .c4 {
     padding: 0px 10px;
   }
 }
 
 @media (max-width: 600px) {
-  .c6 {
+  .c5 {
     padding: 0px;
   }
 }
 
 @media (max-width: 720px) {
   .c0 .c2 {
-    opacity: 1;
+    opacity: 0.6;
   }
 }
 
@@ -462,11 +428,9 @@ exports[`renders properly 1`] = `
       src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco8j2xq40ROMyBrJQm_4eQ%252FDafenOilPaintingVillage_AK03.jpg&width=1200&quality=95"
       width="100%"
     />
-    <div
-      className="c2 c3"
-    >
+    <div>
       <div
-        className="c4"
+        className="c2 c3"
         onClick={[Function]}
       >
         <svg
@@ -518,10 +482,10 @@ exports[`renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c5"
+    className="c4"
   >
     <div
-      className="c6"
+      className="c5"
     >
       <div
         dangerouslySetInnerHTML={

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/ImageCollection.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/ImageCollection.test.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a single image properly 1`] = `
-.c10 {
+.c9 {
   color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c8 {
+.c7 {
   padding: 0;
   margin-top: 10px;
   display: -webkit-box;
@@ -20,14 +20,14 @@ exports[`renders a single image properly 1`] = `
   line-height: 1.4em;
 }
 
-.c8 .title {
+.c7 .title {
   font-family: Unica77LLWebItalic ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
-.c9 {
+.c8 {
   color: #999;
   display: block;
   -webkit-text-overflow: ellipsis;
@@ -37,11 +37,11 @@ exports[`renders a single image properly 1`] = `
   width: 100%;
 }
 
-.c9 .artist-name {
+.c8 .artist-name {
   margin-right: 30px;
 }
 
-.c7 {
+.c6 {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -49,19 +49,9 @@ exports[`renders a single image properly 1`] = `
   width: 25px;
   height: 25px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-}
-
-.c7:hover {
-  opacity: 1;
-}
-
-.c6 {
-  opacity: 0;
-  -webkit-transition: opacity .3s;
-  transition: opacity .3s;
 }
 
 .c3 {
@@ -69,7 +59,7 @@ exports[`renders a single image properly 1`] = `
 }
 
 .c3:hover .c5 {
-  opacity: 1;
+  opacity: 0.6;
 }
 
 .c4 {
@@ -95,14 +85,14 @@ exports[`renders a single image properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c8 {
+  .c7 {
     padding: 0 10px;
   }
 }
 
 @media (max-width: 720px) {
   .c3 .c5 {
-    opacity: 1;
+    opacity: 0.6;
   }
 }
 
@@ -144,11 +134,9 @@ exports[`renders a single image properly 1`] = `
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0aRUvnVgQKbQk5dj8xcCAg%2Flarger.jpg&width=1200&quality=95"
             width="100%"
           />
-          <div
-            className="c5 c6"
-          >
+          <div>
             <div
-              className="c7"
+              className="c5 c6"
               onClick={[Function]}
             >
               <svg
@@ -201,10 +189,10 @@ exports[`renders a single image properly 1`] = `
         </div>
       </a>
       <div
-        className="display-artwork__caption c8"
+        className="display-artwork__caption c7"
       >
         <div
-          className="c9"
+          className="c8"
         >
           <span
             className="artist-name"
@@ -213,7 +201,7 @@ exports[`renders a single image properly 1`] = `
               className="name"
             >
               <a
-                className="c10"
+                className="c9"
                 href="/artist/fernando-botero"
               >
                 Fernando Botero
@@ -224,7 +212,7 @@ exports[`renders a single image properly 1`] = `
             className="title"
           >
             <a
-              className="c10"
+              className="c9"
               href="/artwork/fernando-botero-nude-on-the-beach"
             >
               Nude on the Beach
@@ -246,7 +234,7 @@ exports[`renders a single image properly 1`] = `
             , 
           </span>
           <a
-            className="c10"
+            className="c9"
             href="/partner/gary-nader"
           >
             Gary Nader
@@ -259,13 +247,13 @@ exports[`renders a single image properly 1`] = `
 `;
 
 exports[`renders properly 1`] = `
-.c10 {
+.c9 {
   color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c8 {
+.c7 {
   padding: 0;
   margin-top: 10px;
   display: -webkit-box;
@@ -278,14 +266,14 @@ exports[`renders properly 1`] = `
   line-height: 1.4em;
 }
 
-.c8 .title {
+.c7 .title {
   font-family: Unica77LLWebItalic ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
-.c9 {
+.c8 {
   color: #999;
   display: block;
   -webkit-text-overflow: ellipsis;
@@ -295,11 +283,11 @@ exports[`renders properly 1`] = `
   width: 100%;
 }
 
-.c9 .artist-name {
+.c8 .artist-name {
   margin-right: 30px;
 }
 
-.c7 {
+.c6 {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -307,19 +295,9 @@ exports[`renders properly 1`] = `
   width: 25px;
   height: 25px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-}
-
-.c7:hover {
-  opacity: 1;
-}
-
-.c6 {
-  opacity: 0;
-  -webkit-transition: opacity .3s;
-  transition: opacity .3s;
 }
 
 .c3 {
@@ -327,7 +305,7 @@ exports[`renders properly 1`] = `
 }
 
 .c3:hover .c5 {
-  opacity: 1;
+  opacity: 0.6;
 }
 
 .c4 {
@@ -339,7 +317,7 @@ exports[`renders properly 1`] = `
   text-decoration: none;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -351,15 +329,15 @@ exports[`renders properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c13 {
+.c12 {
   padding: 0;
   width: 100%;
   word-break: break-word;
 }
 
-.c13 > p,
-.c13 p,
-.c13 .public-DraftEditorPlaceholder-root {
+.c12 > p,
+.c12 p,
+.c12 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -368,13 +346,13 @@ exports[`renders properly 1`] = `
   margin: 0;
 }
 
-.c13 > a,
-.c13 a {
+.c12 > a,
+.c12 a {
   color: #999;
 }
 
-.c13 > a:hover,
-.c13 a:hover {
+.c12 > a:hover,
+.c12 a:hover {
   color: black;
 }
 
@@ -383,12 +361,12 @@ exports[`renders properly 1`] = `
   width: 312px;
 }
 
-.c11 {
+.c10 {
   margin-right: 10px;
   width: 168px;
 }
 
-.c14 {
+.c13 {
   margin-right: 0px;
   width: 178px;
 }
@@ -402,25 +380,25 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c8 {
+  .c7 {
     padding: 0 10px;
   }
 }
 
 @media (max-width: 720px) {
   .c3 .c5 {
-    opacity: 1;
+    opacity: 0.6;
   }
 }
 
 @media (max-width: 600px) {
-  .c12 {
+  .c11 {
     padding: 0px 10px;
   }
 }
 
 @media (max-width: 600px) {
-  .c13 {
+  .c12 {
     padding: 0px;
   }
 }
@@ -432,13 +410,13 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c11 {
+  .c10 {
     margin-bottom: 10px;
   }
 }
 
 @media (max-width: 600px) {
-  .c14 {
+  .c13 {
     margin-bottom: 10px;
   }
 }
@@ -475,11 +453,9 @@ exports[`renders properly 1`] = `
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0aRUvnVgQKbQk5dj8xcCAg%2Flarger.jpg&width=1200&quality=95"
             width={312}
           />
-          <div
-            className="c5 c6"
-          >
+          <div>
             <div
-              className="c7"
+              className="c5 c6"
               onClick={[Function]}
             >
               <svg
@@ -532,10 +508,10 @@ exports[`renders properly 1`] = `
         </div>
       </a>
       <div
-        className="display-artwork__caption c8"
+        className="display-artwork__caption c7"
       >
         <div
-          className="c9"
+          className="c8"
         >
           <span
             className="artist-name"
@@ -544,7 +520,7 @@ exports[`renders properly 1`] = `
               className="name"
             >
               <a
-                className="c10"
+                className="c9"
                 href="/artist/fernando-botero"
               >
                 Fernando Botero
@@ -555,7 +531,7 @@ exports[`renders properly 1`] = `
             className="title"
           >
             <a
-              className="c10"
+              className="c9"
               href="/artwork/fernando-botero-nude-on-the-beach"
             >
               Nude on the Beach
@@ -577,7 +553,7 @@ exports[`renders properly 1`] = `
             , 
           </span>
           <a
-            className="c10"
+            className="c9"
             href="/partner/gary-nader"
           >
             Gary Nader
@@ -587,7 +563,7 @@ exports[`renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c11"
+    className="c10"
     width={168}
   >
     <div
@@ -603,11 +579,9 @@ exports[`renders properly 1`] = `
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco8j2xq40ROMyBrJQm_4eQ%252FDafenOilPaintingVillage_AK03.jpg&width=1200&quality=95"
           width={168}
         />
-        <div
-          className="c5 c6"
-        >
+        <div>
           <div
-            className="c7"
+            className="c5 c6"
             onClick={[Function]}
           >
             <svg
@@ -659,10 +633,10 @@ exports[`renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c12"
+        className="c11"
       >
         <div
-          className="c13"
+          className="c12"
         >
           <div
             dangerouslySetInnerHTML={
@@ -676,7 +650,7 @@ exports[`renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c14"
+    className="c13"
     width={178}
   >
     <div
@@ -692,11 +666,9 @@ exports[`renders properly 1`] = `
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCpHY-DRr7KW0HGXLslCXHw%2Flarger.jpg&width=1200&quality=95"
           width={178}
         />
-        <div
-          className="c5 c6"
-        >
+        <div>
           <div
-            className="c7"
+            className="c5 c6"
             onClick={[Function]}
           >
             <svg
@@ -748,10 +720,10 @@ exports[`renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c12"
+        className="c11"
       >
         <div
-          className="c13"
+          className="c12"
         >
           <div
             dangerouslySetInnerHTML={

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`renders column_width properly 1`] = `
 @media (max-width: 900px) {
   .c1 {
     max-width: calc(100% - 40px);
-    margin: 0 auto;
+    margin: 0;
   }
 }
 
@@ -483,7 +483,7 @@ exports[`renders fillwidth properly 1`] = `
 @media (max-width: 900px) {
   .c1 {
     max-width: calc(100% - 40px);
-    margin: 0 auto;
+    margin: 0;
   }
 }
 
@@ -767,7 +767,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 @media (max-width: 900px) {
   .c1 {
     max-width: calc(100% - 40px);
-    margin: 0 auto;
+    margin: 0;
   }
 }
 

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders properly 1`] = `
-.c22 {
+.c21 {
   width: 100%;
   height: 1000px;
 }
 
-.c18 {
+.c17 {
   color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c16 {
+.c15 {
   padding: 0;
   margin-top: 10px;
   display: -webkit-box;
@@ -25,14 +25,14 @@ exports[`renders properly 1`] = `
   line-height: 1.4em;
 }
 
-.c16 .title {
+.c15 .title {
   font-family: Unica77LLWebItalic ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
-.c17 {
+.c16 {
   color: #999;
   display: block;
   -webkit-text-overflow: ellipsis;
@@ -42,11 +42,11 @@ exports[`renders properly 1`] = `
   width: 100%;
 }
 
-.c17 .artist-name {
+.c16 .artist-name {
   margin-right: 30px;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -54,19 +54,9 @@ exports[`renders properly 1`] = `
   width: 25px;
   height: 25px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-}
-
-.c11:hover {
-  opacity: 1;
-}
-
-.c10 {
-  opacity: 0;
-  -webkit-transition: opacity .3s;
-  transition: opacity .3s;
 }
 
 .c7 {
@@ -74,19 +64,19 @@ exports[`renders properly 1`] = `
 }
 
 .c7:hover .c9 {
-  opacity: 1;
+  opacity: 0.6;
 }
 
 .c8 {
   display: block;
 }
 
-.c15 {
+.c14 {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -98,15 +88,15 @@ exports[`renders properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c13 {
+.c12 {
   padding: 0;
   width: 100%;
   word-break: break-word;
 }
 
-.c13 > p,
-.c13 p,
-.c13 .public-DraftEditorPlaceholder-root {
+.c12 > p,
+.c12 p,
+.c12 .public-DraftEditorPlaceholder-root {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -115,13 +105,13 @@ exports[`renders properly 1`] = `
   margin: 0;
 }
 
-.c13 > a,
-.c13 a {
+.c12 > a,
+.c12 a {
   color: #999;
 }
 
-.c13 > a:hover,
-.c13 a:hover {
+.c12 > a:hover,
+.c12 a:hover {
   color: black;
 }
 
@@ -130,32 +120,32 @@ exports[`renders properly 1`] = `
   width: 197px;
 }
 
-.c14 {
+.c13 {
   margin-right: 0px;
   width: 264px;
 }
 
-.c19 {
+.c18 {
   margin-right: 10px;
+  width: 219px;
+}
+
+.c19 {
+  margin-right: 0px;
   width: 219px;
 }
 
 .c20 {
   margin-right: 0px;
-  width: 219px;
-}
-
-.c21 {
-  margin-right: 0px;
   width: 100%;
 }
 
-.c23 {
+.c22 {
   margin-right: 10px;
   width: 216px;
 }
 
-.c24 {
+.c23 {
   margin-right: 0px;
   width: 222px;
 }
@@ -168,7 +158,7 @@ exports[`renders properly 1`] = `
   width: 100%;
 }
 
-.c33 {
+.c32 {
   height: 45px;
   position: relative;
   margin-left: 40px;
@@ -176,11 +166,11 @@ exports[`renders properly 1`] = `
   text-align: right;
 }
 
-.c33 > svg {
+.c32 > svg {
   height: 98%;
 }
 
-.c26 {
+.c25 {
   position: absolute;
   bottom: 20px;
   left: 20px;
@@ -206,16 +196,16 @@ exports[`renders properly 1`] = `
   cursor: pointer;
 }
 
-.c26:hover {
+.c25:hover {
   background: rgba(0, 0, 0, 0.6);
   color: white;
 }
 
-.c26:hover .c32 {
+.c25:hover .c31 {
   fill: white;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -230,7 +220,7 @@ exports[`renders properly 1`] = `
   height: 50px;
 }
 
-.c28 {
+.c27 {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -239,21 +229,21 @@ exports[`renders properly 1`] = `
   line-height: 1.1em;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c30 {
+.c29 {
   font-family: Unica77LLWebMedium ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
-.c31 {
+.c30 {
   font-family: Unica77LLWebRegular ,      'Arial',      'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -294,7 +284,7 @@ exports[`renders properly 1`] = `
   margin-bottom: 40px;
 }
 
-.c25 {
+.c24 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -493,31 +483,31 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c22 {
+  .c21 {
     height: 1300px;
   }
 }
 
 @media (max-width: 600px) {
-  .c16 {
+  .c15 {
     padding: 0 10px;
   }
 }
 
 @media (max-width: 720px) {
   .c7 .c9 {
-    opacity: 1;
+    opacity: 0.6;
   }
 }
 
 @media (max-width: 600px) {
-  .c12 {
+  .c11 {
     padding: 0px 10px;
   }
 }
 
 @media (max-width: 600px) {
-  .c13 {
+  .c12 {
     padding: 0px;
   }
 }
@@ -529,7 +519,13 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c14 {
+  .c13 {
+    margin-bottom: 10px;
+  }
+}
+
+@media (max-width: 600px) {
+  .c18 {
     margin-bottom: 10px;
   }
 }
@@ -547,19 +543,13 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c21 {
+  .c22 {
     margin-bottom: 10px;
   }
 }
 
 @media (max-width: 600px) {
   .c23 {
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width: 600px) {
-  .c24 {
     margin-bottom: 10px;
   }
 }
@@ -573,13 +563,13 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c33 {
+  .c32 {
     display: none;
   }
 }
 
 @media (max-width: 600px) {
-  .c28 {
+  .c27 {
     font-family: Unica77LLWebMedium ,      'Arial',      'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -588,7 +578,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c30 {
+  .c29 {
     font-family: Unica77LLWebMedium ,      'Arial',      'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
@@ -597,7 +587,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 600px) {
-  .c31 {
+  .c30 {
     font-family: Unica77LLWebRegular ,      'Arial',      'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
@@ -648,13 +638,13 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width: 1250px) {
-  .c25 {
+  .c24 {
     width: 680px;
   }
 }
 
 @media (max-width: 900px) {
-  .c25 {
+  .c24 {
     width: 100%;
     padding: 0px;
     margin: 0 0 40px 0;
@@ -664,7 +654,7 @@ exports[`renders properly 1`] = `
 @media (max-width: 900px) {
   .c2 {
     max-width: calc(100% - 40px);
-    margin: 0 auto;
+    margin: 0;
   }
 }
 
@@ -831,11 +821,9 @@ exports[`renders properly 1`] = `
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F5ZP7vKuVPqiynVU0jpFewQ%252Funnamed.png&width=1200&quality=95"
               width={197}
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -887,10 +875,10 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -920,11 +908,9 @@ exports[`renders properly 1`] = `
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FPcvH_rh89gRGxRXgCyGGng%252Funnamed-5.png&width=1200&quality=95"
               width={197}
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -976,10 +962,10 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -993,14 +979,14 @@ exports[`renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c14"
+        className="c13"
         width={264}
       >
         <div
           className="display-artwork"
         >
           <a
-            className="c15"
+            className="c14"
             href="/artwork/matt-devine-brass-tax"
           >
             <div
@@ -1013,11 +999,9 @@ exports[`renders properly 1`] = `
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FlSBz0tsfvOAm2qKdWwgxLw%2Flarger.jpg&width=1200&quality=95"
                 width={264}
               />
-              <div
-                className="c9 c10"
-              >
+              <div>
                 <div
-                  className="c11"
+                  className="c9 c10"
                   onClick={[Function]}
                 >
                   <svg
@@ -1070,10 +1054,10 @@ exports[`renders properly 1`] = `
             </div>
           </a>
           <div
-            className="display-artwork__caption c16"
+            className="display-artwork__caption c15"
           >
             <div
-              className="c17"
+              className="c16"
             >
               <span
                 className="artist-name"
@@ -1082,7 +1066,7 @@ exports[`renders properly 1`] = `
                   className="name"
                 >
                   <a
-                    className="c18"
+                    className="c17"
                     href="/artist/matt-devine"
                   >
                     Matt Devine
@@ -1093,7 +1077,7 @@ exports[`renders properly 1`] = `
                 className="title"
               >
                 <a
-                  className="c18"
+                  className="c17"
                   href="/artwork/matt-devine-brass-tax"
                 >
                   Brass Tax
@@ -1105,7 +1089,7 @@ exports[`renders properly 1`] = `
                 , 
               </span>
               <a
-                className="c18"
+                className="c17"
                 href="/partner/joanne-artman-gallery"
               >
                 Joanne Artman Gallery
@@ -1138,7 +1122,7 @@ exports[`renders properly 1`] = `
       className="c5"
     >
       <div
-        className="c19"
+        className="c18"
         width={219}
       >
         <div
@@ -1154,11 +1138,9 @@ exports[`renders properly 1`] = `
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGwIVCQftjauWBCQie9oQ-A%252FTarot_de_Marseille_major21_world.jpg&width=1200&quality=95"
               width={219}
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -1210,15 +1192,102 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="c18"
+        width={219}
+      >
+        <div
+          className="article-image"
+        >
+          <div
+            className="c7"
+          >
+            <img
+              alt="Nicolas Conver, Queen of Clubs. Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
+              className="c8"
+              height={425}
+              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FUaNPuL9iz-X7Xm-SNtat7Q%252FTarot_de_Marseille_clubs13_queen.jpg&width=1200&quality=95"
+              width={219}
+            />
+            <div>
+              <div
+                className="c9 c10"
+                onClick={[Function]}
+              >
+                <svg
+                  className="expand"
+                  version="1.1"
+                  viewBox="0 0 27 27"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    fill="none"
+                    fillRule="evenodd"
+                    stroke="none"
+                    strokeWidth="1"
+                  >
+                    <g>
+                      <circle
+                        cx="13.9575195"
+                        cy="13.0588379"
+                        fill="#000000"
+                        fillRule="nonzero"
+                        r="13"
+                      />
+                      <g
+                        stroke="#FFFFFF"
+                        transform="translate(8.000000, 7.000000)"
+                      >
+                        <g>
+                          <g
+                            transform="translate(0.382532, 0.382532)"
+                          >
+                            <polyline
+                              points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
+                            />
+                            <polyline
+                              points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
+                              transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
+                            />
+                            <path
+                              d="M10.360254,0.796942618 L0.796942618,10.360254"
+                              strokeLinecap="square"
+                            />
+                          </g>
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div
+            className="c11"
+          >
+            <div
+              className="c12"
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Nicolas Conver, <em>Queen of Clubs</em>. Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
                   }
                 }
               />
@@ -1237,106 +1306,15 @@ exports[`renders properly 1`] = `
             className="c7"
           >
             <img
-              alt="Nicolas Conver, Queen of Clubs. Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
-              className="c8"
-              height={425}
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FUaNPuL9iz-X7Xm-SNtat7Q%252FTarot_de_Marseille_clubs13_queen.jpg&width=1200&quality=95"
-              width={219}
-            />
-            <div
-              className="c9 c10"
-            >
-              <div
-                className="c11"
-                onClick={[Function]}
-              >
-                <svg
-                  className="expand"
-                  version="1.1"
-                  viewBox="0 0 27 27"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <g
-                    fill="none"
-                    fillRule="evenodd"
-                    stroke="none"
-                    strokeWidth="1"
-                  >
-                    <g>
-                      <circle
-                        cx="13.9575195"
-                        cy="13.0588379"
-                        fill="#000000"
-                        fillRule="nonzero"
-                        r="13"
-                      />
-                      <g
-                        stroke="#FFFFFF"
-                        transform="translate(8.000000, 7.000000)"
-                      >
-                        <g>
-                          <g
-                            transform="translate(0.382532, 0.382532)"
-                          >
-                            <polyline
-                              points="4.78165571 0 11.1571966 0 11.1571966 6.37554094"
-                            />
-                            <polyline
-                              points="-1.01881144e-06 4.78165537 6.37553992 4.78165537 6.37553992 11.1571963"
-                              transform="translate(3.187769, 7.969426) rotate(-180.000000) translate(-3.187769, -7.969426) "
-                            />
-                            <path
-                              d="M10.360254,0.796942618 L0.796942618,10.360254"
-                              strokeLinecap="square"
-                            />
-                          </g>
-                        </g>
-                      </g>
-                    </g>
-                  </g>
-                </svg>
-              </div>
-            </div>
-          </div>
-          <div
-            className="c12"
-          >
-            <div
-              className="c13"
-            >
-              <div
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Nicolas Conver, <em>Queen of Clubs</em>. Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. </p>",
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="c20"
-        width={219}
-      >
-        <div
-          className="article-image"
-        >
-          <div
-            className="c7"
-          >
-            <img
               alt="Nicolas Conver, Tarot card from Tarot de Marseille, ca. 1760. Via Wikimedia Commons. "
               className="c8"
               height={426}
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fx5EcmVNBKoUJqQa8BQgqJA%252FTarot_de_Marseille_major06_lovers.jpg&width=1200&quality=95"
               width={219}
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -1388,10 +1366,10 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1428,7 +1406,7 @@ exports[`renders properly 1`] = `
       className="c5"
     >
       <div
-        className="c21"
+        className="c20"
         width={undefined}
       >
         <div
@@ -1444,11 +1422,9 @@ exports[`renders properly 1`] = `
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0aRUvnVgQKbQk5dj8xcCAg%2Flarger.jpg&width=1200&quality=95"
               width="100%"
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -1500,10 +1476,10 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1537,7 +1513,7 @@ exports[`renders properly 1`] = `
     className="c4"
   >
     <iframe
-      className="c22"
+      className="c21"
       frameBorder="0"
       height={1000}
       scrolling="no"
@@ -1566,7 +1542,7 @@ exports[`renders properly 1`] = `
       className="c5"
     >
       <div
-        className="c23"
+        className="c22"
         width={216}
       >
         <div
@@ -1582,11 +1558,9 @@ exports[`renders properly 1`] = `
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fjmrvzuo7VfRidule-4zWNA%252F07272017170054-0001%2B%2528dragged%2529%2Bcopy.jpg&width=1200&quality=95"
               width={216}
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -1638,10 +1612,10 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1655,7 +1629,7 @@ exports[`renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c19"
+        className="c18"
         width={219}
       >
         <div
@@ -1671,11 +1645,9 @@ exports[`renders properly 1`] = `
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F66XOTGwZQzAAa0igYKSNTQ%252F07272017170207-0001%2B%2528dragged%2529.jpg&width=1200&quality=95"
               width={219}
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -1727,10 +1699,10 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1744,7 +1716,7 @@ exports[`renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="c23"
         width={222}
       >
         <div
@@ -1760,11 +1732,9 @@ exports[`renders properly 1`] = `
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fl0Qu946mLja0Dbv4ME4MHg%252F07272017170259-0001%2B%2528dragged%2529.jpg&width=1200&quality=95"
               width={222}
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -1816,10 +1786,10 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={
@@ -1850,7 +1820,7 @@ exports[`renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c25"
+    className="c24"
   >
     <div
       style={
@@ -1861,27 +1831,27 @@ exports[`renders properly 1`] = `
       }
     >
       <div
-        className="c26"
+        className="c25"
         onClick={[Function]}
       >
         <div
-          className="c27"
+          className="c26"
         >
           <div
-            className="c28"
+            className="c27"
           >
             The Work of Bruce M. Sherman
           </div>
           <div
-            className="c29"
+            className="c28"
           >
             <div
-              className="c30"
+              className="c29"
             >
               View Slideshow
             </div>
             <div
-              className="c31"
+              className="c30"
             >
               3
                Images
@@ -1889,7 +1859,7 @@ exports[`renders properly 1`] = `
           </div>
         </div>
         <div
-          className="c32 c33"
+          className="c31 c32"
         >
           <svg
             className="image-set"
@@ -1933,13 +1903,13 @@ exports[`renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c25"
+    className="c24"
   >
     <div
       className="c5"
     >
       <div
-        className="c21"
+        className="c20"
         width={undefined}
       >
         <div
@@ -1955,11 +1925,9 @@ exports[`renders properly 1`] = `
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGk95i1tUaDJKeqQ-jcq6Cw%252FIMG_2142.jpg&width=1200&quality=95"
               width="100%"
             />
-            <div
-              className="c9 c10"
-            >
+            <div>
               <div
-                className="c11"
+                className="c9 c10"
                 onClick={[Function]}
               >
                 <svg
@@ -2011,10 +1979,10 @@ exports[`renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c12"
+            className="c11"
           >
             <div
-              className="c13"
+              className="c12"
             >
               <div
                 dangerouslySetInnerHTML={

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders classic text properly 1`] = `
 <div
-  className="article__text-section sc-bdVaJa vKJlg"
+  className="article__text-section sc-bdVaJa dGQCcX"
 >
   <div
     dangerouslySetInnerHTML={
@@ -16,7 +16,7 @@ exports[`renders classic text properly 1`] = `
 
 exports[`renders feature text properly 1`] = `
 <div
-  className="article__text-section sc-bdVaJa gdoYdK"
+  className="article__text-section sc-bdVaJa fTwoqG"
 >
   <div
     dangerouslySetInnerHTML={
@@ -30,7 +30,7 @@ exports[`renders feature text properly 1`] = `
 
 exports[`renders standard text properly 1`] = `
 <div
-  className="article__text-section sc-bdVaJa jFIhsF"
+  className="article__text-section sc-bdVaJa dPsFFb"
 >
   <div
     dangerouslySetInnerHTML={


### PR DESCRIPTION
This refactors the fullscreen slideshow component to move down the tree so we don't need to use React context (a feature React encourages not using). The ViewFullscreenLink now lives _next_ to the slideshow component so that the state toggling it visible is consolidated there instead of all the way at the top Article component.

This was an attempt at fixing...

![image](https://user-images.githubusercontent.com/555859/31462889-2455c35c-ae9c-11e7-9aa7-ddfa2e9f5e81.png)

of [this issue](https://github.com/artsy/publishing/issues/45). Lmk if I'm overlooking something.