### PR TITLE
@damassi => Fix SSR slideshow bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "tslint-react": "^2.4.0",
     "typescript": "^2.3.4",
     "typescript-babel-jest": "^1.0.3",
+    "typescript-styled-plugin": "^0.1.2",
     "uglify-js": "^2.8.22",
     "uglifyjs-webpack-plugin": "^0.4.2",
     "webpack": "^3.5.6",

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -167,6 +167,7 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
     const DisplayPanelAd = () =>
       hasPanel &&
       <DisplayPanel
+        isMobile={this.props.isMobile}
         unit={this.props.display.panel}
         campaign={campaign}
       />
@@ -226,7 +227,7 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
                       {/*
                         Display Ad
                       */}
-                      {this.props.display &&
+                      {!isMobile && this.props.display &&
                         <DisplayPanelAd />}
 
                     </Sidebar>
@@ -265,17 +266,17 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
 
                   {displayOverflows
                     ? <FooterContainerOverflow>
-                      <DisplayCanvas
-                        unit={this.props.display.canvas}
-                        campaign={campaign}
-                      />
-                    </FooterContainerOverflow>
+                        <DisplayCanvas
+                          unit={this.props.display.canvas}
+                          campaign={campaign}
+                        />
+                      </FooterContainerOverflow>
                     : <FooterContainer>
-                      <DisplayCanvas
-                        unit={this.props.display.canvas}
-                        campaign={campaign}
-                      />
-                    </FooterContainer>
+                        <DisplayCanvas
+                          unit={this.props.display.canvas}
+                          campaign={campaign}
+                        />
+                      </FooterContainer>
                   }
                 </div>
               )}
