### PR TITLE
@kanaabe => Display panel should insert itself into the body of the article on mobile

### DIFF
--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -4,6 +4,7 @@ import styled, { StyledFunction } from "styled-components"
 import Colors from "../../../Assets/Colors"
 import { crop, resize } from "../../../Utils/resizer"
 import { track } from "../../../Utils/track"
+import { pMedia } from "../../Helpers"
 import { Fonts } from "../Fonts"
 import { VideoControls } from '../Sections/VideoControls'
 
@@ -218,6 +219,18 @@ const DisplayPanelContainer = Div`
       ${props => !props.isMobile && "display: none;"}
     }
   }
+
+  ${pMedia.md`
+    margin: auto;
+  `}
+
+  ${pMedia.sm`
+    margin: auto;
+  `}
+
+  ${pMedia.xs`
+    margin: auto;
+  `}
 `
 
 const Headline = styled.div`

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`renders the display panel with an image 1`] = `
   background-size: cover;
 }
 
-.c1 .vmu4h5-1-file__Image-iTToDH {
+.c1 .s1jk35ya-1-file__Image-iTToDH {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -45,7 +45,7 @@ exports[`renders the display panel with an image 1`] = `
   border: 10px solid black;
 }
 
-.c1:hover .vmu4h5-1-file__Image-iTToDH {
+.c1:hover .s1jk35ya-1-file__Image-iTToDH {
   display: none;
 }
 
@@ -86,6 +86,24 @@ exports[`renders the display panel with an image 1`] = `
   -ms-letter-spacing: 1px;
   letter-spacing: 1px;
   color: #e5e5e5;
+}
+
+@media (max-width:900px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media (max-width:720px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media (max-width:600px) {
+  .c1 {
+    margin: auto;
+  }
 }
 
 <div
@@ -154,12 +172,12 @@ exports[`renders the display panel with video 1`] = `
   justify-content: center;
 }
 
-.cZkmNc .c3 {
+.kIJkvs .c3 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
 
-.cZkmNc:hover .c3 {
+.kIJkvs:hover .c3 {
   display: none;
 }
 
@@ -177,7 +195,7 @@ exports[`renders the display panel with video 1`] = `
   box-sizing: border-box;
 }
 
-.c1 .file__Image-vmu4h5-1 {
+.c1 .file__Image-s1jk35ya-1 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fz9w_n6UxxoZ_u1lzt4vwrw%252FHero%2BLoop%2B02.mp4&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -187,7 +205,7 @@ exports[`renders the display panel with video 1`] = `
   background-size: cover;
 }
 
-.c1:hover .file__Image-vmu4h5-1 {
+.c1:hover .file__Image-s1jk35ya-1 {
   background: black url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-vanity-files-production.s3.amazonaws.com%2Fimages%2Fartsy_logo_square_white_transparent.png&width=680&quality=95) no-repeat center center;
   background-size: contain;
   border: 10px solid black;
@@ -258,6 +276,24 @@ exports[`renders the display panel with video 1`] = `
   object-fit: cover;
   object-position: 50%;
   width: 100%;
+}
+
+@media (max-width:900px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media (max-width:720px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media (max-width:600px) {
+  .c1 {
+    margin: auto;
+  }
 }
 
 <div

--- a/src/Components/Publishing/__test__/Article.test.tsx
+++ b/src/Components/Publishing/__test__/Article.test.tsx
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme"
+import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import { Article } from "../Article"
@@ -15,7 +15,7 @@ jest.mock("react-sizeme", () => jest.fn(c => d => d))
 jest.mock("react-tracking", () => jest.fn(c => d => d))
 
 it("indexes and titles images", () => {
-  const article = shallow(<Article article={StandardArticle} />)
+  const article = mount(<Article article={StandardArticle} />)
   expect(article.state("article").sections[4].images[0].setTitle).toBe("A World Without Capitalism")
   expect(article.state("article").sections[4].images[0].index).toBe(0)
   expect(article.state("article").sections[4].images[1].index).toBe(1)
@@ -24,7 +24,7 @@ it("indexes and titles images", () => {
 })
 
 it("renders related articles in standard layout", () => {
-  const article = shallow(
+  const article = mount(
     <Article
       article={StandardArticle}
       display={Display("standard")}
@@ -37,7 +37,7 @@ it("renders related articles in standard layout", () => {
 })
 
 it("renders RelatedArticlesCanvas in feature layout", () => {
-  const article = shallow(
+  const article = mount(
     <Article
       article={FeatureArticle}
       display={Display("slideshow")}

--- a/src/Utils/Responsive.tsx
+++ b/src/Utils/Responsive.tsx
@@ -1,6 +1,10 @@
+import { each } from 'lodash'
 import React from 'react'
+import theme from '../Assets/Theme'
 
 // TODO: IProps
+// TODO: Docs
+// TODO: Tests
 
 interface State {
   isMobile: boolean
@@ -9,11 +13,12 @@ interface State {
 const MOBILE_BREAKPOINT = 600
 
 class ResponsiveWrapper extends React.Component<any, State> {
+
   static defaultProps = {
     initialState: {
       isMobile: false
     },
-    media: x => x, // FIXME: Force: `media` is not a function
+    media: x => x,
     mobileBreakpoint: MOBILE_BREAKPOINT
   }
 
@@ -24,19 +29,52 @@ class ResponsiveWrapper extends React.Component<any, State> {
   constructor(props) {
     super(props)
 
-    const {
-      initialState: {
-        isMobile
-      }
-    } = props
-
     this.state = {
-      isMobile
+      ...props.initialState
     }
   }
 
   componentDidMount() {
+    this.registerBreakpoints()
+  }
+
+  registerBreakpoints() {
     const { mobileBreakpoint, media } = this.props
+    const { breakpoints } = theme.publishing
+
+    /**
+     * Iterate over breakpoints in theme file and generate corresponding
+     * handlers for each. Options include xs, sm, md, lg, xl.
+     */
+    const registerMedia = ({ breakpoint, width }) => {
+      const toggle = () => Object
+        .keys(breakpoints)
+        .reduce((acc, bp) => ({ ...acc, [bp]: false }), {})
+
+      const breakAt: any = [
+        { maxWidth: width },
+        { minWidth: width + 1 }
+      ]
+
+      breakAt.forEach(point => {
+        media(point, () => {
+          this.setState({
+            ...toggle(),
+            [breakpoint]: true
+          })
+        })
+      })
+    }
+
+    each(breakpoints, (width, breakpoint) => {
+      registerMedia({
+        breakpoint,
+        width
+      })
+    })
+
+    // TODO:
+    // Remove references below in favor of above
 
     // Mobile
     media({ maxWidth: mobileBreakpoint }, () => {
@@ -54,12 +92,8 @@ class ResponsiveWrapper extends React.Component<any, State> {
   }
 
   render() {
-    const { isMobile } = this.state
-
     return (
-      this.props.children({
-        isMobile
-      })
+      this.props.children(this.state)
     )
   }
 }

--- a/src/__stories__/config.js
+++ b/src/__stories__/config.js
@@ -1,4 +1,6 @@
-const { configure } = require("@storybook/react")
+const {
+  configure
+} = require("@storybook/react")
 const Events = require("../Utils/Events").default
 const req = require.context("../", true, /\.story\.tsx$/)
 
@@ -7,7 +9,10 @@ function loadStories() {
 }
 
 configure(loadStories, module)
-Events.onEvent(data => console.log("Tracked event", data))
+
+Events.onEvent(data => {
+  console.log("Tracked event", data)
+})
 
 setOptions({
   name: "Reaction",


### PR DESCRIPTION
Addresses https://github.com/artsy/publishing/issues/160

<img width="245" alt="screen shot 2017-11-01 at 9 01 55 pm" src="https://user-images.githubusercontent.com/236943/32310365-fd23872e-bf4e-11e7-8c58-e7fa8ccf158a.png">

Also, added additional functionality to our `<Responsive>` util (cc @eessex) that can be used like so:

```jsx
<Responsive>
  {({ xs, sm, md, lg, xl }) => 
    <div>
      {xs && 
        <ExtraSmallDiv /> }

      {md && 
        <MediumDiv /> }
    </div>
  }}
</Responsive>
```

