### PR TITLE
@alloy => Copy and transpile __generated__ files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ const gulp = require("gulp")
 const path = require("path")
 const sourcemaps = require("gulp-sourcemaps")
 const tsc = require("gulp-typescript")
+const mergeStream = require("merge-stream")
 
 const srcDir = "./src"
 const outDir = "./dist"
@@ -20,7 +21,7 @@ gulp.task("compile", () => {
     .pipe(sourcemaps.init())
     .pipe(tsProject())
 
-  return tsResult.js
+  const tsStream = tsResult.js
     .pipe(babel())
     .pipe(
       sourcemaps.write(".", {
@@ -34,6 +35,13 @@ gulp.task("compile", () => {
       })
     )
     .pipe(gulp.dest(outDir))
+
+  const graphqlJsStream = gulp
+    .src(`${srcDir}/**/*.graphql.js`)
+    .pipe(babel())
+    .pipe(gulp.dest(outDir))
+
+  return mergeStream(tsStream, graphqlJsStream)
 })
 
 gulp.task("default", ["clean", "compile"])

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "jest": "^21.1.1",
     "jest-styled-components": "^4.9.0",
     "lint-staged": "^4.0.0",
+    "merge-stream": "^1.0.1",
     "prettier": "^1.7.4",
     "react": "^15.5.4",
     "react-addons-test-utils": "^15.5.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "rootDir": "src",
     "jsx": "react",
-    "allowJs": true,
+    "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "src",
     "experimentalDecorators": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6355,7 +6355,7 @@ merge-stream@^0.1.7:
   dependencies:
     through2 "^0.6.1"
 
-merge-stream@^1.0.0:
+merge-stream@^1.0.0, merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
   dependencies:


### PR DESCRIPTION
re-adding all the gulp stuff, but with the critical `pipe(babel())` line.