### PR TITLE
@alloy => Only load History on client

### DIFF
--- a/src/Components/History.tsx
+++ b/src/Components/History.tsx
@@ -1,5 +1,10 @@
 import createHistory from "history/createBrowserHistory"
 
-const history = createHistory()
+let history = {}
+
+// Only load history on client
+if (typeof window !== 'undefined') {
+  history = createHistory()
+}
 
 export default history


### PR DESCRIPTION
This arose while trying to debug some publishing work. This adds a guard so that we only load history on the client. 