### PR TITLE
Unlock Node 8 minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "docs"
   ],
   "engines": {
-    "node": "8.4.x",
+    "node": "8.x.x",
     "npm": "5.4.x"
   },
   "scripts": {


### PR DESCRIPTION
Removes required `8.4.x` in favor of `8.x.x` in `package.json`. 