### PR TITLE
@kanaabe => Update share labels

### DIFF
--- a/src/Components/Publishing/Byline/Share.tsx
+++ b/src/Components/Publishing/Byline/Share.tsx
@@ -37,8 +37,9 @@ export class Share extends React.Component<Props, null> {
     window.open(e.currentTarget.attributes.href.value, "Share", "width = 600,height = 300")
 
     this.props.tracking.trackEvent({
-      action: "Article share",
-      service: (() => {
+      action: "Click",
+      type: "share",
+      label: (() => {
         const href = e.currentTarget.attributes.href.value
         if (href.match("facebook")) return "facebook"
         if (href.match("twitter")) return "twitter"

--- a/src/Components/Publishing/__test__/ArticleTracking.test.tsx
+++ b/src/Components/Publishing/__test__/ArticleTracking.test.tsx
@@ -15,7 +15,8 @@ jest.mock("react-sizeme", () => jest.fn(c => d => d))
 it("emits analytics events to an event emitter", done => {
   const article = mount(<Article article={StandardArticle} />)
   Events.onEvent(data => {
-    expect(data.action).toEqual("Article share")
+    expect(data.action).toEqual("Click")
+    expect(data.type).toEqual("share")
     done()
   })
   const shareUrl = getArticleFullHref(StandardArticle.slug)


### PR DESCRIPTION
Per [input from @wrgoldstein](https://github.com/artsy/positron/issues/1416), updates labels on 'share' tracking data