### PR TITLE
@alloy => Don't show dropcaps unless feature, icon colors

### DIFF
--- a/src/Components/Publishing/Icon/IconDrag.tsx
+++ b/src/Components/Publishing/Icon/IconDrag.tsx
@@ -14,8 +14,8 @@ export class IconDrag extends Component<any, null> {
             <g transform="translate(0.785741, 0.701007)">
               <circle fill={this.props.background} cx="14.5" cy="15" r="14.5" />
               <g transform="translate(10.000000, 6.500000)" strokeWidth="2" stroke={this.props.color}>
-                <polyline transform="translate(4.500000, 4.923718) rotate(-45.000000) translate(-4.500000, -4.923718)" points="1.5 1.92371784 7.5 1.92371784 7.5 7.92371784" />
-                <polyline transform="translate(4.500000, 12.227216) rotate(-225.000000) translate(-4.500000, -12.227216)" points="1.5 9.2272156 7.5 9.2272156 7.5 15.2272156" />
+                <polyline fill={this.props.background} transform="translate(4.500000, 4.923718) rotate(-45.000000) translate(-4.500000, -4.923718)" points="1.5 1.92371784 7.5 1.92371784 7.5 7.92371784" />
+                <polyline fill={this.props.background} transform="translate(4.500000, 12.227216) rotate(-225.000000) translate(-4.500000, -12.227216)" points="1.5 9.2272156 7.5 9.2272156 7.5 15.2272156" />
                 <path d="M4.5,1.98457492 L4.5,16.0089159" />
               </g>
             </g>

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -113,8 +113,10 @@ export const StyledText = div`
     word-break: break-word;
   }
   p:first-child:first-letter {
-    ${props => props.isContentStart && Fonts.unica("s67", "medium")}
-    ${props => props.isContentStart && `
+    ${props => props.isContentStart && props.layout === "feature" &&
+      Fonts.unica("s67", "medium")
+    }
+    ${props => props.isContentStart && props.layout === "feature" && `
       float: left;
       line-height: .5em;
       margin-right: 10px;


### PR DESCRIPTION
Two minor fixes -- 

- In StyledText, check if feature before showing drop-caps styles
- In IconDrag, add fill color two two shapes that were missed