### PR TITLE
Text component should accept all props

### DIFF
--- a/src/Apps/Loyalty/Containers/3wThankYou/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/3wThankYou/__tests__/__snapshots__/index.ts.snap
@@ -40,7 +40,7 @@ exports[`3-way Handshake Thank You renders the snapshot 1`] = `
     className="file__TextSection-s1lvtw1r-2 dWcmTp"
   >
     <p
-      className="file__Text-s63pphj-0 kRUshZ"
+      className="file__Text-s1qz329q-0 jtAMIH"
     >
       Thank you for your interest in the program.
       <br />

--- a/src/Apps/Loyalty/Containers/AcbThankYou/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/AcbThankYou/__tests__/__snapshots__/index.ts.snap
@@ -29,7 +29,7 @@ exports[`ACB Thank You renders the snapshot 1`] = `
     className="file__Section-s15134u5-1 bQNJbm"
   >
     <p
-      className="file__Text-s63pphj-0 euxBwz"
+      className="file__Text-s1qz329q-0 bVfXSh"
     >
       EARLY ACCESS
     </p>
@@ -44,7 +44,7 @@ exports[`ACB Thank You renders the snapshot 1`] = `
     className="file__Section-s15134u5-1 bQNJbm"
   >
     <p
-      className="file__Text-s63pphj-0 kRUshZ"
+      className="file__Text-s1qz329q-0 jtAMIH"
     >
       Thank you for your interest in the program.
       <br />

--- a/src/Apps/Loyalty/Containers/ForgotPassword/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/ForgotPassword/__tests__/__snapshots__/index.tsx.snap
@@ -11,7 +11,7 @@ exports[`<ForgotPassword /> renders the snapshot 1`] = `
     
   </div>
   <p
-    className="file__Text-s63pphj-0 kRUshZ"
+    className="file__Text-s1qz329q-0 jtAMIH"
   >
     Enter the email address associated
     <br />

--- a/src/Apps/Loyalty/Containers/Inquiries/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/Inquiries/__tests__/__snapshots__/index.tsx.snap
@@ -35,7 +35,7 @@ exports[`inquiries renders the inquiries listing 1`] = `
       Please select all works you purchased
     </div>
     <p
-      className="header-subtitle file__Text-s63pphj-0 cpmTaU"
+      className="header-subtitle file__Text-s1qz329q-0 bPbEAT"
     >
       We will confirm submitted purchases with the galleries in order to qualify you for the program membership.
     </p>
@@ -127,7 +127,7 @@ exports[`inquiries renders the inquiries listing 1`] = `
     className="footer"
   >
     <p
-      className="file__Text-s63pphj-0 kRUshZ"
+      className="file__Text-s1qz329q-0 jtAMIH"
     >
       If you purchased any works not included
       <br />

--- a/src/Apps/Loyalty/Containers/Login/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/Login/__tests__/__snapshots__/index.tsx.snap
@@ -11,7 +11,7 @@ exports[`login renders the snapshot 1`] = `
     
   </div>
   <p
-    className="file__Text-s63pphj-0 kRUshZ"
+    className="file__Text-s1qz329q-0 jtAMIH"
   >
     Welcome back, please log in 
     <br />

--- a/src/Apps/Loyalty/Containers/RepeatVisitor/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/RepeatVisitor/__tests__/__snapshots__/index.ts.snap
@@ -35,7 +35,7 @@ exports[`RepeatVisitor renders the snapshot 1`] = `
     className="file__Section-s1fo0l6p-1 hnqVsZ"
   >
     <p
-      className="file__Text-s63pphj-0 kRUshZ"
+      className="file__Text-s1qz329q-0 jtAMIH"
     >
       We will be in touch once we confirm your
       <br />

--- a/src/Components/Text.tsx
+++ b/src/Components/Text.tsx
@@ -39,10 +39,11 @@ const textStyleNameToCss = {
   secondary: fonts.secondary.style,
 }
 
-const RawText: React.SFC<TextProps> = props =>
-  <p className={props.className}>
-    {props.children}
-  </p>
+const RawText: React.SFC<TextProps> = (props: TextProps) => {
+  const { textSize, textStyle, align, color, ...remainderProps } = props
+
+  return <p {...remainderProps}>{props.children}</p>
+}
 
 const Text = styled(RawText)`
   font-size: ${props => TextStyleToTextSize[props.textStyle][props.textSize]};


### PR DESCRIPTION
Right now the `Text` component only passes the `className` prop down to the `p` tag. This makes it difficult to apply a style workaround and requires us to update the upstream `@artsy/reaction-force`(this repo), which has more steps than just changing it in e.g. Force. This PR changes the component to pass down any props to the `p` tag so we'll be able to have more control without having to change upstream.