### PR TITLE
@kanaabe => Image editing tweaks

### DIFF
--- a/src/Components/Publishing/Sections/Artwork.tsx
+++ b/src/Components/Publishing/Sections/Artwork.tsx
@@ -23,12 +23,13 @@ export class Artwork extends React.PureComponent<ArtworkProps, null> {
   }
 
   render() {
-    const { artwork, linked, height, width, layout } = this.props
+    const { artwork, children, linked, height, width, layout } = this.props
     const src = resize(artwork.image, { width: 1200, quality: GLOBAL_IMAGE_QUALITY })
 
     const Image = () =>
       <ImageWrapper
         layout={layout}
+        linked={linked}
         src={src}
         width={width}
         height={height}
@@ -40,14 +41,15 @@ export class Artwork extends React.PureComponent<ArtworkProps, null> {
       <div className="display-artwork">
         {linked
           ? <ArtworkImageLink href={`/artwork/${artwork.slug}`}>
-              <Image />
-            </ArtworkImageLink>
+            <Image />
+          </ArtworkImageLink>
           : <Image />
         }
 
         <ArtworkCaption
           {...this.props}
         />
+        {children}
       </div>
     )
   }

--- a/src/Components/Publishing/Sections/Image.tsx
+++ b/src/Components/Publishing/Sections/Image.tsx
@@ -6,8 +6,10 @@ import { Caption } from "./Caption"
 import { ImageWrapper } from "./ImageWrapper"
 
 interface ImageProps extends React.HTMLProps<HTMLDivElement> {
+  editCaption?: any
   image?: any
   layout?: Layout
+  linked?: boolean
   sectionLayout?: SectionLayout
   width?: number | string
   height?: number | string
@@ -16,19 +18,22 @@ interface ImageProps extends React.HTMLProps<HTMLDivElement> {
 export const Image: React.SFC<ImageProps> = props => {
   const {
     children,
+    editCaption,
     height,
     image,
     layout,
+    linked,
     sectionLayout,
     width,
   } = props
-
+  const caption = image.caption || ''
   const src = resize(image.url, { width: 1200, quality: GLOBAL_IMAGE_QUALITY })
-  const alt = image.caption.replace(/<[^>]*>/g, "") /* strip caption html */
+  const alt = caption.replace(/<[^>]*>/g, "") /* strip caption html */
 
   return (
     <div className="article-image">
       <ImageWrapper
+        linked={linked}
         layout={layout}
         src={src}
         width={width}
@@ -38,12 +43,13 @@ export const Image: React.SFC<ImageProps> = props => {
       />
 
       <Caption
-        caption={image.caption}
+        caption={caption}
         layout={layout}
         sectionLayout={sectionLayout}
       >
-        {children}
+        {editCaption && editCaption()}
       </Caption>
+      {children}
     </div>
   )
 }
@@ -51,4 +57,5 @@ export const Image: React.SFC<ImageProps> = props => {
 Image.defaultProps = {
   width: "100%",
   height: "auto",
+  linked: true,
 }

--- a/src/Components/Publishing/Sections/ImageWrapper.tsx
+++ b/src/Components/Publishing/Sections/ImageWrapper.tsx
@@ -8,6 +8,7 @@ import { ViewFullscreen } from "./ViewFullscreen"
 interface Props extends React.HTMLProps<HTMLImageElement> {
   src: string
   layout?: Layout
+  linked?: boolean
   width?: string | number
   height?: string | number
   alt?: string
@@ -54,7 +55,7 @@ export class ImageWrapper extends React.PureComponent<Props, any> {
   }
 
   render() {
-    const { layout, index, ...blockImageProps }: any = this.props
+    const { layout, linked, index, ...blockImageProps }: any = this.props
     let className = 'BlockImage__container'
 
     if (this.state.isLoaded) {
@@ -69,7 +70,7 @@ export class ImageWrapper extends React.PureComponent<Props, any> {
           {...blockImageProps}
         />
 
-        {layout !== 'classic' &&
+        {layout !== 'classic' && linked &&
           <Fullscreen>
             <ViewFullscreen index={index} />
           </Fullscreen>

--- a/src/Components/Publishing/Sections/__test__/Artwork.test.tsx
+++ b/src/Components/Publishing/Sections/__test__/Artwork.test.tsx
@@ -1,8 +1,11 @@
+import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import renderer from "react-test-renderer"
 import { Images } from "../../Fixtures/Components"
+import { EditableChild } from "../../Fixtures/Helpers"
 import { Artwork } from "../Artwork"
+import { ViewFullscreen } from "../ViewFullscreen"
 
 jest.mock("react-lines-ellipsis/lib/html", () => {
   const React = require('react')
@@ -16,4 +19,30 @@ jest.mock('react-dom/server', () => ({
 it("renders properly", () => {
   const artwork = renderer.create(<Artwork artwork={Images[0]} />).toJSON()
   expect(artwork).toMatchSnapshot()
+})
+
+it("renders a fullscreen button if linked", () => {
+  const component = mount(
+    <Artwork artwork={Images[0]} linked />
+  )
+  expect(component.find(ViewFullscreen).length).toBe(1)
+})
+
+it("does not render a fullscreen button if not linked", () => {
+  const component = mount(
+    <Artwork
+      artwork={Images[0]}
+      linked={false}
+    />
+  )
+  expect(component.find(ViewFullscreen).length).toBe(0)
+})
+
+it("renders a child if present", () => {
+  const component = mount(
+    <Artwork artwork={Images[0]}>
+      {EditableChild('A React child.')}
+    </Artwork>
+  )
+  expect(component.text()).toMatch('A React child.')
 })

--- a/src/Components/Publishing/Sections/__test__/Image.test.tsx
+++ b/src/Components/Publishing/Sections/__test__/Image.test.tsx
@@ -1,8 +1,11 @@
+import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import renderer from "react-test-renderer"
 import { Images } from "../../Fixtures/Components"
+import { EditableChild } from "../../Fixtures/Helpers"
 import { Image } from "../Image"
+import { ViewFullscreen } from "../ViewFullscreen"
 
 it("renders properly", () => {
   const image = renderer.create(<Image image={Images[1]} />).toJSON()
@@ -17,12 +20,49 @@ it("renders a long caption properly", () => {
 it("renders a react child as caption properly", () => {
   const image = renderer
     .create(
-      <Image image={Images[2]}>
-        <div>
-          <p>A React child as caption.</p>
-        </div>
-      </Image>
+    <Image image={Images[2]}>
+      {EditableChild('A React child.')}
+    </Image>
     )
     .toJSON()
   expect(image).toMatchSnapshot()
+})
+
+it("renders a fullscreen button if linked", () => {
+  const component = mount(
+    <Image
+      image={Images[2]}
+      linked
+    />
+  )
+  expect(component.find(ViewFullscreen).length).toBe(1)
+})
+
+it("does not render a fullscreen button if not linked", () => {
+  const component = mount(
+    <Image
+      image={Images[2]}
+      linked={false}
+    />
+  )
+  expect(component.find(ViewFullscreen).length).toBe(0)
+})
+
+it("renders editCaption if present", () => {
+  const component = mount(
+    <Image
+      image={Images[2]}
+      editCaption={() => EditableChild('editCaption')}
+    />
+  )
+  expect(component.text()).toMatch('editCaption')
+})
+
+it("renders a child if present", () => {
+  const component = mount(
+    <Image image={Images[2]}>
+      {EditableChild('A React child.')}
+    </Image>
+  )
+  expect(component.text()).toMatch('A React child.')
 })

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Image.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Image.test.tsx.snap
@@ -366,12 +366,18 @@ exports[`renders a react child as caption properly 1`] = `
     <div
       className="c6"
     >
-      <div>
-        <p>
-          A React child as caption.
-        </p>
-      </div>
+      <div
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>Photo by <a href='artsy.net'>Adam Kuehl</a> for Artsy. Image courtesy of the Guggenheim Museum.</p>",
+          }
+        }
+      />
     </div>
+  </div>
+  <div>
+    Child 
+    A React child.
   </div>
 </div>
 `;


### PR DESCRIPTION
Some changes to images and artworks to allow better control in Positron--

- Use `editCaption` prop rather than children to render caption fields
- Allow children in both artwork and image (for remove buttons and potentially other things, renders without styles or container)
- Allow image captions to be empty
- Use linked prop in images to determine if `ViewFullscreen` button is displayed
- Adds unit tests for images and artworks

  This will affect https://github.com/artsy/reaction/pull/455/files, but I can update that PR once this is merged. 
  