### PR TITLE
@alloy => Exclude certain common packages from bundle 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,6 @@
     "dist/": true
   },
   "editor.tabSize": 2,
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/src/Apps/Loyalty/Containers/ForgotPassword/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/ForgotPassword/__tests__/__snapshots__/index.tsx.snap
@@ -24,7 +24,7 @@ exports[`<ForgotPassword /> renders the snapshot 1`] = `
   </div>
   <input
     autoFocus={true}
-    className="file__StyledInput-s46ncg-1 dNpGkO file__StyledInput-nvgs54-0 guxuny"
+    className="file__StyledInput-s46ncg-1 dNpGkO file__StyledInput-h3ssd9-0 liOjYP"
     name="email"
     onChange={[Function]}
     placeholder="Email"

--- a/src/Apps/Loyalty/Containers/Login/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/Login/__tests__/__snapshots__/index.tsx.snap
@@ -24,20 +24,20 @@ exports[`login renders the snapshot 1`] = `
   >
     <input
       autoFocus={true}
-      className="file__StyledInput-c8o48u-1 eHLdcm file__StyledInput-nvgs54-0 guxuny"
+      className="file__StyledInput-c8o48u-1 eHLdcm file__StyledInput-h3ssd9-0 liOjYP"
       name="email"
       onChange={[Function]}
       placeholder="Email"
       value=""
     />
     <div
-      className="file__StyledDiv-nvgs54-2 lipob"
+      className="file__StyledDiv-h3ssd9-2 cAyso"
     >
       <div
         className="border-container"
       />
       <input
-        className="file__BorderlessInput-nvgs54-1 fIiImj"
+        className="file__BorderlessInput-h3ssd9-1 kVplOY"
         name="password"
         onBlur={[Function]}
         onChange={[Function]}