@@ -292,7 +293,10 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
 
     return (
       <ArticleContainer marginTop={marginTop}>
-        {article.layout === "feature" ? this.renderFeatureArticle() : this.renderStandardArticle()}
+        {article.layout === "feature"
+          ? this.renderFeatureArticle()
+          : this.renderStandardArticle()}
+
         <FullscreenViewer
           onClose={this.closeViewer}
           show={this.state.viewerIsOpen}
@@ -329,6 +333,6 @@ const FooterContainer = styled.div`
 const FooterContainerOverflow = styled.div`
   margin-left: 40px;
   ${pMedia.md`
-    margin-left: 0
+    margin-left: 0;
   `}
 `

--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -19,13 +19,21 @@ interface CanvasContainerProps {
   unit?: any
 }
 
+interface State {
+  isMounted: boolean
+}
+
 @track()
-export class CanvasContainerComponent extends React.Component<CanvasContainerProps, null> {
+export class CanvasContainerComponent extends React.Component<CanvasContainerProps, State> {
   static defaultProps = {
     size: { width: 1250 }
   }
 
   public canvasVideoHandlers: any
+
+  state = {
+    isMounted: false
+  }
 
   constructor(props) {
     super(props)
@@ -39,7 +47,9 @@ export class CanvasContainerComponent extends React.Component<CanvasContainerPro
     unit_layout: unitLayout(props)
   })))
   componentDidMount() {
-    // noop
+    this.setState({
+      isMounted: true
+    })
   }
 
   // TODO: Ensure that full element can be clicked on video complete
@@ -83,6 +93,12 @@ export class CanvasContainerComponent extends React.Component<CanvasContainerPro
       target: "_blank",
       containerWidth: size.width,
       layout
+    }
+
+    // TODO: For whatever the slideshow leads to a race condition when rendering
+    // app in Force. Defer execution and everything works fine.
+    if (!this.state.isMounted) {
+      return <div />
     }
 
     // Overlay

--- a/src/Components/Publishing/Display/__test__/DisplayPanel.test.js
+++ b/src/Components/Publishing/Display/__test__/DisplayPanel.test.js
@@ -46,6 +46,10 @@ describe('units', () => {
     )
   }
 
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   describe('#componentDidMount', () => {
     it('tracks interaction', () => {
       getWrapper()
@@ -121,7 +125,7 @@ describe('units', () => {
         })
 
         it('clicks away if outside media area', () => {
-          global.open = jest.fn()
+          const spy = jest.spyOn(global, 'open')
           const wrapper = getWrapper({ isMobile: true, isVideo: true })
           const event = {
             preventDefault: jest.fn(),
@@ -131,13 +135,13 @@ describe('units', () => {
           }
           wrapper.instance().handleClick(event)
           expect(wrapper.state().isPlaying).toEqual(false)
-          expect(global.open).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
         })
       })
 
       describe('Image', () => {
         it('opens a link if user has already clicked once', () => {
-          global.open = jest.fn()
+          const spy = jest.spyOn(global, 'open')
           const wrapper = getWrapper({ isMobile: true })
           const event = {
             preventDefault: jest.fn(),
@@ -146,13 +150,12 @@ describe('units', () => {
             }
           }
           wrapper.instance().handleClick(event)
-          expect(global.open).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           wrapper.instance().handleClick(event)
-          expect(global.open).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
         })
 
         it('toggles cover image on click and toggles back on click away', () => {
-          global.open = jest.fn()
           const wrapper = getWrapper({ isMobile: true })
           const event = {
             preventDefault: jest.fn(),
@@ -167,7 +170,7 @@ describe('units', () => {
         })
 
         it('clicks away if outside media area', () => {
-          global.open = jest.fn()
+          const spy = jest.spyOn(global, 'open')
           const wrapper = getWrapper({ isMobile: true })
           const event = {
             preventDefault: jest.fn(),
@@ -176,14 +179,13 @@ describe('units', () => {
             }
           }
           wrapper.instance().handleClick(event)
-          expect(global.open).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
         })
       })
     })
 
     describe('Desktop', () => {
       it('pauses the video if video', () => {
-        global.open = jest.fn()
         const spy = jest.spyOn(DisplayPanel.prototype, 'pauseVideo')
         const wrapper = getWrapper({ isVideo: true })
         const event = {
@@ -199,7 +201,7 @@ describe('units', () => {
       it('always clicks away', () => {
         const isVideo = [true, false]
         isVideo.forEach(type => {
-          global.open = jest.fn()
+          const spy = jest.spyOn(global, 'open')
           const wrapper = getWrapper({ isVideo: type })
           const event = {
             preventDefault: jest.fn(),
@@ -208,7 +210,7 @@ describe('units', () => {
             }
           }
           wrapper.instance().handleClick(event)
-          expect(global.open).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
         })
       })
     })

--- a/src/Components/Publishing/Header/BasicHeader.tsx
+++ b/src/Components/Publishing/Header/BasicHeader.tsx
@@ -149,7 +149,7 @@ const Container = div`
   margin-top: 70px;
 
   ${p => p.hasVideo && `
-    margin-top: -20px;
+    margin-top: -40px;
   `}
 
   ${CoverImage}, ${IFrame} {

--- a/src/Components/Publishing/Sections/ImageWrapper.tsx
+++ b/src/Components/Publishing/Sections/ImageWrapper.tsx
@@ -86,11 +86,13 @@ const Fullscreen = styled.div`
 
 const StyledImageWrapper = styled.div`
   position: relative;
+
   &:hover {
     ${Fullscreen} {
       opacity: 1;
     }
   }
+
   ${pMedia.sm`
     ${Fullscreen} {
       opacity: 1;

--- a/src/Components/Publishing/__stories__/Article.story.tsx
+++ b/src/Components/Publishing/__stories__/Article.story.tsx
@@ -66,13 +66,13 @@ const story = storiesOf("Publishing/Articles", module)
   })
 
 
-const ads = ["overlay", "image", "video", "slideshow"]
-ads.forEach(mediaType => {
-  story.add(`Standard with ${mediaType} ad`, () => {
+const displays = ["overlay", "image", "video", "slideshow"]
+displays.forEach(displayType => {
+  story.add(`Standard with ${displayType} ad`, () => {
     return (
       <Article
         article={StandardArticle}
-        display={Display(mediaType)}
+        display={Display(displayType)}
         relatedArticlesForPanel={RelatedPanel}
         relatedArticlesForCanvas={RelatedCanvas}
         emailSignupUrl="#"
@@ -146,6 +146,7 @@ story.add("Feature", () => {
     return (
       <Article
         article={article}
+        display={Display('image')}
         relatedArticlesForPanel={RelatedPanel}
         relatedArticlesForCanvas={RelatedCanvas}
         emailSignupUrl="#"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "es2015",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "rootDir": "src",
-    "jsx": "react",
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "src",
-    "outDir": "dist",
+    "experimentalDecorators": true,
+    "jsx": "react",
+    "module": "es2015",
+    "moduleResolution": "node",
     "noUnusedLocals": true,
-    "experimentalDecorators": true
+    "outDir": "dist",
+    "plugins": [
+      { "name": "typescript-styled-plugin" }
+    ],
+    "rootDir": "src",
+    "sourceMap": true,
+    "target": "es6"
   },
   "exclude": ["node_modules", "dist", "data", "externals", "danger"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9035,6 +9035,18 @@ typescript-babel-jest@^1.0.3:
     babel-jest "19.0.0"
     typescript "2.2.2"
 
+typescript-styled-plugin@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/typescript-styled-plugin/-/typescript-styled-plugin-0.1.2.tgz#c889be34c881c4f63a71d04d826c1e7ea7bbeec1"
+  dependencies:
+    typescript-template-language-service-decorator "0.1.2"
+    vscode-css-languageservice "^2.1.10"
+    vscode-languageserver-types "^3.4.0"
+
+typescript-template-language-service-decorator@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-0.1.2.tgz#d64153b3417af4a7b0143a5e6d10a26ba034db83"
+
 typescript@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
@@ -9374,6 +9386,21 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+vscode-css-languageservice@^2.1.10:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-2.1.11.tgz#051ad9681d50ceee5f83a20142c8c659a8011ede"
+  dependencies:
+    vscode-languageserver-types "^3.4.0"
+    vscode-nls "^2.0.1"
+
+vscode-languageserver-types@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.4.0.tgz#5043ae47ee4ac16af07bb3d0ca561235e0c0d2fa"
+
+vscode-nls@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-2.0.2.tgz#808522380844b8ad153499af5c3b03921aea02da"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
One of the more frustrating bug sequences I've encountered:

1. When testing the new Publishing layout in staging, I would notice that the view would occasionally break
1. Digging in, I noticed that it would only break when the Display ad was image-based, not video 
1. That led me to conclude that the immediate right sidebar link was the culprit -- and more specifically the new mobile-based injection code
1. I pulled that all apart, compiled and restarted innumerable times
1. This led me to uncover an issue related to infinite scroll Display injection, so i guess that 1/2 day's worth of time was worth it 😓 
1. Realized however that the issue has nothing to do with the sidebar Display, although the state of the sidebar Display is indicative of the problem -- if image, it breaks, if video, all good
1. Proceeded to comment out JSX node after JSX node to track down execution; yay to binary search
1. Found it was related to the Canvas Display and learned...
1. That there's always a canvas display if there's a sidebar display, and the canvas display state is tied to the sidebar display state -- if video on side, standard on bottom; if standard on side, slideshow on bottom
1. Continued commenting out nodes -- all the while having to compile Reaction, stop / start force, and then refresh page until proper combo appeared -- until it occurred to me that this was a race related to SSR and all I had to do was defer rendering of slideshow until on client
1. Bug fixed, chris ☠️ 
