### PR TITLE
Add examples for circle icons with different scale

### DIFF
--- a/src/Components/__stories__/Icons.story.tsx
+++ b/src/Components/__stories__/Icons.story.tsx
@@ -67,6 +67,42 @@ storiesOf("Components/Icons", module).add("All Icons", () => {
           <CircleIcon name='logo' color='#6E1FFF' fontSize="60px" />
         </Col>
       </Row>
+
+      <Row>
+        <Title>Circle Icons with Different Scale</Title>
+      </Row>
+      <Row>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='check' color='black' fontSize="60px" ratio={0.7}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='check' color='black' fontSize="60px" ratio={0.6}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='check' color='black' fontSize="60px" ratio={0.5}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='check' color='black' fontSize="60px" ratio={0.4}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='check' color='black' fontSize="60px" ratio={0.3}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='heart-small' color='black' fontSize="60px" ratio={0.7}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='heart-small' color='black' fontSize="60px" ratio={0.6}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='heart-small' color='black' fontSize="60px" ratio={0.5}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='heart-small' color='black' fontSize="60px" ratio={0.4}/>
+        </Col>
+        <Col style={{ padding: 10 }}>
+          <CircleIcon name='heart-small' color='black' fontSize="60px" ratio={0.3}/>
+        </Col>
+      </Row>
     </div>
   )
 })


### PR DESCRIPTION
added some examples we implemented on Wednesday:

![screen shot 2017-11-03 at 11 56 02 am](https://user-images.githubusercontent.com/386234/32383292-0048e76a-c08e-11e7-8643-8c82e440ee9b.png)
