### PR TITLE
[Package] Add @types/storybook__react

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/react-slick": "^0.14.1",
     "@types/react-test-renderer": "^15.4.4",
     "@types/segment-analytics": "^0.0.27",
+    "@types/storybook__react": "^3.0.5",
     "awesome-typescript-loader": "^3.1.2",
     "babel-core": "^6.24.0",
     "babel-plugin-react-relay": "0.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,9 +298,20 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/storybook__react@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/storybook__react/-/storybook__react-3.0.5.tgz#aea4d67146a59de9cf5bacfe8bd24f7abd6128a6"
+  dependencies:
+    "@types/react" "*"
+    "@types/webpack-env" "*"
+
 "@types/underscore@*":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.8.0.tgz#7a22ef584d6fe59af2e407bae079e2b7f8a5102f"
+
+"@types/webpack-env@*":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.13.2.tgz#c290b99dbef74df21b06671aea36e355bf3b27e1"
 
 abab@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Updating types per your comment, but running into an issue with `yarn type-check`: 

```
export type Renderable = React.ComponentType | JSX.Element;
                                  ~~~~~~~~~~~~~
node_modules/@types/storybook__react/index.d.ts(11,32): error TS2694: Namespace 'React' has no exported member 'ComponentType'.
```

I believe this is a React 16 issue? Its on my Radar to update Force / Positron, and I saw [this PR](https://github.com/artsy/reaction/pull/273) is in progress for Reaction. 