### PR TITLE
@kanaabe => Make video widths fixed

### DIFF
--- a/src/Components/Publishing/Header/BasicHeader.tsx
+++ b/src/Components/Publishing/Header/BasicHeader.tsx
@@ -7,7 +7,7 @@ import { pMedia as breakpoint } from "../../Helpers"
 import { Share } from "../Byline/Share"
 import { articleHref, getAuthorByline, getDate } from "../Constants"
 import { Fonts } from "../Fonts"
-import { isValidVideoUrl, Video } from '../Sections/Video'
+import { CoverImage, IFrame, isValidVideoUrl, Video } from '../Sections/Video'
 
 interface Props {
   article: any
@@ -136,6 +136,34 @@ const defaults = css`
 
 const Container = styled.div`
   text-align: center;
+
+  ${CoverImage}, ${IFrame} {
+    width: 100%;
+
+    @media screen and (min-width: 1250px) {
+      height: 619px;
+    }
+
+    ${breakpoint.xl`
+      height: 619px;
+    `}
+
+    ${breakpoint.lg`
+      height: 535px;
+    `}
+
+    ${breakpoint.md`
+      height: 449px;
+    `}
+
+    ${breakpoint.sm`
+      height: 349px;
+    `}
+
+    ${breakpoint.xs`
+      height: 292px;
+    `}
+  }
 
   .BasicHeader__video {
     margin-top: 40px;

--- a/src/Components/Publishing/Sections/Video.tsx
+++ b/src/Components/Publishing/Sections/Video.tsx
@@ -139,7 +139,7 @@ function getId(url) {
 
 const iframe: StyledFunction<React.HTMLProps<HTMLIFrameElement>> = styled.iframe
 
-const IFrame = iframe`
+export const IFrame = iframe`
   width: 100%;
   height: ${props => props.height + "px"};
 `
@@ -176,7 +176,7 @@ const VideoContainer = Div`
   }}
 `
 
-const CoverImage = Div`
+export const CoverImage = Div`
   display: ${props => (props.hidden || !props.src ? "none" : "flex")};
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
Addresses https://github.com/artsy/publishing/issues/189

This locks our Basic Video header to fixed heights so that the css doesn't jump during SSR. 