### PR TITLE
@kanaabe => iOS overlapping text bug

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`renders a series properly 1`] = `
 .c23 {
   position: relative;
   width: 50%;
-  height: 100%;
+  height: inherit;
   margin-left: 30px;
 }
 
@@ -1188,7 +1188,7 @@ exports[`renders a sponsored series properly 1`] = `
 .c28 {
   position: relative;
   width: 50%;
-  height: 100%;
+  height: inherit;
   margin-left: 30px;
 }
 

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
@@ -200,7 +200,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 .c70 {
   position: relative;
   width: 50%;
-  height: 100%;
+  height: inherit;
   margin-left: 30px;
 }
 

--- a/src/Components/Publishing/Series/ArticleCard.tsx
+++ b/src/Components/Publishing/Series/ArticleCard.tsx
@@ -188,7 +188,7 @@ const Image = styled.img`
 const ImageContainer = styled.div`
   position: relative;
   width: 50%;
-  height: 100%;
+  height: inherit;
   margin-left: 30px;
   ${props => pMedia.md`
     width: 100%;

--- a/src/Components/Publishing/Series/__test__/__snapshots__/ArticleCard.test.tsx.snap
+++ b/src/Components/Publishing/Series/__test__/__snapshots__/ArticleCard.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`ArticleCard renders an article properly 1`] = `
 .c9 {
   position: relative;
   width: 50%;
-  height: 100%;
+  height: inherit;
   margin-left: 30px;
 }
 
@@ -294,7 +294,7 @@ exports[`ArticleCard renders an article with children properly 1`] = `
 .c7 {
   position: relative;
   width: 50%;
-  height: 100%;
+  height: inherit;
   margin-left: 30px;
 }
 
@@ -312,11 +312,11 @@ exports[`ArticleCard renders an article with children properly 1`] = `
   display: flex;
 }
 
-.c0 .file__Image-s1ofd19w-0 {
+.c0 .file__Image-s1d2f2vs-0 {
   opacity: 1;
 }
 
-.c0:hover .file__Image-s1ofd19w-0 {
+.c0:hover .file__Image-s1d2f2vs-0 {
   opacity: .7;
 }
 
@@ -576,7 +576,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
 .c7 {
   position: relative;
   width: 50%;
-  height: 100%;
+  height: inherit;
   margin-left: 30px;
 }
 


### PR DESCRIPTION
Was able to replicate this bug in browserstack, but not xCode's simulators -- maybe we should get an account... the free trial is only 30min.

- Changes articleCard's image container height to 'inherit' 
