### PR TITLE
@craigspaeth => Mobile Panel video, allow empty links

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -178,6 +178,7 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
                   <DisplayPanel
                     unit={this.props.display.panel}
                     campaign={campaign}
+                    isMobile={isMobile}
                   />}
 
               </Sidebar>

--- a/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import styled from "styled-components"
 import track from "../../../../Utils/track"
 import { pMedia } from "../../../Helpers"
+import { VideoControls } from '../../Sections/VideoControls'
 
 interface VideoProps {
   campaign: any
@@ -41,9 +42,7 @@ export class CanvasVideo extends React.Component<VideoProps, any> {
     if (!this.state.isPlaying) {
       return (
         <Cover>
-          <PlayButton>
-            <PlayButtonCaret />
-          </PlayButton>
+          <VideoControls />
         </Cover>
       )
     }
@@ -89,23 +88,4 @@ const Cover = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-`
-const PlayButtonCaret = styled.div`
-  color: black;
-  border-top: 20px solid transparent;
-  border-bottom: 20px solid transparent;
-  border-left: 30px solid black;
-`
-
-const PlayButton = styled.div`
-  background: white;
-  width: 70px;
-  height: 70px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 2;
-  cursor: pointer;
-  border: 0;
-  outline: 0;
 `

--- a/src/Components/Publishing/Display/Canvas/index.tsx
+++ b/src/Components/Publishing/Display/Canvas/index.tsx
@@ -16,7 +16,7 @@ export const DisplayCanvas: React.SFC<DisplayCanvasProps> = props => {
 
   return (
     <DisplayContainer layout={unit.layout}>
-      <a href={unit.link.url} target="_blank">
+      <a href={unit.link ? unit.link.url : ''} target="_blank">
         <AdvertisementBy>{`Advertisement by ${campaign.name}`}</AdvertisementBy>
       </a>
       <CanvasContainer unit={unit} campaign={campaign} disclaimer={disclaimer} />

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -80,7 +80,7 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, null> {
   render() {
     const { unit, campaign } = this.props
     const url = get(unit.assets, '0.url', '')
-    const cover = get(unit.assets, '1.url', '')
+    const cover = unit.cover_image_url || ''
     const imageUrl = crop(url, { width: 680, height: 284 })
     const hoverImageUrl = resize(unit.logo, { width: 680 })
     const coverUrl = crop(cover, { width: 680, height: 284 })

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -58,8 +58,11 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
     unit_layout: "panel"
   }))
   openLink(e) {
+    const { link } = this.props.unit
     e.preventDefault()
-    window.open(this.props.unit.link.url, '_blank')
+    if (link) {
+      window.open(link.url, '_blank')
+    }
   }
 
   @track(once((props) => ({

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -29,6 +29,7 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
   constructor(props) {
     super(props)
     this.openLink = this.openLink.bind(this)
+    this.playVideo = this.playVideo.bind(this)
 
     this.state = {
       isPlaying: false
@@ -61,11 +62,14 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
     window.open(this.props.unit.link.url, '_blank')
   }
 
-  onMouseLeave = () => {
-    this.video.pause()
-  }
-
-  playVideo = () => {
+  @track(once((props) => ({
+    action: "Click",
+    label: "Display ad play video",
+    entity_type: "display_ad",
+    campaign_name: props.campaign.name,
+    unit_layout: "panel"
+  })))
+  playVideo() {
     if (this.video) {
       if (this.video.paused) {
         this.video.play()
@@ -75,6 +79,10 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
         this.setState({ isPlaying: false })
       }
     }
+  }
+
+  onMouseLeave = () => {
+    this.video.pause()
   }
 
   renderVideo = (url) => {

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -43,8 +43,10 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
     unit_layout: "panel"
   })))
   componentDidMount() {
-    this.video.onended = () => {
-      this.setState({ isPlaying: false })
+    if (this.video) {
+      this.video.onended = () => {
+        this.setState({ isPlaying: false })
+      }
     }
   }
 

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -29,7 +29,8 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
   constructor(props) {
     super(props)
     this.openLink = this.openLink.bind(this)
-    this.playVideo = this.playVideo.bind(this)
+    this.onClickVideo = this.onClickVideo.bind(this)
+    this.onMouseEnter = this.onMouseEnter.bind(this)
 
     this.state = {
       isPlaying: false
@@ -67,14 +68,33 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
     }
   }
 
-  @track(once((props) => ({
+  @track(props => ({
     action: "Click",
     label: "Display ad play video",
     entity_type: "display_ad",
     campaign_name: props.campaign.name,
     unit_layout: "panel"
-  })))
-  playVideo() {
+  }))
+  onClickVideo() {
+    this.playVideo()
+  }
+
+  @track(props => ({
+    action: "MouseEnter",
+    label: "Display ad play video",
+    entity_type: "display_ad",
+    campaign_name: props.campaign.name,
+    unit_layout: "panel"
+  }))
+  onMouseEnter() {
+    this.playVideo()
+  }
+
+  onMouseLeave = () => {
+    this.video.pause()
+  }
+
+  playVideo = () => {
     if (this.video) {
       if (this.video.paused) {
         this.video.play()
@@ -86,14 +106,10 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
     }
   }
 
-  onMouseLeave = () => {
-    this.video.pause()
-  }
-
   renderVideo = (url) => {
     const { isMobile } = this.props
     return (
-      <VideoContainer onClick={isMobile && this.playVideo}>
+      <VideoContainer onClick={isMobile && this.onClickVideo}>
         {!this.state.isPlaying &&
           <VideoCover>
             {isMobile &&
@@ -119,7 +135,7 @@ export class DisplayPanel extends React.Component<DisplayPanelProps, any> {
     return (
       <Wrapper onClick={!isMobile && this.openLink}>
         <DisplayPanelContainer
-          onMouseEnter={!isMobile && this.playVideo}
+          onMouseEnter={!isMobile && this.onMouseEnter}
           onMouseLeave={!isMobile && this.onMouseLeave}
           imageUrl={imageUrl}
           isMobile={isMobile}

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -1081,6 +1081,35 @@ exports[`renders the canvas in standard layout with video 1`] = `
   opacity: .6;
 }
 
+.c6 {
+  color: black;
+  border-top: 20px solid transparent;
+  border-bottom: 20px solid transparent;
+  border-left: 30px solid black;
+}
+
+.c5 {
+  background: white;
+  width: 70px;
+  height: 70px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: 2;
+  cursor: pointer;
+  border: 0;
+  outline: 0;
+}
+
 .c3 {
   width: 65%;
   max-width: 760px;
@@ -1113,35 +1142,6 @@ exports[`renders the canvas in standard layout with video 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c6 {
-  color: black;
-  border-top: 20px solid transparent;
-  border-bottom: 20px solid transparent;
-  border-left: 30px solid black;
-}
-
-.c5 {
-  background: white;
-  width: 70px;
-  height: 70px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  z-index: 2;
-  cursor: pointer;
-  border: 0;
-  outline: 0;
 }
 
 .c2 {

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`renders the display panel with an image 1`] = `
   background-size: cover;
 }
 
-.c1 .m49hnr-1-file__Image-iTToDH {
+.c1 .mfei63-1-file__Image-iTToDH {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -46,7 +46,7 @@ exports[`renders the display panel with an image 1`] = `
   border: 10px solid black;
 }
 
-.c1:hover .m49hnr-1-file__Image-iTToDH {
+.c1:hover .mfei63-1-file__Image-iTToDH {
   display: none;
 }
 
@@ -102,22 +102,26 @@ exports[`renders the display panel with an image 1`] = `
       className="c2 c3"
     />
     <div
-      className="c4"
+      onClick={undefined}
     >
-      Euismod Inceptos Quam
-    </div>
-    <div
-      className="c5"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. <a href='http://artsy.net/articles'>Example Link</a>",
+      <div
+        className="c4"
+      >
+        Euismod Inceptos Quam
+      </div>
+      <div
+        className="c5"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. <a href='http://artsy.net/articles'>Example Link</a>",
+          }
         }
-      }
-    />
-    <div
-      className="c6"
-    >
-      Sponsored by Artsy
+      />
+      <div
+        className="c6"
+      >
+        Sponsored by Artsy
+      </div>
     </div>
   </div>
 </div>
@@ -138,14 +142,26 @@ exports[`renders the display panel with video 1`] = `
   background-color: black;
   box-sizing: border-box;
   position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
-.ioQrvi .c3 {
+.eMZrHQ .c3 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
 
-.ioQrvi:hover .c3 {
+.eMZrHQ:hover .c3 {
   display: none;
 }
 
@@ -163,7 +179,7 @@ exports[`renders the display panel with video 1`] = `
   box-sizing: border-box;
 }
 
