### PR TITLE
@eessex => Cleaner responsive StandardLayout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 .vscode/cSpell.json
 yarn-error.log
 npm-debug.log
+package-lock.json

--- a/src/Assets/Theme.ts
+++ b/src/Assets/Theme.ts
@@ -20,7 +20,7 @@ export default {
       xs: 600, // px
       sm: 720, // px
       md: 900, // px
-      lg: 1150, // px
+      lg: 1080, // px
       xl: 1250, // px
     },
   },

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -10,7 +10,7 @@ import { EmailSignup } from "./EmailSignup"
 import { Header } from "./Header/Header"
 import { FeatureLayout } from "./Layouts/FeatureLayout"
 import { Sidebar } from "./Layouts/Sidebar"
-import { StandardLayout } from "./Layouts/StandardLayout"
+import { StandardLayout, StandardLayoutParent } from "./Layouts/StandardLayout"
 import { ReadMore } from "./ReadMore/ReadMoreButton"
 import { ReadMoreWrapper } from "./ReadMore/ReadMoreWrapper"
 import { RelatedArticlesCanvas } from "./RelatedArticles/RelatedArticlesCanvas"
@@ -153,28 +153,30 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
             isMobile={isMobile}
           />
 
-          <StandardLayout>
-            <Sections article={article} />
-            <Sidebar>
-              {this.props.emailSignupUrl &&
-                <EmailSignup
-                  signupUrl={this.props.emailSignupUrl}
-                />}
+          <StandardLayoutParent>
+            <StandardLayout>
+              <Sections article={article} />
+              <Sidebar>
+                {this.props.emailSignupUrl &&
+                  <EmailSignup
+                    signupUrl={this.props.emailSignupUrl}
+                  />}
 
-              {relatedArticlesForPanel &&
-                <RelatedArticlesPanel
-                  label={"Related Stories"}
-                  articles={relatedArticlesForPanel}
-                />}
+                {relatedArticlesForPanel &&
+                  <RelatedArticlesPanel
+                    label={"Related Stories"}
+                    articles={relatedArticlesForPanel}
+                  />}
 
-              {this.props.display &&
-                <DisplayPanel
-                  unit={this.props.display.panel}
-                  campaign={campaign}
-                />}
+                {this.props.display &&
+                  <DisplayPanel
+                    unit={this.props.display.panel}
+                    campaign={campaign}
+                  />}
 
