### PR TITLE
@craigspaeth => QA / Headers margins

### DIFF
--- a/src/Assets/Theme.ts
+++ b/src/Assets/Theme.ts
@@ -21,7 +21,7 @@ export default {
       sm: 720, // px
       md: 900, // px
       lg: 1080, // px
-      xl: 1250, // px
+      xl: 1280, // px
     },
   },
 }

--- a/src/Components/Publishing/Header/BasicHeader.tsx
+++ b/src/Components/Publishing/Header/BasicHeader.tsx
@@ -143,7 +143,7 @@ const defaults = css`
 
 const Container = styled.div`
   text-align: center;
-
+  margin-top: 40px;
   ${CoverImage}, ${IFrame} {
     width: 100%;
 
@@ -170,10 +170,6 @@ const Container = styled.div`
     ${breakpoint.xs`
       height: ${520 * VIDEO_RATIO}px;
     `}
-  }
-
-  .BasicHeader__video {
-    margin-top: 40px;
   }
 
   .Byline__Container {

--- a/src/Components/Publishing/Header/FeatureHeader.tsx
+++ b/src/Components/Publishing/Header/FeatureHeader.tsx
@@ -109,7 +109,7 @@ interface FeatureHeaderProps {
 @track()
 class FeatureHeaderComponent extends React.Component<FeatureHeaderProps, any> {
   static defaultProps = {
-    height: "100vh"
+    height: "calc(100vh - 50px)"
   }
 
   @track(props => ({
@@ -329,6 +329,7 @@ const Deck = styled.div`
 const FeatureHeaderContainer = Div.extend`
   width: 100%;
   height: ${props => props.height};
+  position: relative;
   &[data-type="text"] {
     height: auto;
     ${Title} {
@@ -385,7 +386,6 @@ const FeatureHeaderContainer = Div.extend`
     `}
   }
   &[data-type="fullscreen"] {
-    margin-bottom: 80px;
     ${HeaderText} {
       padding: 50px;
       color: #fff;
@@ -393,7 +393,7 @@ const FeatureHeaderContainer = Div.extend`
       margin: auto;
       text-shadow: 0 0 40px rgba(0, 0, 0, 0.4);
     }
