### PR TITLE
@craigspaeth => Video accepts custom tracking params

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -52,9 +52,15 @@ interface ArticleContainerProps {
   marginTop?: string
 }
 
-@track({ page: "Article" }, {
-  dispatch: data => Events.postEvent(data)
-})
+@track((props) => {
+  return {
+    page: "Article",
+    entity_type: "article",
+    entity_id: props.article.id
+  }}, {
+    dispatch: data => Events.postEvent(data)
+  }
+)
 export class Article extends React.Component<ArticleProps, ArticleState> {
   static childContextTypes = {
     onViewFullscreen: PropTypes.func,

--- a/src/Components/Publishing/Sections/Video.tsx
+++ b/src/Components/Publishing/Sections/Video.tsx
@@ -2,7 +2,9 @@ import React from "react"
 import sizeMe from "react-sizeme"
 import styled, { StyledFunction } from "styled-components"
 import urlParser from "url"
+import Events from "../../../Utils/Events"
 import { resize } from "../../../Utils/resizer"
+import track from "../../../Utils/track"
 import { pMedia as breakpoint } from "../../Helpers"
 import { SIZE_ME_REFRESH_RATE } from "../Constants"
 import { Layout } from "../Typings"
@@ -20,6 +22,8 @@ interface VideoProps {
     cover_image_url?: string
   }
   size?: any
+  tracking?: any
+  trackingData?: any
   layout?: Layout
 }
 
@@ -28,11 +32,23 @@ interface VideoState {
   hidden: boolean
 }
 
+@track({}, {
+  dispatch: data => Events.postEvent(data)
+})
+
+@track((props) => {
+  return props.trackingData ? props.trackingData : {}
+}, {
+  dispatch: data => Events.postEvent(data)
+})
 class VideoComponent extends React.Component<VideoProps, VideoState> {
   static defaultProps = {
     size: {
       width: 500,
     },
+    tracking: {
+      trackEvent: x => x
+    }
   }
 
   constructor(props) {
@@ -60,12 +76,22 @@ class VideoComponent extends React.Component<VideoProps, VideoState> {
         hidden: true
       }
     }
-
+    this.playVideo = this.playVideo.bind(this)
+ 
   }
 
-  playVideo = () => {
+  trackVideoClick() {
+    const trackParams = {
+      action: "Click",
+      label: "Play video",
+    }
+    this.props.tracking.trackEvent(trackParams)
+  }
+
+  playVideo() {
     const playerSrc = this.state.src + "&autoplay=1"
     this.setState({ src: playerSrc, hidden: true })
+    this.trackVideoClick()
   }
 
   render() {

--- a/src/Components/Publishing/Sections/Video.tsx
+++ b/src/Components/Publishing/Sections/Video.tsx
@@ -32,10 +32,6 @@ interface VideoState {
   hidden: boolean
 }
 
-@track({}, {
-  dispatch: data => Events.postEvent(data)
-})
-
 @track((props) => {
   return props.trackingData ? props.trackingData : {}
 }, {
@@ -81,11 +77,10 @@ class VideoComponent extends React.Component<VideoProps, VideoState> {
   }
 
   trackVideoClick() {
-    const trackParams = {
+    this.props.tracking.trackEvent({
       action: "Click",
       label: "Play video",
-    }
-    this.props.tracking.trackEvent(trackParams)
+    })
   }
 
   playVideo() {

--- a/src/Components/Publishing/__stories__/Video.story.tsx
+++ b/src/Components/Publishing/__stories__/Video.story.tsx
@@ -26,3 +26,11 @@ storiesOf("Publishing/Video", module)
       </div>
     )
   })
+  .add("Video with custom tracking data", () => {
+    const data = { entity_id: "1234", entity_type: "feature" }
+    return (
+      <div style={{ width: "100vw", position: "relative" }}>
+        <Video section={Videos[0]} layout="standard" trackingData={data} />
+      </div>
+    )
+  })


### PR DESCRIPTION
Pairing w @kanaabe 

- Adds entity_type and enitity_id to Article root tracking event
- Adds event for video play to Video component, accepts custom trackingData as a prop or defaults to Article's track event data.