### PR TITLE
Add tracking to display components

### DIFF
--- a/src/Components/Publishing/Display/Canvas/CanvasSlideshow.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasSlideshow.tsx
@@ -4,7 +4,7 @@ import Slider from "react-slick"
 import styled, { StyledFunction } from "styled-components"
 import Colors from "../../../../Assets/Colors"
 import { crop } from "../../../../Utils/resizer"
-import track from "../../../../Utils/track"
+import { track } from "../../../../Utils/track"
 import { pMedia } from "../../../Helpers"
 import Icon from "../../../Icon"
 import { Fonts } from "../../Fonts"
@@ -47,8 +47,11 @@ export class CanvasSlideshow extends React.Component<CanvasSlideshowProps, any> 
   }
 
   @track(props => ({
-    action: "Display Navigate Slideshow",
+    action: "Click",
+    label: "Display ad carousel arrow",
+    entity_type: "display_ad",
     campaign_name: props.campaign.name,
+    unit_layout: "canvas_slideshow"
   }))
   onChangeSlide(slide) {
     this.slider.slickGoTo(slide)

--- a/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
@@ -18,12 +18,14 @@ export class CanvasVideo extends React.Component<VideoProps, any> {
     this.state = { isPlaying: false }
   }
 
-  @track((props) => ({
-    action: "Display Play Video",
+  @track(props => ({
+    action: "Click",
+    label: "Display ad play video",
+    entity_type: "display_ad",
     campaign_name: props.campaign.name,
+    unit_layout: "canvas_standard"
   }))
-  onPlayVideo(e) {
-    e.preventDefault()
+  onPlayVideo() {
     if (this.video) {
       if (this.video.paused) {
         this.video.play()

--- a/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
@@ -1,3 +1,4 @@
+import { once } from "lodash"
 import React from "react"
 import styled from "styled-components"
 import track from "../../../../Utils/track"
@@ -18,13 +19,13 @@ export class CanvasVideo extends React.Component<VideoProps, any> {
     this.state = { isPlaying: false }
   }
 
-  @track(props => ({
+  @track(once((props) => ({
     action: "Click",
     label: "Display ad play video",
     entity_type: "display_ad",
     campaign_name: props.campaign.name,
     unit_layout: "canvas_standard"
-  }))
+  })))
   onPlayVideo() {
     if (this.video) {
       if (this.video.paused) {

--- a/src/Components/Publishing/Display/Canvas/index.tsx
+++ b/src/Components/Publishing/Display/Canvas/index.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import styled, { StyledFunction } from "styled-components"
 import Colors from "../../../../Assets/Colors"
+import { track } from "../../../../Utils/track"
 import { pMedia } from "../../../Helpers"
 import { Fonts } from "../../Fonts"
 import { CanvasContainer } from "./CanvasContainer"
@@ -10,19 +11,32 @@ interface DisplayCanvasProps {
   campaign: any
 }
 
-export const DisplayCanvas: React.SFC<DisplayCanvasProps> = props => {
-  const { unit, campaign } = props
-  const disclaimer = <Disclaimer layout={unit.layout}>{unit.disclaimer}</Disclaimer>
+@track()
+export class DisplayCanvas extends React.Component<DisplayCanvasProps, any> {
+  @track(props => ({
+    action: "Click",
+    label: "Display ad carousel arrow",
+    entity_type: "display_ad",
+    campaign_name: props.campaign.name,
+    unit_layout: "canvas_slideshow"
+  }))
+  // tslint:disable-next-line:no-empty
+  componentDidMount() { }
 
-  return (
-    <DisplayContainer layout={unit.layout}>
-      <a href={unit.link.url} target="_blank">
-        <AdvertisementBy>{`Advertisement by ${campaign.name}`}</AdvertisementBy>
-      </a>
-      <CanvasContainer unit={unit} campaign={campaign} disclaimer={disclaimer} />
-      {unit.layout === "overlay" && disclaimer}
-    </DisplayContainer>
-  )
+  render() {
+    const { unit, campaign } = this.props
+    const disclaimer = <Disclaimer layout={unit.layout}>{unit.disclaimer}</Disclaimer>
+
+    return (
+      <DisplayContainer layout={unit.layout}>
+        <a href={unit.link.url} target="_blank">
+          <AdvertisementBy>{`Advertisement by ${campaign.name}`}</AdvertisementBy>
+        </a>
+        <CanvasContainer unit={unit} campaign={campaign} disclaimer={disclaimer} />
+        {unit.layout === "overlay" && disclaimer}
+      </DisplayContainer>
+    )
+  }
 }
 
 interface DivProps extends React.HTMLProps<HTMLDivElement> {

--- a/src/Components/Publishing/Display/Canvas/index.tsx
+++ b/src/Components/Publishing/Display/Canvas/index.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import styled, { StyledFunction } from "styled-components"
 import Colors from "../../../../Assets/Colors"
-import { track } from "../../../../Utils/track"
 import { pMedia } from "../../../Helpers"
 import { Fonts } from "../../Fonts"
 import { CanvasContainer } from "./CanvasContainer"
@@ -11,32 +10,19 @@ interface DisplayCanvasProps {
   campaign: any
 }
 
-@track()
-export class DisplayCanvas extends React.Component<DisplayCanvasProps, any> {
-  @track(props => ({
-    action: "Click",
-    label: "Display ad carousel arrow",
-    entity_type: "display_ad",
-    campaign_name: props.campaign.name,
-    unit_layout: "canvas_slideshow"
-  }))
-  // tslint:disable-next-line:no-empty
-  componentDidMount() { }
+export const DisplayCanvas: React.SFC<DisplayCanvasProps> = props => {
+  const { unit, campaign } = props
+  const disclaimer = <Disclaimer layout={unit.layout}>{unit.disclaimer}</Disclaimer>
 
-  render() {
-    const { unit, campaign } = this.props
-    const disclaimer = <Disclaimer layout={unit.layout}>{unit.disclaimer}</Disclaimer>
-
-    return (
-      <DisplayContainer layout={unit.layout}>
-        <a href={unit.link.url} target="_blank">
-          <AdvertisementBy>{`Advertisement by ${campaign.name}`}</AdvertisementBy>
-        </a>
-        <CanvasContainer unit={unit} campaign={campaign} disclaimer={disclaimer} />
-        {unit.layout === "overlay" && disclaimer}
-      </DisplayContainer>
-    )
-  }
+  return (
+    <DisplayContainer layout={unit.layout}>
+      <a href={unit.link.url} target="_blank">
+        <AdvertisementBy>{`Advertisement by ${campaign.name}`}</AdvertisementBy>
+      </a>
+      <CanvasContainer unit={unit} campaign={campaign} disclaimer={disclaimer} />
+      {unit.layout === "overlay" && disclaimer}
+    </DisplayContainer>
+  )
 }
 
 interface DivProps extends React.HTMLProps<HTMLDivElement> {

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`renders the display panel 1`] = `
 
 <div
   className="c0"
+  href="http://artsy.net"
   onClick={[Function]}
 >
   <div

--- a/src/__stories__/config.js
+++ b/src/__stories__/config.js
@@ -1,6 +1,5 @@
 const { configure } = require("@storybook/react")
 const Events = require("../Utils/Events").default
-
 const req = require.context("../", true, /\.story\.tsx$/)
 
 function loadStories() {
@@ -8,6 +7,7 @@ function loadStories() {
 }
 
 configure(loadStories, module)
+Events.onEvent(data => console.log("Tracked event", data))
 
 import { setOptions } from "@storybook/addon-options"
 
@@ -17,5 +17,3 @@ setOptions({
   showDownPanel: false,
   sortStoriesByKind: true,
 })
-
-Events.onEvent(data => console.log("Tracked event", data))


### PR DESCRIPTION
Makes progress on https://github.com/artsy/publishing/issues/101

This puts in the tracking decorators for the events we need for display ads. Next for me is to figure out a Looker dashboard + export for Content Sales to use.