-    ${pMedia.xs`
+    ${pMedia.sm`
       ${HeaderText} {
         padding: 20px;
       }

--- a/src/Components/Publishing/Header/__test__/__snapshots__/ClassicHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/ClassicHeader.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`Classic Header renders classic header properly 1`] = `
   margin-bottom: 30px;
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c0 {
     padding: 0 20px;
   }

--- a/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
@@ -178,7 +178,8 @@ exports[`feature renders feature full header properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 50px);
+  position: relative;
 }
 
 .c0[data-type="text"] {
@@ -204,12 +205,12 @@ exports[`feature renders feature full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
   width: 50vw;
 }
 
@@ -225,10 +226,6 @@ exports[`feature renders feature full header properly 1`] = `
 
 .c0[data-type="split"] .c12 {
   margin-bottom: 30px;
-}
-
-.c0[data-type="fullscreen"] {
-  margin-bottom: 80px;
 }
 
 .c0[data-type="fullscreen"] .c5 {
@@ -304,7 +301,7 @@ exports[`feature renders feature full header properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c9 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -357,19 +354,19 @@ exports[`feature renders feature full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
     width: 100%;
   }
 }
 
-@media (max-width:600px) {
+@media (max-width:720px) {
   .c0[data-type="fullscreen"] .c5 {
     padding: 20px;
   }
@@ -378,7 +375,7 @@ exports[`feature renders feature full header properly 1`] = `
 <div
   className="c0"
   data-type="fullscreen"
-  height="100vh"
+  height="calc(100vh - 50px)"
 >
   <div>
     <div
@@ -688,7 +685,8 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 50px);
+  position: relative;
 }
 
 .c0[data-type="text"] {
@@ -714,12 +712,12 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
   width: 50vw;
 }
 
@@ -733,12 +731,8 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   flex-direction: column;
 }
 
-.c0[data-type="split"] .file__Deck-s16elnyh-11 {
+.c0[data-type="split"] .file__Deck-s1tgun5o-11 {
   margin-bottom: 30px;
-}
-
-.c0[data-type="fullscreen"] {
-  margin-bottom: 80px;
 }
 
 .c0[data-type="fullscreen"] .c5 {
@@ -814,7 +808,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c9 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -857,19 +851,19 @@ exports[`feature renders feature full header without a deck properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
     width: 100%;
   }
 }
 
-@media (max-width:600px) {
+@media (max-width:720px) {
   .c0[data-type="fullscreen"] .c5 {
     padding: 20px;
   }
@@ -878,7 +872,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
 <div
   className="c0"
   data-type="fullscreen"
-  height="100vh"
+  height="calc(100vh - 50px)"
 >
   <div>
     <div
@@ -1189,7 +1183,8 @@ exports[`feature renders feature header with children properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 50px);
+  position: relative;
 }
 
 .c0[data-type="text"] {
@@ -1215,12 +1210,12 @@ exports[`feature renders feature header with children properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
   width: 50vw;
 }
 
@@ -1236,10 +1231,6 @@ exports[`feature renders feature header with children properly 1`] = `
 
 .c0[data-type="split"] .c12 {
   margin-bottom: 30px;
-}
-
-.c0[data-type="fullscreen"] {
-  margin-bottom: 80px;
 }
 
 .c0[data-type="fullscreen"] .c5 {
@@ -1315,7 +1306,7 @@ exports[`feature renders feature header with children properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c9 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -1368,19 +1359,19 @@ exports[`feature renders feature header with children properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
     width: 100%;
   }
 }
 
-@media (max-width:600px) {
+@media (max-width:720px) {
   .c0[data-type="fullscreen"] .c5 {
     padding: 20px;
   }
@@ -1389,7 +1380,7 @@ exports[`feature renders feature header with children properly 1`] = `
 <div
   className="c0"
   data-type="fullscreen"
-  height="100vh"
+  height="calc(100vh - 50px)"
 >
   <div>
     <div
@@ -1709,7 +1700,8 @@ exports[`feature renders feature split header properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 50px);
+  position: relative;
 }
 
 .c0[data-type="text"] {
@@ -1735,12 +1727,12 @@ exports[`feature renders feature split header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
   width: 50vw;
 }
 
@@ -1756,10 +1748,6 @@ exports[`feature renders feature split header properly 1`] = `
 
 .c0[data-type="split"] .c11 {
   margin-bottom: 30px;
-}
-
-.c0[data-type="fullscreen"] {
-  margin-bottom: 80px;
 }
 
 .c0[data-type="fullscreen"] .c4 {
@@ -1835,7 +1823,7 @@ exports[`feature renders feature split header properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c8 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -1888,19 +1876,19 @@ exports[`feature renders feature split header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
     width: 100%;
   }
 }
 
-@media (max-width:600px) {
+@media (max-width:720px) {
   .c0[data-type="fullscreen"] .c4 {
     padding: 20px;
   }
@@ -1909,7 +1897,7 @@ exports[`feature renders feature split header properly 1`] = `
 <div
   className="c0"
   data-type="split"
-  height="100vh"
+  height="calc(100vh - 50px)"
 >
   <div
     alt="What’s the Path to Winning an Art Prize?"
@@ -2215,7 +2203,8 @@ exports[`feature renders feature text header properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 50px);
+  position: relative;
 }
 
 .c0[data-type="text"] {
@@ -2236,17 +2225,17 @@ exports[`feature renders feature text header properly 1`] = `
   width: 50%;
 }
 
-.c0[data-type="split"] .s16elnyh-0-file__Div-dCIIWC {
+.c0[data-type="split"] .s1tgun5o-0-file__Div-dCIIWC {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
   width: 50vw;
 }
 
@@ -2262,10 +2251,6 @@ exports[`feature renders feature text header properly 1`] = `
 
 .c0[data-type="split"] .c9 {
   margin-bottom: 30px;
-}
-
-.c0[data-type="fullscreen"] {
-  margin-bottom: 80px;
 }
 
 .c0[data-type="fullscreen"] .c2 {
@@ -2341,7 +2326,7 @@ exports[`feature renders feature text header properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c6 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -2387,26 +2372,26 @@ exports[`feature renders feature text header properly 1`] = `
     width: 100%;
   }
 
-  .c0[data-type="split"] .s16elnyh-0-file__Div-dCIIWC {
+  .c0[data-type="split"] .s1tgun5o-0-file__Div-dCIIWC {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
     width: 100%;
   }
 }
 
-@media (max-width:600px) {
+@media (max-width:720px) {
   .c0[data-type="fullscreen"] .c2 {
     padding: 20px;
   }
@@ -2415,7 +2400,7 @@ exports[`feature renders feature text header properly 1`] = `
 <div
   className="c0"
   data-type="text"
-  height="100vh"
+  height="calc(100vh - 50px)"
 >
   <div
     className="c1"
@@ -2783,7 +2768,8 @@ exports[`feature renders superArticle full header properly 1`] = `
   height: 100%;
   box-sizing: border-box;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 50px);
+  position: relative;
 }
 
 .c0[data-type="text"] {
@@ -2809,12 +2795,12 @@ exports[`feature renders superArticle full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
   width: 50vw;
 }
 
@@ -2830,10 +2816,6 @@ exports[`feature renders superArticle full header properly 1`] = `
 
 .c0[data-type="split"] .c17 {
   margin-bottom: 30px;
-}
-
-.c0[data-type="fullscreen"] {
-  margin-bottom: 80px;
 }
 
 .c0[data-type="fullscreen"] .c10 {
@@ -2927,7 +2909,7 @@ exports[`feature renders superArticle full header properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c14 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -2980,19 +2962,19 @@ exports[`feature renders superArticle full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s16elnyh-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1tgun5o-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s16elnyh-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1tgun5o-2 {
     width: 100%;
   }
 }
 
-@media (max-width:600px) {
+@media (max-width:720px) {
   .c0[data-type="fullscreen"] .c10 {
     padding: 20px;
   }
@@ -3001,7 +2983,7 @@ exports[`feature renders superArticle full header properly 1`] = `
 <div
   className="c0"
   data-type="fullscreen"
-  height="100vh"
+  height="calc(100vh - 50px)"
 >
   <div>
     <div

--- a/src/Components/Publishing/RelatedArticles/__test__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/__test__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
@@ -207,13 +207,13 @@ exports[`renders the related articles canvas 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c0 {
     margin: 30px 0 30px 0;
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c1 {
     margin: 0 20px 30px 40px;
   }
@@ -231,7 +231,7 @@ exports[`renders the related articles canvas 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c3 a {
     margin: 0 10px;
   }

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`renders column_width properly 1`] = `
   text-transform: none;
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c0 {
     width: 680px;
   }
@@ -470,7 +470,7 @@ exports[`renders fillwidth properly 1`] = `
   text-transform: none;
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c0 {
     width: 100%;
   }
@@ -756,7 +756,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
   text-transform: none;
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c0 {
     width: 780px;
   }

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.tsx.snap
@@ -615,7 +615,7 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c1 {
     width: 680px;
   }
@@ -629,7 +629,7 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c3 {
     width: 680px;
   }
@@ -643,7 +643,7 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c4 {
     width: 680px;
   }
@@ -657,7 +657,7 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c24 {
     width: 680px;
   }
@@ -742,7 +742,7 @@ exports[`renders properly 1`] = `
   }
 }
 
-@media (max-width:1250px) {
+@media (max-width:1280px) {
   .c0 {
     max-width: 680px;
   }


### PR DESCRIPTION
- Ups breakpoint to 1280 -- macbook screens are ~ 1260, meaning they loaded pages with no margins.
- Adds relative positioning to feature header and cleans up some overlap/margin problems
- Adds top margin to basic headers without embeds