-.c1 .file__Image-m49hnr-1 {
+.c1 .file__Image-mfei63-1 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fz9w_n6UxxoZ_u1lzt4vwrw%252FHero%2BLoop%2B02.mp4&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -173,7 +189,7 @@ exports[`renders the display panel with video 1`] = `
   background-size: cover;
 }
 
-.c1:hover .file__Image-m49hnr-1 {
+.c1:hover .file__Image-mfei63-1 {
   background: black url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-vanity-files-production.s3.amazonaws.com%2Fimages%2Fartsy_logo_square_white_transparent.png&width=680&quality=95) no-repeat center center;
   background-size: contain;
   border: 10px solid black;
@@ -257,6 +273,7 @@ exports[`renders the display panel with video 1`] = `
   >
     <div
       className="c2"
+      onClick={undefined}
     >
       <div
         className="c3 c4"
@@ -268,22 +285,26 @@ exports[`renders the display panel with video 1`] = `
       />
     </div>
     <div
-      className="c5"
+      onClick={undefined}
     >
-      Euismod Inceptos Quam
-    </div>
-    <div
-      className="c6"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. <a href='http://artsy.net/articles'>Example Link</a>",
+      <div
+        className="c5"
+      >
+        Euismod Inceptos Quam
+      </div>
+      <div
+        className="c6"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. <a href='http://artsy.net/articles'>Example Link</a>",
+          }
         }
-      }
-    />
-    <div
-      className="c7"
-    >
-      Sponsored by Artsy
+      />
+      <div
+        className="c7"
+      >
+        Sponsored by Artsy
+      </div>
     </div>
   </div>
 </div>

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -182,8 +182,8 @@ export const UnitPanelVideo = {
   "Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. <a href='http://artsy.net/articles'>Example Link</a>",
   assets: [
     { url: "https://artsy-media-uploads.s3.amazonaws.com/z9w_n6UxxoZ_u1lzt4vwrw%2FHero+Loop+02.mp4" },
-    { url: "https://artsy-media-uploads.s3.amazonaws.com/YqTtwB7AWqKD95NGItwjJg%2FRachel_Rossin_portrait_2.jpg" },
   ],
+  cover_image_url: "https://artsy-media-uploads.s3.amazonaws.com/YqTtwB7AWqKD95NGItwjJg%2FRachel_Rossin_portrait_2.jpg",
   logo: "https://artsy-vanity-files-production.s3.amazonaws.com/images/artsy_logo_square_white_transparent.png",
   link: {
     text: "",

--- a/src/Components/Publishing/Sections/Video.tsx
+++ b/src/Components/Publishing/Sections/Video.tsx
@@ -7,6 +7,7 @@ import { pMedia as breakpoint } from "../../Helpers"
 import { sizeMeRefreshRate } from "../Constants"
 import { Layout } from "../Typings"
 import { Caption } from "./Caption"
+import { VideoControls } from './VideoControls'
 
 const BLACKLIST = ['gif', 'jpg', 'jpeg', 'png']
 const QUERYSTRING = "?title=0&portrait=0&badge=0&byline=0&showinfo=0&rel=0&controls=2&modestbranding=1&iv_load_policy=3&color=E5E5E5"
@@ -77,9 +78,7 @@ class VideoComponent extends React.Component<VideoProps, VideoState> {
       <VideoContainer layout={this.props.layout} className='VideoContainer__StyledComponent'>
         {cover_image_url &&
           <CoverImage src={src} height={width * videoRatio} onClick={this.playVideo} hidden={this.state.hidden}>
-            <PlayButton>
-              <PlayButtonCaret />
-            </PlayButton>
+            <VideoControls />
           </CoverImage>
         }
 
@@ -186,26 +185,6 @@ const CoverImage = Div`
   position: absolute;
   background: url(${props => props.src || ""}) no-repeat center center;
   background-size: cover;
-`
-
-const PlayButtonCaret = styled.div`
-  color: black;
-  border-top: 20px solid transparent;
-  border-bottom: 20px solid transparent;
-  border-left: 30px solid black;
-`
-
-const PlayButton = styled.div`
-  background: white;
-  width: 70px;
-  height: 70px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 2;
-  cursor: pointer;
-  border: 0;
-  outline: 0;
 `
 
 const sizeMeOptions = {

--- a/src/Components/Publishing/Sections/VideoControls.tsx
+++ b/src/Components/Publishing/Sections/VideoControls.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import styled, { StyledFunction } from "styled-components"
+
+interface VideoControlsProps extends React.HTMLProps<HTMLDivElement> {
+  mini?: boolean
+}
+
+export const VideoControls: React.SFC<VideoControlsProps> = props => {
+  const { mini } = props
+
+  return (
+    <PlayButton mini={mini}>
+      <PlayButtonCaret mini={mini} />
+    </PlayButton>
+  )
+}
+
+const Div: StyledFunction<VideoControlsProps & React.HTMLProps<HTMLDivElement>> = styled.div
+
+const PlayButtonCaret = Div`
+  color: black;
+  border-top: ${props => (props.mini ? "13" : "20")}px solid transparent;
+  border-bottom: ${props => (props.mini ? "13" : "20")}px solid transparent;
+  border-left: ${props => (props.mini ? "20" : "30")}px solid black;
+`
+
+const PlayButton = Div`
+  background: white;
+  width: ${props => (props.mini ? "50px" : "70px")};
+  height: ${props => (props.mini ? "50px" : "70px")};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2;
+  cursor: pointer;
+  border: 0;
+  outline: 0;
+`

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Video.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Video.test.tsx.snap
@@ -40,6 +40,35 @@ exports[`renders properly 1`] = `
   color: black;
 }
 
