### PR TITLE
@eessex => Use grid in SeriesAbout

### DIFF
--- a/src/Apps/Loyalty/Containers/3wThankYou/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/3wThankYou/__tests__/__snapshots__/index.ts.snap
@@ -30,7 +30,7 @@ exports[`3-way Handshake Thank You renders the snapshot 1`] = `
     className="file__TitleSection-s1ds4mkl-1 kLJIlb"
   >
     <div
-      className="file__StyledTitle-s1hq9j8q-0 dyBmig"
+      className="file__StyledTitle-s1hq9j8q-0 cbQDSR"
       color="inherit"
     >
       Thank you, 

--- a/src/Apps/Loyalty/Containers/AcbThankYou/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/AcbThankYou/__tests__/__snapshots__/index.ts.snap
@@ -36,7 +36,7 @@ exports[`ACB Thank You renders the snapshot 1`] = `
     </p>
   </div>
   <div
-    className="file__StyledTitle-s1hq9j8q-0 dyBmig"
+    className="file__StyledTitle-s1hq9j8q-0 cbQDSR"
     color="inherit"
   >
     Artsy Collector Loyalty Program

--- a/src/Apps/Loyalty/Containers/Inquiries/__tests__/__snapshots__/index.tsx.snap
+++ b/src/Apps/Loyalty/Containers/Inquiries/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`inquiries renders the inquiries listing 1`] = `
 <div
-  className="file__Container-s1pyl2uv-1 bHSzYR"
+  className="file__Container-s1pyl2uv-1 ecpOat"
 >
   <div
     className="file__Nav-s1u3mk74-0 eyFpUf"
@@ -27,10 +27,10 @@ exports[`inquiries renders the inquiries listing 1`] = `
     </a>
   </div>
   <header
-    className="file__Header-s1pyl2uv-2 eTSwKS"
+    className="file__Header-s1pyl2uv-2 fankch"
   >
     <div
-      className="header-title file__StyledTitle-s1hq9j8q-0 bLQcDL"
+      className="header-title file__StyledTitle-s1hq9j8q-0 kLzHVD"
       color="inherit"
     >
       Please select all works you purchased
@@ -48,10 +48,10 @@ exports[`inquiries renders the inquiries listing 1`] = `
       className="Grid__Grid-bojwg gdLArs"
     >
       <div
-        className="file__Row-lw0n7x-1 hpRVPU Row__Row-kNtYPA hicFUP"
+        className="file__Row-lw0n7x-1 KyAri Row__Row-kNtYPA hicFUP"
       >
         <div
-          className="file__Col-lw0n7x-0 ifVZX Col__Col-hCQanm jItcmX"
+          className="file__Col-lw0n7x-0 eaAlCt Col__Col-hCQanm jItcmX"
         >
           <div
             className="file__InquiryContainer-s1pyl2uv-0 ivebzq"

--- a/src/Apps/Loyalty/Containers/RepeatVisitor/__tests__/__snapshots__/index.ts.snap
+++ b/src/Apps/Loyalty/Containers/RepeatVisitor/__tests__/__snapshots__/index.ts.snap
@@ -27,7 +27,7 @@ exports[`RepeatVisitor renders the snapshot 1`] = `
     </a>
   </div>
   <div
-    className="file__StyledTitle-s1hq9j8q-0 dyBmig"
+    className="file__StyledTitle-s1hq9j8q-0 cbQDSR"
     color="inherit"
   >
     Your purchases are being reviewed

