### PR TITLE
Add 'xlarge: 26px' for to the Text component

### DIFF
--- a/src/Apps/Loyalty/Containers/3wThankYou/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/3wThankYou/__tests__/__snapshots__/index.ts.snap
@@ -40,7 +40,7 @@ exports[`3-way Handshake Thank You renders the snapshot 1`] = `
     className="file__TextSection-s1lvtw1r-2 dWcmTp"
   >
     <p
-      className="file__Text-s1j50yi-0 gnnjbx"
+      className="file__Text-s63pphj-0 kRUshZ"
     >
       Thank you for your interest in the program.
       <br />

--- a/src/Apps/Loyalty/Containers/AcbThankYou/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/AcbThankYou/__tests__/__snapshots__/index.ts.snap
@@ -29,7 +29,7 @@ exports[`ACB Thank You renders the snapshot 1`] = `
     className="file__Section-s15134u5-1 bQNJbm"
   >
     <p
-      className="file__Text-s1j50yi-0 kcCxRN"
+      className="file__Text-s63pphj-0 euxBwz"
     >
       EARLY ACCESS
     </p>
@@ -44,7 +44,7 @@ exports[`ACB Thank You renders the snapshot 1`] = `
     className="file__Section-s15134u5-1 bQNJbm"
   >
     <p
-      className="file__Text-s1j50yi-0 gnnjbx"
+      className="file__Text-s63pphj-0 kRUshZ"
     >
       Thank you for your interest in the program.
       <br />

--- a/src/Apps/Loyalty/Containers/ForgotPassword/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/ForgotPassword/__tests__/__snapshots__/index.tsx.snap
@@ -11,7 +11,7 @@ exports[`<ForgotPassword /> renders the snapshot 1`] = `
     
   </div>
   <p
-    className="file__Text-s1j50yi-0 gnnjbx"
+    className="file__Text-s63pphj-0 kRUshZ"
   >
     Enter the email address associated
     <br />

--- a/src/Apps/Loyalty/Containers/Inquiries/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/Inquiries/__tests__/__snapshots__/index.tsx.snap
@@ -35,7 +35,7 @@ exports[`inquiries renders the inquiries listing 1`] = `
       Please select all works you purchased
     </div>
     <p
-      className="header-subtitle file__Text-s1j50yi-0 jzToAc"
+      className="header-subtitle file__Text-s63pphj-0 cpmTaU"
     >
       We will confirm submitted purchases with the galleries in order to qualify you for the program membership.
     </p>
@@ -127,7 +127,7 @@ exports[`inquiries renders the inquiries listing 1`] = `
     className="footer"
   >
     <p
-      className="file__Text-s1j50yi-0 gnnjbx"
+      className="file__Text-s63pphj-0 kRUshZ"
     >
       If you purchased any works not included
       <br />

--- a/src/Apps/Loyalty/Containers/Login/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/Login/__tests__/__snapshots__/index.tsx.snap
@@ -11,7 +11,7 @@ exports[`login renders the snapshot 1`] = `
     
   </div>
   <p
-    className="file__Text-s1j50yi-0 gnnjbx"
+    className="file__Text-s63pphj-0 kRUshZ"
   >
     Welcome back, please log in 
     <br />

--- a/src/Apps/Loyalty/Containers/RepeatVisitor/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/RepeatVisitor/__tests__/__snapshots__/index.ts.snap
@@ -35,7 +35,7 @@ exports[`RepeatVisitor renders the snapshot 1`] = `
     className="file__Section-s1fo0l6p-1 hnqVsZ"
   >
     <p
-      className="file__Text-s1j50yi-0 gnnjbx"
+      className="file__Text-s63pphj-0 kRUshZ"
     >
       We will be in touch once we confirm your
       <br />

--- a/src/Components/Text.tsx
+++ b/src/Components/Text.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components"
 import * as fonts from "../Assets/Fonts"
 
 type TextAlign = "start" | "center" | "end"
-type TextSize = "small" | "medium" | "large"
+type TextSize = "small" | "medium" | "large" | "xlarge"
 type TextStyle = "primary" | "secondary"
 
 interface TextProps extends React.HTMLProps<HTMLParagraphElement> {
@@ -22,6 +22,7 @@ const textSizesForPrimaryStyle = {
 }
 
 const textSizesForSecondaryStyle = {
+  xlarge: "26px",
   large: "20px",
   medium: "17px",
   small: "15px",

--- a/src/Components/__stories__/Typography.story.tsx
+++ b/src/Components/__stories__/Typography.story.tsx
@@ -22,6 +22,9 @@ storiesOf("Typography", module)
         Plain Text
       </Title>
 
+      <Text textSize="xlarge">
+        Xlarge text: Thank you for your interest in the program.
+      </Text>
       <Text textSize="large">
         Large text: Thank you for your interest in the program.
       </Text>


### PR DESCRIPTION
We have [a requirement](https://github.com/artsy/collector-experience/issues/609#issuecomment-338811236) where we need to show texts in the size of 26px.

![screen shot 2017-10-24 at 11 39 52 am](https://user-images.githubusercontent.com/386234/31953031-1ec332b2-b8b0-11e7-9d0e-dcfbcb4f98f2.png)
