### PR TITLE
Make Events API truly global

### DIFF
--- a/src/Utils/Events.ts
+++ b/src/Utils/Events.ts
@@ -1,6 +1,14 @@
 import EventEmitter from "events"
 
-const emitter = new EventEmitter()
+/* tslint:disable:no-namespace */
+declare global {
+  interface Window { __reactionEventsEventEmitter: any; }
+}
+/* tslint:disable:no-namespace */
+
+const emitter = typeof window !== 'undefined'
+  ? window.__reactionEventsEventEmitter || (window.__reactionEventsEventEmitter = new EventEmitter())
+  : new EventEmitter()
 const postEvent = data => emitter.emit("postEvent", data)
 const onEvent = callback => emitter.on("postEvent", callback)
 


### PR DESCRIPTION
This adds the `Events` API to the `window` object which is kinda ugly in TS, but luckily not something we commonly need to do. The reason for it here is that we want a truly global singleton object that is shared across asset packages and between Reaction & Force—otherwise, the Reaction components instantiate one object and Force instantiates a different one and they don't communicate. This is a pattern we use in other truly global event emitters like our [analytics hooks](https://github.com/artsy/force/blob/master/desktop/lib/analytics_hooks.coffee#L10).