### PR TITLE
@damassi => Hide play button if missing thumbnail

### DIFF
--- a/src/Components/Publishing/Sections/Video.tsx
+++ b/src/Components/Publishing/Sections/Video.tsx
@@ -72,12 +72,20 @@ class VideoComponent extends React.Component<VideoProps, VideoState> {
 
     return (
       <VideoContainer layout={this.props.layout} className='VideoContainer__StyledComponent'>
-        <CoverImage src={src} height={width * videoRatio} onClick={this.playVideo} hidden={this.state.hidden}>
-          <PlayButton>
-            <PlayButtonCaret />
-          </PlayButton>
-        </CoverImage>
-        <IFrame src={this.state.src} frameBorder="0" allowFullScreen height={width * videoRatio} />
+        {cover_image_url &&
+          <CoverImage src={src} height={width * videoRatio} onClick={this.playVideo} hidden={this.state.hidden}>
+            <PlayButton>
+              <PlayButtonCaret />
+            </PlayButton>
+          </CoverImage>
+        }
+
+        <IFrame
+          src={this.state.src}
+          frameBorder="0"
+          allowFullScreen
+          height={width * videoRatio}
+        />
 
         {showCaption &&
           <Caption caption={caption} layout={this.props.layout}>


### PR DESCRIPTION
When attaching an image to a player, ensure that it has a cover image before showing play button. 