### PR TITLE
User can see a related artist after searching and following an artist

### DIFF
--- a/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
@@ -1,18 +1,33 @@
 import * as React from "react"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
+import { RecordSourceSelectorProxy, SelectorData } from "relay-runtime"
 import { ContextConsumer, ContextProps } from "../../../Artsy"
 import SelectableItemContainer from "./SelectableItemContainer"
 
 export interface RelayProps {
+  term: string
   viewer: {
     match_artist: any[]
   }
 }
 
 class ArtistSearchResultsContent extends React.Component<RelayProps, null> {
+  onArtistFollowed(artistId: string, store: RecordSourceSelectorProxy, data: SelectorData): void {
+    const suggestedArtist = store.get(data.followArtist.artist.related.suggested.edges[0].node.__id)
+
+    const popularArtistsRootField = store.get("client:root:viewer")
+    const popularArtists = popularArtistsRootField.getLinkedRecords("match_artist", { term: this.props.term })
+    const updatedPopularArtists = popularArtists.map(popularArtist =>
+      popularArtist.getDataID() === artistId ? suggestedArtist : popularArtist)
+
+    popularArtistsRootField.setLinkedRecords(updatedPopularArtists, "match_artist", { term: this.props.term })
+  }
+
   render() {
-    return <SelectableItemContainer artists={this.props.viewer.match_artist} />
+    return <SelectableItemContainer
+              artists={this.props.viewer.match_artist}
+              onArtistFollowed={this.onArtistFollowed.bind(this)} />
   }
 }
 
@@ -45,7 +60,7 @@ const ArtistSearchResultsComponent: React.SFC<Props & ContextProps> = ({ term, r
       variables={{ term }}
       render={({ error, props }) => {
         if (props) {
-          return <ArtistSearchResultsContentContainer viewer={props.viewer} />
+          return <ArtistSearchResultsContentContainer viewer={props.viewer} term={term} />
         } else {
           return null
         }

--- a/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
+++ b/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
+import { RecordSourceSelectorProxy, SelectorData } from "relay-runtime"
 import { ContextConsumer, ContextProps } from "../../../Artsy"
 import SelectableItemContainer from "./SelectableItemContainer"
 
@@ -11,8 +12,21 @@ export interface RelayProps {
 }
 
 class PopularArtistsContent extends React.Component<RelayProps, null> {
+  onArtistFollowed(artistId: string, store: RecordSourceSelectorProxy, data: SelectorData): void {
+    const suggestedArtist = store.get(data.followArtist.artist.related.suggested.edges[0].node.__id)
+
+    const popularArtistsRootField = store.get("client:root:popular_artists")
+    const popularArtists = popularArtistsRootField.getLinkedRecords("artists")
+    const updatedPopularArtists = popularArtists.map(popularArtist =>
+      popularArtist.getDataID() === artistId ? suggestedArtist : popularArtist)
+
+    popularArtistsRootField.setLinkedRecords(updatedPopularArtists, "artists")
+  }
+
   render() {
-    return <SelectableItemContainer artists={this.props.popular_artists.artists} />
+    return <SelectableItemContainer
+              artists={this.props.popular_artists.artists}
+              onArtistFollowed={this.onArtistFollowed.bind(this)} />
   }
 }
 

--- a/src/Components/Onboarding/Steps/Artists/SelectableItemContainer.tsx
+++ b/src/Components/Onboarding/Steps/Artists/SelectableItemContainer.tsx
@@ -1,15 +1,17 @@
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-
+import { RecordSourceSelectorProxy, SelectorData } from "relay-runtime"
 import ItemLink from "./ItemLink"
 
 interface Props {
   artists: any[]
+  onArtistFollowed(artist: string, store: RecordSourceSelectorProxy, data: SelectorData): void
 }
 
 class SelectableItemContainer extends React.Component<Props, null> {
   render() {
-    const items = this.props.artists.map((artist, index) => <ItemLink href="#" artist={artist} key={index} />)
+    const items = this.props.artists && this.props.artists.map((artist, index) =>
+      <ItemLink href="#" artist={artist} key={index} onArtistFollowed={this.props.onArtistFollowed} />)
 
     return <div>{items}</div>
   }


### PR DESCRIPTION
Now the user can click an artist and see a related artist. 

 * moved the `#onArtistFollowed` function up to the `ArtistSearchResultsContent` and `PopularArtistsContent` to be able to update different stores for different relay queries. Not sure about the interface yet but I think we should be able to figure out and make it more mature as we add more logic to it (e.g. Follow Gene)
 * Animation is not implemented yet, but could be addressed as a separate task
 * The `SelectableItemContainer` component could be inlined since all it does is just to iterate over each item on `this.props.artists` (proof of concept: https://github.com/yuki24/reaction/commit/bd2bdd312c39340ed8014fe299de8b2c7e4a9b58)

## To-dos

 * [x] Rebase once https://github.com/artsy/reaction/pull/403 is merged
 * [x] Use TypeScript's `interface` to expose the API for `updater`