### PR TITLE
@damassi => Fixes CanvasSlideshow cutting text off

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -277,13 +277,13 @@ export class Article extends React.Component<ArticleProps, ArticleState> {
                   <LineBreak />
 
                   {displayOverflows
-                    ? <FooterContainerOverflow>
+                    ? <div>
                         <DisplayCanvas
                           unit={this.props.display.canvas}
                           campaign={campaign}
                           article={article}
                         />
-                      </FooterContainerOverflow>
+                      </div>
                     : <FooterContainer>
                         <DisplayCanvas
                           unit={this.props.display.canvas}
@@ -341,12 +341,5 @@ const FooterContainer = styled.div`
   margin: 0 40px;
   ${pMedia.sm`
     margin: 0 20px;
-  `}
-`
-
-const FooterContainerOverflow = styled.div`
-  margin-left: 40px;
-  ${pMedia.md`
-    margin-left: 0;
   `}
 `

--- a/src/Components/Publishing/Display/Canvas/CanvasSlideshow.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasSlideshow.tsx
@@ -223,6 +223,7 @@ const SliderContainer = responsiveDiv`
     max-height: ${props => "calc(" + maxAssetSize(props.containerWidth).height + "px + 2.5em);"}
     padding: 0 !important;
   }
+
   ${props => pMedia.md`
     max-height: ${maxAssetSize(props.containerWidth).height + "px;"}
   `}
@@ -230,30 +231,28 @@ const SliderContainer = responsiveDiv`
 const Slide = responsiveDiv`
   margin-right: 20px;
   &.title-card {
+    max-width: 1250px;
+    width: ${props => props.containerWidth + "px;"}
     display: flex;
     justify-content: space-between;
-    width: 1250px;
-    ${props => pMedia.lg`
-      max-width: ${props.containerWidth + "px;"}
-    `}
     ${props => pMedia.md`
       max-width: ${maxAssetSize(props.containerWidth).width + "px;"}
-  `}
+    `}
   }
 `
 const Title = responsiveDiv`
-  display: inline-block;
   width: 380px;
   padding: 0 20px 0 0;
-  ${props => pMedia.lg`
+  ${props => pMedia.xl`
+    padding: 0 40px;
     width: ${props.containerWidth * 0.35 + "px;"}
     a {
       max-height: ${maxAssetSize(props.containerWidth).height + "px;"}
     }
   `}
   ${pMedia.md`
-    width: 100%;
     padding: 0 20px;
+    width: 100%;
     a {
       height: initial;
       max-height: initial;
@@ -269,8 +268,7 @@ const Disclaimer = styled.div`
 `
 const Image = responsiveImage`
   height: auto;
-  max-width: 780px;
-  max-height: 460px;
+  max-width: ${props => maxAssetSize(props.containerWidth).width + "px;"}
   object-fit: cover;
   object-position: center;
   ${props => pMedia.lg`

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -292,6 +292,8 @@ exports[`renders the canvas in slideshow layout 1`] = `
 }
 
 .c3.title-card {
+  max-width: 1250px;
+  width: 1250px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -300,11 +302,9 @@ exports[`renders the canvas in slideshow layout 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 1250px;
 }
 
 .c4 {
-  display: inline-block;
   width: 380px;
   padding: 0 20px 0 0;
 }
@@ -315,8 +315,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
 
 .c12 {
   height: auto;
-  max-width: 780px;
-  max-height: 460px;
+  max-width: 812.5px;
   object-fit: cover;
   object-position: center;
 }
@@ -460,20 +459,15 @@ exports[`renders the canvas in slideshow layout 1`] = `
   }
 }
 
-@media (max-width:1080px) {
-  .c3.title-card {
-    max-width: 1250px;
-  }
-}
-
 @media (max-width:900px) {
   .c3.title-card {
     max-width: 812.5px;
   }
 }
 
-@media (max-width:1080px) {
+@media (max-width:1280px) {
   .c4 {
+    padding: 0 40px;
     width: 437.5px;
   }
 
@@ -484,8 +478,8 @@ exports[`renders the canvas in slideshow layout 1`] = `
 
 @media (max-width:900px) {
   .c4 {
-    width: 100%;
     padding: 0 20px;
+    width: 100%;
   }
 
   .c4 a {


### PR DESCRIPTION
Addresses https://waffle.io/artsy/publishing/cards/5a031d4133995d00a880c149

This fixes the issue of cutting off text, but the margins still aren't perfect. There's a moment between 1280px and 1320px where the margin isn't consistent. After faffing with this one for a while, I think it's best we rewrite the way these slides work with `react-slick`. Half of this battle was understanding the CSS. 

For now, this solves the problem but I look forward to refactoring this component. 