### PR TITLE
Use yarn 1.3.2 to install dependencies in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ general:
 checkout:
   post:
     - nvm install && nvm alias default $(cat .nvmrc)
+    - npm install yarn@1.3.2
+    - ./node_modules/.bin/yarn
 
 dependencies:
   pre:


### PR DESCRIPTION
This should fix the `tslint` failure occurring in CircleCI.