### PR TITLE
@kanaabe: Refactored article component to fix fullscreen slideshow

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -97,59 +97,61 @@ class Article extends React.Component<ArticleProps, ArticleState> {
     return { fullscreenImages, article }
   }
 
-  render() {
-    const { relatedArticlesForCanvas, relatedArticlesForPanel, headerHeight, marginTop } = this.props
-    const article = this.state.article
-    if (article.layout === "feature") {
-      return (
-        <ArticleContainer marginTop={marginTop}>
-          <Header article={article} height={headerHeight} />
-          <FeatureLayout className="article-content">
+  renderFeatureArticle() {
+    const { headerHeight } = this.props
+    const { article } = this.state
+    return (
+      <div>
+        <Header article={article} height={headerHeight} />
+        <FeatureLayout className="article-content">
+          <Sections article={article} />
+        </FeatureLayout>
+      </div>
+    )
+  }
+
+  renderStandardArticle() {
+    const { relatedArticlesForCanvas, relatedArticlesForPanel } = this.props
+    const { article } = this.state
+    const relatedArticlePanel = relatedArticlesForPanel
+      ? <RelatedArticlesPanel label={"Related Stories"} articles={relatedArticlesForPanel} />
+      : false
+    const relatedArticleCanvas = relatedArticlesForCanvas
+      ? <RelatedArticlesCanvas articles={relatedArticlesForCanvas} vertical={article.vertical} />
+      : false
+    const emailSignup = this.props.emailSignupUrl ? <EmailSignup signupUrl={this.props.emailSignupUrl} /> : false
+    return (
+      <div>
+        <ReadMoreWrapper isTruncated={this.state.isTruncated} hideButton={this.removeTruncation}>
+          <Header article={article} />
+          <StandardLayout>
             <Sections article={article} />
-          </FeatureLayout>
-          <FullscreenViewer
-            onClose={this.closeViewer}
-            show={this.state.viewerIsOpen}
-            slideIndex={this.state.slideIndex}
-            images={this.state.fullscreenImages}
-          />
-        </ArticleContainer>
-      )
-    } else {
-      const relatedArticlePanel = relatedArticlesForPanel ? (
-        <RelatedArticlesPanel label={"Related Stories"} articles={relatedArticlesForPanel} />
-      ) : (
-        false
-      )
-      const relatedArticleCanvas = relatedArticlesForCanvas ? (
-        <RelatedArticlesCanvas articles={relatedArticlesForCanvas} vertical={article.vertical} />
-      ) : (
-        false
-      )
-      const emailSignup = this.props.emailSignupUrl ? <EmailSignup signupUrl={this.props.emailSignupUrl} /> : false
-      return (
-        <ArticleContainer marginTop={marginTop}>
-          <ReadMoreWrapper isTruncated={this.state.isTruncated} hideButton={this.removeTruncation}>
-            <Header article={article} />
-            <StandardLayout>
-              <Sections article={article} />
-              <Sidebar>
-                {emailSignup}
-                {relatedArticlePanel}
-              </Sidebar>
-            </StandardLayout>
-            {relatedArticleCanvas}
-          </ReadMoreWrapper>
-          {this.state.isTruncated ? <ReadMore onClick={this.removeTruncation} /> : false}
-          <FullscreenViewer
-            onClose={this.closeViewer}
-            show={this.state.viewerIsOpen}
-            slideIndex={this.state.slideIndex}
-            images={this.state.fullscreenImages}
-          />
-        </ArticleContainer>
-      )
-    }
+            <Sidebar>
+              {emailSignup}
+              {relatedArticlePanel}
+            </Sidebar>
+          </StandardLayout>
+          {relatedArticleCanvas}
+        </ReadMoreWrapper>
+        {this.state.isTruncated ? <ReadMore onClick={this.removeTruncation} /> : false}
+      </div>
+    )
+  }
+
+  render() {
+    const { marginTop } = this.props
+    const { article } = this.state
+    return (
+      <ArticleContainer marginTop={marginTop}>
+        {article.layout === "feature" ? this.renderFeatureArticle() : this.renderStandardArticle()}
+        <FullscreenViewer
+          onClose={this.closeViewer}
+          show={this.state.viewerIsOpen}
+          slideIndex={this.state.slideIndex}
+          images={this.state.fullscreenImages}
+        />
+      </ArticleContainer>
+    )
   }
 }
 

--- a/src/Components/Publishing/Sections/ViewFullscreen.tsx
+++ b/src/Components/Publishing/Sections/ViewFullscreen.tsx
@@ -10,7 +10,7 @@ interface ViewFullscreenProps extends React.HTMLProps<HTMLDivElement> {
 
 @track()
 class ViewFullscreen extends React.Component<ViewFullscreenProps, void> {
-  static childContextTypes = {
+  static contextTypes = {
     onViewFullscreen: PropTypes.func,
   }
 


### PR DESCRIPTION
The issue with the slideshow was simply using `childContextTypes` in the child component vs. `contextTypes` but I also decided to loop in the refactors from the last PR.

I can't find a way to use the simulator to test the mobile tap issue you encountered because of the un-pollyfilled advanced browser features Reaction uses. Maybe @alloy or @orta has an idea of how to do this? Barring a way to locally test this should allow us to test on GH pages atleast.

![image](https://user-images.githubusercontent.com/555859/31469689-b683924a-aeb0-11e7-9447-bb768941e045.png)
