### PR TITLE
@damassi => Use authors field and set better empty state

### DIFF
--- a/src/Components/Publishing/Byline/Byline.tsx
+++ b/src/Components/Publishing/Byline/Byline.tsx
@@ -15,7 +15,7 @@ interface BylineContainerProps {
 
 export const Byline: React.SFC<BylineProps> = props => {
   const { article } = props
-  const { contributing_authors, published_at } = article
+  const { authors, published_at } = article
   const layout = props.layout || article.layout
   const title = article.social_title || article.thumbnail_title
   const url = articleFullHref(article.slug)
@@ -23,10 +23,7 @@ export const Byline: React.SFC<BylineProps> = props => {
   return (
     <BylineContainer layout={layout}>
       <Author
-        /*
-          FIXME: Will need to be updated with new `author_ids` backfill when ready
-        */
-        authors={contributing_authors}
+        authors={authors}
         layout={layout}
       />
 

--- a/src/Components/Publishing/Byline/__test__/__snapshots__/Byline.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__test__/__snapshots__/Byline.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`Byline renders a byline 1`] = `
     className="author c1"
   >
     By 
-    Artsy Editorial
+    Artsy Editors
   </div>
   <div
     className="date c2"

--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -35,7 +35,7 @@ export const getAuthorByline = authors => {
 
     // No Author
   } else {
-    return "Artsy Editorial"
+    return "Artsy Editors"
   }
 }
 

--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -395,7 +395,7 @@ export const BasicArticle: ArticleData = {
     },
     ...StandardArticle.sections
   ],
-  contributing_authors: [
+  authors: [
     {
       id: "523783258b3b815f7100055a",
       name: "Casey Lesser",
@@ -428,12 +428,6 @@ export const FeatureArticle: ArticleData = {
     url: "https://artsy-media-uploads.s3.amazonaws.com/z9w_n6UxxoZ_u1lzt4vwrw%2FHero+Loop+02.mp4",
     deck: "Lorem Ipsum",
   },
-  contributing_authors: [
-    {
-      id: "523783258b3b815f7100055a",
-      name: "Casey Lesser",
-    },
-  ],
   authors: [
     {
       id: "523783258b3b815f7100055a",

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -77,6 +77,11 @@ export const Authors = [
     bio: "[Halley Johnson](https://artsy.net/molly) is an Writer Guru at Artsy. She enjoys speaking Georgian.",
     twitter_handle: "halleyjohnson",
   },
+  {
+    name: "Kana Abe",
+    bio: "",
+    twitter_handle: "",
+  },
 ]
 
 export const Campaign = {
@@ -370,28 +375,28 @@ export const RelatedCanvas = [
     thumbnail_image:
     "https://artsy-media-uploads.s3.amazonaws.com/4Tq-iYkN8dOpshFoKRXyYw%2Fcustom-Custom_Size___PoetterHall_Exterior+copy.jpg",
     slug: "artsy-editorial-15-top-art-schools-united-states",
-    contributing_authors: [{ name: "Anna Louis-Sussman" }, { name: "Kana Abe" }],
+    authors: [{ name: "Anna Louis-Sussman" }, { name: "Kana Abe" }],
     published_at: "2017-05-19T13:09:18.567Z",
   },
   {
     thumbnail_title: "Four Years after Walter De Maria’s Death, His Final Work Is Complete",
     thumbnail_image: "https://artsy-media-uploads.s3.amazonaws.com/6IqxBTQCkExip2auQ7ZWCA%2FDEMAR-2011.0006-B.jpg",
     slug: "artsy-editorial-four-years-walter-de-marias-death-final-work-complete",
-    contributing_authors: [{ name: "Halley Johnson" }],
+    authors: [{ name: "Halley Johnson" }],
     published_at: "2017-05-19T13:09:18.567Z",
   },
   {
     thumbnail_title: "French Art History in a Nutshell",
     thumbnail_image: "https://artsy-media-uploads.s3.amazonaws.com/lEcCm2XbfZ7bPAVgLlM21w%2Flarger-21.jpg",
     slug: "artsy-editorial-french-art-history-in-a-nutshell",
-    contributing_authors: [{ name: "Casey Lesser" }],
+    authors: [{ name: "Casey Lesser" }],
     published_at: "2017-05-19T13:09:18.567Z",
   },
   {
     thumbnail_title: "Miami Artists and Museums Brace for Hurricane Irma",
     thumbnail_image: "https://artsy-media-uploads.s3.amazonaws.com/jAu4NaKnr_m53OnnMaDe_w%2Fmag.jpg",
     slug: "artsy-editorial-miami-artists-museums-brace-hurricane-irma",
-    contributing_authors: [{ name: "Owen Dodd" }],
+    authors: [{ name: "Owen Dodd" }],
     published_at: "2017-05-19T13:09:18.567Z",
   },
 ]

--- a/src/Components/Publishing/Header/BasicHeader.tsx
+++ b/src/Components/Publishing/Header/BasicHeader.tsx
@@ -43,7 +43,7 @@ export class BasicHeader extends React.Component<Props, State> {
   render() {
     const {
       article: {
-      contributing_authors,
+      authors,
       hero_section,
       lead_paragraph,
       published_at,
@@ -99,7 +99,7 @@ export class BasicHeader extends React.Component<Props, State> {
                     <Row>
                       <Col xs={12} sm={12} md={12} lg={12} className='Byline__Container'>
                         <Author>
-                          By {getAuthorByline(contributing_authors)}
+                          By {getAuthorByline(authors)}
                         </Author>
                         <Date>
                           {getDate(published_at, isMobile ? 'condensed' : 'basic')}

--- a/src/Components/Publishing/Header/__test__/__snapshots__/ClassicHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/ClassicHeader.test.tsx.snap
@@ -477,7 +477,7 @@ exports[`Classic Header renders classic header with children properly 1`] = `
         className="author c5"
       >
         By 
-        Artsy Editorial
+        Artsy Editors
       </div>
       <div
         className="date c6"

--- a/src/Components/Publishing/Header/__test__/__snapshots__/StandardHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/StandardHeader.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`Standard Header renders standard header properly 1`] = `
         className="author c5"
       >
         By 
-        Artsy Editorial
+        Artsy Editors
       </div>
       <div
         className="date c6"
@@ -495,7 +495,7 @@ exports[`Standard Header renders standard header with children properly 1`] = `
         className="author c5"
       >
         By 
-        Artsy Editorial
+        Artsy Editors
       </div>
       <div
         className="date c6"

--- a/src/Components/Publishing/RelatedArticles/RelatedArticleFigure.tsx
+++ b/src/Components/Publishing/RelatedArticles/RelatedArticleFigure.tsx
@@ -12,7 +12,7 @@ interface RelatedArticleFigureProps extends React.HTMLProps<HTMLDivElement> {
     thumbnail_title: string
     thumbnail_image: string
     slug: string
-    contributing_authors: any
+    authors: any
     published_at: string
   }
 }

--- a/src/Components/Publishing/Sections/Author.tsx
+++ b/src/Components/Publishing/Sections/Author.tsx
@@ -17,13 +17,23 @@ export const Author: React.SFC<AuthorProps> = props => {
     <AuthorContainer>
       {profileImage}
       <AuthorInfo>
-        <Markdown source={author.bio} disallowedTypes={["Paragraph"]} unwrapDisallowed containerTagName="span" />
-        <Twitter>
-          <TwitterHandle href={`http://twitter.com/${author.twitter_handle}`}>
-            <Icon name="twitter" color="black" />
-            {`@${author.twitter_handle}`}
-          </TwitterHandle>
-        </Twitter>
+        {
+          author.bio && author.bio.length ?
+            <Markdown source={author.bio} disallowedTypes={["Paragraph"]} unwrapDisallowed containerTagName="span" />
+            :
+            <div>{author.name}</div>
+        }
+        {
+          author.twitter_handle && author.twitter_handle.length ?
+            <Twitter>
+              <TwitterHandle href={`http://twitter.com/${author.twitter_handle}`}>
+                <Icon name="twitter" color="black" />
+                {`@${author.twitter_handle}`}
+              </TwitterHandle>
+            </Twitter>
+            :
+            false
+        }
       </AuthorInfo>
     </AuthorContainer>
   )

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Authors.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Authors.test.tsx.snap
@@ -222,5 +222,16 @@ exports[`renders properly 1`] = `
       </span>
     </div>
   </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c3"
+    >
+      <div>
+        Kana Abe
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/src/Components/Publishing/__stories__/Byline.story.tsx
+++ b/src/Components/Publishing/__stories__/Byline.story.tsx
@@ -22,7 +22,7 @@ storiesOf("Publishing/Byline", module)
   })
   .add("Many Authors Byline", () => {
     const article = extend({}, StandardArticle, {
-      contributing_authors: [{ name: "Kana Abe" }, { name: "Anna Louis-Sussman" }, { name: "Halley Johnson" }],
+      authors: [{ name: "Kana Abe" }, { name: "Anna Louis-Sussman" }, { name: "Halley Johnson" }],
     })
     return (
       <div>


### PR DESCRIPTION
- Gives us a better empty state for twitter handles and author bios.
- Converts all the things to `authors` now that the backfill is complete

![image](https://user-images.githubusercontent.com/2236794/32258616-e0f9af64-be91-11e7-9667-3d895cf8023a.png)
