### PR TITLE
@kanaabe => Component spacing

### DIFF
--- a/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
@@ -224,12 +224,12 @@ exports[`feature renders feature full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+.c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+.c0[data-type="split"] .file__FeatureVideo-swevth-2 {
   width: 50vw;
 }
 
@@ -371,7 +371,7 @@ exports[`feature renders feature full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
     width: 100%;
     height: 50%;
     position: relative;
@@ -379,7 +379,7 @@ exports[`feature renders feature full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+  .c0[data-type="split"] .file__FeatureVideo-swevth-2 {
     width: 100%;
   }
 }
@@ -749,12 +749,12 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+.c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+.c0[data-type="split"] .file__FeatureVideo-swevth-2 {
   width: 50vw;
 }
 
@@ -768,7 +768,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   flex-direction: column;
 }
 
-.c0[data-type="split"] .file__Deck-s10iwek3-8 {
+.c0[data-type="split"] .file__Deck-swevth-8 {
   margin-bottom: 30px;
 }
 
@@ -886,7 +886,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
     width: 100%;
     height: 50%;
     position: relative;
@@ -894,7 +894,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+  .c0[data-type="split"] .file__FeatureVideo-swevth-2 {
     width: 100%;
   }
 }
@@ -1265,12 +1265,12 @@ exports[`feature renders feature header with children properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+.c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+.c0[data-type="split"] .file__FeatureVideo-swevth-2 {
   width: 50vw;
 }
 
@@ -1412,7 +1412,7 @@ exports[`feature renders feature header with children properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
     width: 100%;
     height: 50%;
     position: relative;
@@ -1420,7 +1420,7 @@ exports[`feature renders feature header with children properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+  .c0[data-type="split"] .file__FeatureVideo-swevth-2 {
     width: 100%;
   }
 }
@@ -1801,12 +1801,12 @@ exports[`feature renders feature split header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+.c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+.c0[data-type="split"] .file__FeatureVideo-swevth-2 {
   width: 50vw;
 }
 
@@ -1948,7 +1948,7 @@ exports[`feature renders feature split header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
     width: 100%;
     height: 50%;
     position: relative;
@@ -1956,7 +1956,7 @@ exports[`feature renders feature split header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+  .c0[data-type="split"] .file__FeatureVideo-swevth-2 {
     width: 100%;
   }
 }
@@ -2318,17 +2318,17 @@ exports[`feature renders feature text header properly 1`] = `
   width: 50%;
 }
 
-.c0[data-type="split"] .s10iwek3-0-file__Div-dCIIWC {
+.c0[data-type="split"] .swevth-0-file__Div-dCIIWC {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+.c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+.c0[data-type="split"] .file__FeatureVideo-swevth-2 {
   width: 50vw;
 }
 
@@ -2462,7 +2462,7 @@ exports[`feature renders feature text header properly 1`] = `
     width: 100%;
   }
 
-  .c0[data-type="split"] .s10iwek3-0-file__Div-dCIIWC {
+  .c0[data-type="split"] .swevth-0-file__Div-dCIIWC {
     width: 100%;
     height: 50%;
     position: relative;
@@ -2470,7 +2470,7 @@ exports[`feature renders feature text header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
     width: 100%;
     height: 50%;
     position: relative;
@@ -2478,7 +2478,7 @@ exports[`feature renders feature text header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+  .c0[data-type="split"] .file__FeatureVideo-swevth-2 {
     width: 100%;
   }
 }
@@ -2873,12 +2873,12 @@ exports[`feature renders superArticle full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+.c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+.c0[data-type="split"] .file__FeatureVideo-swevth-2 {
   width: 50vw;
 }
 
@@ -2916,8 +2916,8 @@ exports[`feature renders superArticle full header properly 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  z-index: 100;
-  padding: 50px;
+  z-index: 1;
+  padding: 50px 45px 50px;
 }
 
 .c7 {
@@ -3040,7 +3040,7 @@ exports[`feature renders superArticle full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s10iwek3-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .swevth-0-file__Div-bbbPPm {
     width: 100%;
     height: 50%;
     position: relative;
@@ -3048,7 +3048,7 @@ exports[`feature renders superArticle full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s10iwek3-2 {
+  .c0[data-type="split"] .file__FeatureVideo-swevth-2 {
     width: 100%;
   }
 }
@@ -3061,7 +3061,7 @@ exports[`feature renders superArticle full header properly 1`] = `
 
 @media (max-width:600px) {
   .c5 {
-    padding: 20px;
+    padding: 20px 15px 20px;
   }
 }
 

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -84,7 +84,7 @@ export const StyledText = div`
     font-weight: normal;
     margin: 0;
     a {
-      background-size: 1.25px 6px;
+      background-size: 1.25px 1px;
     }
   }
   h3 {

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`renders column_width properly 1`] = `
 }
 
 .c1 h2 a {
-  background-size: 1.25px 6px;
+  background-size: 1.25px 1px;
 }
 
 .c1 h3 {
@@ -379,7 +379,7 @@ exports[`renders fillwidth properly 1`] = `
 }
 
 .c1 h2 a {
-  background-size: 1.25px 6px;
+  background-size: 1.25px 1px;
 }
 
 .c1 h3 {
@@ -659,7 +659,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 }
 
 .c1 h2 a {
-  background-size: 1.25px 6px;
+  background-size: 1.25px 1px;
 }
 
 .c1 h3 {

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
@@ -390,7 +390,7 @@ exports[`renders properly 1`] = `
 }
 
 .c2 h2 a {
-  background-size: 1.25px 6px;
+  background-size: 1.25px 1px;
 }
 
 .c2 h3 {

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`renders classic text properly 1`] = `
 }
 
 .c0 h2 a {
-  background-size: 1.25px 6px;
+  background-size: 1.25px 1px;
 }
 
 .c0 h3 {
@@ -349,7 +349,7 @@ exports[`renders feature text properly 1`] = `
 }
 
 .c0 h2 a {
-  background-size: 1.25px 6px;
+  background-size: 1.25px 1px;
 }
 
 .c0 h3 {
@@ -600,7 +600,7 @@ exports[`renders standard text properly 1`] = `
 }
 
 .c0 h2 a {
-  background-size: 1.25px 6px;
+  background-size: 1.25px 1px;
 }
 
 .c0 h3 {

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -1,5 +1,5 @@
 export type Layout = "classic" | "standard" | "feature"
-export type SectionLayout = "blockquote" | "column_width" | "fillwidth" | "overflow_fillwidth"
+export type SectionLayout = "blockquote" | "column_width" | "fillwidth" | "full" | "mini" | "overflow_fillwidth"
 
 export type ArticleData = {
   layout: Layout

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -1,5 +1,5 @@
 export type Layout = "classic" | "standard" | "feature"
-export type SectionLayout = "column_width" | "fillwidth" | "overflow_fillwidth"
+export type SectionLayout = "blockquote" | "column_width" | "fillwidth" | "overflow_fillwidth"
 
 export type ArticleData = {
   layout: Layout


### PR DESCRIPTION
- Updates spacing on h2 > a
- Adds 'blockquote' and image_set layouts to typings for section layouts

Gets close to closing https://github.com/artsy/publishing/issues/128
(Still need to backfill image_sets with 'overflow_fillwidth' layouts)