### PR TITLE
@kanaabe => Use title instead of thumbnail_title for ArticleCard #minor

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1075,7 +1075,7 @@ exports[`renders a series properly 1`] = `
           <div
             className="c25"
           >
-            New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+            Trevor Paglan
           </div>
           <div
             className="c26"
@@ -2353,7 +2353,7 @@ exports[`renders a sponsored series properly 1`] = `
           <div
             className="c28"
           >
-            New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+            Trevor Paglan
           </div>
           <div
             className="c29"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
@@ -2102,7 +2102,7 @@ exports[`Video Layout matches the snapshot 1`] = `
             <div
               className="c74"
             >
-              New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+              Trevor Paglan
             </div>
             <div
               className="c75"

--- a/src/Components/Publishing/Series/ArticleCard.tsx
+++ b/src/Components/Publishing/Series/ArticleCard.tsx
@@ -131,7 +131,7 @@ export class ArticleCard extends Component<Props, null> {
             <Title>
               {editTitle
                 ? editTitle
-                : article.thumbnail_title
+                : article.title
               }
             </Title>
             <Description>

--- a/src/Components/Publishing/Series/__test__/__snapshots__/ArticleCard.test.tsx.snap
+++ b/src/Components/Publishing/Series/__test__/__snapshots__/ArticleCard.test.tsx.snap
@@ -312,11 +312,11 @@ exports[`ArticleCard renders an article with children properly 1`] = `
   display: flex;
 }
 
-.c0 .file__Image-s107dzpm-0 {
+.c0 .file__Image-s15g7hw5-0 {
   opacity: 1;
 }
 
-.c0:hover .file__Image-s107dzpm-0 {
+.c0:hover .file__Image-s15g7hw5-0 {
   opacity: .7;
 }
 
@@ -763,7 +763,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
       <div
         className="c3"
       >
-        New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+        Trevor Paglan
       </div>
       <div
         className="c4"


### PR DESCRIPTION
Uses the title for ArticleCard instead of thumbnail_title. Addresses a point in https://github.com/artsy/publishing/issues/277