+.c3 {
+  color: black;
+  border-top: 20px solid transparent;
+  border-bottom: 20px solid transparent;
+  border-left: 30px solid black;
+}
+
+.c2 {
+  background: white;
+  width: 70px;
+  height: 70px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: 2;
+  cursor: pointer;
+  border: 0;
+  outline: 0;
+}
+
 .c4 {
   width: 100%;
   height: 281.25px;
@@ -68,35 +97,6 @@ exports[`renders properly 1`] = `
   position: absolute;
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FIB6epb5L_l0rm9btaDsY7Q%252F14183_MDP_Evening_240.jpg&width=1200&quality=95) no-repeat center center;
   background-size: cover;
-}
-
-.c3 {
-  color: black;
-  border-top: 20px solid transparent;
-  border-bottom: 20px solid transparent;
-  border-left: 30px solid black;
-}
-
-.c2 {
-  background: white;
-  width: 70px;
-  height: 70px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  z-index: 2;
-  cursor: pointer;
-  border: 0;
-  outline: 0;
 }
 
 @media (max-width:600px) {

--- a/src/Components/Publishing/__stories__/Display.story.tsx
+++ b/src/Components/Publishing/__stories__/Display.story.tsx
@@ -19,6 +19,9 @@ storiesOf("Publishing/Display", module)
   .add("Panel: Video", () => {
     return <DisplayPanel unit={UnitPanelVideo} campaign={Campaign} />
   })
+  .add("Panel: Video (mobile)", () => {
+    return <DisplayPanel unit={UnitPanelVideo} campaign={Campaign} isMobile />
+  })
   .add("Canvas: Overlay", () => {
     return <DisplayCanvas unit={UnitCanvasOverlay} campaign={Campaign} />
   })


### PR DESCRIPTION
- Use `cover_image_url` instead of `assets` for video cover images
- Adds mobile styles for Panel video (cover image has play button, plays on click)
- Moves video caret/controls into reusable component
- Allows for unit.link to be empty

I added a tracking event for the video play with `action: "Click"` -- is there a way to make this accommodate both click and mouseenter, or should we make separate events?

![panel-video](https://user-images.githubusercontent.com/1497424/32293466-97a96894-bf19-11e7-860d-e73847e0c29c.gif)