-            </Sidebar>
-          </StandardLayout>
+              </Sidebar>
+            </StandardLayout>
+          </StandardLayoutParent>
 
           {relatedArticlesForCanvas &&
             <RelatedArticlesCanvas

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -454,7 +454,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
   margin: 15px 0 0 0;
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c3.title-card {
     max-width: 1250px;
   }
@@ -466,7 +466,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c4 {
     width: 437.5px;
     padding: 0 20px;
@@ -495,7 +495,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c12 {
     max-height: 479.375px;
   }
@@ -522,7 +522,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c8 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -545,7 +545,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c9 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -564,7 +564,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c5 {
     max-height: 479.375px;
   }
@@ -868,7 +868,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c7 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -891,7 +891,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c8 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -920,7 +920,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c2 {
     max-height: 479.375px;
     padding: 0 20px;
@@ -1229,7 +1229,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c10 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -1252,7 +1252,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c11 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -1283,7 +1283,7 @@ exports[`renders the canvas in standard layout with video 1`] = `
   }
 }
 
-@media (max-width:1150px) {
+@media (max-width:1080px) {
   .c2 {
     max-height: 479.375px;
     padding: 0 20px;

--- a/src/Components/Publishing/Header/StandardHeader.tsx
+++ b/src/Components/Publishing/Header/StandardHeader.tsx
@@ -13,13 +13,22 @@ interface StandardHeaderProps {
 export const StandardHeader: React.SFC<StandardHeaderProps> = props => {
   const { article, title, vertical } = props
   return (
-    <StandardHeaderContainer>
-      <Vertical>{vertical}</Vertical>
-      <Title>{title}</Title>
-      <Byline article={article} layout="standard" />
-    </StandardHeaderContainer>
+    <StandardHeaderParent>
+      <StandardHeaderContainer>
+        <Vertical>{vertical}</Vertical>
+        <Title>{title}</Title>
+        <Byline article={article} layout="standard" />
+      </StandardHeaderContainer>
+    </StandardHeaderParent>
   )
 }
+
+const StandardHeaderParent = styled.div`
+  margin: 0 40px;
+  ${pMedia.sm`
+    margin: 0 20px;
+  `}
+`
 
 const StandardHeaderContainer = styled.div`
   display: flex;
@@ -28,24 +37,21 @@ const StandardHeaderContainer = styled.div`
   width: 100%;
   margin: 40px auto;
   box-sizing: border-box;
-  ${pMedia.xl`
-    padding: 0 20px;
-  `}
-  ${pMedia.xs`
+  ${pMedia.sm`
     margin: 30px auto;
   `}
 `
 const Title = styled.div`
   ${Fonts.garamond("s50")}
   margin-bottom: 50px;
-  ${pMedia.xs`
+  ${pMedia.sm`
     ${Fonts.garamond("s34")}
   `}
 `
 const Vertical = styled.div`
   ${Fonts.unica("s16", "medium")}
   margin-bottom: 10px;
-  ${pMedia.xs`
+  ${pMedia.sm`
     ${Fonts.unica("s14", "medium")}
   `}
 `

--- a/src/Components/Publishing/Header/__test__/__snapshots__/ClassicHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/ClassicHeader.test.tsx.snap
@@ -276,6 +276,18 @@ exports[`Classic Header renders classic header properly 1`] = `
 `;
 
 exports[`Classic Header renders classic header with children properly 1`] = `
+.c6 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  line-height: 1.1em;
+  margin: 10px 30px 0 0;
+}
+
+.c6.date {
+  white-space: nowrap;
+}
+
 .c5 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -288,19 +300,7 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   white-space: nowrap;
 }
 
-.c4 {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 16px;
-  line-height: 1.1em;
-  margin: 10px 30px 0 0;
-}
-
-.c4.date {
-  white-space: nowrap;
-}
-
-.c4:before {
+.c5:before {
   content: "";
   display: inline-block;
   min-width: 10px;
@@ -310,7 +310,7 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   background-color: #000;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -318,7 +318,7 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   margin: 5px 0 4px;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -335,11 +335,11 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   margin-right: 14px;
 }
 
-.c7:hover {
+.c8:hover {
   opacity: 0.6;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -358,6 +358,10 @@ exports[`Classic Header renders classic header with children properly 1`] = `
 }
 
 .c0 {
+  margin: 0 40px;
+}
+
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -371,7 +375,7 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c3 {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
@@ -379,12 +383,26 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   margin-bottom: 50px;
 }
 
-.c1 {
+.c2 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
   margin-bottom: 10px;
+}
+
+@media (max-width:720px) {
+  .c6 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 10px 20px 0 0;
+  }
 }
 
 @media (max-width:720px) {
@@ -402,40 +420,26 @@ exports[`Classic Header renders classic header with children properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c4 {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 14px;
-    line-height: 1.4em;
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 14px;
-    line-height: 1.4em;
-    margin: 10px 20px 0 0;
-  }
-}
-
-@media (max-width:720px) {
-  .c4:before {
+  .c5:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:720px) {
   .c0 {
-    padding: 0 20px;
+    margin: 0 20px;
   }
 }
 
-@media (max-width:600px) {
-  .c0 {
+@media (max-width:720px) {
+  .c1 {
     margin: 30px auto;
   }
 }
 
-@media (max-width:600px) {
-  .c2 {
+@media (max-width:720px) {
+  .c3 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
@@ -443,8 +447,8 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   }
 }
 
-@media (max-width:600px) {
-  .c1 {
+@media (max-width:720px) {
+  .c2 {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -458,109 +462,113 @@ exports[`Classic Header renders classic header with children properly 1`] = `
   <div
     className="c1"
   >
-    Art Market
-  </div>
-  <div
-    className="c2"
-  >
-    <div>
-      Child 1: Lead Paragraph
-    </div>
-  </div>
-  <div
-    className="c3"
-  >
     <div
-      className="author c4"
+      className="c2"
     >
-      By 
-      Artsy Editorial
+      Art Market
     </div>
     <div
-      className="date c5"
+      className="c3"
     >
-      May 19, 2017 9:09 am
+      <div>
+        Child 1: Lead Paragraph
+      </div>
     </div>
     <div
-      className="c6"
+      className="c4"
     >
-      <a
-        className="c7"
-        href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
-        onClick={[Function]}
-        target="_blank"
+      <div
+        className="author c5"
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 14 14"
-          width="14px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <path
-              d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
-      <a
-        className="c7"
-        href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
-        onClick={[Function]}
-        target="_blank"
+        By 
+        Artsy Editorial
+      </div>
+      <div
+        className="date c6"
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 16 14"
-          width="16px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <path
-              d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
-      <a
+        May 19, 2017 9:09 am
+      </div>
+      <div
         className="c7"
-        href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
-        onClick={[Function]}
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 17 14"
-          width="17px"
-          xmlns="http://www.w3.org/2000/svg"
+        <a
+          className="c8"
+          href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
+          onClick={[Function]}
+          target="_blank"
         >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 14 14"
+            width="14px"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <path
-              d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+        <a
+          className="c8"
+          href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
+          onClick={[Function]}
+          target="_blank"
+        >
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 16 14"
+            width="16px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+        <a
+          className="c8"
+          href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
+          onClick={[Function]}
+        >
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 17 14"
+            width="17px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/src/Components/Publishing/Header/__test__/__snapshots__/StandardHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/StandardHeader.test.tsx.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Standard Header renders standard header properly 1`] = `
+.c6 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  line-height: 1.1em;
+  margin: 10px 30px 0 0;
+}
+
+.c6.date {
+  white-space: nowrap;
+}
+
 .c5 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -13,19 +25,7 @@ exports[`Standard Header renders standard header properly 1`] = `
   white-space: nowrap;
 }
 
-.c4 {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 16px;
-  line-height: 1.1em;
-  margin: 10px 30px 0 0;
-}
-
-.c4.date {
-  white-space: nowrap;
-}
-
-.c4:before {
+.c5:before {
   content: "";
   display: inline-block;
   min-width: 10px;
@@ -35,7 +35,7 @@ exports[`Standard Header renders standard header properly 1`] = `
   background-color: #000;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -43,7 +43,7 @@ exports[`Standard Header renders standard header properly 1`] = `
   margin: 5px 0 4px;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -60,11 +60,11 @@ exports[`Standard Header renders standard header properly 1`] = `
   margin-right: 14px;
 }
 
-.c7:hover {
+.c8:hover {
   opacity: 0.6;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -83,6 +83,10 @@ exports[`Standard Header renders standard header properly 1`] = `
 }
 
 .c0 {
+  margin: 0 40px;
+}
+
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -96,7 +100,7 @@ exports[`Standard Header renders standard header properly 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c3 {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
@@ -104,12 +108,26 @@ exports[`Standard Header renders standard header properly 1`] = `
   margin-bottom: 50px;
 }
 
-.c1 {
+.c2 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
   margin-bottom: 10px;
+}
+
+@media (max-width:720px) {
+  .c6 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 10px 20px 0 0;
+  }
 }
 
 @media (max-width:720px) {
@@ -127,40 +145,26 @@ exports[`Standard Header renders standard header properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c4 {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 14px;
-    line-height: 1.4em;
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 14px;
-    line-height: 1.4em;
-    margin: 10px 20px 0 0;
-  }
-}
-
-@media (max-width:720px) {
-  .c4:before {
+  .c5:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:720px) {
   .c0 {
-    padding: 0 20px;
+    margin: 0 20px;
   }
 }
 
-@media (max-width:600px) {
-  .c0 {
+@media (max-width:720px) {
+  .c1 {
     margin: 30px auto;
   }
 }
 
-@media (max-width:600px) {
-  .c2 {
+@media (max-width:720px) {
+  .c3 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
@@ -168,8 +172,8 @@ exports[`Standard Header renders standard header properly 1`] = `
   }
 }
 
-@media (max-width:600px) {
-  .c1 {
+@media (max-width:720px) {
+  .c2 {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -183,113 +187,129 @@ exports[`Standard Header renders standard header properly 1`] = `
   <div
     className="c1"
   >
-    Art Market
-  </div>
-  <div
-    className="c2"
-  >
-    New York's Next Art District
-  </div>
-  <div
-    className="c3"
-  >
     <div
-      className="author c4"
+      className="c2"
     >
-      By 
-      Artsy Editorial
+      Art Market
     </div>
     <div
-      className="date c5"
+      className="c3"
     >
-      May 19, 2017 9:09 am
+      New York's Next Art District
     </div>
     <div
-      className="c6"
+      className="c4"
     >
-      <a
-        className="c7"
-        href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
-        onClick={[Function]}
-        target="_blank"
+      <div
+        className="author c5"
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 14 14"
-          width="14px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <path
-              d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
-      <a
-        className="c7"
-        href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
-        onClick={[Function]}
-        target="_blank"
+        By 
+        Artsy Editorial
+      </div>
+      <div
+        className="date c6"
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 16 14"
-          width="16px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <path
-              d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
-      <a
+        May 19, 2017 9:09 am
+      </div>
+      <div
         className="c7"
-        href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
-        onClick={[Function]}
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 17 14"
-          width="17px"
-          xmlns="http://www.w3.org/2000/svg"
+        <a
+          className="c8"
+          href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
+          onClick={[Function]}
+          target="_blank"
         >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 14 14"
+            width="14px"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <path
-              d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+        <a
+          className="c8"
+          href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
+          onClick={[Function]}
+          target="_blank"
+        >
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 16 14"
+            width="16px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+        <a
+          className="c8"
+          href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
+          onClick={[Function]}
+        >
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 17 14"
+            width="17px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`Standard Header renders standard header with children properly 1`] = `
+.c6 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  line-height: 1.1em;
+  margin: 10px 30px 0 0;
+}
+
+.c6.date {
+  white-space: nowrap;
+}
+
 .c5 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -302,19 +322,7 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   white-space: nowrap;
 }
 
-.c4 {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 16px;
-  line-height: 1.1em;
-  margin: 10px 30px 0 0;
-}
-
-.c4.date {
-  white-space: nowrap;
-}
-
-.c4:before {
+.c5:before {
   content: "";
   display: inline-block;
   min-width: 10px;
@@ -324,7 +332,7 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   background-color: #000;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -332,7 +340,7 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   margin: 5px 0 4px;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -349,11 +357,11 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   margin-right: 14px;
 }
 
-.c7:hover {
+.c8:hover {
   opacity: 0.6;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -372,6 +380,10 @@ exports[`Standard Header renders standard header with children properly 1`] = `
 }
 
 .c0 {
+  margin: 0 40px;
+}
+
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -385,7 +397,7 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c3 {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 50px;
@@ -393,12 +405,26 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   margin-bottom: 50px;
 }
 
-.c1 {
+.c2 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
   margin-bottom: 10px;
+}
+
+@media (max-width:720px) {
+  .c6 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 10px 20px 0 0;
+  }
 }
 
 @media (max-width:720px) {
@@ -416,40 +442,26 @@ exports[`Standard Header renders standard header with children properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c4 {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 14px;
-    line-height: 1.4em;
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 14px;
-    line-height: 1.4em;
-    margin: 10px 20px 0 0;
-  }
-}
-
-@media (max-width:720px) {
-  .c4:before {
+  .c5:before {
     min-width: 8px;
     min-height: 8px;
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:720px) {
   .c0 {
-    padding: 0 20px;
+    margin: 0 20px;
   }
 }
 
-@media (max-width:600px) {
-  .c0 {
+@media (max-width:720px) {
+  .c1 {
     margin: 30px auto;
   }
 }
 
-@media (max-width:600px) {
-  .c2 {
+@media (max-width:720px) {
+  .c3 {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
@@ -457,8 +469,8 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   }
 }
 
-@media (max-width:600px) {
-  .c1 {
+@media (max-width:720px) {
+  .c2 {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -472,109 +484,113 @@ exports[`Standard Header renders standard header with children properly 1`] = `
   <div
     className="c1"
   >
-    Art Market
-  </div>
-  <div
-    className="c2"
-  >
-    <div>
-      Child 1: Title
-    </div>
-  </div>
-  <div
-    className="c3"
-  >
     <div
-      className="author c4"
+      className="c2"
     >
-      By 
-      Artsy Editorial
+      Art Market
     </div>
     <div
-      className="date c5"
+      className="c3"
     >
-      May 19, 2017 9:09 am
+      <div>
+        Child 1: Title
+      </div>
     </div>
     <div
-      className="c6"
+      className="c4"
     >
-      <a
-        className="c7"
-        href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
-        onClick={[Function]}
-        target="_blank"
+      <div
+        className="author c5"
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 14 14"
-          width="14px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <path
-              d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
-      <a
-        className="c7"
-        href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
-        onClick={[Function]}
-        target="_blank"
+        By 
+        Artsy Editorial
+      </div>
+      <div
+        className="date c6"
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 16 14"
-          width="16px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <path
-              d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
-      <a
+        May 19, 2017 9:09 am
+      </div>
+      <div
         className="c7"
-        href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
-        onClick={[Function]}
       >
-        <svg
-          height="14px"
-          version="1.1"
-          viewBox="0 0 17 14"
-          width="17px"
-          xmlns="http://www.w3.org/2000/svg"
+        <a
+          className="c8"
+          href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
+          onClick={[Function]}
+          target="_blank"
         >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 14 14"
+            width="14px"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <path
-              d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-              fill="black"
-            />
-          </g>
-        </svg>
-      </a>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+        <a
+          className="c8"
+          href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
+          onClick={[Function]}
+          target="_blank"
+        >
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 16 14"
+            width="16px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+        <a
+          className="c8"
+          href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
+          onClick={[Function]}
+        >
+          <svg
+            height="14px"
+            version="1.1"
+            viewBox="0 0 17 14"
+            width="17px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                fill="black"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/src/Components/Publishing/Layouts/Sidebar.tsx
+++ b/src/Components/Publishing/Layouts/Sidebar.tsx
@@ -11,7 +11,10 @@ const SidebarContainer = styled.div`
   flex-direction: column;
   margin: -63px 0 0 60px;
   min-width: 300px;
-  ${pMedia.md`
+  ${pMedia.xl`
+    margin-left: 40px;
+  `}
+  ${pMedia.lg`
     display: none;
   `}
 `

--- a/src/Components/Publishing/Layouts/Sidebar.tsx
+++ b/src/Components/Publishing/Layouts/Sidebar.tsx
@@ -10,7 +10,7 @@ const SidebarContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin: -63px 0 0 60px;
-  min-width: 300px;
+  min-width: 280px;
   ${pMedia.xl`
     margin-left: 40px;
   `}

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -1,11 +1,22 @@
 import styled from "styled-components"
 import { pMedia } from "../../Helpers"
 
-export const StandardLayout = styled.div`
-  display: flex;
-  max-width: 1250px;
-  margin: auto auto 100px auto;
-  ${pMedia.md`
-    padding: 0px;
+export const StandardLayoutParent = styled.div`
+  margin: 0 40px 100px 40px;
+  ${pMedia.sm`
+    margin: 0 0 100px 0;
   `}
 `
+
+export const StandardLayout = styled.div`
+  max-width: 1250px;
+  display: flex;
+  margin: auto;
+  justify-content: space-between;
+`
+
+  // max-width: 1250px;
+  // margin: 0 20px 100px 20px;
+  // ${pMedia.md`
+  //   padding: 0px;
+  // `}

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -14,9 +14,3 @@ export const StandardLayout = styled.div`
   margin: auto;
   justify-content: space-between;
 `
-
-  // max-width: 1250px;
-  // margin: 0 20px 100px 20px;
-  // ${pMedia.md`
-  //   padding: 0px;
-  // `}

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -105,10 +105,12 @@ const StyledSections = Div`
   width: 100%;
   margin: ${props => chooseMargin(props.layout)}
   max-width: ${props => (props.layout === "standard" ? "780px" : "auto")};
+
   ${props => pMedia.xl`
     max-width: ${props.layout === "standard" ? "680px" : "auto"};
-    margin: ${props.layout === "standard" ? "auto" : "80px auto 0 auto"};
+    ${props.layout === 'feature' ? "margin: 80px auto 0 auto" : ""}
   `}
+
   ${props => pMedia.md`
     max-width: ${props.layout === "standard" ? "780px" : "auto"};
   `}

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
@@ -729,7 +729,6 @@ exports[`renders properly 1`] = `
 @media (max-width:1250px) {
   .c0 {
     max-width: 680px;
-    margin: auto;
   }
 }
 

--- a/src/Components/Publishing/__stories__/Article.story.tsx
+++ b/src/Components/Publishing/__stories__/Article.story.tsx
@@ -4,8 +4,8 @@ import _ from "underscore"
 import { Article } from "../Article"
 import {
   FeatureArticle,
+  ImageHeavyStandardArticle,
   MissingVerticalStandardArticle,
-  ShortStandardArticle,
   StandardArticle,
   SuperArticle,
 } from "../Fixtures/Articles"
@@ -35,7 +35,7 @@ const story = storiesOf("Publishing/Articles", module)
   .add("Standard with top margin", () => {
     return (
       <Article
-        article={ShortStandardArticle}
+        article={ImageHeavyStandardArticle}
         relatedArticlesForPanel={RelatedPanel}
         relatedArticlesForCanvas={RelatedCanvas}
         emailSignupUrl="#"


### PR DESCRIPTION
Alright, this feels so much better. See screenshots below. Once @owendodd approves of the layout, I'll reassign it for code review.

Couple things to point out:

1. Breakpoint is changed to 1080 for `lg`
   - This number makes more sense with the layouts and a 40px margin. 680px (sections) + 120 (3*40px margins) + 280 (minimum sidebar width) = 1080
   - I saw this only affected the Display Canvas so I'll make sure that looks good too **(WIP)** 
2. No grid..yet. I think the layout could benefit from a Grid layout but it also worked nicely by adding a parent with a strict margin and letting the child div do auto margins. 
3. Right after 1080 I hide the sidebar because it will no longer fit - I'm thinking we either come up with a condensed sidebar, or just opt for centering everything. Centering everything kinda looks strange though with the header being so far to the left.


<br><br>


![standard-text-layout](https://user-images.githubusercontent.com/2236794/32080739-5cf104ee-ba7f-11e7-87e3-08094153a8cb.gif)
![standard-image-layout](https://user-images.githubusercontent.com/2236794/32080773-9171d2ac-ba7f-11e7-9c00-ffee1b7c1e23.gif)
