### PR TITLE
Update tracking / tests

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -164,17 +164,22 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
     const campaign = omit(display, "panel", "canvas")
     const displayOverflows = display && display.canvas.layout === "slideshow"
 
-    const DisplayPanelAd = () =>
-      hasPanel &&
-      <DisplayPanel
-        isMobile={this.props.isMobile}
-        unit={this.props.display.panel}
-        campaign={campaign}
-      />
-
     return (
       <Responsive initialState={{ isMobile: this.props.isMobile }}>
         {({ isMobile, xs, sm, md }) => {
+          const isMobileAd = Boolean(isMobile || xs || sm || md)
+
+          const DisplayPanelAd = () => {
+            return (
+              hasPanel &&
+              <DisplayPanel
+                isMobile={isMobileAd}
+                unit={this.props.display.panel}
+                campaign={campaign}
+              />
+            )
+          }
+
           return (
             <div>
               <ReadMoreWrapper
@@ -197,7 +202,7 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
                     <Sections
                       DisplayPanel={DisplayPanelAd}
                       article={article}
-                      isMobile={Boolean(isMobile || xs || sm || md)}
+                      isMobile={isMobile}
                     />
 
                     {/*
@@ -227,7 +232,7 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
                       {/*
                         Display Ad
                       */}
-                      {!isMobile && this.props.display &&
+                      {!isMobileAd && this.props.display &&
                         <DisplayPanelAd />}
 
                     </Sidebar>

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
@@ -35,7 +35,7 @@ exports[`snapshots renders the display panel with an image 1`] = `
   background-size: cover;
 }
 
-.c1 .wwfs2u-1-file__Image-iTToDH {
+.c1 .xu5qbr-1-file__Image-iTToDH {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -168,7 +168,7 @@ exports[`snapshots renders the display panel with video 1`] = `
   justify-content: center;
 }
 
-.ctoaKm .c3 {
+.foDurm .c3 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -187,7 +187,7 @@ exports[`snapshots renders the display panel with video 1`] = `
   box-sizing: border-box;
 }
 
-.c1 .file__Image-wwfs2u-1 {
+.c1 .file__Image-xu5qbr-1 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlHEsRROMLasYi9yZtgTR7A%252Fbombay_artsy_panel_640_28_480.mp4&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -296,7 +296,6 @@ exports[`snapshots renders the display panel with video 1`] = `
   >
     <div
       className="VideoContainer c2"
-      onClick={[Function]}
     >
       <div
         className="VideoContainer__VideoCover c3 c4"

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -102,11 +102,11 @@ export class Sections extends Component<Props, State> {
   }
 
   mountDisplayToMarker() {
-    const { DisplayPanel, isMobile } = this.props
+    const { DisplayPanel } = this.props
     const displayMountPoint = document.getElementById(this.displayInjectId)
 
     if (displayMountPoint) {
-      ReactDOM.render(<DisplayPanel isMobile={isMobile} />, displayMountPoint)
+      ReactDOM.render(<DisplayPanel />, displayMountPoint)
     } else {
       console.error(
         '(reaction/Sections.tsx) Error mounting Display: DOM node ',


### PR DESCRIPTION
This fixes an issue that was noticed where tracking wasn't firing on mobile due to `ReactDOM.render` not passing along context (during ad injection). Also added some more tests.

cc @craigspaeth - I ditched the method decorators so that this would be easier to test! 