### PR TITLE
@kanaabe => [Bugfix]: Ad Unit video playback

### DIFF
--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -19,9 +19,29 @@ interface CanvasContainerProps {
 
 function renderAsset(asset, campaign) {
   if (asset.url.includes("mp4")) {
-    return <CanvasVideo src={asset.url} campaign={campaign} />
+    return (
+      <CanvasVideo
+        src={asset.url}
+        campaign={campaign}
+      />
+    )
   } else {
-    return <Image src={crop(asset.url, { width: 1200, height: 760 })} />
+    return (
+      <Image
+        src={crop(asset.url, {
+          width: 1200,
+          height: 760
+        })}
+      />
+    )
+  }
+}
+
+function handleVideoLinkClick(event) {
+  // TODO: Ensure that full element can be clicked on video complete
+  // Prevent links from blocking video playback.
+  if (event.target.className.includes('CanvasVideo')) {
+    event.target.preventDefault()
   }
 }
 
@@ -45,7 +65,7 @@ const CanvasContainerComponent: React.SFC<CanvasContainerProps> = props => {
     )
   } else {
     return (
-      <CanvasLink href={unit.link.url} target="_blank" containerWidth={size.width} layout={unit.layout}>
+      <CanvasLink onClick={handleVideoLinkClick} href={unit.link.url} target="_blank" containerWidth={size.width} layout={unit.layout}>
         {renderAsset(unit.assets[0], campaign)}
         <StandardContainer>
           <CanvasText unit={unit} disclaimer={disclaimer} />

--- a/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
@@ -18,9 +18,9 @@ export class CanvasVideo extends React.Component<VideoProps, any> {
     this.state = { isPlaying: false }
   }
 
-  @track(() => ({
+  @track((props) => ({
     action: "Display Play Video",
-    campaign_name: this.props.campaign.name,
+    campaign_name: props.campaign.name,
   }))
   onPlayVideo(e) {
     e.preventDefault()

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -974,6 +974,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   <a
     className="c2"
     href="http://artsy.net"
+    onClick={[Function]}
     target="_blank"
   >
     <img
@@ -1336,6 +1337,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
   <a
     className="c2"
     href="http://artsy.net"
+    onClick={[Function]}
     target="_blank"
   >
     <div


### PR DESCRIPTION
Fixes https://github.com/artsy/publishing/issues/96

This PR checks to see what target is underneath the click target and if a `CanvasVideo` prevent default behavior. 

**TODO:** 
Expand the click target to cover video if the video has already been played and playback is complete. 