### PR TITLE
Stop multiple impression tracking calls

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -182,6 +182,7 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
                 isMobile={isMobileAd}
                 unit={this.props.display.panel}
                 campaign={campaign}
+                article={article}
               />
             )
           }
@@ -280,12 +281,14 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
                         <DisplayCanvas
                           unit={this.props.display.canvas}
                           campaign={campaign}
+                          article={article}
                         />
                       </FooterContainerOverflow>
                     : <FooterContainer>
                         <DisplayCanvas
                           unit={this.props.display.canvas}
                           campaign={campaign}
+                          article={article}
                         />
                       </FooterContainer>
                   }

--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -1,4 +1,3 @@
-import { once } from "lodash"
 import React from "react"
 import sizeMe from "react-sizeme"
 import styled, { StyledFunction } from "styled-components"
@@ -6,12 +5,14 @@ import { crop } from "../../../../Utils/resizer"
 import { track } from "../../../../Utils/track"
 import { pMedia } from "../../../Helpers"
 import { SIZE_ME_REFRESH_RATE } from "../../Constants"
+import { trackImpression } from "../track-impression"
 import { CanvasSlideshow } from "./CanvasSlideshow"
 import { CanvasText } from "./CanvasText"
 import { CanvasVideo } from "./CanvasVideo"
 
 interface CanvasContainerProps {
   campaign: any
+  article?: any
   disclaimer?: any
   size?: {
     width: number
@@ -40,12 +41,7 @@ export class CanvasContainerComponent extends React.Component<CanvasContainerPro
     this.openLink = this.openLink.bind(this)
   }
 
-  @track(once((props) => ({
-    action: "Impression",
-    entity_type: "display_ad",
-    campaign_name: props.campaign.name,
-    unit_layout: unitLayout(props)
-  })))
+  @trackImpression((props) => unitLayout(props))
   componentDidMount() {
     this.setState({
       isMounted: true

--- a/src/Components/Publishing/Display/Canvas/index.tsx
+++ b/src/Components/Publishing/Display/Canvas/index.tsx
@@ -9,10 +9,11 @@ import { CanvasContainer } from "./CanvasContainer"
 interface DisplayCanvasProps {
   unit: any
   campaign: any
+  article?: any
 }
 
 export const DisplayCanvas: React.SFC<DisplayCanvasProps> = props => {
-  const { unit, campaign } = props
+  const { unit, campaign, article } = props
   const url = get(unit, 'link.url', '')
 
   const disclaimer = (
@@ -32,6 +33,7 @@ export const DisplayCanvas: React.SFC<DisplayCanvasProps> = props => {
       <CanvasContainer
         unit={unit}
         campaign={campaign}
+        article={article}
         disclaimer={disclaimer}
       />
 

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -8,9 +8,11 @@ import { track } from "../../../Utils/track"
 import { pMedia as breakpoint } from "../../Helpers"
 import { Fonts } from "../Fonts"
 import { VideoControls } from "../Sections/VideoControls"
+import { trackImpression } from "./track-impression"
 
 interface Props extends React.HTMLProps<HTMLDivElement> {
   campaign: any
+  article?: any
   isMobile?: boolean
   unit: any
   tracking?: any
@@ -45,17 +47,11 @@ export class DisplayPanel extends Component<Props, State> {
     this.handleMouseLeave = this.handleMouseLeave.bind(this)
   }
 
+  @trackImpression(() => "panel")
   componentDidMount() {
     if (this.video) {
       this.video.onended = this.pauseVideo
     }
-
-    this.props.tracking.trackEvent({
-      action: "Impression",
-      entity_type: "display_ad",
-      campaign_name: this.props.campaign.name,
-      unit_layout: "panel"
-    })
   }
 
   componentWillUpdate() {

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
@@ -35,7 +35,7 @@ exports[`snapshots renders the display panel with an image 1`] = `
   background-size: cover;
 }
 
-.c1 .xu5qbr-1-file__Image-iTToDH {
+.c1 .s1osrrjc-1-file__Image-iTToDH {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -168,7 +168,7 @@ exports[`snapshots renders the display panel with video 1`] = `
   justify-content: center;
 }
 
-.foDurm .c3 {
+.iJhdQN .c3 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -187,7 +187,7 @@ exports[`snapshots renders the display panel with video 1`] = `
   box-sizing: border-box;
 }
 
-.c1 .file__Image-xu5qbr-1 {
+.c1 .file__Image-s1osrrjc-1 {
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlHEsRROMLasYi9yZtgTR7A%252Fbombay_artsy_panel_640_28_480.mp4&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }

--- a/src/Components/Publishing/Display/track-impression.ts
+++ b/src/Components/Publishing/Display/track-impression.ts
@@ -1,0 +1,42 @@
+const alreadyFired = {}
+
+/**
+ * An impression tracking utility for display ads that tries to not double 
+ * track the same impression by checking a cache of previous impressions.
+ * 
+ * @example
+ *
+ *      import { track } from "src/utils/track"
+ *
+ *      @track()
+ *      class DisplayAd extends React.Component<{}, null> {
+ * 
+ *        @trackImpression(() => "panel")
+ *        componentDidMount() {
+ *          // ...
+ *        }
+ *      }
+ */
+export function trackImpression(unitLayout) {
+  return (target, name, descriptor) => {
+    const decoratedFn = descriptor.value
+    // tslint:disable-next-line:only-arrow-functions
+    descriptor.value = function () {
+      const key = [
+        this.props.campaign.name,
+        unitLayout(this.props),
+        (this.props.article && this.props.article.id) ||
+        this._reactInternalInstance._debugID
+      ].join(':')
+      if (alreadyFired[key]) return decoratedFn.apply(this, arguments)
+      this.props.tracking && this.props.tracking.trackEvent({
+        action: "Impression",
+        entity_type: "display_ad",
+        campaign_name: this.props.campaign.name,
+        unit_layout: unitLayout(this.props)
+      })
+      alreadyFired[key] = true
+      decoratedFn.apply(this, arguments)
+    }
+  }
+}


### PR DESCRIPTION
Yikes, what a rabbit hole. This implements a `trackImpression` decorator that stores a cache of the previous impressions to prevent multiples being fired. This avoids the React lifecycle pitfalls and the decorator hides some ugliness and feels a bit more in the style of React Tracking. [Context from Slack](https://artsy.slack.com/archives/C3YTM6BTK/p1510171534000387)

PS. I thought I disliked decorators before—now after writing one... 😵 ...so complicated
