### PR TITLE
Remove duplicate HMR loader

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -5,22 +5,24 @@ const sharify = require("./sharify")
 
 const webpack = require("webpack")
 const webpackMerge = require("webpack-merge")
-const { CheckerPlugin } = require("awesome-typescript-loader")
+
+const {
+  CheckerPlugin
+} = require("awesome-typescript-loader")
 
 /**
  * Write out a file that stubs the data that’s normally shared with the client through the `sharify` module. This file
  * is then replaced in the product of webpack where normally the actual `sharify` module would be loaded.
  */
-const { METAPHYSICS_ENDPOINT } = env.config().parsed
-const sharifyPath = sharify({ METAPHYSICS_ENDPOINT })
+const {
+  METAPHYSICS_ENDPOINT
+} = env.config().parsed
 
-/**
- * Only use HMR plugin in dev mode
- */
+const sharifyPath = sharify({
+  METAPHYSICS_ENDPOINT
+})
+
 let plugins = [new CheckerPlugin()]
-if (process.env.NODE_ENV === "development") {
-  plugins.push(new webpack.HotModuleReplacementPlugin())
-}
 
 // A mix of  the base from Emission's webpack setup, and the simple config for
 // storybooks: https://storybook.js.org/configurations/custom-webpack-config/
@@ -34,20 +36,20 @@ module.exports = {
     },
   },
   module: {
-    rules: [
-      { test: /\.json$/, loader: "json-loader" },
+    rules: [{
+        test: /\.json$/,
+        loader: "json-loader"
+      },
       {
         exclude: [/node_modules/, /__tests__/],
-        use: [
-          {
-            loader: "awesome-typescript-loader",
-            options: {
-              useBabel: true,
-              useCache: true,
-              useTranspileModule: true, // Supposedly faster, won’t work if/when we emit TS declaration files.
-            },
+        use: [{
+          loader: "awesome-typescript-loader",
+          options: {
+            useBabel: true,
+            useCache: true,
+            useTranspileModule: true, // Supposedly faster, won’t work if/when we emit TS declaration files.
           },
-        ],
+        }, ],
         test: /\.tsx?$/,
       },
     ],


### PR DESCRIPTION
Fixes issue where after file change the process locks up with thousands of console errors leading to slow iteration time: 

<img width="492" alt="screen shot 2017-10-18 at 11 59 44 am" src="https://user-images.githubusercontent.com/236943/31737562-cf2e53f6-b3fc-11e7-9549-a9ecc56b0dda.png">

Hot reloading is already in the environment via `webpack/development.js`. 

Note that this warning now appears: 

<img width="383" alt="screen shot 2017-10-18 at 12 15 15 pm" src="https://user-images.githubusercontent.com/236943/31737979-148fa994-b3fe-11e7-8523-a49acd59aff2.png">

But its only a few and doesn't impact performance. (Don't have time right now to debug further.)