--- a/src/Components/Helpers.tsx
+++ b/src/Components/Helpers.tsx
@@ -25,7 +25,7 @@ export const media: Media = Object.keys(sizes).reduce((accumulator, label) => {
   // https://zellwk.com/blog/media-query-units/
   const emSize = sizes[label]
   accumulator[label] = (strings, ...args) => css`
-    @media (max-width: ${emSize}px) {
+    @media (max-width: ${emSize}em) {
       ${css(strings, ...args)}
     }
   `

--- a/src/Components/Publishing/Series/Series.tsx
+++ b/src/Components/Publishing/Series/Series.tsx
@@ -27,7 +27,7 @@ export class Series extends Component<Props, null> {
             article={article}
             color={color}
           />
-          
+
           {articles.map((relatedArticle, i) =>
             <ArticleCard
               key={i}
@@ -36,7 +36,7 @@ export class Series extends Component<Props, null> {
               color={color}
             />
           )}
-          
+
           <SeriesAbout
             article={article}
             color={color}

--- a/src/Components/Publishing/Series/SeriesAbout.tsx
+++ b/src/Components/Publishing/Series/SeriesAbout.tsx
@@ -1,6 +1,7 @@
-import React, { Component  } from "react"
+import React, { Component } from "react"
+import { Col } from "react-styled-flexboxgrid"
 import styled, { StyledFunction } from "styled-components"
-import { pMedia } from "../../Helpers"
+import { media } from "../../Helpers"
 import { Fonts } from "../Fonts"
 import { PartnerBlock, PartnerBlockContainer } from '../Partner/PartnerBlock'
 import { Text } from '../Sections/Text'
@@ -19,9 +20,9 @@ export class SeriesAbout extends Component<Props, null> {
     const { series_description, sponsor } = article
 
     return (
-      <SeriesAboutContainer className='SeriesAbout' color={color}>
+      <SeriesAboutContainer color={color}>
 
-        <Col first>
+        <StyledCol sm={12} md={4}>
           <Title>About the Series</Title>
           {sponsor &&
             <PartnerBlock
@@ -33,9 +34,9 @@ export class SeriesAbout extends Component<Props, null> {
               }}
             />
           }
-        </Col>
+        </StyledCol>
 
-        <Col>
+        <StyledCol sm={12} md={8}>
           {editDescription
             ? <Text layout='standard'>{editDescription}</Text>
             : <Text layout='standard' html={series_description} />
@@ -50,8 +51,7 @@ export class SeriesAbout extends Component<Props, null> {
               }}
             />
           }
-        </Col>
-
+        </StyledCol>
       </SeriesAboutContainer>
     )
   }
@@ -71,37 +71,49 @@ export const SeriesAboutContainer = Div`
   color: ${props => props.color};
   display: flex;
   justify-content: space-between;
+  max-width: 1200px;
+  margin: auto;
 
-  ${props => pMedia.md`
+  ${props => media.sm`
     display: block;
   `}
 `
+const StyledCol = styled(Col)`
 
-const Col = Div`
-  width: ${props => props.first ? '30' : '60'}%;
-  ${props => props.first && `
+  ${PartnerBlockContainer} {
+    display: none;
+  }
+
+  &:first-of-type {
     display: flex;
     justify-content: space-between;
     flex-direction: column;
-  `}
-
-  ${PartnerBlockContainer} {
-    ${props => !props.first && "display: none;"}
+    ${PartnerBlockContainer} {
+      display: block;
+    }
   }
 
-  ${props => pMedia.md`
-    width: 100%;
+  &:nth-of-type(2) {
+    flex: auto;
+  }
+
+  ${props => media.sm`
+    &:first-of-type {
+      ${PartnerBlockContainer} {
+        display: none;
+      }
+    }
 
     ${PartnerBlockContainer} {
       margin-top: 60px;
-      display: ${props.first ? "none" : "block"};
+      display: block;
     }
   `}
 `
 
 const Title = styled.div`
   ${Fonts.unica("s32", "medium")}
-  ${props => pMedia.md`
+  ${props => media.sm`
     margin-bottom: 20px;
   `}
 `

--- a/src/Components/Publishing/Series/SeriesAbout.tsx
+++ b/src/Components/Publishing/Series/SeriesAbout.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import { Col } from "react-styled-flexboxgrid"
+import { Col, Row } from "react-styled-flexboxgrid"
 import styled, { StyledFunction } from "styled-components"
 import { media } from "../../Helpers"
 import { Fonts } from "../Fonts"
@@ -15,14 +15,13 @@ interface Props {
 export class SeriesAbout extends Component<Props, null> {
   public static defaultProps: Partial<Props>
 
-  render () {
+  render() {
     const { article, color, editDescription } = this.props
     const { series_description, sponsor } = article
 
     return (
       <SeriesAboutContainer color={color}>
-
-        <StyledCol sm={12} md={4}>
+        <StyledCol xs={12} sm={4}>
           <Title>About the Series</Title>
           {sponsor &&
             <PartnerBlock
@@ -35,8 +34,7 @@ export class SeriesAbout extends Component<Props, null> {
             />
           }
         </StyledCol>
-
-        <StyledCol sm={12} md={8}>
+        <StyledCol xs={12} sm={8}>
           {editDescription
             ? <Text layout='standard'>{editDescription}</Text>
             : <Text layout='standard' html={series_description} />
@@ -65,20 +63,13 @@ interface ColProps {
   first?: boolean
 }
 
-const Div: StyledFunction<Props & ColProps & React.HTMLProps<HTMLDivElement>> = styled.div
+const Div: StyledFunction<Props & ColProps & React.HTMLProps<HTMLDivElement>> = styled(Row)
 
 export const SeriesAboutContainer = Div`
   color: ${props => props.color};
-  display: flex;
-  justify-content: space-between;
   max-width: 1200px;
-  margin: auto;
-
-  ${props => media.sm`
-    display: block;
-  `}
 `
-const StyledCol = styled(Col)`
+const StyledCol = styled(Col) `
 
   ${PartnerBlockContainer} {
     display: none;
@@ -91,10 +82,6 @@ const StyledCol = styled(Col)`
     ${PartnerBlockContainer} {
       display: block;
     }
-  }
-
-  &:nth-of-type(2) {
-    flex: auto;
   }
 
   ${props => media.sm`

--- a/src/Components/Publishing/Series/SeriesAbout2.tsx
+++ b/src/Components/Publishing/Series/SeriesAbout2.tsx
@@ -1,0 +1,2 @@
+import React, { Component } from "react"
+

--- a/src/Components/Publishing/Series/SeriesAbout2.tsx
+++ b/src/Components/Publishing/Series/SeriesAbout2.tsx
@@ -1,2 +1,0 @@
-import React, { Component } from "react"
-

--- a/src/Components/Publishing/Series/__test__/__snapshots__/Series.test.tsx.snap
+++ b/src/Components/Publishing/Series/__test__/__snapshots__/Series.test.tsx.snap
@@ -221,12 +221,49 @@ exports[`renders a series properly 1`] = `
   line-height: 1.2em;
 }
 
-.c26 {
+.c23 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+}
+
+.c25 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c27 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c28 {
   position: relative;
   width: 100%;
 }
 
-.c26 a {
+.c28 a {
   color: black;
   text-decoration: none;
   position: relative;
@@ -236,13 +273,13 @@ exports[`renders a series properly 1`] = `
   background-position: bottom;
 }
 
-.c26 a:hover {
+.c28 a:hover {
   color: #999;
 }
 
-.c26 p,
-.c26 ul,
-.c26 ol {
+.c28 p,
+.c28 ul,
+.c28 ol {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -253,20 +290,20 @@ exports[`renders a series properly 1`] = `
   font-style: inherit;
 }
 
-.c26 p:first-child {
+.c28 p:first-child {
   padding-top: 0;
 }
 
-.c26 p:last-child {
+.c28 p:last-child {
   padding-bottom: 0;
 }
 
-.c26 ul,
-.c26 ol {
+.c28 ul,
+.c28 ol {
   padding-left: 1em;
 }
 
-.c26 li {
+.c28 li {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -275,7 +312,7 @@ exports[`renders a series properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c26 h1 {
+.c28 h1 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -288,7 +325,7 @@ exports[`renders a series properly 1`] = `
   text-align: center;
 }
 
-.c26 h1:before {
+.c28 h1:before {
   content: "";
   width: 15px;
   height: 15px;
@@ -299,7 +336,7 @@ exports[`renders a series properly 1`] = `
   right: calc(50% - 7.5px);
 }
 
-.c26 h2 {
+.c28 h2 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -308,11 +345,11 @@ exports[`renders a series properly 1`] = `
   margin: 0;
 }
 
-.c26 h2 a {
+.c28 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c26 h3 {
+.c28 h3 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -322,7 +359,7 @@ exports[`renders a series properly 1`] = `
   margin: 0;
 }
 
-.c26 h3 strong {
+.c28 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -330,11 +367,11 @@ exports[`renders a series properly 1`] = `
   line-height: 1.5em;
 }
 
-.c26 h3 a {
+.c28 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c26 blockquote {
+.c28 blockquote {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -347,7 +384,7 @@ exports[`renders a series properly 1`] = `
   word-break: break-word;
 }
 
-.c26 .content-end {
+.c28 .content-end {
   display: inline-block;
   content: "";
   width: 12px;
@@ -357,14 +394,14 @@ exports[`renders a series properly 1`] = `
   margin-left: 12px;
 }
 
-.c26 .artist-follow {
+.c28 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c26 .artist-follow:before {
+.c28 .artist-follow:before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -372,7 +409,7 @@ exports[`renders a series properly 1`] = `
   font-size: 32px;
 }
 
-.c26 .artist-follow:after {
+.c28 .artist-follow:after {
   content: "Follow";
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -383,18 +420,14 @@ exports[`renders a series properly 1`] = `
 
 .c22 {
   color: white;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  max-width: 1200px;
 }
 
-.c23 {
-  width: 30%;
+.c24 .file__PartnerBlockContainer-s8dqalt-0 {
+  display: none;
+}
+
+.c24:first-of-type {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -408,15 +441,11 @@ exports[`renders a series properly 1`] = `
   flex-direction: column;
 }
 
-.c25 {
-  width: 60%;
+.c24:first-of-type .file__PartnerBlockContainer-s8dqalt-0 {
+  display: block;
 }
 
-.c25 .file__PartnerBlockContainer-s8dqalt-0 {
-  display: none;
-}
-
-.c24 {
+.c26 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -567,38 +596,78 @@ exports[`renders a series properly 1`] = `
   }
 }
 
+@media only screen and (min-width:0em) {
+  .c25 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c25 {
+    -webkit-flex-basis: 33.333333333333336%;
+    -ms-flex-basis: 33.333333333333336%;
+    flex-basis: 33.333333333333336%;
+    max-width: 33.333333333333336%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:0em) {
+  .c27 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c27 {
+    -webkit-flex-basis: 66.66666666666667%;
+    -ms-flex-basis: 66.66666666666667%;
+    flex-basis: 66.66666666666667%;
+    max-width: 66.66666666666667%;
+    display: block;
+  }
+}
+
 @media (max-width:600px) {
-  .c26 p,
-  .c26 ul,
-  .c26 ol {
+  .c28 p,
+  .c28 ul,
+  .c28 ol {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c26 li {
+  .c28 li {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c26 h1 {
+  .c28 h1 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c26 h2 {
+  .c28 h2 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c26 h3 {
+  .c28 h3 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -606,55 +675,38 @@ exports[`renders a series properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c26 h3 strong {
+  .c28 h3 strong {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c26 blockquote {
+  .c28 blockquote {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c26 .content-start {
+  .c28 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:900px) {
-  .c22 {
-    display: block;
-  }
-}
-
-@media (max-width:900px) {
-  .c23 {
-    width: 100%;
-  }
-
-  .c23 .file__PartnerBlockContainer-s8dqalt-0 {
-    margin-top: 60px;
+@media (max-width:48em) {
+  .c24:first-of-type .file__PartnerBlockContainer-s8dqalt-0 {
     display: none;
   }
-}
 
-@media (max-width:900px) {
-  .c25 {
-    width: 100%;
-  }
-
-  .c25 .file__PartnerBlockContainer-s8dqalt-0 {
+  .c24 .file__PartnerBlockContainer-s8dqalt-0 {
     margin-top: 60px;
     display: block;
   }
 }
 
-@media (max-width:900px) {
-  .c24 {
+@media (max-width:48em) {
+  .c26 {
     margin-bottom: 20px;
   }
 }
@@ -897,23 +949,23 @@ exports[`renders a series properly 1`] = `
       </div>
     </a>
     <div
-      className="SeriesAbout c21 c22"
+      className="c21 c22 c23"
       color="white"
     >
       <div
-        className="c23"
+        className="c24 c25"
       >
         <div
-          className="c24"
+          className="c26"
         >
           About the Series
         </div>
       </div>
       <div
-        className="c25"
+        className="c24 c27"
       >
         <div
-          className="article__text-section c26"
+          className="article__text-section c28"
         >
           <div
             dangerouslySetInnerHTML={
@@ -1150,6 +1202,43 @@ exports[`renders a sponsored series properly 1`] = `
   line-height: 1.2em;
 }
 
+.c26 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+}
+
+.c28 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c30 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
 .c6 img {
   max-width: 220px;
   padding-top: 20px;
@@ -1162,12 +1251,12 @@ exports[`renders a sponsored series properly 1`] = `
   line-height: 1.1em;
 }
 
-.c29 {
+.c31 {
   position: relative;
   width: 100%;
 }
 
-.c29 a {
+.c31 a {
   color: black;
   text-decoration: none;
   position: relative;
@@ -1177,13 +1266,13 @@ exports[`renders a sponsored series properly 1`] = `
   background-position: bottom;
 }
 
-.c29 a:hover {
+.c31 a:hover {
   color: #999;
 }
 
-.c29 p,
-.c29 ul,
-.c29 ol {
+.c31 p,
+.c31 ul,
+.c31 ol {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -1194,20 +1283,20 @@ exports[`renders a sponsored series properly 1`] = `
   font-style: inherit;
 }
 
-.c29 p:first-child {
+.c31 p:first-child {
   padding-top: 0;
 }
 
-.c29 p:last-child {
+.c31 p:last-child {
   padding-bottom: 0;
 }
 
-.c29 ul,
-.c29 ol {
+.c31 ul,
+.c31 ol {
   padding-left: 1em;
 }
 
-.c29 li {
+.c31 li {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -1216,7 +1305,7 @@ exports[`renders a sponsored series properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c29 h1 {
+.c31 h1 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -1229,7 +1318,7 @@ exports[`renders a sponsored series properly 1`] = `
   text-align: center;
 }
 
-.c29 h1:before {
+.c31 h1:before {
   content: "";
   width: 15px;
   height: 15px;
@@ -1240,7 +1329,7 @@ exports[`renders a sponsored series properly 1`] = `
   right: calc(50% - 7.5px);
 }
 
-.c29 h2 {
+.c31 h2 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -1249,11 +1338,11 @@ exports[`renders a sponsored series properly 1`] = `
   margin: 0;
 }
 
-.c29 h2 a {
+.c31 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c29 h3 {
+.c31 h3 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -1263,7 +1352,7 @@ exports[`renders a sponsored series properly 1`] = `
   margin: 0;
 }
 
-.c29 h3 strong {
+.c31 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -1271,11 +1360,11 @@ exports[`renders a sponsored series properly 1`] = `
   line-height: 1.5em;
 }
 
-.c29 h3 a {
+.c31 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c29 blockquote {
+.c31 blockquote {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -1288,7 +1377,7 @@ exports[`renders a sponsored series properly 1`] = `
   word-break: break-word;
 }
 
-.c29 .content-end {
+.c31 .content-end {
   display: inline-block;
   content: "";
   width: 12px;
@@ -1298,14 +1387,14 @@ exports[`renders a sponsored series properly 1`] = `
   margin-left: 12px;
 }
 
-.c29 .artist-follow {
+.c31 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c29 .artist-follow:before {
+.c31 .artist-follow:before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -1313,7 +1402,7 @@ exports[`renders a sponsored series properly 1`] = `
   font-size: 32px;
 }
 
-.c29 .artist-follow:after {
+.c31 .artist-follow:after {
   content: "Follow";
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -1324,18 +1413,14 @@ exports[`renders a sponsored series properly 1`] = `
 
 .c25 {
   color: white;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  max-width: 1200px;
 }
 
-.c26 {
-  width: 30%;
+.c27 .c5 {
+  display: none;
+}
+
+.c27:first-of-type {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1349,15 +1434,11 @@ exports[`renders a sponsored series properly 1`] = `
   flex-direction: column;
 }
 
-.c28 {
-  width: 60%;
+.c27:first-of-type .c5 {
+  display: block;
 }
 
-.c28 .c5 {
-  display: none;
-}
-
-.c27 {
+.c29 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -1508,6 +1589,46 @@ exports[`renders a sponsored series properly 1`] = `
   }
 }
 
+@media only screen and (min-width:0em) {
+  .c28 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c28 {
+    -webkit-flex-basis: 33.333333333333336%;
+    -ms-flex-basis: 33.333333333333336%;
+    flex-basis: 33.333333333333336%;
+    max-width: 33.333333333333336%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:0em) {
+  .c30 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c30 {
+    -webkit-flex-basis: 66.66666666666667%;
+    -ms-flex-basis: 66.66666666666667%;
+    flex-basis: 66.66666666666667%;
+    max-width: 66.66666666666667%;
+    display: block;
+  }
+}
+
 @media (max-width:720px) {
   .c6 img {
     max-width: 195px;
@@ -1524,37 +1645,37 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media (max-width:600px) {
-  .c29 p,
-  .c29 ul,
-  .c29 ol {
+  .c31 p,
+  .c31 ul,
+  .c31 ol {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c29 li {
+  .c31 li {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c29 h1 {
+  .c31 h1 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c29 h2 {
+  .c31 h2 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c29 h3 {
+  .c31 h3 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1562,55 +1683,38 @@ exports[`renders a sponsored series properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c29 h3 strong {
+  .c31 h3 strong {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c29 blockquote {
+  .c31 blockquote {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c29 .content-start {
+  .c31 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:900px) {
-  .c25 {
-    display: block;
-  }
-}
-
-@media (max-width:900px) {
-  .c26 {
-    width: 100%;
-  }
-
-  .c26 .c5 {
-    margin-top: 60px;
+@media (max-width:48em) {
+  .c27:first-of-type .c5 {
     display: none;
   }
-}
 
-@media (max-width:900px) {
-  .c28 {
-    width: 100%;
-  }
-
-  .c28 .c5 {
+  .c27 .c5 {
     margin-top: 60px;
     display: block;
   }
 }
 
-@media (max-width:900px) {
-  .c27 {
+@media (max-width:48em) {
+  .c29 {
     margin-bottom: 20px;
   }
 }
@@ -1871,14 +1975,14 @@ exports[`renders a sponsored series properly 1`] = `
       </div>
     </a>
     <div
-      className="SeriesAbout c24 c25"
+      className="c24 c25 c26"
       color="white"
     >
       <div
-        className="c26"
+        className="c27 c28"
       >
         <div
-          className="c27"
+          className="c29"
         >
           About the Series
         </div>
@@ -1902,10 +2006,10 @@ exports[`renders a sponsored series properly 1`] = `
         </div>
       </div>
       <div
-        className="c28"
+        className="c27 c30"
       >
         <div
-          className="article__text-section c29"
+          className="article__text-section c31"
         >
           <div
             dangerouslySetInnerHTML={

--- a/src/Components/Publishing/Series/__test__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__test__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -1,12 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a series about properly 1`] = `
-.c4 {
+.c1 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+}
+
+.c3 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c4 a {
+.c6 a {
   color: black;
   text-decoration: none;
   position: relative;
@@ -16,13 +53,13 @@ exports[`renders a series about properly 1`] = `
   background-position: bottom;
 }
 
-.c4 a:hover {
+.c6 a:hover {
   color: #999;
 }
 
-.c4 p,
-.c4 ul,
-.c4 ol {
+.c6 p,
+.c6 ul,
+.c6 ol {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -33,20 +70,20 @@ exports[`renders a series about properly 1`] = `
   font-style: inherit;
 }
 
-.c4 p:first-child {
+.c6 p:first-child {
   padding-top: 0;
 }
 
-.c4 p:last-child {
+.c6 p:last-child {
   padding-bottom: 0;
 }
 
-.c4 ul,
-.c4 ol {
+.c6 ul,
+.c6 ol {
   padding-left: 1em;
 }
 
-.c4 li {
+.c6 li {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -55,7 +92,7 @@ exports[`renders a series about properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c4 h1 {
+.c6 h1 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -68,7 +105,7 @@ exports[`renders a series about properly 1`] = `
   text-align: center;
 }
 
-.c4 h1:before {
+.c6 h1:before {
   content: "";
   width: 15px;
   height: 15px;
@@ -79,7 +116,7 @@ exports[`renders a series about properly 1`] = `
   right: calc(50% - 7.5px);
 }
 
-.c4 h2 {
+.c6 h2 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -88,11 +125,11 @@ exports[`renders a series about properly 1`] = `
   margin: 0;
 }
 
-.c4 h2 a {
+.c6 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c4 h3 {
+.c6 h3 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -102,7 +139,7 @@ exports[`renders a series about properly 1`] = `
   margin: 0;
 }
 
-.c4 h3 strong {
+.c6 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -110,11 +147,11 @@ exports[`renders a series about properly 1`] = `
   line-height: 1.5em;
 }
 
-.c4 h3 a {
+.c6 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c4 blockquote {
+.c6 blockquote {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -127,7 +164,7 @@ exports[`renders a series about properly 1`] = `
   word-break: break-word;
 }
 
-.c4 .content-end {
+.c6 .content-end {
   display: inline-block;
   content: "";
   width: 12px;
@@ -137,14 +174,14 @@ exports[`renders a series about properly 1`] = `
   margin-left: 12px;
 }
 
-.c4 .artist-follow {
+.c6 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c4 .artist-follow:before {
+.c6 .artist-follow:before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -152,7 +189,7 @@ exports[`renders a series about properly 1`] = `
   font-size: 32px;
 }
 
-.c4 .artist-follow:after {
+.c6 .artist-follow:after {
   content: "Follow";
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -163,18 +200,14 @@ exports[`renders a series about properly 1`] = `
 
 .c0 {
   color: black;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  max-width: 1200px;
 }
 
-.c1 {
-  width: 30%;
+.c2 .file__PartnerBlockContainer-s8dqalt-0 {
+  display: none;
+}
+
+.c2:first-of-type {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -188,53 +221,89 @@ exports[`renders a series about properly 1`] = `
   flex-direction: column;
 }
 
-.c3 {
-  width: 60%;
+.c2:first-of-type .file__PartnerBlockContainer-s8dqalt-0 {
+  display: block;
 }
 
-.c3 .file__PartnerBlockContainer-s8dqalt-0 {
-  display: none;
-}
-
-.c2 {
+.c4 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
 }
 
+@media only screen and (min-width:0em) {
+  .c3 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c3 {
+    -webkit-flex-basis: 33.333333333333336%;
+    -ms-flex-basis: 33.333333333333336%;
+    flex-basis: 33.333333333333336%;
+    max-width: 33.333333333333336%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:0em) {
+  .c5 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c5 {
+    -webkit-flex-basis: 66.66666666666667%;
+    -ms-flex-basis: 66.66666666666667%;
+    flex-basis: 66.66666666666667%;
+    max-width: 66.66666666666667%;
+    display: block;
+  }
+}
+
 @media (max-width:600px) {
-  .c4 p,
-  .c4 ul,
-  .c4 ol {
+  .c6 p,
+  .c6 ul,
+  .c6 ol {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c4 li {
+  .c6 li {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c4 h1 {
+  .c6 h1 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c4 h2 {
+  .c6 h2 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c4 h3 {
+  .c6 h3 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -242,77 +311,60 @@ exports[`renders a series about properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c4 h3 strong {
+  .c6 h3 strong {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c4 blockquote {
+  .c6 blockquote {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c4 .content-start {
+  .c6 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:900px) {
-  .c0 {
-    display: block;
-  }
-}
-
-@media (max-width:900px) {
-  .c1 {
-    width: 100%;
-  }
-
-  .c1 .file__PartnerBlockContainer-s8dqalt-0 {
-    margin-top: 60px;
+@media (max-width:48em) {
+  .c2:first-of-type .file__PartnerBlockContainer-s8dqalt-0 {
     display: none;
   }
-}
 
-@media (max-width:900px) {
-  .c3 {
-    width: 100%;
-  }
-
-  .c3 .file__PartnerBlockContainer-s8dqalt-0 {
+  .c2 .file__PartnerBlockContainer-s8dqalt-0 {
     margin-top: 60px;
     display: block;
   }
 }
 
-@media (max-width:900px) {
-  .c2 {
+@media (max-width:48em) {
+  .c4 {
     margin-bottom: 20px;
   }
 }
 
 <div
-  className="SeriesAbout c0"
+  className="c0 c1"
   color="black"
 >
   <div
-    className="c1"
+    className="c2 c3"
   >
     <div
-      className="c2"
+      className="c4"
     >
       About the Series
     </div>
   </div>
   <div
-    className="c3"
+    className="c2 c5"
   >
     <div
-      className="article__text-section c4"
+      className="article__text-section c6"
     >
       <div
         dangerouslySetInnerHTML={
@@ -327,24 +379,61 @@ exports[`renders a series about properly 1`] = `
 `;
 
 exports[`renders a sponsored series about properly 1`] = `
-.c4 img {
+.c1 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+}
+
+.c3 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c8 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c6 img {
   max-width: 220px;
   padding-top: 20px;
 }
 
-.c5 {
+.c7 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
   line-height: 1.1em;
 }
 
-.c7 {
+.c9 {
   position: relative;
   width: 100%;
 }
 
-.c7 a {
+.c9 a {
   color: black;
   text-decoration: none;
   position: relative;
@@ -354,13 +443,13 @@ exports[`renders a sponsored series about properly 1`] = `
   background-position: bottom;
 }
 
-.c7 a:hover {
+.c9 a:hover {
   color: #999;
 }
 
-.c7 p,
-.c7 ul,
-.c7 ol {
+.c9 p,
+.c9 ul,
+.c9 ol {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -371,20 +460,20 @@ exports[`renders a sponsored series about properly 1`] = `
   font-style: inherit;
 }
 
-.c7 p:first-child {
+.c9 p:first-child {
   padding-top: 0;
 }
 
-.c7 p:last-child {
+.c9 p:last-child {
   padding-bottom: 0;
 }
 
-.c7 ul,
-.c7 ol {
+.c9 ul,
+.c9 ol {
   padding-left: 1em;
 }
 
-.c7 li {
+.c9 li {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -393,7 +482,7 @@ exports[`renders a sponsored series about properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c7 h1 {
+.c9 h1 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -406,7 +495,7 @@ exports[`renders a sponsored series about properly 1`] = `
   text-align: center;
 }
 
-.c7 h1:before {
+.c9 h1:before {
   content: "";
   width: 15px;
   height: 15px;
@@ -417,7 +506,7 @@ exports[`renders a sponsored series about properly 1`] = `
   right: calc(50% - 7.5px);
 }
 
-.c7 h2 {
+.c9 h2 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -426,11 +515,11 @@ exports[`renders a sponsored series about properly 1`] = `
   margin: 0;
 }
 
-.c7 h2 a {
+.c9 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c7 h3 {
+.c9 h3 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -440,7 +529,7 @@ exports[`renders a sponsored series about properly 1`] = `
   margin: 0;
 }
 
-.c7 h3 strong {
+.c9 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -448,11 +537,11 @@ exports[`renders a sponsored series about properly 1`] = `
   line-height: 1.5em;
 }
 
-.c7 h3 a {
+.c9 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c7 blockquote {
+.c9 blockquote {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -465,7 +554,7 @@ exports[`renders a sponsored series about properly 1`] = `
   word-break: break-word;
 }
 
-.c7 .content-end {
+.c9 .content-end {
   display: inline-block;
   content: "";
   width: 12px;
@@ -475,14 +564,14 @@ exports[`renders a sponsored series about properly 1`] = `
   margin-left: 12px;
 }
 
-.c7 .artist-follow {
+.c9 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c7 .artist-follow:before {
+.c9 .artist-follow:before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -490,7 +579,7 @@ exports[`renders a sponsored series about properly 1`] = `
   font-size: 32px;
 }
 
-.c7 .artist-follow:after {
+.c9 .artist-follow:after {
   content: "Follow";
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -501,18 +590,14 @@ exports[`renders a sponsored series about properly 1`] = `
 
 .c0 {
   color: black;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  max-width: 1200px;
 }
 
-.c1 {
-  width: 30%;
+.c2 .c5 {
+  display: none;
+}
+
+.c2:first-of-type {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -526,29 +611,65 @@ exports[`renders a sponsored series about properly 1`] = `
   flex-direction: column;
 }
 
-.c6 {
-  width: 60%;
+.c2:first-of-type .c5 {
+  display: block;
 }
 
-.c6 .c3 {
-  display: none;
-}
-
-.c2 {
+.c4 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
 }
 
+@media only screen and (min-width:0em) {
+  .c3 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c3 {
+    -webkit-flex-basis: 33.333333333333336%;
+    -ms-flex-basis: 33.333333333333336%;
+    flex-basis: 33.333333333333336%;
+    max-width: 33.333333333333336%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:0em) {
+  .c8 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c8 {
+    -webkit-flex-basis: 66.66666666666667%;
+    -ms-flex-basis: 66.66666666666667%;
+    flex-basis: 66.66666666666667%;
+    max-width: 66.66666666666667%;
+    display: block;
+  }
+}
+
 @media (max-width:720px) {
-  .c4 img {
+  .c6 img {
     max-width: 195px;
   }
 }
 
 @media (max-width:720px) {
-  .c5 {
+  .c7 {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -557,37 +678,37 @@ exports[`renders a sponsored series about properly 1`] = `
 }
 
 @media (max-width:600px) {
-  .c7 p,
-  .c7 ul,
-  .c7 ol {
+  .c9 p,
+  .c9 ul,
+  .c9 ol {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c7 li {
+  .c9 li {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c7 h1 {
+  .c9 h1 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c7 h2 {
+  .c9 h2 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c7 h3 {
+  .c9 h3 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -595,76 +716,59 @@ exports[`renders a sponsored series about properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c7 h3 strong {
+  .c9 h3 strong {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c7 blockquote {
+  .c9 blockquote {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c7 .content-start {
+  .c9 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:900px) {
-  .c0 {
-    display: block;
-  }
-}
-
-@media (max-width:900px) {
-  .c1 {
-    width: 100%;
-  }
-
-  .c1 .c3 {
-    margin-top: 60px;
+@media (max-width:48em) {
+  .c2:first-of-type .c5 {
     display: none;
   }
-}
 
-@media (max-width:900px) {
-  .c6 {
-    width: 100%;
-  }
-
-  .c6 .c3 {
+  .c2 .c5 {
     margin-top: 60px;
     display: block;
   }
 }
 
-@media (max-width:900px) {
-  .c2 {
+@media (max-width:48em) {
+  .c4 {
     margin-bottom: 20px;
   }
 }
 
 <div
-  className="SeriesAbout c0"
+  className="c0 c1"
   color="black"
 >
   <div
-    className="c1"
+    className="c2 c3"
   >
     <div
-      className="c2"
+      className="c4"
     >
       About the Series
     </div>
     <div
-      className="PartnerBlock c3 c4"
+      className="PartnerBlock c5 c6"
     >
       <div
-        className="c5"
+        className="c7"
       >
         Presented In Partnership With
       </div>
@@ -680,10 +784,10 @@ exports[`renders a sponsored series about properly 1`] = `
     </div>
   </div>
   <div
-    className="c6"
+    className="c2 c8"
   >
     <div
-      className="article__text-section c7"
+      className="article__text-section c9"
     >
       <div
         dangerouslySetInnerHTML={
@@ -694,10 +798,10 @@ exports[`renders a sponsored series about properly 1`] = `
       />
     </div>
     <div
-      className="PartnerBlock c3 c4"
+      className="PartnerBlock c5 c6"
     >
       <div
-        className="c5"
+        className="c7"
       >
         Presented In Partnership With
       </div>
@@ -716,12 +820,49 @@ exports[`renders a sponsored series about properly 1`] = `
 `;
 
 exports[`renders series about with children properly 1`] = `
-.c4 {
+.c1 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+}
+
+.c3 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c4 a {
+.c6 a {
   color: black;
   text-decoration: none;
   position: relative;
@@ -731,13 +872,13 @@ exports[`renders series about with children properly 1`] = `
   background-position: bottom;
 }
 
-.c4 a:hover {
+.c6 a:hover {
   color: #999;
 }
 
-.c4 p,
-.c4 ul,
-.c4 ol {
+.c6 p,
+.c6 ul,
+.c6 ol {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -748,20 +889,20 @@ exports[`renders series about with children properly 1`] = `
   font-style: inherit;
 }
 
-.c4 p:first-child {
+.c6 p:first-child {
   padding-top: 0;
 }
 
-.c4 p:last-child {
+.c6 p:last-child {
   padding-bottom: 0;
 }
 
-.c4 ul,
-.c4 ol {
+.c6 ul,
+.c6 ol {
   padding-left: 1em;
 }
 
-.c4 li {
+.c6 li {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -770,7 +911,7 @@ exports[`renders series about with children properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c4 h1 {
+.c6 h1 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -783,7 +924,7 @@ exports[`renders series about with children properly 1`] = `
   text-align: center;
 }
 
-.c4 h1:before {
+.c6 h1:before {
   content: "";
   width: 15px;
   height: 15px;
@@ -794,7 +935,7 @@ exports[`renders series about with children properly 1`] = `
   right: calc(50% - 7.5px);
 }
 
-.c4 h2 {
+.c6 h2 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -803,11 +944,11 @@ exports[`renders series about with children properly 1`] = `
   margin: 0;
 }
 
-.c4 h2 a {
+.c6 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c4 h3 {
+.c6 h3 {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -817,7 +958,7 @@ exports[`renders series about with children properly 1`] = `
   margin: 0;
 }
 
-.c4 h3 strong {
+.c6 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -825,11 +966,11 @@ exports[`renders series about with children properly 1`] = `
   line-height: 1.5em;
 }
 
-.c4 h3 a {
+.c6 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c4 blockquote {
+.c6 blockquote {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -842,7 +983,7 @@ exports[`renders series about with children properly 1`] = `
   word-break: break-word;
 }
 
-.c4 .content-end {
+.c6 .content-end {
   display: inline-block;
   content: "";
   width: 12px;
@@ -852,14 +993,14 @@ exports[`renders series about with children properly 1`] = `
   margin-left: 12px;
 }
 
-.c4 .artist-follow {
+.c6 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c4 .artist-follow:before {
+.c6 .artist-follow:before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -867,7 +1008,7 @@ exports[`renders series about with children properly 1`] = `
   font-size: 32px;
 }
 
-.c4 .artist-follow:after {
+.c6 .artist-follow:after {
   content: "Follow";
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
@@ -878,18 +1019,14 @@ exports[`renders series about with children properly 1`] = `
 
 .c0 {
   color: black;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  max-width: 1200px;
 }
 
-.c1 {
-  width: 30%;
+.c2 .file__PartnerBlockContainer-s8dqalt-0 {
+  display: none;
+}
+
+.c2:first-of-type {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -903,53 +1040,89 @@ exports[`renders series about with children properly 1`] = `
   flex-direction: column;
 }
 
-.c3 {
-  width: 60%;
+.c2:first-of-type .file__PartnerBlockContainer-s8dqalt-0 {
+  display: block;
 }
 
-.c3 .file__PartnerBlockContainer-s8dqalt-0 {
-  display: none;
-}
-
-.c2 {
+.c4 {
   font-family: Unica77LLWebMedium , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
   line-height: 1.1em;
 }
 
+@media only screen and (min-width:0em) {
+  .c3 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c3 {
+    -webkit-flex-basis: 33.333333333333336%;
+    -ms-flex-basis: 33.333333333333336%;
+    flex-basis: 33.333333333333336%;
+    max-width: 33.333333333333336%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:0em) {
+  .c5 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-basis: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c5 {
+    -webkit-flex-basis: 66.66666666666667%;
+    -ms-flex-basis: 66.66666666666667%;
+    flex-basis: 66.66666666666667%;
+    max-width: 66.66666666666667%;
+    display: block;
+  }
+}
+
 @media (max-width:600px) {
-  .c4 p,
-  .c4 ul,
-  .c4 ol {
+  .c6 p,
+  .c6 ul,
+  .c6 ol {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c4 li {
+  .c6 li {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
     line-height: 1.5em;
   }
 
-  .c4 h1 {
+  .c6 h1 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c4 h2 {
+  .c6 h2 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c4 h3 {
+  .c6 h3 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -957,77 +1130,60 @@ exports[`renders series about with children properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c4 h3 strong {
+  .c6 h3 strong {
     font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c4 blockquote {
+  .c6 blockquote {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c4 .content-start {
+  .c6 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:900px) {
-  .c0 {
-    display: block;
-  }
-}
-
-@media (max-width:900px) {
-  .c1 {
-    width: 100%;
-  }
-
-  .c1 .file__PartnerBlockContainer-s8dqalt-0 {
-    margin-top: 60px;
+@media (max-width:48em) {
+  .c2:first-of-type .file__PartnerBlockContainer-s8dqalt-0 {
     display: none;
   }
-}
 
-@media (max-width:900px) {
-  .c3 {
-    width: 100%;
-  }
-
-  .c3 .file__PartnerBlockContainer-s8dqalt-0 {
+  .c2 .file__PartnerBlockContainer-s8dqalt-0 {
     margin-top: 60px;
     display: block;
   }
 }
 
-@media (max-width:900px) {
-  .c2 {
+@media (max-width:48em) {
+  .c4 {
     margin-bottom: 20px;
   }
 }
 
 <div
-  className="SeriesAbout c0"
+  className="c0 c1"
   color="black"
 >
   <div
-    className="c1"
+    className="c2 c3"
   >
     <div
-      className="c2"
+      className="c4"
     >
       About the Series
     </div>
   </div>
   <div
-    className="c3"
+    className="c2 c5"
   >
     <div
-      className="article__text-section c4"
+      className="article__text-section c6"
     >
       <div>
         Child 


### PR DESCRIPTION
One thing I noticed while building out the video landing pages was that Series components don't use `react-styled-flexboxgrid` so it causes a little inconsistency when importing them into the video pages. I think if we're committed to using grid systems, we should start with these pages since they're new. This converts the SeriesAbout component to use `react-styled-flexboxgrid`. We'll have to get to regular article pages another time!

Note that this uses the breakpoints and sizes of the regular grid layout, not our publishing ones.

Some screenshots:
![image](https://user-images.githubusercontent.com/2236794/33902964-a6fdb46c-df44-11e7-95ba-c4bc25411d68.png)
![image](https://user-images.githubusercontent.com/2236794/33902973-b38d724e-df44-11e7-8e95-ede7296247d8.png)
