### PR TITLE
@damassi => Use props to set drop-caps

### DIFF
--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -115,7 +115,25 @@ export class Sections extends Component<Props, State> {
     }
   }
 
-  getSection(section) {
+  getContentStartIndex = () => {
+    const {
+      article: {
+        layout,
+        sections
+      }
+    } = this.props
+
+    if (layout === 'feature') {
+      const firstText = sections.findIndex(
+        (section) => {
+          return section.type === 'text'
+        }
+      )
+      return firstText
+    }
+  }
+
+  getSection(section, index) {
     const sections = {
       image_collection: (
         <ImageCollection
@@ -132,7 +150,11 @@ export class Sections extends Component<Props, State> {
       embed:
         <Embed section={section} />,
       text:
-        <Text html={section.body} layout={this.props.article.layout} />,
+        <Text
+          html={section.body}
+          layout={this.props.article.layout}
+          isContentStart={index === this.getContentStartIndex()}
+        />,
       default:
         false
     }
@@ -163,7 +185,7 @@ export class Sections extends Component<Props, State> {
         }
       }
 
-      const child = this.getSection(section)
+      const child = this.getSection(section, index)
 
       if (child) {
         return (

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -5,6 +5,7 @@ import { Fonts } from "../Fonts"
 import { Layout } from "../Typings"
 
 interface StyledTextProps {
+  isContentStart: boolean
   layout: Layout
   postscript?: Boolean
 }
@@ -111,13 +112,16 @@ export const StyledText = div`
     margin: 0;
     word-break: break-word;
   }
-  .content-start {
-    ${Fonts.unica("s67", "medium")}
-    float: left;
-    line-height: .5em;
-    margin-right: 10px;
-    margin-top: .298em;
-    text-transform: uppercase;
+  p:first-child:first-letter {
+    ${props => props.isContentStart && `
+      ${Fonts.unica("s67", "medium")}
+      float: left;
+      float: left;
+      line-height: .5em;
+      margin-right: 10px;
+      margin-top: .298em;
+      text-transform: uppercase;
+  `}
   }
   .content-end {
     display: inline-block;

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -3,16 +3,22 @@ import { Layout } from "../Typings"
 import { StyledText } from "./StyledText"
 
 interface TextProps extends React.HTMLProps<HTMLDivElement> {
+  html?: string
+  isContentStart?: boolean
   layout: Layout
   postscript?: boolean
-  html?: string
 }
 
 export const Text: React.SFC<TextProps> = props => {
-  const { html, layout, postscript } = props
+  const { html, isContentStart, layout, postscript } = props
   const child = html ? <div dangerouslySetInnerHTML={{ __html: html }} /> : props.children
   return (
-    <StyledText className="article__text-section" layout={layout} postscript={postscript}>
+    <StyledText
+      className="article__text-section"
+      isContentStart={isContentStart}
+      layout={layout}
+      postscript={postscript}
+    >
       {child}
     </StyledText>
   )

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
@@ -138,18 +138,6 @@ exports[`renders column_width properly 1`] = `
   word-break: break-word;
 }
 
-.c1 .content-start {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 67px;
-  line-height: 1em;
-  float: left;
-  line-height: .5em;
-  margin-right: 10px;
-  margin-top: .298em;
-  text-transform: uppercase;
-}
-
 .c1 .content-end {
   display: inline-block;
   content: "";
@@ -424,18 +412,6 @@ exports[`renders fillwidth properly 1`] = `
   word-break: break-word;
 }
 
-.c1 .content-start {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 67px;
-  line-height: 1em;
-  float: left;
-  line-height: .5em;
-  margin-right: 10px;
-  margin-top: .298em;
-  text-transform: uppercase;
-}
-
 .c1 .content-end {
   display: inline-block;
   content: "";
@@ -708,18 +684,6 @@ exports[`renders overflow_fillwidth properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   word-break: break-word;
-}
-
-.c1 .content-start {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 67px;
-  line-height: 1em;
-  float: left;
-  line-height: .5em;
-  margin-right: 10px;
-  margin-top: .298em;
-  text-transform: uppercase;
 }
 
 .c1 .content-end {

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
@@ -439,18 +439,6 @@ exports[`snapshots renders properly 1`] = `
   word-break: break-word;
 }
 
-.c2 .content-start {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 67px;
-  line-height: 1em;
-  float: left;
-  line-height: .5em;
-  margin-right: 10px;
-  margin-top: .298em;
-  text-transform: uppercase;
-}
-
 .c2 .content-end {
   display: inline-block;
   content: "";

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
@@ -136,18 +136,6 @@ exports[`renders classic text properly 1`] = `
   word-break: break-word;
 }
 
-.c0 .content-start {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 67px;
-  line-height: 1em;
-  float: left;
-  line-height: .5em;
-  margin-right: 10px;
-  margin-top: .298em;
-  text-transform: uppercase;
-}
-
 .c0 .content-end {
   display: inline-block;
   content: "";
@@ -394,18 +382,6 @@ exports[`renders feature text properly 1`] = `
   word-break: break-word;
 }
 
-.c0 .content-start {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 67px;
-  line-height: 1em;
-  float: left;
-  line-height: .5em;
-  margin-right: 10px;
-  margin-top: .298em;
-  text-transform: uppercase;
-}
-
 .c0 .content-end {
   display: inline-block;
   content: "";
@@ -649,18 +625,6 @@ exports[`renders standard text properly 1`] = `
   padding-bottom: 46px;
   margin: 0;
   word-break: break-word;
-}
-
-.c0 .content-start {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 67px;
-  line-height: 1em;
-  float: left;
-  line-height: .5em;
-  margin-right: 10px;
-  margin-top: .298em;
-  text-transform: uppercase;
 }
 
 .c0 .content-end {


### PR DESCRIPTION
Rather than using html classes for drop-caps, the parent container (in this case sections, in Positron, sectionContainer) determines whether the section is the first text in a feature article.

Related to https://github.com/artsy/positron/pull/1451