### PR TITLE
@kanaabe => Complete Display Ad interactions on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "transform": {
       ".(ts|tsx)": "typescript-babel-jest"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js|jsx)$",
     "testPathIgnorePatterns": [
       "<rootDir>/dist/"
     ],

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -44,14 +44,12 @@ export class DisplayPanel extends Component<Props, State> {
   })))
   componentDidMount() {
     if (this.video) {
-      this.video.onended = () => {
-        this.pauseVideo()
-      }
+      this.video.onended = this.pauseVideo
     }
   }
 
-  withinMediaArea(event) {
-    const classes = [
+  isWithinMediaArea(event) {
+    const valid = [
       "DisplayPanel__Image",
       "VideoContainer",
       "VideoContainer__VideoCover",
@@ -60,7 +58,7 @@ export class DisplayPanel extends Component<Props, State> {
       "PlayButton",
       "PlayButton__PlayButtonCaret"
     ]
-    const withinMediaArea = classes.some(c => event.target.className.includes(c))
+    const withinMediaArea = valid.some(className => event.target.className.includes(className))
     return withinMediaArea
   }
 
@@ -79,19 +77,19 @@ export class DisplayPanel extends Component<Props, State> {
     const { showCoverImage: alreadyClicked } = this.state
     const { isMobile, unit } = this.props
     const url = get(unit, "link.url", false)
-    const isVideo = this.checkIfVideo()
+    const isVideo = this.isVideo()
     const openUrl = () => window.open(url, "_blank")
 
     if (isMobile) {
       if (isVideo) {
-        if (this.withinMediaArea(event)) {
+        if (this.isWithinMediaArea(event)) {
           this.toggleVideo()
         } else {
           openUrl()
         }
         // Image
       } else {
-        if (this.withinMediaArea(event)) {
+        if (this.isWithinMediaArea(event)) {
           if (alreadyClicked) {
             openUrl()
             this.toggleCoverImage()
@@ -140,7 +138,7 @@ export class DisplayPanel extends Component<Props, State> {
     if (this.props.isMobile) {
       return false
     } else {
-      if (this.checkIfVideo()) {
+      if (this.isVideo()) {
         this.playVideo()
       } else {
         this.toggleCoverImage()
@@ -155,7 +153,7 @@ export class DisplayPanel extends Component<Props, State> {
     if (this.props.isMobile) {
       return false
     } else {
-      if (this.checkIfVideo()) {
+      if (this.isVideo()) {
         this.pauseVideo()
       } else {
         this.toggleCoverImage()
@@ -179,7 +177,7 @@ export class DisplayPanel extends Component<Props, State> {
     }
   }
 
-  pauseVideo = () => {
+  pauseVideo() {
     if (this.video) {
       this.video.pause()
 
@@ -189,7 +187,7 @@ export class DisplayPanel extends Component<Props, State> {
     }
   }
 
-  playVideo = () => {
+  playVideo() {
     if (this.video) {
       this.video.play()
 
@@ -199,13 +197,13 @@ export class DisplayPanel extends Component<Props, State> {
     }
   }
 
-  checkIfVideo() {
+  isVideo() {
     const assetUrl = get(this.props.unit, "assets.0.url", "")
     const isVideo = assetUrl.includes("mp4")
     return isVideo
   }
 
-  renderVideo = (url) => {
+  renderVideo(url) {
     const { isPlaying } = this.state
     const { isMobile } = this.props
 
@@ -235,7 +233,7 @@ export class DisplayPanel extends Component<Props, State> {
     const { showCoverImage } = this.state
     const { unit, campaign, isMobile } = this.props
     const url = get(unit.assets, "0.url", "")
-    const isVideo = this.checkIfVideo()
+    const isVideo = this.isVideo()
     const cover = unit.cover_image_url || ""
     const imageUrl = crop(url, { width: 680, height: 284 })
     const hoverImageUrl = resize(unit.logo, { width: 680 })

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -1,10 +1,10 @@
 import { get, once } from "lodash"
-import React, { Component } from "react"
+import React, { Component, HTMLProps  } from "react"
 import styled, { StyledFunction } from "styled-components"
 import Colors from "../../../Assets/Colors"
 import { crop, resize } from "../../../Utils/resizer"
 import { track } from "../../../Utils/track"
-import { pMedia } from "../../Helpers"
+import { pMedia as breakpoint } from "../../Helpers"
 import { Fonts } from "../Fonts"
 import { VideoControls } from "../Sections/VideoControls"
 
@@ -66,7 +66,6 @@ export class DisplayPanel extends Component<Props, State> {
 
   /**
    * Handle clicks to main container
-   * @param event
    */
   @track(props => ({
     action: "Click",
@@ -77,6 +76,7 @@ export class DisplayPanel extends Component<Props, State> {
   }))
   handleClick(event) {
     event.preventDefault()
+    const { showCoverImage: alreadyClicked } = this.state
     const { isMobile, unit } = this.props
     const url = get(unit, "link.url", false)
     const isVideo = this.checkIfVideo()
@@ -92,7 +92,13 @@ export class DisplayPanel extends Component<Props, State> {
         // Image
       } else {
         if (this.withinMediaArea(event)) {
-          this.toggleCoverImage()
+          if (alreadyClicked) {
+            openUrl()
+            this.toggleCoverImage()
+          } else {
+            this.toggleCoverImage()
+          }
+          // Clicked outside of the media area
         } else {
           openUrl()
         }
@@ -108,7 +114,6 @@ export class DisplayPanel extends Component<Props, State> {
 
   /**
    * Handle clicks to Video player
-   * @param event
    */
   @track(props => ({
     action: "Click",
@@ -122,7 +127,7 @@ export class DisplayPanel extends Component<Props, State> {
   }
 
   /**
-   * Handle MouseEnter
+   * Handle MouseEnter, on desktop
    */
   @track(props => ({
     action: "MouseEnter",
@@ -144,7 +149,7 @@ export class DisplayPanel extends Component<Props, State> {
   }
 
   /**
-   * Handle MouseLeave
+   * Handle MouseLeave, on desktop
    */
   handleMouseLeave() {
     if (this.props.isMobile) {
@@ -174,22 +179,22 @@ export class DisplayPanel extends Component<Props, State> {
     }
   }
 
-  playVideo = () => {
-    if (this.video) {
-      this.video.play()
-
-      this.setState({
-        isPlaying: true
-      })
-    }
-  }
-
   pauseVideo = () => {
     if (this.video) {
       this.video.pause()
 
       this.setState({
         isPlaying: false
+      })
+    }
+  }
+
+  playVideo = () => {
+    if (this.video) {
+      this.video.play()
+
+      this.setState({
+        isPlaying: true
       })
     }
   }
@@ -275,6 +280,16 @@ export class DisplayPanel extends Component<Props, State> {
   }
 }
 
+interface DivUrlProps extends HTMLProps<HTMLDivElement> {
+  coverUrl?: string
+  hoverImageUrl?: string
+  isMobile?: boolean
+  imageUrl?: string
+  showCoverImage?: boolean
+}
+
+const div: StyledFunction<DivUrlProps> = styled.div
+
 const Wrapper = styled.div`
   cursor: pointer;
   text-decoration: none;
@@ -296,56 +311,43 @@ const VideoCover = Image.extend`
   justify-content: center;
 `
 
-interface DivUrlProps extends React.HTMLProps<HTMLDivElement> {
-  coverUrl?: string
-  hoverImageUrl?: string
-  isMobile?: boolean
-  imageUrl?: string
-  showCoverImage?: boolean
-}
-
-const Div: StyledFunction<DivUrlProps> = styled.div
-const DisplayPanelContainer = Div`
+const DisplayPanelContainer = div`
   display: flex;
   flex-direction: column;
   border: 1px solid ${Colors.grayRegular};
   padding: 20px;
   max-width: 360px;
   box-sizing: border-box;
+
   ${Image} {
-    background: url(${props => (props.imageUrl || "")}) no-repeat center center;
+    background: url(${p => (p.imageUrl || "")}) no-repeat center center;
     background-size: cover;
 
-    ${props => props.showCoverImage && props.hoverImageUrl
-      ? `
-          background: black url(${props.hoverImageUrl}) no-repeat center center;
-          background-size: contain;
-          border: 10px solid black;
-        `
-      : ""
-    }
+    ${p => p.showCoverImage && p.hoverImageUrl && `
+      background: black url(${p.hoverImageUrl}) no-repeat center center;
+      background-size: contain;
+      border: 10px solid black;
+    `}
   }
 
   ${VideoCover} {
-    background: url(${props => (props.coverUrl || "")}) no-repeat center center;
+    background: url(${p => (p.coverUrl || "")}) no-repeat center center;
     background-size: cover;
+
+    ${p => p.showCoverImage && !p.isMobile && `
+      display: none;
+    `}
   }
 
-  .hover {
-    ${VideoCover} {
-      ${props => !props.isMobile && "display: none;"}
-    }
-  }
-
-  ${pMedia.md`
+  ${breakpoint.md`
     margin: auto;
   `}
 
-  ${pMedia.sm`
+  ${breakpoint.sm`
     margin: auto;
   `}
 
-  ${pMedia.xs`
+  ${breakpoint.xs`
     margin: auto;
   `}
 `

--- a/src/Components/Publishing/Display/__test__/DisplayPanel.test.js
+++ b/src/Components/Publishing/Display/__test__/DisplayPanel.test.js
@@ -1,11 +1,11 @@
-import { mount } from 'enzyme'
 import 'jest-styled-components'
-import { clone } from 'lodash'
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { track } from '../../../../Utils/track'
 import { Campaign, UnitPanel, UnitPanelVideo } from '../../Fixtures/Components'
 import { DisplayPanel } from '../DisplayPanel'
+import { cloneDeep } from 'lodash'
+import { mount } from 'enzyme'
+import { track } from '../../../../Utils/track'
 
 jest.mock('../../../../Utils/track.ts', () => ({
   track: jest.fn()
@@ -16,7 +16,6 @@ describe('snapshots', () => {
     const displayPanel = renderer.create(
       <DisplayPanel unit={UnitPanel} campaign={Campaign} />
     ).toJSON()
-
     expect(displayPanel).toMatchSnapshot()
   })
 
@@ -24,126 +23,328 @@ describe('snapshots', () => {
     const displayPanel = renderer.create(
       <DisplayPanel unit={UnitPanelVideo} campaign={Campaign} />
     ).toJSON()
-
     expect(displayPanel).toMatchSnapshot()
   })
 })
 
 describe('units', () => {
   const getWrapper = (props = {}) => {
+    const { isVideo = false, ...rest } = props
+    let unit = UnitPanel
+
+    if (isVideo) {
+      unit = cloneDeep(UnitPanel)
+      unit.assets[0].url = 'foo.mp4'
+    }
+
     return mount(
       <DisplayPanel
-        unit={UnitPanel}
+        unit={unit}
         campaign={Campaign}
-        {...props}
+        {...rest}
       />
     )
   }
 
-  describe('tracking', () => {
-    it('calls on mount', () => {
+  describe('#componentDidMount', () => {
+    it('tracks interaction', () => {
       getWrapper()
       expect(track).toHaveBeenCalled()
     })
 
-    it('calls on click', () => {
-      const wrapper = getWrapper()
-      wrapper.simulate('click')
-      expect(track).toHaveBeenCalled()
-    })
-
-    it('calls on mouse enter', () => {
-      const wrapper = getWrapper()
-      wrapper.simulate('mouseEnter')
-      expect(track).toHaveBeenCalled()
-    })
-
-    it('calls on video click', () => {
-      const wrapper = getWrapper()
-      wrapper.simulate('mouseEnter')
+    it('attaches an onEnded handler to video', () => {
+      const wrapper = getWrapper({ isVideo: true })
       const instance = wrapper.instance()
-      instance.isVideoClickArea = () => true
-      wrapper.find('DisplayPanelContainer').simulate('click')
+      expect(instance.video.onended).not.toBeUndefined()
+    })
+  })
+
+  describe('#isWithinMediaArea', () => {
+    it('returns true / false if an event is within a media area', () => {
+      const {
+        isWithinMediaArea
+      } = DisplayPanel.prototype
+
+      const valid = [
+        'DisplayPanel__Image',
+        'VideoContainer',
+        'VideoContainer__VideoCover',
+        'VideoContainer__VideoControls',
+        'VideoContainer__video',
+        'PlayButton',
+        'PlayButton__PlayButtonCaret'
+      ]
+      valid.forEach(className => {
+        const event = { target: { className }}
+        expect(isWithinMediaArea(event)).toEqual(true)
+      })
+
+      const invalid = [
+        'nope', 'sorry'
+      ]
+
+      invalid.forEach(className => {
+        const event = { target: { className }}
+        expect(isWithinMediaArea(event)).toEqual(false)
+      })
+    })
+  })
+
+  describe('#handleClick', () => {
+    it('tracks interaction', () => {
+      const wrapper = getWrapper()
+      wrapper.simulate('click')
+      expect(track).toHaveBeenCalled()
+    })
+
+    it('prevents default event from occurring', () => {
+      const wrapper = getWrapper()
+      const event = { preventDefault: jest.fn() }
+      wrapper.instance().handleClick(event)
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    describe('Mobile', () => {
+      describe('Video', () => {
+        it('toggles video if within media area', () => {
+          const wrapper = getWrapper({ isMobile: true, isVideo: true })
+          const event = {
+            preventDefault: jest.fn(),
+            target: {
+              className: 'PlayButton'
+            }
+          }
+          wrapper.instance().handleClick(event)
+          expect(wrapper.state().isPlaying).toEqual(true)
+          wrapper.instance().handleClick(event)
+          expect(wrapper.state().isPlaying).toEqual(false)
+        })
+
+        it('clicks away if outside media area', () => {
+          global.open = jest.fn()
+          const wrapper = getWrapper({ isMobile: true, isVideo: true })
+          const event = {
+            preventDefault: jest.fn(),
+            target: {
+              className: 'nope'
+            }
+          }
+          wrapper.instance().handleClick(event)
+          expect(wrapper.state().isPlaying).toEqual(false)
+          expect(global.open).toHaveBeenCalled()
+        })
+      })
+
+      describe('Image', () => {
+        it('opens a link if user has already clicked once', () => {
+          global.open = jest.fn()
+          const wrapper = getWrapper({ isMobile: true })
+          const event = {
+            preventDefault: jest.fn(),
+            target: {
+              className: 'PlayButton'
+            }
+          }
+          wrapper.instance().handleClick(event)
+          expect(global.open).not.toHaveBeenCalled()
+          wrapper.instance().handleClick(event)
+          expect(global.open).toHaveBeenCalled()
+        })
+
+        it('toggles cover image on click and toggles back on click away', () => {
+          global.open = jest.fn()
+          const wrapper = getWrapper({ isMobile: true })
+          const event = {
+            preventDefault: jest.fn(),
+            target: {
+              className: 'PlayButton'
+            }
+          }
+          wrapper.instance().handleClick(event)
+          expect(wrapper.state().showCoverImage).toEqual(true)
+          wrapper.instance().handleClick(event)
+          expect(wrapper.state().showCoverImage).toEqual(false)
+        })
+
+        it('clicks away if outside media area', () => {
+          global.open = jest.fn()
+          const wrapper = getWrapper({ isMobile: true })
+          const event = {
+            preventDefault: jest.fn(),
+            target: {
+              className: 'nope'
+            }
+          }
+          wrapper.instance().handleClick(event)
+          expect(global.open).toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('Desktop', () => {
+      it('pauses the video if video', () => {
+        global.open = jest.fn()
+        const spy = jest.spyOn(DisplayPanel.prototype, 'pauseVideo')
+        const wrapper = getWrapper({ isVideo: true })
+        const event = {
+          preventDefault: jest.fn(),
+          target: {
+            className: 'PlayButton'
+          }
+        }
+        wrapper.instance().handleClick(event)
+        expect(spy).toHaveBeenCalled()
+      })
+
+      it('always clicks away', () => {
+        const isVideo = [true, false]
+        isVideo.forEach(type => {
+          global.open = jest.fn()
+          const wrapper = getWrapper({ isVideo: type })
+          const event = {
+            preventDefault: jest.fn(),
+            target: {
+              className: 'PlayButton'
+            }
+          }
+          wrapper.instance().handleClick(event)
+          expect(global.open).toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe('#handleVideoClick', () => {
+    it('tracks interaction', () => {
+      const wrapper = getWrapper()
+      wrapper.simulate('mouseEnter')
       expect(track).toHaveBeenCalled()
     })
   })
 
-  it('opens link on click', () => {
-    const wrapper = getWrapper()
-    const spy = jest.spyOn(wrapper.instance(), 'openLink')
-    wrapper.update()
-    wrapper.simulate('click')
-    expect(spy).toHaveBeenCalled()
+  describe('#handleMouseEnter', () => {
+    it('tracks interaction', () => {
+      const wrapper = getWrapper()
+      wrapper.simulate('mouseEnter')
+      expect(track).toHaveBeenCalled()
+    })
+
+    it('does nothing if mobile', () => {
+      const wrapper = getWrapper({ isMobile: true })
+      expect(wrapper.instance().handleMouseEnter()).toEqual(false)
+    })
+
+    it('plays video if video', () => {
+      const spy = jest.spyOn(DisplayPanel.prototype, 'playVideo')
+      const wrapper = getWrapper({ isVideo: true })
+      wrapper.instance().handleMouseEnter()
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it('toggles cover image if image', () => {
+      const spy = jest.spyOn(DisplayPanel.prototype, 'toggleCoverImage')
+      const wrapper = getWrapper()
+      wrapper.instance().handleMouseEnter()
+      expect(spy).toHaveBeenCalled()
+    })
   })
 
-  describe('image', () => {
-    it('renders an image', () => {
-      const wrapper = getWrapper()
-      expect(wrapper.find('Image').length).toEqual(1)
+  describe('#handleMouseLeave', () => {
+    it('does nothing if mobile', () => {
+      const wrapper = getWrapper({ isMobile: true })
+      expect(wrapper.instance().handleMouseLeave()).toEqual(false)
     })
 
-    it('renders an image', () => {
-      const wrapper = getWrapper()
-      wrapper.simulate('click')
-      expect(wrapper.find('Image').length).toEqual(1)
+    it('pauses video if video', () => {
+      const spy = jest.spyOn(DisplayPanel.prototype, 'pauseVideo')
+      const wrapper = getWrapper({ isVideo: true })
+      wrapper.instance().handleMouseLeave()
+      expect(spy).toHaveBeenCalled()
     })
+
+    it('toggles cover image if image', () => {
+      const spy = jest.spyOn(DisplayPanel.prototype, 'toggleCoverImage')
+      const wrapper = getWrapper()
+      wrapper.instance().handleMouseLeave()
+      expect(spy).toHaveBeenCalled()
+    })
+  })
+
+  it('#toggleVideo', () => {
+    const pauseSpy = jest.spyOn(DisplayPanel.prototype, 'pauseVideo')
+    const playSpy = jest.spyOn(DisplayPanel.prototype, 'playVideo')
+    const wrapper = getWrapper({ isVideo: true })
+    wrapper.instance().toggleVideo()
+    expect(playSpy).toHaveBeenCalled()
+    wrapper.instance().toggleVideo()
+    expect(pauseSpy).toHaveBeenCalled()
+  })
+
+  it('#pauseVideo', () => {
+    const wrapper = getWrapper({ isVideo: true })
+    const instance = wrapper.instance()
+    const spy = jest.spyOn(instance.video, 'pause')
+    instance.pauseVideo()
+    expect(spy).toHaveBeenCalled()
+    expect(wrapper.state().isPlaying).toEqual(false)
+  })
+
+  it('#playVideo', () => {
+    const wrapper = getWrapper({ isVideo: true })
+    const instance = wrapper.instance()
+    const spy = jest.spyOn(instance.video, 'play')
+    instance.playVideo()
+    expect(spy).toHaveBeenCalled()
+    expect(wrapper.state().isPlaying).toEqual(true)
+  })
+
+  describe('#isVideo', () => {
+    it('returns true if asset contains video url', () => {
+      const wrapper = getWrapper({ isVideo: true })
+      expect(wrapper.instance().isVideo()).toEqual(true)
+    })
+
+    it('returns false if asset does not contain video url', () => {
+      const wrapper = getWrapper({ isVideo: false })
+      expect(wrapper.instance().isVideo()).toEqual(false)
+    })
+
   })
 
   describe('video', () => {
     it('renders a video cover if not playing', () => {
-      const unit = clone(UnitPanel)
-      unit.assets[0].url = 'foo.mp4'
-      const wrapper = getWrapper({ unit })
+      const wrapper = getWrapper({ isVideo: true })
       expect(wrapper.find('VideoCover').length).toEqual(1)
     })
 
     it('hides the video cover when playing', () => {
-      const unit = clone(UnitPanel)
-      unit.assets[0].url = 'foo.mp4'
-      const wrapper = getWrapper({ unit, isMobile: true })
+      const wrapper = getWrapper({ isVideo: true, isMobile: true })
       const instance = wrapper.instance()
-      instance.isVideoClickArea = () => true
-      wrapper.find('DisplayPanelContainer').simulate('click')
+      const event = {
+        preventDefault: jest.fn(),
+        target: {
+          className: 'PlayButton'
+        }
+      }
+      instance.handleClick(event)
+      wrapper.update()
       expect(wrapper.find('VideoCover').length).toEqual(0)
     })
 
     it('on mobile, renders mini video controls', () => {
-      const wrapper = getWrapper({ isMobile: true })
+      const wrapper = getWrapper({ isVideo: true, isMobile: true })
       expect(wrapper.find('VideoControls').length).toEqual(1)
     })
 
     it('renders a <video />', () => {
-      const wrapper = getWrapper()
+      const wrapper = getWrapper({ isVideo: true })
       expect(wrapper.find('video').length).toEqual(1)
     })
+  })
 
-    it('on mobile, plays video on click', () => {
-      const wrapper = getWrapper({ isMobile: true })
-      const instance = wrapper.instance()
-      instance.isVideoClickArea = () => true
-      const spy = jest.spyOn(instance, 'onClickVideo')
-      const toggleSpy = jest.spyOn(instance, 'toggleVideo')
-      wrapper.update()
-      wrapper.find('DisplayPanelContainer').simulate('click')
-      expect(spy).toHaveBeenCalled()
-      expect(toggleSpy).toHaveBeenCalled()
-      expect(wrapper.state().isPlaying).toEqual(true)
-      wrapper.find('DisplayPanelContainer').simulate('click')
-      expect(wrapper.state().isPlaying).toEqual(false)
-    })
-
-    it('plays / pauses video on onMouseEnter / onMouseLeave', () => {
-      const unit = clone(UnitPanel)
-      unit.assets[0].url = 'foo.mp4'
-      const wrapper = getWrapper({ unit, isMobile: false })
-      const instance = wrapper.instance()
-      instance.isVideoClickArea = () => true
-      instance.video = { play: jest.fn(), pause: jest.fn() }
-      wrapper.find('DisplayPanelContainer').simulate('mouseEnter')
-      expect(wrapper.state().isPlaying).toEqual(true)
-      wrapper.find('DisplayPanelContainer').simulate('mouseLeave')
-      expect(wrapper.state().isPlaying).toEqual(false)
-    })
+  it('renders an image', () => {
+    const wrapper = getWrapper()
+    expect(wrapper.find('Image').length).toEqual(1)
   })
 })
 

--- a/src/Components/Publishing/Display/__test__/DisplayPanel.test.js
+++ b/src/Components/Publishing/Display/__test__/DisplayPanel.test.js
@@ -76,6 +76,19 @@ describe('units', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  describe('image', () => {
+    it('renders an image', () => {
+      const wrapper = getWrapper()
+      expect(wrapper.find('Image').length).toEqual(1)
+    })
+
+    it('renders an image', () => {
+      const wrapper = getWrapper()
+      wrapper.simulate('click')
+      expect(wrapper.find('Image').length).toEqual(1)
+    })
+  })
+
   describe('video', () => {
     it('renders a video cover if not playing', () => {
       const unit = clone(UnitPanel)

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
@@ -34,19 +34,9 @@ exports[`snapshots renders the display panel with an image 1`] = `
   background-size: cover;
 }
 
-.c1 .s1vgk0vk-1-file__Image-iTToDH {
+.c1 .o9kx22-1-file__Image-iTToDH {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
-}
-
-.c1 .hover--over .c2 {
-  background: black url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-vanity-files-production.s3.amazonaws.com%2Fimages%2Fartsy_logo_square_white_transparent.png&width=680&quality=95) no-repeat center center;
-  background-size: contain;
-  border: 10px solid black;
-}
-
-.c1 .hover--over .s1vgk0vk-1-file__Image-iTToDH {
-  display: none;
 }
 
 .c4 {
@@ -109,19 +99,16 @@ exports[`snapshots renders the display panel with an image 1`] = `
 <div
   className="c0"
   onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <div
     className="DisplayPanel__DisplayPanelContainer c1"
-    onClick={undefined}
-    onMouseEnter={false}
-    onMouseLeave={false}
   >
     <div
       className="DisplayPanel__Image c2 c3"
     />
-    <div
-      onClick={undefined}
-    >
+    <div>
       <div
         className="c4"
       >
@@ -173,13 +160,9 @@ exports[`snapshots renders the display panel with video 1`] = `
   justify-content: center;
 }
 
-.ipyUAq .c3 {
+.eRrKwU .c3 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
-}
-
-.ipyUAq .hover--over .c3 {
-  display: none;
 }
 
 .c1 {
@@ -196,7 +179,7 @@ exports[`snapshots renders the display panel with video 1`] = `
   box-sizing: border-box;
 }
 
-.c1 .file__Image-s1vgk0vk-1 {
+.c1 .file__Image-o9kx22-1 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlHEsRROMLasYi9yZtgTR7A%252Fbombay_artsy_panel_640_28_480.mp4&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -204,16 +187,6 @@ exports[`snapshots renders the display panel with video 1`] = `
 .c1 .c3 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
-}
-
-.c1 .hover--over .file__Image-s1vgk0vk-1 {
-  background: black url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-vanity-files-production.s3.amazonaws.com%2Fimages%2Fartsy_logo_square_white_transparent.png&width=680&quality=95) no-repeat center center;
-  background-size: contain;
-  border: 10px solid black;
-}
-
-.c1 .hover--over .c3 {
-  display: none;
 }
 
 .c5 {
@@ -301,15 +274,15 @@ exports[`snapshots renders the display panel with video 1`] = `
 <div
   className="c0"
   onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <div
     className="DisplayPanel__DisplayPanelContainer c1"
-    onClick={undefined}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
   >
     <div
       className="VideoContainer c2"
+      onClick={[Function]}
     >
       <div
         className="VideoContainer__VideoCover c3 c4"
@@ -321,9 +294,7 @@ exports[`snapshots renders the display panel with video 1`] = `
         src="https://artsy-media-uploads.s3.amazonaws.com/lHEsRROMLasYi9yZtgTR7A%2Fbombay_artsy_panel_640_28_480.mp4"
       />
     </div>
-    <div
-      onClick={undefined}
-    >
+    <div>
       <div
         className="c5"
       >

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
@@ -1,0 +1,348 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots renders the display panel with an image 1`] = `
+.c0 {
+  cursor: pointer;
+  text-decoration: none;
+  color: black;
+}
+
+.c3 {
+  margin-bottom: 15px;
+  width: 100%;
+  height: 142px;
+  background-color: black;
+  box-sizing: border-box;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border: 1px solid #e5e5e5;
+  padding: 20px;
+  max-width: 360px;
+  box-sizing: border-box;
+}
+
+.c1 .c2 {
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=680&height=284&quality=95) no-repeat center center;
+  background-size: cover;
+}
+
+.c1 .s1vgk0vk-1-file__Image-iTToDH {
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
+  background-size: cover;
+}
+
+.c1 .hover--over .c2 {
+  background: black url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-vanity-files-production.s3.amazonaws.com%2Fimages%2Fartsy_logo_square_white_transparent.png&width=680&quality=95) no-repeat center center;
+  background-size: contain;
+  border: 10px solid black;
+}
+
+.c1 .hover--over .s1vgk0vk-1-file__Image-iTToDH {
+  display: none;
+}
+
+.c4 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  line-height: 1.1em;
+  line-height: 1.23em;
+  margin-bottom: 3px;
+}
+
+.c5 {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 17px;
+  line-height: 1.1em;
+  line-height: 1.53em;
+  margin-bottom: 20px;
+}
+
+.c5 a {
+  color: black;
+}
+
+.c6 {
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
+  -webkit-font-smoothing: antialiased;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-size: 11px;
+  line-height: 1.65em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  color: #e5e5e5;
+}
+
+@media (max-width:900px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media (max-width:720px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media (max-width:600px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+<div
+  className="c0"
+  onClick={[Function]}
+>
+  <div
+    className="DisplayPanel__DisplayPanelContainer c1"
+    onClick={undefined}
+    onMouseEnter={false}
+    onMouseLeave={false}
+  >
+    <div
+      className="DisplayPanel__Image c2 c3"
+    />
+    <div
+      onClick={undefined}
+    >
+      <div
+        className="c4"
+      >
+        Euismod Inceptos Quam
+      </div>
+      <div
+        className="c5"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. <a href='http://artsy.net/articles'>Example Link</a>",
+          }
+        }
+      />
+      <div
+        className="c6"
+      >
+        Sponsored by Artsy
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`snapshots renders the display panel with video 1`] = `
+.c0 {
+  cursor: pointer;
+  text-decoration: none;
+  color: black;
+}
+
+.c4 {
+  margin-bottom: 15px;
+  width: 100%;
+  height: 142px;
+  background-color: black;
+  box-sizing: border-box;
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.ipyUAq .c3 {
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
+  background-size: cover;
+}
+
+.ipyUAq .hover--over .c3 {
+  display: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border: 1px solid #e5e5e5;
+  padding: 20px;
+  max-width: 360px;
+  box-sizing: border-box;
+}
+
+.c1 .file__Image-s1vgk0vk-1 {
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlHEsRROMLasYi9yZtgTR7A%252Fbombay_artsy_panel_640_28_480.mp4&width=680&height=284&quality=95) no-repeat center center;
+  background-size: cover;
+}
+
+.c1 .c3 {
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=680&height=284&quality=95) no-repeat center center;
+  background-size: cover;
+}
+
+.c1 .hover--over .file__Image-s1vgk0vk-1 {
+  background: black url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-vanity-files-production.s3.amazonaws.com%2Fimages%2Fartsy_logo_square_white_transparent.png&width=680&quality=95) no-repeat center center;
+  background-size: contain;
+  border: 10px solid black;
+}
+
+.c1 .hover--over .c3 {
+  display: none;
+}
+
+.c5 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  line-height: 1.1em;
+  line-height: 1.23em;
+  margin-bottom: 3px;
+}
+
+.c6 {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 17px;
+  line-height: 1.1em;
+  line-height: 1.53em;
+  margin-bottom: 20px;
+}
+
+.c6 a {
+  color: black;
+}
+
+.c7 {
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075', 'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
+  -webkit-font-smoothing: antialiased;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-size: 11px;
+  line-height: 1.65em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  color: #e5e5e5;
+}
+
+.c2 {
+  margin-bottom: 15px;
+  width: 100%;
+  height: 142px;
+  background-color: black;
+  box-sizing: border-box;
+  position: relative;
+  overflow: hidden;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 video {
+  object-fit: cover;
+  object-position: 50%;
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width:900px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media (max-width:720px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media (max-width:600px) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+<div
+  className="c0"
+  onClick={[Function]}
+>
+  <div
+    className="DisplayPanel__DisplayPanelContainer c1"
+    onClick={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className="VideoContainer c2"
+    >
+      <div
+        className="VideoContainer__VideoCover c3 c4"
+      />
+      <video
+        className="VideoContainer__video"
+        controls={false}
+        playsInline={true}
+        src="https://artsy-media-uploads.s3.amazonaws.com/lHEsRROMLasYi9yZtgTR7A%2Fbombay_artsy_panel_640_28_480.mp4"
+      />
+    </div>
+    <div
+      onClick={undefined}
+    >
+      <div
+        className="c5"
+      >
+        Euismod Inceptos Quam
+      </div>
+      <div
+        className="c6"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. <a href='http://artsy.net/articles'>Example Link</a>",
+          }
+        }
+      />
+      <div
+        className="c7"
+      >
+        Sponsored by Artsy
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -1,5 +1,5 @@
 import { clone, compact } from 'lodash'
-import React from "react"
+import React, { Component } from "react"
 import ReactDOM from 'react-dom'
 import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../Helpers"
@@ -12,7 +12,7 @@ import { SectionContainer } from "./SectionContainer"
 import { Text } from "./Text"
 import { Video } from "./Video"
 
-interface SectionsProps {
+interface Props {
   DisplayPanel?: any
   article: {
     layout: Layout
@@ -23,6 +23,10 @@ interface SectionsProps {
   isMobile?: boolean
 }
 
+interface State {
+  shouldInjectMobileDisplay: boolean
+}
+
 /**
  * When isMobile, hide sidebar and inject DisplayAd into the body of the
  * article at a specific paragraph index.
@@ -30,7 +34,7 @@ interface SectionsProps {
 const MOBILE_DISPLAY_INJECT_INDEX = 1
 const MOBILE_DISPLAY_INJECT_ID = '__mobile_display_inject__'
 
-export class Sections extends React.Component<SectionsProps, any> {
+export class Sections extends Component<Props, State> {
 
   state = {
     shouldInjectMobileDisplay: false
@@ -45,6 +49,20 @@ export class Sections extends React.Component<SectionsProps, any> {
   componentDidMount() {
     if (this.state.shouldInjectMobileDisplay) {
       this.mountDisplayToMarker()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isMobile } = this.props
+
+    if (prevProps.isMobile !== isMobile) {
+      this.setState({
+        shouldInjectMobileDisplay: isMobile
+      }, () => {
+        if (isMobile) {
+          this.mountDisplayToMarker()
+        }
+      })
     }
   }
 
@@ -81,8 +99,6 @@ export class Sections extends React.Component<SectionsProps, any> {
   }
 
   getSection(section) {
-    const { article } = this.props
-
     const sections = {
       image_collection: (
         <ImageCollection
@@ -92,28 +108,16 @@ export class Sections extends React.Component<SectionsProps, any> {
           gutter={10}
         />
       ),
-      image_set: (
-        <ImageSetPreview
-          section={section}
-        />
-      ),
-      video: (
-        <Video
-          section={section}
-        />
-      ),
-      embed: (
-        <Embed
-          section={section}
-        />
-      ),
-      text: (
-        <Text
-          html={section.body}
-          layout={article.layout}
-        />
-      ),
-      default: false,
+      image_set:
+        <ImageSetPreview section={section} />,
+      video:
+        <Video section={section} />,
+      embed:
+        <Embed section={section} />,
+      text:
+        <Text html={section.body} layout={this.props.article.layout} />,
+      default:
+        false
     }
 
     const sectionComponent = sections[section.type] || sections.default

--- a/src/Components/Publishing/__stories__/Article.story.tsx
+++ b/src/Components/Publishing/__stories__/Article.story.tsx
@@ -76,6 +76,7 @@ ads.forEach(mediaType => {
         relatedArticlesForPanel={RelatedPanel}
         relatedArticlesForCanvas={RelatedCanvas}
         emailSignupUrl="#"
+        isMobile
       />
     )
   })

--- a/src/Components/Publishing/__stories__/Display.story.tsx
+++ b/src/Components/Publishing/__stories__/Display.story.tsx
@@ -20,6 +20,9 @@ const story = storiesOf("Publishing/Display", module)
   .add("Panel", () => {
     return <DisplayPanel unit={UnitPanel} campaign={Campaign} />
   })
+  .add("Panel (mobile)", () => {
+    return <DisplayPanel unit={UnitPanel} campaign={Campaign} isMobile />
+  })
   .add("Panel: Video", () => {
     return <DisplayPanel unit={UnitPanelVideo} campaign={Campaign} />
   })


### PR DESCRIPTION
This PR refactors our display unit to further account for mobile behaviors. Some states were missing such as image toggles on mobile (as it only accounted for css `:hover` events on desktop). Additionally tightened up the behavior pipeline so that things funnel through the component more systematically.