### PR TITLE
[Dep] Move React to peerDeps 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction-force",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",
@@ -44,6 +44,10 @@
     "singleQuote": false,
     "trailingComma": "es5",
     "bracketSpacing": true
+  },
+  "peerDependencies": {
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   },
   "devDependencies": {
     "@playlyfe/gql": "^2.3.2",
@@ -109,7 +113,6 @@
     "numeral": "^2.0.4",
     "prop-types": "^15.5.10",
     "qs": "^6.5.0",
-    "react": "^15.5.4",
     "react-lines-ellipsis": "^0.8.0",
     "react-markdown": "^2.5.0",
     "react-relay": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/react-relay-1.3.0-artsy.1.tgz",


### PR DESCRIPTION
I'm upgrading Force to React 16 right now and ran into an issue where `yarn list react` shows multiple copies, which was leading to client errors; one copy installed at the root and one in `@artsy/reaction-force`. Moving to peerDeps and testing locally by pointing at this branch in Force's `package.json` and navigating to http://localhost:5000/gene/collective-history confirms a fix. 

https://github.com/artsy/force/pull/2053 is blocked in the meantime. 