### PR TITLE
@kanaabe => [Minor] Don't require hero.url to render FeatureHeader

### DIFF
--- a/src/Components/Publishing/Header/FeatureHeader.tsx
+++ b/src/Components/Publishing/Header/FeatureHeader.tsx
@@ -97,21 +97,22 @@ interface FeatureHeaderProps {
 const FeatureHeader: React.SFC<FeatureHeaderProps> = props => {
   const { article, vertical, title, deck, image, size, height } = props
   const hero = article.hero_section
+  const url = hero.url || ''
   const isMobile = size.width && size.width < 600 ? true : false
   return (
     <FeatureHeaderContainer data-type={hero.type} height={height}>
-      {renderFeatureAsset(hero.url, hero.type, isMobile, article.title, image)}
+      {renderFeatureAsset(url, hero.type, isMobile, article.title, image)}
       <HeaderTextContainer>
         <HeaderText>
           <Vertical>{vertical}</Vertical>
           <Title>{title}</Title>
-          {renderMobileSplitAsset(hero.url, hero.type, isMobile, article.title, image)}
+          {renderMobileSplitAsset(url, hero.type, isMobile, article.title, image)}
           <SubHeader>
             {renderDeck(deck)}
             <Byline article={article} layout={hero.type} />
           </SubHeader>
         </HeaderText>
-        {renderTextLayoutAsset(hero.url, hero.type, article.title, image)}
+        {renderTextLayoutAsset(url, hero.type, article.title, image)}
       </HeaderTextContainer>
     </FeatureHeaderContainer>
   )

--- a/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`feature renders feature full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+.c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
   width: 50vw;
 }
 
@@ -366,7 +366,7 @@ exports[`feature renders feature full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+  .c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
     width: 100%;
   }
 }
@@ -732,7 +732,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+.c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
   width: 50vw;
 }
 
@@ -746,7 +746,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   flex-direction: column;
 }
 
-.c0[data-type='split'] .file__Deck-zzrn85-8 {
+.c0[data-type='split'] .file__Deck-hx4kbi-8 {
   margin-bottom: 30px;
 }
 
@@ -868,7 +868,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+  .c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
     width: 100%;
   }
 }
@@ -1235,7 +1235,7 @@ exports[`feature renders feature header with children properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+.c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
   width: 50vw;
 }
 
@@ -1381,7 +1381,7 @@ exports[`feature renders feature header with children properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+  .c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
     width: 100%;
   }
 }
@@ -1757,7 +1757,7 @@ exports[`feature renders feature split header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+.c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
   width: 50vw;
 }
 
@@ -1903,7 +1903,7 @@ exports[`feature renders feature split header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+  .c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
     width: 100%;
   }
 }
@@ -2265,7 +2265,7 @@ exports[`feature renders feature text header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+.c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
   width: 50vw;
 }
 
@@ -2411,7 +2411,7 @@ exports[`feature renders feature text header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type='split'] .file__FeatureVideo-zzrn85-2 {
+  .c0[data-type='split'] .file__FeatureVideo-hx4kbi-2 {
     width: 100%;
   }
 }


### PR DESCRIPTION
Related to https://github.com/artsy/publishing/issues/83

If there is no hero.url, pass a string rather than undefined. Allows a new feature article with empty heroSection to render in Writer. 