### PR TITLE
[WIP] Add Publishing SSR App / Fix Webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,101 @@
+const webpack = require("webpack")
+const path = require("path")
+const { NODE_ENV, PORT } = process.env
+const isDevelopment = NODE_ENV === "development"
+const isStaging = NODE_ENV === "staging"
+const isProduction = NODE_ENV === "production"
+const isDeploy = isStaging || isProduction
+
+const config = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: {
+    login: ["./src/Apps/Loyalty/Containers/Login/Browser"],
+    inquiries: ["./src/Apps/Loyalty/Containers/Inquiries/Browser"],
+    forgot_password: ["./src/Apps/Loyalty/Containers/ForgotPassword/Browser"],
+    analytics: ["./src/Apps/Loyalty/ClientSideAnalytics"],
+  },
+  module: {
+    rules: [
+      { test: /\.json$/, loader: "json-loader" },
+      {
+        test: /\.tsx?$/,
+        exclude: [/node_modules/, /__stories__/, /__tests__/],
+        use: [
+          {
+            loader: "awesome-typescript-loader",
+            options: {
+              useBabel: true,
+              useCache: true,
+              useTranspileModule: true, // Supposedly faster, won’t work if/when we emit TS declaration files.
+            },
+          },
+        ],
+      },
+    ],
+  },
+  output: {
+    filename: "[name].js",
+    path: path.join(__dirname, "../dist/Apps/Loyalty/Server/bundles"),
+    publicPath: "/Loyalty/bundles",
+  },
+  externals: {
+    react: 'react',
+    "react-dom": 'react-dom'
+  },
+  plugins: [
+    new webpack.optimize.CommonsChunkPlugin("commons.chunk"),
+    new webpack.DefinePlugin({
+      "process.env": {
+        'NODE_ENV': JSON.stringify(NODE_ENV)
+      }
+    })
+  ],
+  resolve: {
+    extensions: [".ts", ".tsx", ".js", ".jsx"],
+  }
+}
+
+// Development
+if (isDevelopment) {
+  config.entry = Object.keys(config.entry)
+    .reduce((entry, key) => {
+      const app = config.entry[key]
+      return {
+        ...entry,
+        [key]: app.unshift([
+          "babel-polyfill",
+          "webpack-hot-middleware/client?reload=true"
+        ])
+      }
+    }, {})
+
+  config.module.rules.push({
+    test: /\.tsx?$/,
+    include: /src/,
+    use: ["react-hot-loader"]
+  })
+
+  config.plugins.push([
+    new CheckerPlugin(),
+    new webpack.HotModuleReplacementPlugin()
+  ])
+
+  // Production
+} else if (isProduction) {
+  config.devtool = "source-map"
+  config.plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      beautify: false,
+      comments: false,
+      compress: {
+        warnings: false,
+      },
+      mangle: {
+        keep_fnames: true,
+      },
+      sourceMap: true,
+    }),
+  )
+}
+
+module.exports = config


### PR DESCRIPTION
#### WIP

After running into some unforeseen issues related to SSR and Force, I wanted to add the new Publishing work into our `apps` folder so that we can get a better idea of how things appear in the real-world, but while doing that work realized that there are some things broken configuration-wise and `webpack-hot-middleware` isn't working as it should.

This PR will include:

- Cleaned up Webpack config. There's some unnecessary stuff that we could trim out to make things a little bit speedier and more predictable (including errors that currently appear in console, etc)
- Add a new command `yarn watch` that will allow us (in hand with recent [express-reloadable](https://github.com/artsy/express-reloadable/pull/3) work) to "watch" compilation changes and output them to `dist` folder so that client apps pick them up
- Add a new Publishing `app`. Preliminary work has already been done [here](https://github.com/damassi/reaction/commit/0c0211401e4755f6d3960156574b653c193a20e4) but i think we could clean this up too to make it less `loyalty` specific and more generic. 

