### PR TITLE
@craigspaeth => Fixes jump on clicking "Read More"

### DIFF
--- a/src/Components/Publishing/ReadMore/ReadMoreWrapper.tsx
+++ b/src/Components/Publishing/ReadMore/ReadMoreWrapper.tsx
@@ -77,7 +77,7 @@ export class ReadMoreWrapper extends React.Component<ReadMoreWrapperProps, ReadM
   }
 
   getOverflow = () => {
-    return this.props.isTruncated ? "hidden" : "unset"
+    return this.props.isTruncated ? "hidden" : "auto"
   }
 
   render() {

--- a/src/Components/Publishing/ReadMore/__test__/ReadMore.test.tsx
+++ b/src/Components/Publishing/ReadMore/__test__/ReadMore.test.tsx
@@ -29,6 +29,20 @@ describe("ReadMore", () => {
     expect(viewer.state().truncationHeight).toEqual(200)
   })
 
+  it("shows the whole article when not truncated", () => {
+    const readMore = (
+      <ReadMoreWrapper isTruncated={false} hideButton={jest.fn()}>
+        <Sections article={StandardArticle} />
+      </ReadMoreWrapper>
+    )
+    const viewer = mount(readMore)
+    jest.runAllTimers()
+    expect(viewer.state().truncationHeight).toEqual("100%")
+    expect(viewer.find("div").at(0).prop("style")).toEqual({
+      height: "100%",
+      overflow: "auto" })
+  })
+
   it("calls hideButton when truncation is too small", () => {
     const smallArticle = extend({}, StandardArticle, {
       sections: [


### PR DESCRIPTION
Addresses https://waffle.io/artsy/publishing/cards/59fa24a2d0de2e016e8386a3

Fixes a bug where the contents of the article shifted up a tiny bit on clicking Read More.