### PR TITLE
@mzikherman => Use a different on-the-fly Cloudfront url for Display Ads

### DIFF
--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -137,7 +137,8 @@ export class CanvasContainerComponent extends React.Component<CanvasContainerPro
             : <Image
                 src={crop(asset.url, {
                   width: 1200,
-                  height: 760
+                  height: 760,
+                  isDisplay: true
                 })}
               />}
 

--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -138,7 +138,7 @@ export class CanvasContainerComponent extends React.Component<CanvasContainerPro
                 src={crop(asset.url, {
                   width: 1200,
                   height: 760,
-                  isDisplay: true
+                  isDisplayAd: true
                 })}
               />}
 

--- a/src/Components/Publishing/Display/Canvas/CanvasSlideshow.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasSlideshow.tsx
@@ -78,7 +78,7 @@ export class CanvasSlideshow extends React.Component<CanvasSlideshowProps, any> 
 
     return unit.assets.map((image, i) => {
       const renderTitleCard = i === 0 && containerWidth >= 900
-      const imageSrc = crop(image.url, { width: 780, height: 460 })
+      const imageSrc = crop(image.url, { width: 780, height: 460, isDisplay: true })
       const caption = image.caption || ''
 
       return (

--- a/src/Components/Publishing/Display/Canvas/CanvasSlideshow.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasSlideshow.tsx
@@ -78,7 +78,7 @@ export class CanvasSlideshow extends React.Component<CanvasSlideshowProps, any> 
 
     return unit.assets.map((image, i) => {
       const renderTitleCard = i === 0 && containerWidth >= 900
-      const imageSrc = crop(image.url, { width: 780, height: 460, isDisplay: true })
+      const imageSrc = crop(image.url, { width: 780, height: 460, isDisplayAd: true })
       const caption = image.caption || ''
 
       return (

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -334,9 +334,9 @@ export class DisplayPanel extends Component<Props, State> {
     const url = get(unit.assets, "0.url", "")
     const isVideo = this.isVideo()
     const cover = unit.cover_image_url || ""
-    const imageUrl = crop(url, { width: 680, height: 284, isDisplay: true })
-    const hoverImageUrl = resize(unit.logo, { width: 680, isDisplay: true })
-    const coverUrl = crop(cover, { width: 680, height: 284, isDisplay: true })
+    const imageUrl = crop(url, { width: 680, height: 284, isDisplayAd: true })
+    const hoverImageUrl = resize(unit.logo, { width: 680, isDisplayAd: true })
+    const coverUrl = crop(cover, { width: 680, height: 284, isDisplayAd: true })
 
     return (
       <Wrapper

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -334,9 +334,9 @@ export class DisplayPanel extends Component<Props, State> {
     const url = get(unit.assets, "0.url", "")
     const isVideo = this.isVideo()
     const cover = unit.cover_image_url || ""
-    const imageUrl = crop(url, { width: 680, height: 284 })
-    const hoverImageUrl = resize(unit.logo, { width: 680 })
-    const coverUrl = crop(cover, { width: 680, height: 284 })
+    const imageUrl = crop(url, { width: 680, height: 284, isDisplay: true })
+    const hoverImageUrl = resize(unit.logo, { width: 680, isDisplay: true })
+    const coverUrl = crop(cover, { width: 680, height: 284, isDisplay: true })
 
     return (
       <Wrapper

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -663,7 +663,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
             <img
               alt="Nullam id dolor ultricies vehicula."
               className="c12"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=780&height=460&quality=95"
+              src="https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=780&height=460&quality=95"
             />
             <div
               className="c13"
@@ -679,7 +679,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
             <img
               alt=""
               className="c12"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0aRUvnVgQKbQk5dj8xcCAg%2Flarger.jpg&width=780&height=460&quality=95"
+              src="https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0aRUvnVgQKbQk5dj8xcCAg%2Flarger.jpg&width=780&height=460&quality=95"
             />
             
           </div>
@@ -691,7 +691,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
             <img
               alt="Cras justo odio, dapibus ac facilisis in, egestas eget quam."
               className="c12"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco8j2xq40ROMyBrJQm_4eQ%252FDafenOilPaintingVillage_AK03.jpg&width=780&height=460&quality=95"
+              src="https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco8j2xq40ROMyBrJQm_4eQ%252FDafenOilPaintingVillage_AK03.jpg&width=780&height=460&quality=95"
             />
             <div
               className="c13"
@@ -707,7 +707,7 @@ exports[`renders the canvas in slideshow layout 1`] = `
             <img
               alt=""
               className="c12"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FtjVXiaCPt3Tv1EYS3JqX5g%252FFogoIsland_BridgeStudio_4985_photo_Alex_Fradkin.jpg&width=780&height=460&quality=95"
+              src="https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FtjVXiaCPt3Tv1EYS3JqX5g%252FFogoIsland_BridgeStudio_4985_photo_Alex_Fradkin.jpg&width=780&height=460&quality=95"
             />
             
           </div>
@@ -986,7 +986,7 @@ exports[`renders the canvas in standard layout with image 1`] = `
   >
     <img
       className="c3"
-      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=1200&height=760&quality=95"
+      src="https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=1200&height=760&quality=95"
     />
     <div
       className="c4"

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
@@ -31,12 +31,12 @@ exports[`snapshots renders the display panel with an image 1`] = `
 }
 
 .c1 .c2 {
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=680&height=284&quality=95) no-repeat center center;
+  background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
 
-.c1 .iu8kft-1-file__Image-iTToDH {
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
+.c1 .s1b035ml-1-file__Image-iTToDH {
+  background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
 
@@ -168,8 +168,8 @@ exports[`snapshots renders the display panel with video 1`] = `
   justify-content: center;
 }
 
-.dHLSju .c3 {
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
+.cAziSt .c3 {
+  background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
 
@@ -187,13 +187,13 @@ exports[`snapshots renders the display panel with video 1`] = `
   box-sizing: border-box;
 }
 
-.c1 .file__Image-iu8kft-1 {
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlHEsRROMLasYi9yZtgTR7A%252Fbombay_artsy_panel_640_28_480.mp4&width=680&height=284&quality=95) no-repeat center center;
+.c1 .file__Image-s1b035ml-1 {
+  background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlHEsRROMLasYi9yZtgTR7A%252Fbombay_artsy_panel_640_28_480.mp4&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
 
 .c1 .c3 {
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=680&height=284&quality=95) no-repeat center center;
+  background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
 

--- a/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
+++ b/src/Components/Publishing/Display/__test__/__snapshots__/DisplayPanel.test.js.snap
@@ -35,7 +35,7 @@ exports[`snapshots renders the display panel with an image 1`] = `
   background-size: cover;
 }
 
-.c1 .s1b035ml-1-file__Image-iTToDH {
+.c1 .s1vvma5u-1-file__Image-iTToDH {
   background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -168,7 +168,7 @@ exports[`snapshots renders the display panel with video 1`] = `
   justify-content: center;
 }
 
-.cAziSt .c3 {
+.cXgTmK .c3 {
   background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
@@ -187,7 +187,7 @@ exports[`snapshots renders the display panel with video 1`] = `
   box-sizing: border-box;
 }
 
-.c1 .file__Image-s1b035ml-1 {
+.c1 .file__Image-s1vvma5u-1 {
   background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlHEsRROMLasYi9yZtgTR7A%252Fbombay_artsy_panel_640_28_480.mp4&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }

--- a/src/Utils/__test__/resizer.test.ts
+++ b/src/Utils/__test__/resizer.test.ts
@@ -16,7 +16,7 @@ describe('resizer', () => {
       const url = crop('https://media.artsy.net/img.jpg', {
         width: 100,
         height: 100,
-        isDisplay: true
+        isDisplayAd: true
       })
       expect(url).toMatch('de5y2r7wr8mpb')
       expect(url).toMatch('&width=100&height=100&quality=95')
@@ -45,7 +45,7 @@ describe('resizer', () => {
     it('uses display url when passed as an option', () => {
       const url = resize('https://media.artsy.net/img.jpg', {
         width: 100,
-        isDisplay: true
+        isDisplayAd: true
       })
       expect(url).toMatch('de5y2r7wr8mpb')
       expect(url).toMatch('&width=100&quality=95')

--- a/src/Utils/__test__/resizer.test.ts
+++ b/src/Utils/__test__/resizer.test.ts
@@ -1,0 +1,54 @@
+import { crop, resize } from '../resizer'
+
+describe('resizer', () => {
+  describe('#crop', () => {
+    it('uses width, height, and quality', () => {
+      const url = crop('https://media.artsy.net/img.jpg', {
+        width: 100,
+        height: 100,
+        quality: 80
+      })
+      expect(url).toMatch('d7hftxdivxxvm')
+      expect(url).toMatch('&width=100&height=100&quality=80')
+    })
+
+    it('uses display url when passed as an option', () => {
+      const url = crop('https://media.artsy.net/img.jpg', {
+        width: 100,
+        height: 100,
+        isDisplay: true
+      })
+      expect(url).toMatch('de5y2r7wr8mpb')
+      expect(url).toMatch('&width=100&height=100&quality=95')
+    })
+  })
+
+  describe('#resize', () => {
+    it('resizes to a width', () => {
+      const url = resize('https://media.artsy.net/img.jpg', {
+        width: 100
+      })
+      expect(url).toMatch('d7hftxdivxxvm')
+      expect(url).toMatch('&width=100&quality=95')
+      expect(url).toMatch('resize_to=width')
+    })
+
+    it('resizes to a height', () => {
+      const url = resize('https://media.artsy.net/img.jpg', {
+        height: 100
+      })
+      expect(url).toMatch('d7hftxdivxxvm')
+      expect(url).toMatch('&height=100&quality=95')
+      expect(url).toMatch('resize_to=height')
+    })
+
+    it('uses display url when passed as an option', () => {
+      const url = resize('https://media.artsy.net/img.jpg', {
+        width: 100,
+        isDisplay: true
+      })
+      expect(url).toMatch('de5y2r7wr8mpb')
+      expect(url).toMatch('&width=100&quality=95')
+    })
+  })
+})

--- a/src/Utils/resizer.ts
+++ b/src/Utils/resizer.ts
@@ -12,9 +12,9 @@ export const crop = (src: string, options: {
   width: number,
   height: number,
   quality?: number,
-  isDisplay?: boolean
+  isDisplayAd?: boolean
 }) => {
-  const { width, height, quality, isDisplay } = options
+  const { width, height, quality, isDisplayAd } = options
 
   if (!width && !height) {
     warn("requires width and height")
@@ -35,7 +35,7 @@ export const crop = (src: string, options: {
     quality: quality || 95,
   }
 
-  const url = isDisplay ? GEMINI_DISPLAY_CLOUDFRONT_URL : GEMINI_CLOUDFRONT_URL
+  const url = isDisplayAd ? GEMINI_DISPLAY_CLOUDFRONT_URL : GEMINI_CLOUDFRONT_URL
   return [url, qs.stringify(config)].join("?")
 }
 
@@ -43,9 +43,9 @@ export const resize = (src: string, options: {
   width?: number,
   height?: number,
   quality?: number,
-  isDisplay?: boolean
+  isDisplayAd?: boolean
 }) => {
-  const { width, height, quality, isDisplay } = options
+  const { width, height, quality, isDisplayAd } = options
 
   let resizeTo
   if (width && !height) {
@@ -64,6 +64,6 @@ export const resize = (src: string, options: {
     quality: quality || 95,
   }
 
-  const url = isDisplay ? GEMINI_DISPLAY_CLOUDFRONT_URL : GEMINI_CLOUDFRONT_URL
+  const url = isDisplayAd ? GEMINI_DISPLAY_CLOUDFRONT_URL : GEMINI_CLOUDFRONT_URL
   return [url, qs.stringify(config)].join("?")
 }

--- a/src/Utils/resizer.ts
+++ b/src/Utils/resizer.ts
@@ -1,5 +1,6 @@
 import qs from "qs"
 const GEMINI_CLOUDFRONT_URL = "https://d7hftxdivxxvm.cloudfront.net"
+const GEMINI_DISPLAY_CLOUDFRONT_URL = "https://de5y2r7wr8mpb.cloudfront.net"
 
 const warn = message => {
   if (process.env.NODE_ENV === "development") {
@@ -7,8 +8,13 @@ const warn = message => {
   }
 }
 
-export const crop = (src: string, options: { width: number; height: number; quality?: number }) => {
-  const { width, height, quality } = options
+export const crop = (src: string, options: {
+  width: number,
+  height: number,
+  quality?: number,
+  isDisplay?: boolean
+}) => {
+  const { width, height, quality, isDisplay } = options
 
   if (!width && !height) {
     warn("requires width and height")
@@ -29,11 +35,17 @@ export const crop = (src: string, options: { width: number; height: number; qual
     quality: quality || 95,
   }
 
-  return [GEMINI_CLOUDFRONT_URL, qs.stringify(config)].join("?")
+  const url = isDisplay ? GEMINI_DISPLAY_CLOUDFRONT_URL : GEMINI_CLOUDFRONT_URL
+  return [url, qs.stringify(config)].join("?")
 }
 
-export const resize = (src: string, options: { width?: number; height?: number; quality?: number }) => {
-  const { width, height, quality } = options
+export const resize = (src: string, options: {
+  width?: number,
+  height?: number,
+  quality?: number,
+  isDisplay?: boolean
+}) => {
+  const { width, height, quality, isDisplay } = options
 
   let resizeTo
   if (width && !height) {
@@ -52,5 +64,6 @@ export const resize = (src: string, options: { width?: number; height?: number; 
     quality: quality || 95,
   }
 
-  return [GEMINI_CLOUDFRONT_URL, qs.stringify(config)].join("?")
+  const url = isDisplay ? GEMINI_DISPLAY_CLOUDFRONT_URL : GEMINI_CLOUDFRONT_URL
+  return [url, qs.stringify(config)].join("?")
 }


### PR DESCRIPTION
Thanks for helping + setting up the Cloudfront side! This PR makes use of the new url by adding an `isDisplay` option to the resizer methods. 