### PR TITLE
Add video playback tracking to display video component

### DIFF
--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -54,24 +54,17 @@ export class CanvasContainerComponent extends React.Component<CanvasContainerPro
 
   // TODO: Ensure that full element can be clicked on video complete
   // Prevent links from blocking video playback.
-  @track((props, [e]) => ({
+  @track((props, [e]) => !isVideoClickArea(e) && {
     action: "Click",
     label: "Display ad clickthrough",
     entity_type: "display_ad",
     campaign_name: props.campaign.name,
     unit_layout: unitLayout(props)
-  }))
+  })
   openLink(e) {
     e.preventDefault()
 
-    const videoClasses = [
-      'PlayButton',
-      'PlayButton__PlayButtonCaret',
-      'CanvasVideo__video'
-    ]
-    const isVideoClickArea = videoClasses.some(c => e.target.className.includes(c))
-
-    if (!isVideoClickArea) {
+    if (!isVideoClickArea(e)) {
       if (this.canvasVideoHandlers) {
         this.canvasVideoHandlers.pauseVideo()
       }
@@ -183,6 +176,15 @@ const unitLayout = (props) => {
     case "slideshow": return "canvas_slideshow"
     default: return "canvas_standard"
   }
+}
+
+const isVideoClickArea = (e) => {
+  const videoClasses = [
+    'PlayButton',
+    'PlayButton__PlayButtonCaret',
+    'CanvasVideo__video'
+  ]
+  return videoClasses.some(c => e.target.className.includes(c))
 }
 
 export const maxAssetSize = containerWidth => {


### PR DESCRIPTION
This follows the tracking events we did for [Venice 360](https://github.com/artsy/force/blob/master/desktop/apps/editorial_features/components/venice_2017/client/video.coffee#L117-L145) for tracking 3 & 10 second intervals as well as percent complete. It also fixes a small bug where clicking the video play button would count as a clickthrough tracking event.