### PR TITLE
@kanaabe => Add cover image support to Canvas video

### DIFF
--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -75,7 +75,7 @@ export class CanvasContainerComponent extends React.Component<CanvasContainerPro
 
   render() {
     const { campaign, disclaimer, size, unit } = this.props
-    const { assets, layout, link: { url } } = unit
+    const { assets, cover_image_url, layout, link: { url } } = unit
     const isOverlay = layout === 'overlay'
     const isSlideshow = layout === 'slideshow'
 
@@ -133,6 +133,7 @@ export class CanvasContainerComponent extends React.Component<CanvasContainerPro
         <CanvasLink {...linkProps}>
           {isVideo
             ? <CanvasVideo
+                coverUrl={cover_image_url}
                 src={asset.url}
                 campaign={campaign}
                 onInit={h => this.canvasVideoHandlers = h}

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -1124,6 +1124,8 @@ exports[`renders the canvas in standard layout with video 1`] = `
 }
 
 .c4 {
+  background: url(https://artsy-media-uploads.s3.amazonaws.com/XkEYc3dH8HiRVKCIogWfUw%2FBombay+Display+Thumbnail.PNG) no-repeat center center;
+  background-size: cover;
   position: absolute;
   top: 0;
   left: 0;

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -129,6 +129,7 @@ export const UnitCanvasVideo = {
     url: "http://artsy.net",
   },
   assets: [{ url: "https://artsy-media-uploads.s3.amazonaws.com/z9w_n6UxxoZ_u1lzt4vwrw%2FHero+Loop+02.mp4" }],
+  cover_image_url: "https://artsy-media-uploads.s3.amazonaws.com/XkEYc3dH8HiRVKCIogWfUw%2FBombay+Display+Thumbnail.PNG",
   logo: "http://files.artsy.net/images/artsy-logo-wide-black.png",
   disclaimer:
   "Donec id elit non mi porta gravida at eget metus. Cras justo odio, dapibus ac facilisis in, egestas eget quam.",

--- a/tslint.json
+++ b/tslint.json
@@ -3,12 +3,13 @@
   "rules": {
     "curly": false,
     "interface-name": [true, "never-prefix"],
-    "object-literal-sort-keys": false,
-    "member-access": [false],
-    "no-unused-expression": false,
-    "max-classes-per-file": [false],
-    "jsx-no-lambda": false,
     "jsx-boolean-value": [true, "never"],
-    "no-var-requires": false
+    "jsx-no-lambda": false,
+    "max-classes-per-file": [false],
+    "member-access": [false],
+    "member-ordering": false,
+    "no-unused-expression": false,
+    "no-var-requires": false,
+    "object-literal-sort-keys": false
   }
 }


### PR DESCRIPTION
Adds cover image support to canvas video. 

**NOTE!** There is no field in positron for uploading cover images in this way, so pulls from display ad. 

<img width="390" alt="screen shot 2017-11-06 at 3 38 50 pm" src="https://user-images.githubusercontent.com/236943/32469681-9c57750a-c308-11e7-92b6-52b22f2a5b56.png">
