### PR TITLE
@kanaabe => Header can accept date as props

### DIFF
--- a/src/Components/Publishing/Byline/Byline.tsx
+++ b/src/Components/Publishing/Byline/Byline.tsx
@@ -6,6 +6,7 @@ import { Share } from "./Share"
 
 interface BylineProps {
   article: any
+  date?: string
   layout?: string
   color?: string
 }
@@ -15,7 +16,7 @@ interface BylineContainerProps {
 }
 
 export const Byline: React.SFC<BylineProps> = props => {
-  const { article, color } = props
+  const { article, color, date } = props
   const { contributing_authors, published_at } = article
   const layout = props.layout || article.layout
   const title = article.social_title || article.thumbnail_title
@@ -33,7 +34,7 @@ export const Byline: React.SFC<BylineProps> = props => {
       />
 
       <Date
-        date={published_at}
+        date={date ? date : published_at}
         layout={layout}
       />
 

--- a/src/Components/Publishing/Header/BasicHeader.tsx
+++ b/src/Components/Publishing/Header/BasicHeader.tsx
@@ -20,6 +20,7 @@ import {
 interface Props {
   article: any
   isMobile?: any
+  date?: string
   leadParagraph?: any
   layout?: any
   title: any
@@ -58,6 +59,7 @@ export class BasicHeader extends React.Component<Props, State> {
         published_at,
         slug,
       },
+      date,
       isMobile: passedIsMobile,
       title,
       vertical
@@ -69,7 +71,7 @@ export class BasicHeader extends React.Component<Props, State> {
     return (
       <Responsive initialState={{ isMobile: passedIsMobile }}>
         {({ isMobile }) => (
-          <Container hasVideo={hasVideo}>
+          <Container hasVideo={hasVideo} data-type='basic'>
             <Grid fluid>
               {hasVideo &&
                 <Row onClick={this.trackVideoPlay}>
@@ -111,7 +113,7 @@ export class BasicHeader extends React.Component<Props, State> {
                           By {getAuthorByline(contributing_authors)}
                         </Author>
                         <Date>
-                          {getDate(published_at, isMobile ? 'condensed' : 'basic')}
+                          {getDate(date ? date : published_at, isMobile ? 'condensed' : 'basic')}
                         </Date>
                         <Share
                           title={title}

--- a/src/Components/Publishing/Header/ClassicHeader.tsx
+++ b/src/Components/Publishing/Header/ClassicHeader.tsx
@@ -6,18 +6,19 @@ import { AuthorDateClassic } from "./AuthorDateClassic"
 
 interface ClassicHeaderProps {
   article?: any
+  date?: string
   title: any
   leadParagraph?: any
   isMobile?: any
 }
 
 export const ClassicHeader: React.SFC<ClassicHeaderProps> = props => {
-  const { article, leadParagraph, title } = props
+  const { article, date, leadParagraph, title } = props
   return (
     <ClassicHeaderContainer>
       <Title>{title}</Title>
       {leadParagraph}
-      <AuthorDateClassic authors={article.contributing_authors} author={article.author} date={article.published_at} />
+      <AuthorDateClassic authors={article.contributing_authors} author={article.author} date={date ? date : article.published_at} />
     </ClassicHeaderContainer>
   )
 }

--- a/src/Components/Publishing/Header/FeatureHeader.tsx
+++ b/src/Components/Publishing/Header/FeatureHeader.tsx
@@ -88,6 +88,7 @@ const renderDeck = deck => {
 
 interface FeatureHeaderProps {
   article?: any
+  date?: string
   vertical?: any
   title: any
   deck?: any
@@ -122,7 +123,7 @@ class FeatureHeaderComponent extends React.Component<FeatureHeaderProps, any> {
   }
 
   render() {
-    const { article, vertical, title, deck, image, height, isMobile: passedIsMobile } = this.props
+    const { article, date, vertical, title, deck, image, height, isMobile: passedIsMobile } = this.props
     const hero = article.hero_section
     const url = hero && hero.url || ""
     const type = hero && hero.type || "text"
@@ -134,6 +135,7 @@ class FeatureHeaderComponent extends React.Component<FeatureHeaderProps, any> {
           vertical={vertical}
           title={title}
           isMobile={passedIsMobile}
+          date={date && date}
         />
       )
       // Fullscreen, Text, Split
@@ -159,7 +161,7 @@ class FeatureHeaderComponent extends React.Component<FeatureHeaderProps, any> {
                   {renderMobileSplitAsset(url, type, isMobile, article.title, image)}
                   <SubHeader>
                     {renderDeck(deck)}
-                    <Byline article={article} layout={type} />
+                    <Byline article={article} layout={type} date={date && date} />
                   </SubHeader>
                 </HeaderText>
                 {renderTextLayoutAsset(url, type, article.title, image)}

--- a/src/Components/Publishing/Header/Header.tsx
+++ b/src/Components/Publishing/Header/Header.tsx
@@ -5,6 +5,7 @@ import { StandardHeader } from "./StandardHeader"
 
 interface HeaderProps {
   article: any
+  date?: string
   isMobile?: boolean
   height?: string
 }
@@ -42,7 +43,7 @@ const getDeck = (article, children) => {
 }
 
 export const Header: React.SFC<HeaderProps> = props => {
-  const { article, children, height, isMobile } = props
+  const { article, children, date, height, isMobile } = props
   const title = getTitle(article, children)
 
   // Classic Article
@@ -52,6 +53,7 @@ export const Header: React.SFC<HeaderProps> = props => {
       <ClassicHeader
         isMobile={isMobile}
         article={article}
+        date={date && date}
         title={title}
         leadParagraph={leadParagraph}
       />
@@ -68,6 +70,7 @@ export const Header: React.SFC<HeaderProps> = props => {
           article={article}
           title={title}
           vertical={vertical}
+          date={date && date}
           deck={deck}
           image={image}
           height={height}
@@ -79,6 +82,7 @@ export const Header: React.SFC<HeaderProps> = props => {
       return (
         <StandardHeader
           article={article}
+          date={date && date}
           vertical={vertical}
           title={title}
         />

--- a/src/Components/Publishing/Header/StandardHeader.tsx
+++ b/src/Components/Publishing/Header/StandardHeader.tsx
@@ -6,18 +6,19 @@ import { Fonts } from "../Fonts"
 
 interface StandardHeaderProps {
   article?: any
+  date?: string
   title: any
   vertical?: any
 }
 
 export const StandardHeader: React.SFC<StandardHeaderProps> = props => {
-  const { article, title, vertical } = props
+  const { article, date, title, vertical } = props
   return (
     <StandardHeaderParent>
       <StandardHeaderContainer>
         <Vertical>{vertical}</Vertical>
         <Title>{title}</Title>
-        <Byline article={article} layout="standard" />
+        <Byline article={article} layout="standard" date={date && date}/>
       </StandardHeaderContainer>
     </StandardHeaderParent>
   )

--- a/src/Components/Publishing/Header/__test__/FeatureHeader.test.tsx
+++ b/src/Components/Publishing/Header/__test__/FeatureHeader.test.tsx
@@ -1,3 +1,4 @@
+import { mount } from 'enzyme'
 import "jest-styled-components"
 import _ from "lodash"
 import React from "react"
@@ -47,6 +48,11 @@ describe("feature", () => {
     const article = _.extend({}, FeatureArticle, { hero_section: decklessHero })
     const header = renderer.create(<Header article={article} />).toJSON()
     expect(header).toMatchSnapshot()
+  })
+
+  it("renders a date passed as prop", () => {
+    const header = mount(<Header article={FeatureArticle} date={"2017-05-19T13:09:18.567Z"} />)
+    expect(header.html()).toContain("May 19, 2017 9:09 am")
   })
 
   it("renders superArticle full header properly", () => {

--- a/src/Components/Publishing/Header/__test__/Header.test.tsx
+++ b/src/Components/Publishing/Header/__test__/Header.test.tsx
@@ -23,6 +23,11 @@ describe("Header", () => {
     expect(header.html()).toContain("Lead paragraph")
   })
 
+  it("renders a date passed as prop", () => {
+    const header = mount(<Header article={FeatureArticle} date={"2017-05-19T13:09:18.567Z"} />)
+    expect(header.html()).toContain("May 19, 2017 9:09 am")
+  })
+
   it("renders children on classic article", () => {
     const header = mount(
       <Header article={ClassicArticle}>

--- a/src/Components/Publishing/Header/__test__/StandardHeader.test.tsx
+++ b/src/Components/Publishing/Header/__test__/StandardHeader.test.tsx
@@ -1,3 +1,4 @@
+import { mount } from 'enzyme'
 import "jest-styled-components"
 import React from "react"
 import renderer from "react-test-renderer"
@@ -11,6 +12,12 @@ describe("Standard Header", () => {
     const header = renderer.create(<Header article={StandardArticle} />).toJSON()
     expect(header).toMatchSnapshot()
   })
+
+  it("renders a date passed as prop", () => {
+    const header = mount(<Header article={StandardArticle} date={"2017-05-19T13:09:18.567Z"} />)
+    expect(header.html()).toContain("May 19, 2017 9:09 am")
+  })
+
   it("renders standard header with children properly", () => {
     const header = renderer
       .create(

--- a/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
@@ -212,12 +212,12 @@ exports[`feature renders feature full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
   width: 50vw;
 }
 
@@ -367,14 +367,14 @@ exports[`feature renders feature full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
     width: 100%;
   }
 }
@@ -734,12 +734,12 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
   width: 50vw;
 }
 
@@ -753,7 +753,7 @@ exports[`feature renders feature full header without a deck properly 1`] = `
   flex-direction: column;
 }
 
-.c0[data-type="split"] .file__Deck-s1tiw5yr-7 {
+.c0[data-type="split"] .file__Deck-s1ria0lo-7 {
   margin-bottom: 30px;
 }
 
@@ -879,14 +879,14 @@ exports[`feature renders feature full header without a deck properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
     width: 100%;
   }
 }
@@ -1247,12 +1247,12 @@ exports[`feature renders feature header with children properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
   width: 50vw;
 }
 
@@ -1402,14 +1402,14 @@ exports[`feature renders feature header with children properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
     width: 100%;
   }
 }
@@ -1779,12 +1779,12 @@ exports[`feature renders feature split header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
   width: 50vw;
 }
 
@@ -1934,14 +1934,14 @@ exports[`feature renders feature split header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
     width: 100%;
   }
 }
@@ -2292,17 +2292,17 @@ exports[`feature renders feature text header properly 1`] = `
   width: 50%;
 }
 
-.c0[data-type="split"] .s1tiw5yr-0-file__Div-dCIIWC {
+.c0[data-type="split"] .s1ria0lo-0-file__Div-dCIIWC {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
   width: 50vw;
 }
 
@@ -2445,21 +2445,21 @@ exports[`feature renders feature text header properly 1`] = `
     width: 100%;
   }
 
-  .c0[data-type="split"] .s1tiw5yr-0-file__Div-dCIIWC {
+  .c0[data-type="split"] .s1ria0lo-0-file__Div-dCIIWC {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
     width: 100%;
   }
 }
@@ -2867,12 +2867,12 @@ exports[`feature renders superArticle full header properly 1`] = `
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+.c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
   width: 50%;
   border: 20px solid white;
 }
 
-.c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+.c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
   width: 50vw;
 }
 
@@ -3043,14 +3043,14 @@ exports[`feature renders superArticle full header properly 1`] = `
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .s1tiw5yr-0-file__Div-bbbPPm {
+  .c0[data-type="split"] .s1ria0lo-0-file__Div-bbbPPm {
     width: 100%;
     position: relative;
     border: 0px;
     margin-bottom: 30px;
   }
 
-  .c0[data-type="split"] .file__FeatureVideo-s1tiw5yr-2 {
+  .c0[data-type="split"] .file__FeatureVideo-s1ria0lo-2 {
     width: 100%;
   }
 }


### PR DESCRIPTION
Related to the 'invalid date' bug in Writer -- allow a header to accept a date as props (currently we only can render published_at).