--- a/src/Components/ArtworkFilter/Dropdown.tsx
+++ b/src/Components/ArtworkFilter/Dropdown.tsx
@@ -23,7 +23,7 @@ interface DropdownState {
 }
 
 export class Dropdown extends React.Component<DropdownProps, DropdownState> {
-  constructor(props) {
+  constructor(props: DropdownProps) {
     super(props)
     this.state = {
       isHovered: false,

--- a/src/Components/ArtworkFilter/ForSaleCheckbox.tsx
+++ b/src/Components/ArtworkFilter/ForSaleCheckbox.tsx
@@ -15,11 +15,8 @@ interface State {
 }
 
 export class ForSaleCheckbox extends React.Component<Props, State> {
-  constructor(props) {
-    super(props)
-    this.state = {
-      isChecked: false,
-    }
+  state = {
+    isChecked: false,
   }
 
   onClick() {

--- a/src/Components/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid.tsx
@@ -20,12 +20,9 @@ interface State {
 export class ArtworkGrid extends React.Component<Props, State> {
   public static defaultProps: Partial<Props>
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      interval: null,
-      loading: false,
-    }
+  state = {
+    interval: null,
+    loading: false,
   }
 
   componentDidMount() {

--- a/src/Components/BorderedPulldown.tsx
+++ b/src/Components/BorderedPulldown.tsx
@@ -18,12 +18,9 @@ interface State {
 }
 
 export class BorderedPulldown extends React.Component<Props, State> {
-  constructor(props) {
-    super(props)
-    this.state = {
-      selected: null,
-      isHovered: false,
-    }
+  state = {
+    selected: null,
+    isHovered: false,
   }
 
   toggleHover(value) {
@@ -128,8 +125,8 @@ const PulldownOptions = styled.div`
     cursor: pointer;
     &:hover {
       background-color: ${colors.gray};
-    } 
-  } 
+    }
+  }
 `
 
 export default StyledBorderedPulldown

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -50,11 +50,8 @@ const StyledDiv = styled.div`
 const BorderClassname = "border-container"
 
 class Input extends React.Component<InputProps, InputState> {
-  constructor(props) {
-    super(props)
-    this.state = {
-      borderClasses: BorderClassname,
-    }
+  state = {
+    borderClasses: BorderClassname,
   }
 
   onFocus(e: React.FocusEvent<HTMLInputElement>) {

--- a/src/Components/Publishing/Byline/__test__/__snapshots__/AuthorDate.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__test__/__snapshots__/AuthorDate.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Author/Date renders a single author 1`] = `
 .c0 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -23,13 +23,13 @@ exports[`Author/Date renders a single author 1`] = `
   background-color: #000;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -37,7 +37,7 @@ exports[`Author/Date renders a single author 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0:before {
     min-width: 8px;
     min-height: 8px;
@@ -54,7 +54,7 @@ exports[`Author/Date renders a single author 1`] = `
 
 exports[`Author/Date renders multiple authors 1`] = `
 .c0 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -75,13 +75,13 @@ exports[`Author/Date renders multiple authors 1`] = `
   background-color: #000;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -89,7 +89,7 @@ exports[`Author/Date renders multiple authors 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0:before {
     min-width: 8px;
     min-height: 8px;
@@ -106,7 +106,7 @@ exports[`Author/Date renders multiple authors 1`] = `
 
 exports[`Author/Date renders the date 1`] = `
 .c0 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -117,13 +117,13 @@ exports[`Author/Date renders the date 1`] = `
   white-space: nowrap;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;

--- a/src/Components/Publishing/Byline/__test__/__snapshots__/Byline.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__test__/__snapshots__/Byline.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Byline renders a byline 1`] = `
 .c2 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -14,7 +14,7 @@ exports[`Byline renders a byline 1`] = `
 }
 
 .c1 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -56,7 +56,6 @@ exports[`Byline renders a byline 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -83,13 +82,13 @@ exports[`Byline renders a byline 1`] = `
   align-items: flex-end;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -97,13 +96,13 @@ exports[`Byline renders a byline 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c1 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -111,7 +110,7 @@ exports[`Byline renders a byline 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c1:before {
     min-width: 8px;
     min-height: 8px;

--- a/src/Components/Publishing/Byline/__test__/__snapshots__/Share.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__test__/__snapshots__/Share.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`renders a saved caption properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -23,14 +23,13 @@ exports[`renders the canvas in overlay layout 1`] = `
   -webkit-justify-content: space-around;
   -ms-flex-pack: space-around;
   justify-content: space-around;
-  -webkit-text-align: center;
   text-align: center;
   color: #fff;
   max-width: 500px;
 }
 
 .c6 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -39,14 +38,14 @@ exports[`renders the canvas in overlay layout 1`] = `
 }
 
 .c7 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
   line-height: 1.35em;
   margin-bottom: 10px;
   display: initial;
-  background-image: linear-gradient(to bottom, transparent 0, #FFF 2px, transparent 0);
+  background-image: linear-gradient(to bottom,transparent 0,#FFF 2px,transparent 0);
   background-position: bottom;
   background-size: 1px 5px;
   background-repeat: repeat-x;
@@ -62,7 +61,6 @@ exports[`renders the canvas in overlay layout 1`] = `
   width: 100%;
   height: 460px;
   color: #000;
-  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -121,14 +119,12 @@ exports[`renders the canvas in overlay layout 1`] = `
 }
 
 .c0 a {
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -142,22 +138,20 @@ exports[`renders the canvas in overlay layout 1`] = `
   letter-spacing: 1px;
   color: #cccccc;
   margin: 10px 0;
-  -webkit-text-align: center;
   text-align: center;
 }
 
 .c8 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 11px;
   line-height: 1.1em;
   color: #cccccc;
   margin: 15px 0 0 0;
-  -webkit-text-align: center;
   text-align: center;
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c5 {
     object-position: left;
     width: auto;
@@ -166,7 +160,7 @@ exports[`renders the canvas in overlay layout 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
     max-width: 100%;
     width: 100%;
@@ -174,16 +168,16 @@ exports[`renders the canvas in overlay layout 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c6 {
     margin: 0 auto 10px auto;
     max-width: calc(100% - 40px);
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
@@ -191,9 +185,9 @@ exports[`renders the canvas in overlay layout 1`] = `
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c7 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
@@ -201,7 +195,7 @@ exports[`renders the canvas in overlay layout 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
     padding: 0;
     width: 100%;
@@ -216,13 +210,13 @@ exports[`renders the canvas in overlay layout 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
     padding: 0 20px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c8 {
     margin: 35px 0 10px 0;
   }
@@ -298,9 +292,9 @@ exports[`renders the canvas in slideshow layout 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   width: 1200px;
 }
@@ -324,7 +318,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
 }
 
 .c13 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 11px;
   line-height: 1.1em;
@@ -357,7 +351,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
 }
 
 .c8 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -366,14 +360,14 @@ exports[`renders the canvas in slideshow layout 1`] = `
 }
 
 .c9 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
   line-height: 1.35em;
   margin-bottom: 10px;
   display: initial;
-  background-image: linear-gradient(to bottom, transparent 0, #000 2px, transparent 0);
+  background-image: linear-gradient(to bottom,transparent 0,#000 2px,transparent 0);
   background-position: bottom;
   background-size: 1px 5px;
   background-repeat: repeat-x;
@@ -389,7 +383,6 @@ exports[`renders the canvas in slideshow layout 1`] = `
   width: 100%;
   height: 460px;
   color: #000;
-  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -424,14 +417,12 @@ exports[`renders the canvas in slideshow layout 1`] = `
 }
 
 .c0 a {
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -445,12 +436,11 @@ exports[`renders the canvas in slideshow layout 1`] = `
   letter-spacing: 1px;
   color: #cccccc;
   margin: 10px 0;
-  -webkit-text-align: center;
   text-align: center;
 }
 
 .c11 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 11px;
   line-height: 1.1em;
@@ -458,19 +448,19 @@ exports[`renders the canvas in slideshow layout 1`] = `
   margin: 15px 0 0 0;
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c3.title-card {
     max-width: 1250px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c3.title-card {
     max-width: 812.5px;
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c4 {
     width: 437.5px;
   }
@@ -480,7 +470,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c4 {
     width: 100%;
   }
@@ -491,33 +481,33 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c10 {
     margin: 0;
     max-width: calc(100% - 40px);
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c12 {
     max-height: 479.375px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c7 {
     object-position: left;
     width: auto;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c6 {
     width: 100%;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c6 {
     max-width: 100%;
     width: 100%;
@@ -525,16 +515,16 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c8 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 23px;
     line-height: 1.5em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c8 {
     margin: 0 auto 10px auto;
     max-width: calc(100% - 40px);
@@ -542,24 +532,24 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c8 {
     line-height: 1.35em;
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c9 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c9 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
@@ -567,13 +557,13 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c5 {
     max-height: 479.375px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c5 {
     padding: 0;
     width: 100%;
@@ -588,7 +578,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c11 {
     margin: 35px 0 10px 0;
   }
@@ -735,7 +725,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
 }
 
 .c7 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -744,14 +734,14 @@ exports[`renders the canvas in standard layout with image 1`] = `
 }
 
 .c8 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
   line-height: 1.35em;
   margin-bottom: 10px;
   display: initial;
-  background-image: linear-gradient(to bottom, transparent 0, #000 2px, transparent 0);
+  background-image: linear-gradient(to bottom,transparent 0,#000 2px,transparent 0);
   background-position: bottom;
   background-size: 1px 5px;
   background-repeat: repeat-x;
@@ -774,7 +764,6 @@ exports[`renders the canvas in standard layout with image 1`] = `
   width: 100%;
   height: 460px;
   color: #000;
-  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -788,9 +777,9 @@ exports[`renders the canvas in standard layout with image 1`] = `
   -webkit-flex-direction: row-reverse;
   -ms-flex-direction: row-reverse;
   flex-direction: row-reverse;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -814,14 +803,12 @@ exports[`renders the canvas in standard layout with image 1`] = `
 }
 
 .c0 a {
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -835,12 +822,11 @@ exports[`renders the canvas in standard layout with image 1`] = `
   letter-spacing: 1px;
   color: #cccccc;
   margin: 10px 0;
-  -webkit-text-align: center;
   text-align: center;
 }
 
 .c9 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 11px;
   line-height: 1.1em;
@@ -848,14 +834,14 @@ exports[`renders the canvas in standard layout with image 1`] = `
   margin: 15px 0 0 0;
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c6 {
     object-position: left;
     width: auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c5 {
     max-width: 100%;
     width: 100%;
@@ -863,16 +849,16 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c7 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 23px;
     line-height: 1.5em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 {
     margin: 0 auto 10px auto;
     max-width: calc(100% - 40px);
@@ -880,24 +866,24 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c7 {
     line-height: 1.35em;
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c8 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c8 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
@@ -905,7 +891,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 {
     width: 100%;
     max-width: 100%;
@@ -915,7 +901,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c2 {
     max-height: 479.375px;
     padding: 0 20px;
@@ -923,7 +909,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
     padding: 0;
     width: 100%;
@@ -938,7 +924,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
     max-width: 100%;
     width: 100%;
@@ -946,13 +932,13 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
     padding: 0 20px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c9 {
     margin: 35px 0 10px 0;
   }
@@ -1040,7 +1026,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
 }
 
 .c10 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -1049,14 +1035,14 @@ exports[`renders the canvas in standard layout with video 1`] = `
 }
 
 .c11 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
   line-height: 1.35em;
   margin-bottom: 10px;
   display: initial;
-  background-image: linear-gradient(to bottom, transparent 0, #000 2px, transparent 0);
+  background-image: linear-gradient(to bottom,transparent 0,#000 2px,transparent 0);
   background-position: bottom;
   background-size: 1px 5px;
   background-repeat: repeat-x;
@@ -1135,7 +1121,6 @@ exports[`renders the canvas in standard layout with video 1`] = `
   width: 100%;
   height: 460px;
   color: #000;
-  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1149,9 +1134,9 @@ exports[`renders the canvas in standard layout with video 1`] = `
   -webkit-flex-direction: row-reverse;
   -ms-flex-direction: row-reverse;
   flex-direction: row-reverse;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -1175,14 +1160,12 @@ exports[`renders the canvas in standard layout with video 1`] = `
 }
 
 .c0 a {
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -1196,12 +1179,11 @@ exports[`renders the canvas in standard layout with video 1`] = `
   letter-spacing: 1px;
   color: #cccccc;
   margin: 10px 0;
-  -webkit-text-align: center;
   text-align: center;
 }
 
 .c12 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 11px;
   line-height: 1.1em;
@@ -1209,14 +1191,14 @@ exports[`renders the canvas in standard layout with video 1`] = `
   margin: 15px 0 0 0;
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c9 {
     object-position: left;
     width: auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c8 {
     max-width: 100%;
     width: 100%;
@@ -1224,16 +1206,16 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c10 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 23px;
     line-height: 1.5em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c10 {
     margin: 0 auto 10px auto;
     max-width: calc(100% - 40px);
@@ -1241,24 +1223,24 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c10 {
     line-height: 1.35em;
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c11 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c11 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
@@ -1266,7 +1248,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 {
     width: 100%;
     height: auto;
@@ -1278,7 +1260,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width: 1150px) {
+@media (max-width:1150px) {
   .c2 {
     max-height: 479.375px;
     padding: 0 20px;
@@ -1286,7 +1268,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
     padding: 0;
     width: 100%;
@@ -1301,7 +1283,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 {
     max-width: 100%;
     width: 100%;
@@ -1309,13 +1291,13 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
     padding: 0 20px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c12 {
     margin: 35px 0 10px 0;
   }

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`renders the display panel 1`] = `
 .c0 {
   cursor: pointer;
-  -webkit-text-decoration: none;
   text-decoration: none;
   color: black;
 }
@@ -42,7 +41,7 @@ exports[`renders the display panel 1`] = `
 }
 
 .c4 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -51,7 +50,7 @@ exports[`renders the display panel 1`] = `
 }
 
 .c5 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 15px;
   line-height: 1.25em;
@@ -64,9 +63,8 @@ exports[`renders the display panel 1`] = `
 }
 
 .c6 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;

--- a/src/Components/Publishing/Header/__test__/__snapshots__/ClassicHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/ClassicHeader.test.tsx.snap
@@ -2,9 +2,8 @@
 
 exports[`AuthorDate renders a single author 1`] = `
 .c2 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -20,9 +19,8 @@ exports[`AuthorDate renders a single author 1`] = `
 }
 
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -39,9 +37,8 @@ exports[`AuthorDate renders a single author 1`] = `
 
 .c0 {
   display: block;
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -77,9 +74,8 @@ exports[`AuthorDate renders a single author 1`] = `
 
 exports[`AuthorDate renders multiple authors 1`] = `
 .c2 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -95,9 +91,8 @@ exports[`AuthorDate renders multiple authors 1`] = `
 }
 
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -114,9 +109,8 @@ exports[`AuthorDate renders multiple authors 1`] = `
 
 .c0 {
   display: block;
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -152,9 +146,8 @@ exports[`AuthorDate renders multiple authors 1`] = `
 
 exports[`Classic Header renders classic header properly 1`] = `
 .c3 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -171,9 +164,8 @@ exports[`Classic Header renders classic header properly 1`] = `
 
 .c2 {
   display: block;
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -199,18 +191,16 @@ exports[`Classic Header renders classic header properly 1`] = `
   width: 100%;
   margin: 40px auto;
   box-sizing: border-box;
-  -webkit-text-align: center;
   text-align: center;
 }
 
 .c0 p,
 .c0 > p {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
   line-height: 1.35em;
-  -webkit-text-align: left;
   text-align: left;
   max-width: 580px;
   width: 100%;
@@ -219,28 +209,27 @@ exports[`Classic Header renders classic header properly 1`] = `
 }
 
 .c1 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 37px;
   line-height: 1.2em;
   margin-bottom: 30px;
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c0 {
     padding: 0 20px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
-    -webkit-text-align: left;
     text-align: left;
   }
 
   .c0 p,
   .c0 > p {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
@@ -248,9 +237,9 @@ exports[`Classic Header renders classic header properly 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
@@ -288,7 +277,7 @@ exports[`Classic Header renders classic header properly 1`] = `
 
 exports[`Classic Header renders classic header with children properly 1`] = `
 .c5 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -300,7 +289,7 @@ exports[`Classic Header renders classic header with children properly 1`] = `
 }
 
 .c4 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -342,7 +331,6 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -384,7 +372,7 @@ exports[`Classic Header renders classic header with children properly 1`] = `
 }
 
 .c2 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
@@ -392,20 +380,20 @@ exports[`Classic Header renders classic header with children properly 1`] = `
 }
 
 .c1 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
   margin-bottom: 10px;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c5 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -413,13 +401,13 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -427,37 +415,37 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c0 {
     padding: 0 20px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     margin: 30px auto;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c2 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;

--- a/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`feature renders feature full header properly 1`] = `
 .c16 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -14,7 +14,7 @@ exports[`feature renders feature full header properly 1`] = `
 }
 
 .c15 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -56,7 +56,6 @@ exports[`feature renders feature full header properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -88,11 +87,11 @@ exports[`feature renders feature full header properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   position: absolute;
-  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.3));
+  background-image: linear-gradient(to bottom,rgba(0,0,0,0),rgba(0,0,0,0.3));
 }
 
 .c7 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -141,7 +140,7 @@ exports[`feature renders feature full header properly 1`] = `
 }
 
 .c11 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -149,9 +148,9 @@ exports[`feature renders feature full header properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -163,7 +162,7 @@ exports[`feature renders feature full header properly 1`] = `
 }
 
 .c9 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 100px;
   line-height: 1.1em;
@@ -177,7 +176,7 @@ exports[`feature renders feature full header properly 1`] = `
 .c13 {
   max-width: 460px;
   margin-right: 30px;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -215,7 +214,7 @@ exports[`feature renders feature full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .sc-htoDjs {
+.c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
@@ -246,17 +245,16 @@ exports[`feature renders feature full header properly 1`] = `
   -ms-flex-pack: end;
   justify-content: flex-end;
   margin: auto;
-  -webkit-text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
-  text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
+  text-shadow: 0 0 40px rgba(0,0,0,0.4);
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c16 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -264,13 +262,13 @@ exports[`feature renders feature full header properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c15 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -278,23 +276,23 @@ exports[`feature renders feature full header properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c15:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c11 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
@@ -306,44 +304,44 @@ exports[`feature renders feature full header properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 80px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 65px;
     line-height: 1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 45px;
     line-height: 1.2em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c13 {
     margin-bottom: 28px;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="split"] .c8 {
     margin-bottom: 20px;
   }
@@ -359,7 +357,7 @@ exports[`feature renders feature full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .sc-htoDjs {
+  .c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
@@ -371,7 +369,7 @@ exports[`feature renders feature full header properly 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="fullscreen"] .c5 {
     padding: 20px;
   }
@@ -524,7 +522,7 @@ exports[`feature renders feature full header properly 1`] = `
 
 exports[`feature renders feature full header without a deck properly 1`] = `
 .c14 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -536,7 +534,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
 }
 
 .c13 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -578,7 +576,6 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -610,11 +607,11 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   position: absolute;
-  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.3));
+  background-image: linear-gradient(to bottom,rgba(0,0,0,0),rgba(0,0,0,0.3));
 }
 
 .c7 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -663,7 +660,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
 }
 
 .c11 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -671,9 +668,9 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -685,7 +682,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
 }
 
 .c9 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 100px;
   line-height: 1.1em;
@@ -727,7 +724,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .sc-htoDjs {
+.c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
@@ -758,17 +755,16 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   -ms-flex-pack: end;
   justify-content: flex-end;
   margin: auto;
-  -webkit-text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
-  text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
+  text-shadow: 0 0 40px rgba(0,0,0,0.4);
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c14 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -776,13 +772,13 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c13 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -790,23 +786,23 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c13:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c11 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
@@ -818,34 +814,34 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 80px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 65px;
     line-height: 1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 45px;
     line-height: 1.2em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="split"] .c8 {
     margin-bottom: 20px;
   }
@@ -861,7 +857,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .sc-htoDjs {
+  .c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
@@ -873,7 +869,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="fullscreen"] .c5 {
     padding: 20px;
   }
@@ -1017,7 +1013,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
 
 exports[`feature renders feature header with children properly 1`] = `
 .c16 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -1029,7 +1025,7 @@ exports[`feature renders feature header with children properly 1`] = `
 }
 
 .c15 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -1071,7 +1067,6 @@ exports[`feature renders feature header with children properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -1103,11 +1098,11 @@ exports[`feature renders feature header with children properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   position: absolute;
-  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.3));
+  background-image: linear-gradient(to bottom,rgba(0,0,0,0),rgba(0,0,0,0.3));
 }
 
 .c7 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -1156,7 +1151,7 @@ exports[`feature renders feature header with children properly 1`] = `
 }
 
 .c11 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -1164,9 +1159,9 @@ exports[`feature renders feature header with children properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -1178,7 +1173,7 @@ exports[`feature renders feature header with children properly 1`] = `
 }
 
 .c9 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 100px;
   line-height: 1.1em;
@@ -1192,7 +1187,7 @@ exports[`feature renders feature header with children properly 1`] = `
 .c13 {
   max-width: 460px;
   margin-right: 30px;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -1230,7 +1225,7 @@ exports[`feature renders feature header with children properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .sc-htoDjs {
+.c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
@@ -1261,17 +1256,16 @@ exports[`feature renders feature header with children properly 1`] = `
   -ms-flex-pack: end;
   justify-content: flex-end;
   margin: auto;
-  -webkit-text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
-  text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
+  text-shadow: 0 0 40px rgba(0,0,0,0.4);
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c16 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -1279,13 +1273,13 @@ exports[`feature renders feature header with children properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c15 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -1293,23 +1287,23 @@ exports[`feature renders feature header with children properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c15:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c11 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
@@ -1321,44 +1315,44 @@ exports[`feature renders feature header with children properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 80px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 65px;
     line-height: 1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c9 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 45px;
     line-height: 1.2em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c13 {
     margin-bottom: 28px;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="split"] .c8 {
     margin-bottom: 20px;
   }
@@ -1374,7 +1368,7 @@ exports[`feature renders feature header with children properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .sc-htoDjs {
+  .c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
@@ -1386,7 +1380,7 @@ exports[`feature renders feature header with children properly 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="fullscreen"] .c5 {
     padding: 20px;
   }
@@ -1547,7 +1541,7 @@ exports[`feature renders feature header with children properly 1`] = `
 
 exports[`feature renders feature split header properly 1`] = `
 .c15 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -1559,7 +1553,7 @@ exports[`feature renders feature split header properly 1`] = `
 }
 
 .c14 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -1601,7 +1595,6 @@ exports[`feature renders feature split header properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -1629,7 +1622,7 @@ exports[`feature renders feature split header properly 1`] = `
 }
 
 .c4 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -1678,7 +1671,7 @@ exports[`feature renders feature split header properly 1`] = `
 }
 
 .c10 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -1686,9 +1679,9 @@ exports[`feature renders feature split header properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -1700,7 +1693,7 @@ exports[`feature renders feature split header properly 1`] = `
 }
 
 .c6 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 100px;
   line-height: 1.1em;
@@ -1714,7 +1707,7 @@ exports[`feature renders feature split header properly 1`] = `
 .c12 {
   max-width: 460px;
   margin-right: 30px;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -1752,7 +1745,7 @@ exports[`feature renders feature split header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .sc-htoDjs {
+.c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
@@ -1783,17 +1776,16 @@ exports[`feature renders feature split header properly 1`] = `
   -ms-flex-pack: end;
   justify-content: flex-end;
   margin: auto;
-  -webkit-text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
-  text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
+  text-shadow: 0 0 40px rgba(0,0,0,0.4);
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c15 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -1801,13 +1793,13 @@ exports[`feature renders feature split header properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c14 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -1815,23 +1807,23 @@ exports[`feature renders feature split header properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c14:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c10 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
@@ -1843,44 +1835,44 @@ exports[`feature renders feature split header properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c6 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 80px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c6 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 65px;
     line-height: 1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 45px;
     line-height: 1.2em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c12 {
     margin-bottom: 28px;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="split"] .c5 {
     margin-bottom: 20px;
   }
@@ -1896,7 +1888,7 @@ exports[`feature renders feature split header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .sc-htoDjs {
+  .c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
@@ -1908,7 +1900,7 @@ exports[`feature renders feature split header properly 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="fullscreen"] .c2 {
     padding: 20px;
   }
@@ -2056,7 +2048,7 @@ exports[`feature renders feature split header properly 1`] = `
 
 exports[`feature renders feature text header properly 1`] = `
 .c13 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -2068,7 +2060,7 @@ exports[`feature renders feature text header properly 1`] = `
 }
 
 .c12 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -2110,7 +2102,6 @@ exports[`feature renders feature text header properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -2138,7 +2129,7 @@ exports[`feature renders feature text header properly 1`] = `
 }
 
 .c4 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -2186,7 +2177,7 @@ exports[`feature renders feature text header properly 1`] = `
 }
 
 .c8 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -2194,9 +2185,9 @@ exports[`feature renders feature text header properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -2208,7 +2199,7 @@ exports[`feature renders feature text header properly 1`] = `
 }
 
 .c6 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 100px;
   line-height: 1.1em;
@@ -2222,7 +2213,7 @@ exports[`feature renders feature text header properly 1`] = `
 .c10 {
   max-width: 460px;
   margin-right: 30px;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -2255,12 +2246,12 @@ exports[`feature renders feature text header properly 1`] = `
   width: 50%;
 }
 
-.c0[data-type="split"] .sc-gzVnrw {
+.c0[data-type="split"] .s173b3y1-0-file__Div-dCIIWC {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .sc-htoDjs {
+.c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
@@ -2291,17 +2282,16 @@ exports[`feature renders feature text header properly 1`] = `
   -ms-flex-pack: end;
   justify-content: flex-end;
   margin: auto;
-  -webkit-text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
-  text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
+  text-shadow: 0 0 40px rgba(0,0,0,0.4);
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c13 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -2309,13 +2299,13 @@ exports[`feature renders feature text header properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c12 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -2323,23 +2313,23 @@ exports[`feature renders feature text header properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c12:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c8 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
@@ -2351,44 +2341,44 @@ exports[`feature renders feature text header properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c6 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 80px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c6 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 65px;
     line-height: 1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 45px;
     line-height: 1.2em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c10 {
     margin-bottom: 28px;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="split"] .c5 {
     margin-bottom: 20px;
   }
@@ -2397,14 +2387,14 @@ exports[`feature renders feature text header properly 1`] = `
     width: 100%;
   }
 
-  .c0[data-type="split"] .sc-gzVnrw {
+  .c0[data-type="split"] .s173b3y1-0-file__Div-dCIIWC {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .sc-htoDjs {
+  .c0[data-type="split"] .s173b3y1-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
@@ -2416,7 +2406,7 @@ exports[`feature renders feature text header properly 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0[data-type="fullscreen"] .c2 {
     padding: 20px;
   }

--- a/src/Components/Publishing/Header/__test__/__snapshots__/StandardHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/StandardHeader.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Standard Header renders standard header properly 1`] = `
 .c5 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -14,7 +14,7 @@ exports[`Standard Header renders standard header properly 1`] = `
 }
 
 .c4 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -56,7 +56,6 @@ exports[`Standard Header renders standard header properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -98,7 +97,7 @@ exports[`Standard Header renders standard header properly 1`] = `
 }
 
 .c2 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
@@ -106,20 +105,20 @@ exports[`Standard Header renders standard header properly 1`] = `
 }
 
 .c1 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
   margin-bottom: 10px;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c5 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -127,13 +126,13 @@ exports[`Standard Header renders standard header properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -141,37 +140,37 @@ exports[`Standard Header renders standard header properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c0 {
     padding: 0 20px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     margin: 30px auto;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c2 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -292,7 +291,7 @@ exports[`Standard Header renders standard header properly 1`] = `
 
 exports[`Standard Header renders standard header with children properly 1`] = `
 .c5 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -304,7 +303,7 @@ exports[`Standard Header renders standard header with children properly 1`] = `
 }
 
 .c4 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -346,7 +345,6 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
-  -webkit-text-decoration: none;
   text-decoration: none;
   margin-right: 14px;
 }
@@ -388,7 +386,7 @@ exports[`Standard Header renders standard header with children properly 1`] = `
 }
 
 .c2 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
@@ -396,20 +394,20 @@ exports[`Standard Header renders standard header with children properly 1`] = `
 }
 
 .c1 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
   margin-bottom: 10px;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c5 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -417,13 +415,13 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -431,37 +429,37 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c0 {
     padding: 0 20px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     margin: 30px auto;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c2 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;

--- a/src/Components/Publishing/RelatedArticles/__test__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/__test__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders the related articles canvas 1`] = `
 .c11 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -14,7 +14,7 @@ exports[`renders the related articles canvas 1`] = `
 }
 
 .c10 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -68,7 +68,6 @@ exports[`renders the related articles canvas 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   min-height: 270px;
 }
@@ -83,13 +82,12 @@ exports[`renders the related articles canvas 1`] = `
   flex-direction: column;
   max-width: 278px;
   margin-right: 30px;
-  -webkit-text-decoration: none;
   text-decoration: none;
   color: black;
 }
 
 .c8 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -116,7 +114,7 @@ exports[`renders the related articles canvas 1`] = `
 }
 
 .c2 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
@@ -128,9 +126,9 @@ exports[`renders the related articles canvas 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   overflow-x: scroll;
 }
@@ -144,13 +142,13 @@ exports[`renders the related articles canvas 1`] = `
   width: 100%;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c11 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -158,13 +156,13 @@ exports[`renders the related articles canvas 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c10 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -172,41 +170,41 @@ exports[`renders the related articles canvas 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c10:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c6 {
     height: 235px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c8 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 {
     height: 150px;
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c1 {
     margin: 30px 20px 60px 20px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 {
     display: block;
   }

--- a/src/Components/Publishing/RelatedArticles/__test__/__snapshots__/RelatedArticlesPanel.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/__test__/__snapshots__/RelatedArticlesPanel.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`renders the related articles panel 1`] = `
 }
 
 .c1 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -24,7 +24,6 @@ exports[`renders the related articles panel 1`] = `
 }
 
 .c3 {
-  -webkit-text-decoration: none;
   text-decoration: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -44,7 +43,7 @@ exports[`renders the related articles panel 1`] = `
 }
 
 .c5 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;

--- a/src/Components/Publishing/Sections/FullscreenViewer/__test__/__snapshots__/Caption.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__test__/__snapshots__/Caption.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`renders an artwork caption properly 1`] = `
 .c7 {
   color: #999;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -15,14 +14,14 @@ exports[`renders an artwork caption properly 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
 }
 
 .c4 .title {
-  font-family: Unica77LLWebMediumItalic ,      'Arial',      'serif';
+  font-family: Unica77LLWebMediumItalic , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -41,7 +40,7 @@ exports[`renders an artwork caption properly 1`] = `
 }
 
 .c3 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -54,7 +53,7 @@ exports[`renders an artwork caption properly 1`] = `
 .c8 {
   margin-left: 20px;
   white-space: nowrap;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -65,9 +64,9 @@ exports[`renders an artwork caption properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   background-color: #f8f8f8;
   padding: 30px 60px;
@@ -87,9 +86,9 @@ exports[`renders an artwork caption properly 1`] = `
   flex-direction: column;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -99,22 +98,22 @@ exports[`renders an artwork caption properly 1`] = `
   }
 
   .c4 .title {
-    font-family: Unica77LLWebMediumItalic ,      'Arial',      'serif';
+    font-family: Unica77LLWebMediumItalic , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c5.artist-name {
     margin-bottom: 5px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -127,9 +126,9 @@ exports[`renders an artwork caption properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -138,16 +137,16 @@ exports[`renders an artwork caption properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c8 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
     position: absolute;
     bottom: 0;
@@ -245,7 +244,7 @@ exports[`renders an image caption properly 1`] = `
 }
 
 .c3 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -258,7 +257,7 @@ exports[`renders an image caption properly 1`] = `
 .c4 {
   margin-left: 20px;
   white-space: nowrap;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -269,9 +268,9 @@ exports[`renders an image caption properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   background-color: #f8f8f8;
   padding: 30px 60px;
@@ -291,9 +290,9 @@ exports[`renders an image caption properly 1`] = `
   flex-direction: column;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -306,9 +305,9 @@ exports[`renders an image caption properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -317,16 +316,16 @@ exports[`renders an image caption properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
     position: absolute;
     bottom: 0;

--- a/src/Components/Publishing/Sections/FullscreenViewer/__test__/__snapshots__/FullscreenViewer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__test__/__snapshots__/FullscreenViewer.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`renders properly 1`] = `
 
 .c11 {
   color: #999;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -23,14 +22,14 @@ exports[`renders properly 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
 }
 
 .c8 .title {
-  font-family: Unica77LLWebMediumItalic ,      'Arial',      'serif';
+  font-family: Unica77LLWebMediumItalic , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -49,7 +48,7 @@ exports[`renders properly 1`] = `
 }
 
 .c7 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -62,7 +61,7 @@ exports[`renders properly 1`] = `
 .c12 {
   margin-left: 20px;
   white-space: nowrap;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -73,9 +72,9 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   background-color: #f8f8f8;
   padding: 30px 60px;
@@ -141,7 +140,7 @@ exports[`renders properly 1`] = `
 .c2 {
   min-height: 25px;
   padding: 30px 60px 0 60px;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -166,9 +165,9 @@ exports[`renders properly 1`] = `
   cursor: pointer;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c8 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -178,22 +177,22 @@ exports[`renders properly 1`] = `
   }
 
   .c8 .title {
-    font-family: Unica77LLWebMediumItalic ,      'Arial',      'serif';
+    font-family: Unica77LLWebMediumItalic , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c9.artist-name {
     margin-bottom: 5px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c6 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -206,9 +205,9 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -217,16 +216,16 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c12 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c4 {
     position: absolute;
     bottom: 0;
@@ -235,28 +234,28 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 {
     margin: 20px 0 80px 0;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c13 {
     margin: 20px 0 80px 0;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c14 {
     margin: 20px 0 80px 0;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
     padding: 20px 60px 0 20px;
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;

--- a/src/Components/Publishing/Sections/FullscreenViewer/__test__/__snapshots__/Slide.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__test__/__snapshots__/Slide.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`renders properly 1`] = `
 .c10 {
   color: #999;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -15,14 +14,14 @@ exports[`renders properly 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
 }
 
 .c7 .title {
-  font-family: Unica77LLWebMediumItalic ,      'Arial',      'serif';
+  font-family: Unica77LLWebMediumItalic , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -41,7 +40,7 @@ exports[`renders properly 1`] = `
 }
 
 .c6 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -54,7 +53,7 @@ exports[`renders properly 1`] = `
 .c11 {
   margin-left: 20px;
   white-space: nowrap;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -65,9 +64,9 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   background-color: #f8f8f8;
   padding: 30px 60px;
@@ -113,15 +112,15 @@ exports[`renders properly 1`] = `
 .c1 {
   min-height: 25px;
   padding: 30px 60px 0 60px;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -131,22 +130,22 @@ exports[`renders properly 1`] = `
   }
 
   .c7 .title {
-    font-family: Unica77LLWebMediumItalic ,      'Arial',      'serif';
+    font-family: Unica77LLWebMediumItalic , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c8.artist-name {
     margin-bottom: 5px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c5 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -159,9 +158,9 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c6 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
@@ -170,16 +169,16 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c11 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 {
     position: absolute;
     bottom: 0;
@@ -188,16 +187,16 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
     margin: 20px 0 80px 0;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c1 {
     padding: 20px 60px 0 20px;
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Artwork.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Artwork.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`renders properly 1`] = `
 .c8 {
   color: #999;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -14,14 +13,14 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
 .c6 .title {
-  font-family: Unica77LLWebItalic ,      'Arial',      'serif';
+  font-family: Unica77LLWebItalic , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -30,7 +29,6 @@ exports[`renders properly 1`] = `
 .c7 {
   color: #999;
   display: block;
-  -webkit-text-overflow: ellipsis;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -77,17 +75,16 @@ exports[`renders properly 1`] = `
 }
 
 .c0 {
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
     padding: 0 10px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c1 .c3 {
     opacity: 1;
   }

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Authors.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Authors.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`renders properly 1`] = `
 
 .c3 {
   display: block;
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -56,12 +56,11 @@ exports[`renders properly 1`] = `
 }
 
 .c5 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   white-space: nowrap;
 }
@@ -81,32 +80,32 @@ exports[`renders properly 1`] = `
   flex-direction: column;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c2 {
     min-width: 40px;
     min-height: 40px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c8 {
     min-width: 40px;
     min-height: 40px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c3 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 17px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c5 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Caption.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Caption.test.tsx.snap
@@ -6,9 +6,9 @@ exports[`renders a child even if a caption is provided 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   margin: 10px 0 10px 0;
 }
@@ -22,7 +22,7 @@ exports[`renders a child even if a caption is provided 1`] = `
 .c1 > p,
 .c1 p,
 .c1 .public-DraftEditorPlaceholder-root {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -40,13 +40,13 @@ exports[`renders a child even if a caption is provided 1`] = `
   color: black;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     padding: 0px 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 {
     padding: 0px;
   }
@@ -71,9 +71,9 @@ exports[`renders a saved caption properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   margin: 10px 0 10px 0;
 }
@@ -87,7 +87,7 @@ exports[`renders a saved caption properly 1`] = `
 .c1 > p,
 .c1 p,
 .c1 .public-DraftEditorPlaceholder-root {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -105,13 +105,13 @@ exports[`renders a saved caption properly 1`] = `
   color: black;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     padding: 0px 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 {
     padding: 0px;
   }

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Embed.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Embed.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders properly 1`] = `
   height: 1000px;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     height: 1300px;
   }

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Image.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Image.test.tsx.snap
@@ -6,9 +6,9 @@ exports[`renders a long caption properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   margin: 10px 0 10px 0;
 }
@@ -22,7 +22,7 @@ exports[`renders a long caption properly 1`] = `
 .c6 > p,
 .c6 p,
 .c6 .public-DraftEditorPlaceholder-root {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -75,19 +75,19 @@ exports[`renders a long caption properly 1`] = `
   display: block;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c5 {
     padding: 0px 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
     padding: 0px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 .c2 {
     opacity: 1;
   }
@@ -185,9 +185,9 @@ exports[`renders a react child as caption properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   margin: 10px 0 10px 0;
 }
@@ -201,7 +201,7 @@ exports[`renders a react child as caption properly 1`] = `
 .c6 > p,
 .c6 p,
 .c6 .public-DraftEditorPlaceholder-root {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -254,19 +254,19 @@ exports[`renders a react child as caption properly 1`] = `
   display: block;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c5 {
     padding: 0px 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
     padding: 0px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 .c2 {
     opacity: 1;
   }
@@ -362,9 +362,9 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   margin: 10px 0 10px 0;
 }
@@ -378,7 +378,7 @@ exports[`renders properly 1`] = `
 .c6 > p,
 .c6 p,
 .c6 .public-DraftEditorPlaceholder-root {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -431,19 +431,19 @@ exports[`renders properly 1`] = `
   display: block;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c5 {
     padding: 0px 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
     padding: 0px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 .c2 {
     opacity: 1;
   }

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/ImageCollection.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/ImageCollection.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`renders a single image properly 1`] = `
 .c10 {
   color: #999;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -14,14 +13,14 @@ exports[`renders a single image properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
 .c8 .title {
-  font-family: Unica77LLWebItalic ,      'Arial',      'serif';
+  font-family: Unica77LLWebItalic , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -30,7 +29,6 @@ exports[`renders a single image properly 1`] = `
 .c9 {
   color: #999;
   display: block;
-  -webkit-text-overflow: ellipsis;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -77,7 +75,6 @@ exports[`renders a single image properly 1`] = `
 }
 
 .c2 {
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -94,25 +91,25 @@ exports[`renders a single image properly 1`] = `
   width: 100%;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c8 {
     padding: 0 10px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 .c5 {
     opacity: 1;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -263,7 +260,6 @@ exports[`renders a single image properly 1`] = `
 exports[`renders properly 1`] = `
 .c10 {
   color: #999;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -274,14 +270,14 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
 .c8 .title {
-  font-family: Unica77LLWebItalic ,      'Arial',      'serif';
+  font-family: Unica77LLWebItalic , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -290,7 +286,6 @@ exports[`renders properly 1`] = `
 .c9 {
   color: #999;
   display: block;
-  -webkit-text-overflow: ellipsis;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -337,7 +332,6 @@ exports[`renders properly 1`] = `
 }
 
 .c2 {
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -346,9 +340,9 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   margin: 10px 0 10px 0;
 }
@@ -362,7 +356,7 @@ exports[`renders properly 1`] = `
 .c13 > p,
 .c13 p,
 .c13 .public-DraftEditorPlaceholder-root {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -403,49 +397,49 @@ exports[`renders properly 1`] = `
   width: 100%;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c8 {
     padding: 0 10px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c3 .c5 {
     opacity: 1;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c12 {
     padding: 0px 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c13 {
     padding: 0px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c11 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c14 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/ImageSetPreview.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/ImageSetPreview.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`renders a full image set properly 1`] = `
   height: 45px;
   position: relative;
   margin-left: 40px;
-  -webkit-text-align: right;
   text-align: right;
 }
 
@@ -24,23 +23,23 @@ exports[`renders a full image set properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   border-radius: 2px;
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3);
+  background: rgba(255,255,255,0.8);
+  box-shadow: 0 0 10px 0 rgba(0,0,0,0.3);
   padding: 20px;
   cursor: pointer;
 }
 
 .c0:hover {
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0,0,0,0.6);
   color: white;
 }
 
@@ -56,15 +55,15 @@ exports[`renders a full image set properly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   height: 50px;
 }
 
 .c2 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -80,47 +79,47 @@ exports[`renders a full image set properly 1`] = `
 }
 
 .c4 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
 .c5 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
   margin-left: 20px;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c7 {
     display: none;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c2 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c4 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c5 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
@@ -198,7 +197,6 @@ exports[`renders a mini image set properly 1`] = `
   height: 45px;
   position: relative;
   margin-left: 40px;
-  -webkit-text-align: right;
   text-align: right;
 }
 
@@ -218,9 +216,9 @@ exports[`renders a mini image set properly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
 }
@@ -249,9 +247,9 @@ exports[`renders a mini image set properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -261,7 +259,7 @@ exports[`renders a mini image set properly 1`] = `
 }
 
 .c3 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -277,47 +275,47 @@ exports[`renders a mini image set properly 1`] = `
 }
 
 .c5 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
 .c6 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
   margin-left: 20px;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c8 {
     display: none;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c3 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c5 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/ImageSetPreviewClassic.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/ImageSetPreviewClassic.test.tsx.snap
@@ -12,9 +12,8 @@ exports[`renders properly 1`] = `
 }
 
 .c3 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -52,7 +51,6 @@ exports[`renders properly 1`] = `
   -ms-flex-align: center;
   align-items: center;
   border: 1px solid #e5e5e5;
-  -webkit-text-align: center;
   text-align: center;
 }
 

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
@@ -14,12 +14,10 @@ exports[`renders column_width properly 1`] = `
 
 .c1 {
   position: relative;
-  padding-bottom: ;
 }
 
 .c1 a {
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
   background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
@@ -35,7 +33,7 @@ exports[`renders column_width properly 1`] = `
 .c1 p,
 .c1 ul,
 .c1 ol {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -59,7 +57,7 @@ exports[`renders column_width properly 1`] = `
 }
 
 .c1 li {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -68,7 +66,7 @@ exports[`renders column_width properly 1`] = `
 }
 
 .c1 h1 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -77,7 +75,6 @@ exports[`renders column_width properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   position: relative;
-  -webkit-text-align: center;
   text-align: center;
 }
 
@@ -93,7 +90,7 @@ exports[`renders column_width properly 1`] = `
 }
 
 .c1 h2 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
@@ -106,7 +103,7 @@ exports[`renders column_width properly 1`] = `
 }
 
 .c1 h3 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -117,22 +114,17 @@ exports[`renders column_width properly 1`] = `
 
 .c1 h3 strong {
   font-weight: normal;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
 }
 
-.c1 h3 em {
-  font-style: ;
-}
-
 .c1 blockquote {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
-  -webkit-text-align: left;
   text-align: left;
   font-weight: normal;
   padding-top: 46px;
@@ -141,7 +133,7 @@ exports[`renders column_width properly 1`] = `
 }
 
 .c1 .content-start {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 67px;
   line-height: 1em;
@@ -149,7 +141,6 @@ exports[`renders column_width properly 1`] = `
   line-height: .5em;
   margin-right: 10px;
   margin-top: .298em;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
 }
 
@@ -180,21 +171,20 @@ exports[`renders column_width properly 1`] = `
 
 .c1 .artist-follow:after {
   content: "Follow";
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;
-  -webkit-text-transform: none;
   text-transform: none;
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c0 {
     width: 680px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c0 {
     width: 100%;
     padding: 0px;
@@ -202,52 +192,52 @@ exports[`renders column_width properly 1`] = `
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c1 {
     max-width: calc(100% - 40px);
     margin: 0 auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c1 {
     max-width: 100%;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 p,
   .c1 ul,
   .c1 ol {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c1 li {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c1 h1 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
   .c1 h2 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
   .c1 h3 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
@@ -255,14 +245,14 @@ exports[`renders column_width properly 1`] = `
   }
 
   .c1 h3 strong {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
   .c1 blockquote {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 40px;
     line-height: 1.1em;
@@ -304,12 +294,10 @@ exports[`renders fillwidth properly 1`] = `
 
 .c1 {
   position: relative;
-  padding-bottom: ;
 }
 
 .c1 a {
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
   background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
@@ -325,7 +313,7 @@ exports[`renders fillwidth properly 1`] = `
 .c1 p,
 .c1 ul,
 .c1 ol {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -349,7 +337,7 @@ exports[`renders fillwidth properly 1`] = `
 }
 
 .c1 li {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -358,7 +346,7 @@ exports[`renders fillwidth properly 1`] = `
 }
 
 .c1 h1 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -367,7 +355,6 @@ exports[`renders fillwidth properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   position: relative;
-  -webkit-text-align: center;
   text-align: center;
 }
 
@@ -383,7 +370,7 @@ exports[`renders fillwidth properly 1`] = `
 }
 
 .c1 h2 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
@@ -396,7 +383,7 @@ exports[`renders fillwidth properly 1`] = `
 }
 
 .c1 h3 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -407,22 +394,17 @@ exports[`renders fillwidth properly 1`] = `
 
 .c1 h3 strong {
   font-weight: normal;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
 }
 
-.c1 h3 em {
-  font-style: ;
-}
-
 .c1 blockquote {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
-  -webkit-text-align: left;
   text-align: left;
   font-weight: normal;
   padding-top: 46px;
@@ -431,7 +413,7 @@ exports[`renders fillwidth properly 1`] = `
 }
 
 .c1 .content-start {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 67px;
   line-height: 1em;
@@ -439,7 +421,6 @@ exports[`renders fillwidth properly 1`] = `
   line-height: .5em;
   margin-right: 10px;
   margin-top: .298em;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
 }
 
@@ -470,21 +451,20 @@ exports[`renders fillwidth properly 1`] = `
 
 .c1 .artist-follow:after {
   content: "Follow";
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;
-  -webkit-text-transform: none;
   text-transform: none;
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c0 {
     width: 100%;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c0 {
     width: 100%;
     padding: 0px;
@@ -492,52 +472,52 @@ exports[`renders fillwidth properly 1`] = `
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c1 {
     max-width: calc(100% - 40px);
     margin: 0 auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c1 {
     max-width: 100%;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 p,
   .c1 ul,
   .c1 ol {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c1 li {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c1 h1 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
   .c1 h2 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
   .c1 h3 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
@@ -545,14 +525,14 @@ exports[`renders fillwidth properly 1`] = `
   }
 
   .c1 h3 strong {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
   .c1 blockquote {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 40px;
     line-height: 1.1em;
@@ -594,12 +574,10 @@ exports[`renders overflow_fillwidth properly 1`] = `
 
 .c1 {
   position: relative;
-  padding-bottom: ;
 }
 
 .c1 a {
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
   background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
@@ -615,7 +593,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 .c1 p,
 .c1 ul,
 .c1 ol {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -639,7 +617,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 }
 
 .c1 li {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -648,7 +626,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 }
 
 .c1 h1 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -657,7 +635,6 @@ exports[`renders overflow_fillwidth properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   position: relative;
-  -webkit-text-align: center;
   text-align: center;
 }
 
@@ -673,7 +650,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 }
 
 .c1 h2 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
@@ -686,7 +663,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 }
 
 .c1 h3 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -697,22 +674,17 @@ exports[`renders overflow_fillwidth properly 1`] = `
 
 .c1 h3 strong {
   font-weight: normal;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
 }
 
-.c1 h3 em {
-  font-style: ;
-}
-
 .c1 blockquote {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
-  -webkit-text-align: left;
   text-align: left;
   font-weight: normal;
   padding-top: 46px;
@@ -721,7 +693,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 }
 
 .c1 .content-start {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 67px;
   line-height: 1em;
@@ -729,7 +701,6 @@ exports[`renders overflow_fillwidth properly 1`] = `
   line-height: .5em;
   margin-right: 10px;
   margin-top: .298em;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
 }
 
@@ -760,21 +731,20 @@ exports[`renders overflow_fillwidth properly 1`] = `
 
 .c1 .artist-follow:after {
   content: "Follow";
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;
-  -webkit-text-transform: none;
   text-transform: none;
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c0 {
     width: 780px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c0 {
     width: 100%;
     padding: 0px;
@@ -782,52 +752,52 @@ exports[`renders overflow_fillwidth properly 1`] = `
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c1 {
     max-width: calc(100% - 40px);
     margin: 0 auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c1 {
     max-width: 100%;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c1 p,
   .c1 ul,
   .c1 ol {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c1 li {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c1 h1 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
   .c1 h2 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
   .c1 h3 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
@@ -835,14 +805,14 @@ exports[`renders overflow_fillwidth properly 1`] = `
   }
 
   .c1 h3 strong {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
   .c1 blockquote {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 40px;
     line-height: 1.1em;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`renders properly 1`] = `
 
 .c18 {
   color: #999;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -19,14 +18,14 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
 .c16 .title {
-  font-family: Unica77LLWebItalic ,      'Arial',      'serif';
+  font-family: Unica77LLWebItalic , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -35,7 +34,6 @@ exports[`renders properly 1`] = `
 .c17 {
   color: #999;
   display: block;
-  -webkit-text-overflow: ellipsis;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -82,7 +80,6 @@ exports[`renders properly 1`] = `
 }
 
 .c15 {
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -91,9 +88,9 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   margin: 10px 0 10px 0;
 }
@@ -107,7 +104,7 @@ exports[`renders properly 1`] = `
 .c13 > p,
 .c13 p,
 .c13 .public-DraftEditorPlaceholder-root {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -172,7 +169,6 @@ exports[`renders properly 1`] = `
   height: 45px;
   position: relative;
   margin-left: 40px;
-  -webkit-text-align: right;
   text-align: right;
 }
 
@@ -191,23 +187,23 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   border-radius: 2px;
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3);
+  background: rgba(255,255,255,0.8);
+  box-shadow: 0 0 10px 0 rgba(0,0,0,0.3);
   padding: 20px;
   cursor: pointer;
 }
 
 .c26:hover {
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0,0,0,0.6);
   color: white;
 }
 
@@ -223,15 +219,15 @@ exports[`renders properly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   height: 50px;
 }
 
 .c28 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -247,14 +243,14 @@ exports[`renders properly 1`] = `
 }
 
 .c30 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
 }
 
 .c31 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -307,12 +303,10 @@ exports[`renders properly 1`] = `
 
 .c2 {
   position: relative;
-  padding-bottom: ;
 }
 
 .c2 a {
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
   background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
@@ -328,7 +322,7 @@ exports[`renders properly 1`] = `
 .c2 p,
 .c2 ul,
 .c2 ol {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -352,7 +346,7 @@ exports[`renders properly 1`] = `
 }
 
 .c2 li {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -361,7 +355,7 @@ exports[`renders properly 1`] = `
 }
 
 .c2 h1 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -370,7 +364,6 @@ exports[`renders properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   position: relative;
-  -webkit-text-align: center;
   text-align: center;
 }
 
@@ -386,7 +379,7 @@ exports[`renders properly 1`] = `
 }
 
 .c2 h2 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
@@ -399,7 +392,7 @@ exports[`renders properly 1`] = `
 }
 
 .c2 h3 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -410,22 +403,17 @@ exports[`renders properly 1`] = `
 
 .c2 h3 strong {
   font-weight: normal;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
 }
 
-.c2 h3 em {
-  font-style: ;
-}
-
 .c2 blockquote {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
-  -webkit-text-align: left;
   text-align: left;
   font-weight: normal;
   padding-top: 46px;
@@ -434,7 +422,7 @@ exports[`renders properly 1`] = `
 }
 
 .c2 .content-start {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 67px;
   line-height: 1em;
@@ -442,7 +430,6 @@ exports[`renders properly 1`] = `
   line-height: .5em;
   margin-right: 10px;
   margin-top: .298em;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
 }
 
@@ -473,11 +460,10 @@ exports[`renders properly 1`] = `
 
 .c2 .artist-follow:after {
   content: "Follow";
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;
-  -webkit-text-transform: none;
   text-transform: none;
 }
 
@@ -498,79 +484,79 @@ exports[`renders properly 1`] = `
   max-width: 780px;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c22 {
     height: 1300px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c16 {
     padding: 0 10px;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c7 .c9 {
     opacity: 1;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c12 {
     padding: 0px 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c13 {
     padding: 0px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c14 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c19 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c20 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c21 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c23 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c24 {
     margin-bottom: 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c5 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -578,46 +564,46 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c33 {
     display: none;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c28 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c30 {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c31 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c1 {
     width: 680px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c1 {
     width: 100%;
     padding: 0 20px;
@@ -625,13 +611,13 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c3 {
     width: 680px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c3 {
     width: 100%;
     padding: 0 20px;
@@ -639,13 +625,13 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c4 {
     width: 680px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c4 {
     width: 100%;
     padding: 0px;
@@ -653,13 +639,13 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c25 {
     width: 680px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c25 {
     width: 100%;
     padding: 0px;
@@ -667,52 +653,52 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c2 {
     max-width: calc(100% - 40px);
     margin: 0 auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c2 {
     max-width: 100%;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c2 p,
   .c2 ul,
   .c2 ol {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c2 li {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c2 h1 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
   .c2 h2 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
   .c2 h3 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
@@ -720,14 +706,14 @@ exports[`renders properly 1`] = `
   }
 
   .c2 h3 strong {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
   .c2 blockquote {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 40px;
     line-height: 1.1em;
@@ -738,14 +724,14 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width:1250px) {
   .c0 {
     max-width: 680px;
     margin: auto;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c0 {
     max-width: 780px;
   }

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
@@ -3,12 +3,10 @@
 exports[`renders classic text properly 1`] = `
 .c0 {
   position: relative;
-  padding-bottom: ;
 }
 
 .c0 a {
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
   background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
@@ -24,7 +22,7 @@ exports[`renders classic text properly 1`] = `
 .c0 p,
 .c0 ul,
 .c0 ol {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -48,7 +46,7 @@ exports[`renders classic text properly 1`] = `
 }
 
 .c0 li {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -57,7 +55,7 @@ exports[`renders classic text properly 1`] = `
 }
 
 .c0 h1 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -66,7 +64,6 @@ exports[`renders classic text properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   position: relative;
-  -webkit-text-align: center;
   text-align: center;
 }
 
@@ -82,7 +79,7 @@ exports[`renders classic text properly 1`] = `
 }
 
 .c0 h2 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 28px;
   line-height: 1.2em;
@@ -95,9 +92,8 @@ exports[`renders classic text properly 1`] = `
 }
 
 .c0 h3 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -123,11 +119,10 @@ exports[`renders classic text properly 1`] = `
 }
 
 .c0 blockquote {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
-  -webkit-text-align: center;
   text-align: center;
   font-weight: normal;
   padding-top: 46px;
@@ -136,7 +131,7 @@ exports[`renders classic text properly 1`] = `
 }
 
 .c0 .content-start {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 67px;
   line-height: 1em;
@@ -144,7 +139,6 @@ exports[`renders classic text properly 1`] = `
   line-height: .5em;
   margin-right: 10px;
   margin-top: .298em;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
 }
 
@@ -175,62 +169,60 @@ exports[`renders classic text properly 1`] = `
 
 .c0 .artist-follow:after {
   content: "Follow";
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;
-  -webkit-text-transform: none;
   text-transform: none;
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c0 {
     max-width: calc(100% - 40px);
     margin: 0 auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
     max-width: 100%;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 p,
   .c0 ul,
   .c0 ol {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c0 li {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c0 h1 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
   .c0 h2 {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 28px;
     line-height: 1.2em;
   }
 
   .c0 h3 {
-    font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+    font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
     -webkit-font-smoothing: antialiased;
-    -webkit-text-transform: uppercase;
     text-transform: uppercase;
     -webkit-letter-spacing: 1px;
     -moz-letter-spacing: 1px;
@@ -242,11 +234,10 @@ exports[`renders classic text properly 1`] = `
     -moz-letter-spacing: 1px;
     -ms-letter-spacing: 1px;
     letter-spacing: 1px;
-    line-height: ;
   }
 
   .c0 blockquote {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
@@ -273,12 +264,10 @@ exports[`renders classic text properly 1`] = `
 exports[`renders feature text properly 1`] = `
 .c0 {
   position: relative;
-  padding-bottom: ;
 }
 
 .c0 a {
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
   background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
@@ -294,7 +283,7 @@ exports[`renders feature text properly 1`] = `
 .c0 p,
 .c0 ul,
 .c0 ol {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -318,7 +307,7 @@ exports[`renders feature text properly 1`] = `
 }
 
 .c0 li {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -327,7 +316,7 @@ exports[`renders feature text properly 1`] = `
 }
 
 .c0 h1 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -336,7 +325,6 @@ exports[`renders feature text properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   position: relative;
-  -webkit-text-align: center;
   text-align: center;
 }
 
@@ -352,7 +340,7 @@ exports[`renders feature text properly 1`] = `
 }
 
 .c0 h2 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
@@ -365,7 +353,7 @@ exports[`renders feature text properly 1`] = `
 }
 
 .c0 h3 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -376,22 +364,17 @@ exports[`renders feature text properly 1`] = `
 
 .c0 h3 strong {
   font-weight: normal;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
 }
 
-.c0 h3 em {
-  font-style: ;
-}
-
 .c0 blockquote {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 65px;
   line-height: 1em;
-  -webkit-text-align: left;
   text-align: left;
   font-weight: normal;
   padding-top: 46px;
@@ -400,7 +383,7 @@ exports[`renders feature text properly 1`] = `
 }
 
 .c0 .content-start {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 67px;
   line-height: 1em;
@@ -408,7 +391,6 @@ exports[`renders feature text properly 1`] = `
   line-height: .5em;
   margin-right: 10px;
   margin-top: .298em;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
 }
 
@@ -439,60 +421,59 @@ exports[`renders feature text properly 1`] = `
 
 .c0 .artist-follow:after {
   content: "Follow";
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;
-  -webkit-text-transform: none;
   text-transform: none;
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c0 {
     max-width: calc(100% - 40px);
     margin: 0 auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
     max-width: 100%;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 p,
   .c0 ul,
   .c0 ol {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c0 li {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c0 h1 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
   .c0 h2 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
   .c0 h3 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
@@ -500,14 +481,14 @@ exports[`renders feature text properly 1`] = `
   }
 
   .c0 h3 strong {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
   .c0 blockquote {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 40px;
     line-height: 1.1em;
@@ -534,12 +515,10 @@ exports[`renders feature text properly 1`] = `
 exports[`renders standard text properly 1`] = `
 .c0 {
   position: relative;
-  padding-bottom: ;
 }
 
 .c0 a {
   color: black;
-  -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
   background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
@@ -555,7 +534,7 @@ exports[`renders standard text properly 1`] = `
 .c0 p,
 .c0 ul,
 .c0 ol {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -579,7 +558,7 @@ exports[`renders standard text properly 1`] = `
 }
 
 .c0 li {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -588,7 +567,7 @@ exports[`renders standard text properly 1`] = `
 }
 
 .c0 h1 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -597,7 +576,6 @@ exports[`renders standard text properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   position: relative;
-  -webkit-text-align: center;
   text-align: center;
 }
 
@@ -613,7 +591,7 @@ exports[`renders standard text properly 1`] = `
 }
 
 .c0 h2 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
@@ -626,7 +604,7 @@ exports[`renders standard text properly 1`] = `
 }
 
 .c0 h3 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -637,22 +615,17 @@ exports[`renders standard text properly 1`] = `
 
 .c0 h3 strong {
   font-weight: normal;
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
 }
 
-.c0 h3 em {
-  font-style: ;
-}
-
 .c0 blockquote {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
-  -webkit-text-align: left;
   text-align: left;
   font-weight: normal;
   padding-top: 46px;
@@ -661,7 +634,7 @@ exports[`renders standard text properly 1`] = `
 }
 
 .c0 .content-start {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 67px;
   line-height: 1em;
@@ -669,7 +642,6 @@ exports[`renders standard text properly 1`] = `
   line-height: .5em;
   margin-right: 10px;
   margin-top: .298em;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
 }
 
@@ -700,60 +672,59 @@ exports[`renders standard text properly 1`] = `
 
 .c0 .artist-follow:after {
   content: "Follow";
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;
-  -webkit-text-transform: none;
   text-transform: none;
 }
 
-@media (max-width: 900px) {
+@media (max-width:900px) {
   .c0 {
     max-width: calc(100% - 40px);
     margin: 0 auto;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width:720px) {
   .c0 {
     max-width: 100%;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 p,
   .c0 ul,
   .c0 ol {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c0 li {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
   .c0 h1 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
   .c0 h2 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
   .c0 h3 {
-    font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
@@ -761,14 +732,14 @@ exports[`renders standard text properly 1`] = `
   }
 
   .c0 h3 strong {
-    font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
   .c0 blockquote {
-    font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 40px;
     line-height: 1.1em;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Video.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Video.test.tsx.snap
@@ -6,9 +6,9 @@ exports[`renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   margin: 10px 0 10px 0;
 }
@@ -22,7 +22,7 @@ exports[`renders properly 1`] = `
 .c6 > p,
 .c6 p,
 .c6 .public-DraftEditorPlaceholder-root {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -99,13 +99,13 @@ exports[`renders properly 1`] = `
   outline: 0;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c5 {
     padding: 0px 10px;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c6 {
     padding: 0px;
   }

--- a/src/Components/Publishing/__test__/__snapshots__/EmailSignup.test.tsx.snap
+++ b/src/Components/Publishing/__test__/__snapshots__/EmailSignup.test.tsx.snap
@@ -28,11 +28,9 @@ exports[`EmailSignup renders an email signup 1`] = `
   margin: 10px;
   border: none;
   box-sizing: border-box;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -53,7 +51,7 @@ exports[`EmailSignup renders an email signup 1`] = `
   transition: border-color .25s;
   margin-right: 10px;
   resize: none;
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   border: 2px solid #e5e5e5;
   -webkit-transition: border-color .25s;
@@ -87,7 +85,7 @@ exports[`EmailSignup renders an email signup 1`] = `
 }
 
 .c1 {
-  font-family: Unica77LLWebMedium ,      'Arial',      'serif';
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -101,9 +99,8 @@ exports[`EmailSignup renders an email signup 1`] = `
   height: 30px;
   width: 80px;
   margin-left: -100px;
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;

--- a/src/Components/Publishing/__test__/__snapshots__/Typography.test.tsx.snap
+++ b/src/Components/Publishing/__test__/__snapshots__/Typography.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders properly 1`] = `
 .c10 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 11px;
   line-height: 1.1em;
@@ -10,7 +10,7 @@ exports[`renders properly 1`] = `
 }
 
 .c9 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 15px;
   line-height: 1.25em;
@@ -18,7 +18,7 @@ exports[`renders properly 1`] = `
 }
 
 .c8 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 17px;
   line-height: 1.1em;
@@ -26,7 +26,7 @@ exports[`renders properly 1`] = `
 }
 
 .c7 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -34,7 +34,7 @@ exports[`renders properly 1`] = `
 }
 
 .c6 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
   line-height: 1.5em;
@@ -42,7 +42,7 @@ exports[`renders properly 1`] = `
 }
 
 .c5 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 28px;
   line-height: 1.2em;
@@ -50,7 +50,7 @@ exports[`renders properly 1`] = `
 }
 
 .c4 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 30px;
   line-height: 1.25em;
@@ -58,7 +58,7 @@ exports[`renders properly 1`] = `
 }
 
 .c3 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 34px;
   line-height: 1.1em;
@@ -66,7 +66,7 @@ exports[`renders properly 1`] = `
 }
 
 .c2 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 37px;
   line-height: 1.2em;
@@ -74,7 +74,7 @@ exports[`renders properly 1`] = `
 }
 
 .c1 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -82,7 +82,7 @@ exports[`renders properly 1`] = `
 }
 
 .c0 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
   line-height: 1.1em;
@@ -90,9 +90,8 @@ exports[`renders properly 1`] = `
 }
 
 .c12 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -108,9 +107,8 @@ exports[`renders properly 1`] = `
 }
 
 .c11 {
-  font-family: 'ITC Avant Garde Gothic W04',  'AvantGardeGothicITCW01D 731075',  'AvantGardeGothicITCW01Dm',  'Helvetica',  'sans-serif';
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
   -webkit-font-smoothing: antialiased;
-  -webkit-text-transform: uppercase;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
@@ -126,7 +124,7 @@ exports[`renders properly 1`] = `
 }
 
 .c25 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 12px;
   line-height: 1.4em;
@@ -134,7 +132,7 @@ exports[`renders properly 1`] = `
 }
 
 .c24 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
   line-height: 1.4em;
@@ -142,7 +140,7 @@ exports[`renders properly 1`] = `
 }
 
 .c23 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
@@ -150,7 +148,7 @@ exports[`renders properly 1`] = `
 }
 
 .c22 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
   line-height: 1.5em;
@@ -158,7 +156,7 @@ exports[`renders properly 1`] = `
 }
 
 .c21 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
@@ -166,7 +164,7 @@ exports[`renders properly 1`] = `
 }
 
 .c20 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 34px;
   line-height: 1.1em;
@@ -174,7 +172,7 @@ exports[`renders properly 1`] = `
 }
 
 .c19 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
   line-height: 1.1em;
@@ -182,7 +180,7 @@ exports[`renders properly 1`] = `
 }
 
 .c18 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 45px;
   line-height: 1.2em;
@@ -190,7 +188,7 @@ exports[`renders properly 1`] = `
 }
 
 .c17 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 65px;
   line-height: 1em;
@@ -198,7 +196,7 @@ exports[`renders properly 1`] = `
 }
 
 .c16 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 67px;
   line-height: 1em;
@@ -206,7 +204,7 @@ exports[`renders properly 1`] = `
 }
 
 .c15 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 80px;
   line-height: 1.1em;
@@ -214,7 +212,7 @@ exports[`renders properly 1`] = `
 }
 
 .c14 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 100px;
   line-height: 1.1em;
@@ -222,7 +220,7 @@ exports[`renders properly 1`] = `
 }
 
 .c13 {
-  font-family: Unica77LLWebRegular ,      'Arial',      'serif';
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 130px;
   line-height: 1.1em;

--- a/src/Components/__tests__/__snapshots__/Artwork.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/Artwork.test.tsx.snap
@@ -3,25 +3,22 @@
 exports[`Artwork renders correctly 1`] = `
 .c5 {
   color: #333333;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c4 {
   display: block;
-  -webkit-text-overflow: ellipsis;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 }
 
 .c3 {
-  font-family: 'Adobe Garamond W08',  'adobe-garamond-pro',  'AGaramondPro-Regular',  'Times New Roman',  'Times',  'serif';
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   color: #666666;
   margin-top: 12px;
   font-size: 15px;
-  -webkit-text-align: left;
   text-align: left;
   line-height: 20px;
 }
@@ -68,7 +65,7 @@ exports[`Artwork renders correctly 1`] = `
   right: 0;
 }
 
-@media (min-width: 49px) {
+@media (min-width:49px) {
   .c1:hover .overlay-container.hovered {
     opacity: 1;
     visibility: visible;

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -33,6 +33,20 @@ module.exports = () => {
       path: path.join(__dirname, "../dist/Apps/Loyalty/Server/bundles"),
       publicPath: "/Loyalty/bundles",
     },
+    externals: {
+      react: {
+        commonjs: "react",
+        commonjs2: "react"
+      },
+      "react-dom": {
+        commonjs: "react-dom",
+        commonjs2: "react-dom",
+      },
+      "styled-components": {
+        commonjs: "styled-components",
+        commonjs2: "styled-components",
+      },
+    },
     plugins: [new webpack.optimize.CommonsChunkPlugin("commons.chunk")],
     resolve: {
       extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,6 +2980,14 @@ create-react-class@^15.5.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-class@^15.6.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cross-spawn-async@^2.1.1:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
@@ -7615,7 +7623,7 @@ prop-types@15.5.8:
   dependencies:
     fbjs "^0.8.9"
 
-prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@~15.5.7:
+prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -7982,13 +7990,14 @@ react-url-query@^1.1.4:
     query-string "^4.2.3"
 
 react@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
+    create-react-class "^15.6.0"
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "^15.5.7"
+    prop-types "^15.5.10"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -8954,8 +8963,8 @@ style-loader@^0.18.2:
     schema-utils "^0.3.0"
 
 styled-components@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.0.1.tgz#c7b5d211a2f794c0bf5e7c7d028617bed5781625"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.2.1.tgz#f4835f1001c37bcc301ac3865b5d93466de4dd5b"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
@@ -8964,16 +8973,16 @@ styled-components@^2.0.1:
     is-function "^1.0.1"
     is-plain-object "^2.0.1"
     prop-types "^15.5.4"
-    stylis "^3.0.19"
+    stylis "^3.2.1"
     supports-color "^3.2.3"
 
 stylis@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-2.0.0.tgz#6785a6546bd73478799a67d49d67086953b50ad5"
 
-stylis@^3.0.19:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.1.2.tgz#23179ccefdfeda8269d2fa77d5bc65957955fc9e"
+stylis@^3.2.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.3.2.tgz#95ef285836e98243f8b8f64a9a72706ea6c893ea"
 
 superagent-proxy@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Noticed that we were getting some strange errors (and poor stack traces) in Force and realized that we were loading two versions of React -- one from force and one from Reaction. Webpack docs: https://webpack.js.org/configuration/externals/

**Exclusions from build:**
- `react`
- `react-dom`
- `styled-components`

Also, removed `formatOnSave` from `.vscode/settings.json` since we already have Prettier setup on git commit and we shouldn't have to adjust the way we code and look at code during dev... 