### PR TITLE
[WIP] Add animation transition on follow

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "numeral": "^2.0.4",
     "prop-types": "^15.5.10",
     "qs": "^6.5.0",
+    "react-css-transition-replace": "^3.0.2",
     "react-lines-ellipsis": "^0.8.0",
     "react-markdown": "^2.5.0",
     "react-relay": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/react-relay-1.3.0-artsy.1.tgz",

--- a/src/Components/Animation/ReplaceTransition.tsx
+++ b/src/Components/Animation/ReplaceTransition.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import ReactCSSTransitionReplace from 'react-css-transition-replace'
+import { injectGlobal } from "styled-components"
+
+injectGlobal`
+  .fade-wait-leave {
+    opacity: 1;
+  }
+  .fade-wait-leave.fade-wait-leave-active {
+    opacity: 0;
+    transition: opacity .4s ease-in;
+  }
+
+  .fade-wait-enter {
+    opacity: 0;
+  }
+  .fade-wait-enter.fade-wait-enter-active {
+    opacity: 1;
+    /* Delay the enter animation until the leave completes */
+    transition: opacity .4s ease-in .6s;
+  }
+
+  .fade-wait-height {
+    transition: height .6s ease-in-out;
+  }
+`
+
+export default props =>
+  <ReactCSSTransitionReplace transitionName="fade-wait" {...props}>
+    {...props.children}
+  </ReactCSSTransitionReplace>

--- a/src/Components/Icon.tsx
+++ b/src/Components/Icon.tsx
@@ -30,4 +30,5 @@ export default styled(Icon)`
   font-size: ${props => props.fontSize || "24px"};
   margin: 0 5px;
   display: inline-block;
+  letter-spacing: 0px;
 `

--- a/src/Components/Onboarding/ItemLink.tsx
+++ b/src/Components/Onboarding/ItemLink.tsx
@@ -1,18 +1,17 @@
 import * as React from "react"
-import styled, { StyledFunction } from "styled-components"
+import styled from "styled-components"
 
 import Colors from "../../Assets/Colors"
 import * as fonts from "../../Assets/Fonts"
+import CircleIcon from "../CircleIcon";
 import Icon from "../Icon"
 
-const anchor: StyledFunction<React.HTMLProps<HTMLAnchorElement>> = styled.a
-const Link = anchor`
+const Link = styled.a`
   display: flex;
   font-size: 14px;
   color: black;
   text-decoration: none;
-  ${fonts.primary.style}
-  border-top: 1px solid ${Colors.grayRegular};
+  ${fonts.primary.style};
   &:hover {
     background-color: ${Colors.gray};
   }
@@ -33,6 +32,17 @@ const Col = styled.div`
   align-items: center;
 `
 
+const CircleIconContainer = styled.div`
+  width: 50px;
+  text-align: center;
+`
+
+export const LinkContainer = styled.div`
+  border-top: 1px solid ${Colors.grayRegular};
+  border-bottom: 1px solid ${Colors.grayRegular};
+  margin-top: -1px;
+`
+
 interface Props extends React.HTMLProps<HTMLAnchorElement> {
   item?: any
   id: string
@@ -42,10 +52,27 @@ interface Props extends React.HTMLProps<HTMLAnchorElement> {
   image_url: string
 }
 
-export default class ItemLink extends React.Component<Props, null> {
+interface State {
+  selected: boolean
+}
+
+export default class ItemLink extends React.Component<Props, State> {
+  constructor(props, state) {
+    super(props, state)
+
+    this.state = {
+      selected: false,
+    }
+  }
+
+  onClick(e) {
+    this.props.onClick(e)
+    this.setState({ selected: true })
+  }
+
   render() {
     return (
-      <Link onClick={this.props.onClick}>
+      <Link onClick={this.onClick.bind(this)}>
         <Col>
           {
             <Avatar
@@ -57,7 +84,13 @@ export default class ItemLink extends React.Component<Props, null> {
         </Col>
         <FullWidthCol>{this.props.name}</FullWidthCol>
         <Col>
-          <Icon name="follow-circle" color="black" fontSize="39px" />
+          {
+            this.state.selected ?
+              <Icon name="follow-circle.is-following" color="black" fontSize="39px" /> :
+              <CircleIconContainer>
+                <CircleIcon name="close" color="black" fontSize="21px" style={{ transform: 'rotate(45deg)' }} />
+              </CircleIconContainer>
+          }
         </Col>
       </Link>
     )

--- a/src/Components/Onboarding/ItemLink.tsx
+++ b/src/Components/Onboarding/ItemLink.tsx
@@ -14,6 +14,7 @@ const Link = styled.a`
   ${fonts.primary.style};
   &:hover {
     background-color: ${Colors.gray};
+    cursor: pointer;
   }
 `
 

--- a/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
@@ -2,8 +2,9 @@ import * as React from "react"
 import { commitMutation, createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
 
 import { RecordSourceSelectorProxy, SelectorData } from "relay-runtime"
+import ReplaceTransition from "../../../Animation/ReplaceTransition"
 import { ContextConsumer, ContextProps } from "../../../Artsy"
-import ItemLink from "../../ItemLink"
+import ItemLink, { LinkContainer } from "../../ItemLink"
 import { FollowProps } from "../../Types"
 
 export interface Props extends FollowProps {
@@ -99,15 +100,18 @@ class ArtistSearchResultsContent extends React.Component<RelayProps, null> {
 
   render() {
     const artistItems = this.props.viewer.match_artist.map((artist, index) => (
-      <ItemLink
-        href="#"
-        item={artist}
-        key={index}
-        id={artist.id}
-        name={artist.name}
-        image_url={artist.image && artist.image.cropped.url}
-        onClick={() => this.onFollowedArtist(artist)}
-      />
+      <LinkContainer>
+        <ReplaceTransition key={index} transitionEnterTimeout={1000} transitionLeaveTimeout={400}>
+          <ItemLink
+            href="#"
+            item={artist}
+            key={artist.id}
+            id={artist.id}
+            name={artist.name}
+            image_url={artist.image && artist.image.cropped.url}
+            onClick={() => this.onFollowedArtist(artist)} />
+        </ReplaceTransition>
+      </LinkContainer>
     ))
 
     return <div>{artistItems}</div>

--- a/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
+++ b/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
@@ -2,8 +2,9 @@ import * as React from "react"
 import { commitMutation, createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
 
 import { RecordSourceSelectorProxy, SelectorData } from "relay-runtime"
+import ReplaceTransition from "../../../Animation/ReplaceTransition"
 import { ContextConsumer, ContextProps } from "../../../Artsy"
-import ItemLink from "../../ItemLink"
+import ItemLink, { LinkContainer } from "../../ItemLink"
 import { FollowProps } from "../../Types"
 
 export interface RelayProps {
@@ -100,15 +101,18 @@ class PopularArtistsContent extends React.Component<Props, null> {
 
   render() {
     const artistItems = this.props.popular_artists.artists.map((artist, index) => (
-      <ItemLink
-        href="#"
-        item={artist}
-        key={index}
-        id={artist.id}
-        name={artist.name}
-        image_url={artist.image && artist.image.cropped.url}
-        onClick={() => this.onFollowedArtist(artist)}
-      />
+      <LinkContainer>
+        <ReplaceTransition key={index} transitionEnterTimeout={1000} transitionLeaveTimeout={400}>
+          <ItemLink
+            href="#"
+            item={artist}
+            key={artist.id}
+            id={artist.id}
+            name={artist.name}
+            image_url={artist.image && artist.image.cropped.url}
+            onClick={() => this.onFollowedArtist(artist)} />
+        </ReplaceTransition>
+      </LinkContainer>
     ))
 
     return <div>{artistItems}</div>

--- a/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
@@ -4,8 +4,9 @@ import styled from "styled-components"
 
 import { RecordSourceSelectorProxy, SelectorData } from "relay-runtime"
 import * as fonts from "../../../../Assets/Fonts"
+import ReplaceTransition from "../../../Animation/ReplaceTransition"
 import { ContextConsumer, ContextProps } from "../../../Artsy"
-import ItemLink from "../../ItemLink"
+import ItemLink, { LinkContainer } from "../../ItemLink"
 import { FollowProps } from "../../Types"
 
 interface Gene {
@@ -101,19 +102,20 @@ class GeneSearchResultsContent extends React.Component<RelayProps, null> {
   }
 
   render() {
-    const items = this.props.viewer.match_gene.map((item, index) => {
-      return (
-        <ItemLink
-          href="#"
-          item={item}
-          key={index}
-          id={item.id}
-          name={item.name}
-          image_url={item.image.cropped.url}
-          onClick={() => this.followedGene(item)}
-        />
-      )
-    })
+    const items = this.props.viewer.match_gene.map((item, index) => (
+      <LinkContainer>
+        <ReplaceTransition key={index} transitionEnterTimeout={1000} transitionLeaveTimeout={400}>
+          <ItemLink
+            href="#"
+            item={item}
+            key={item.id}
+            id={item.id}
+            name={item.name}
+            image_url={item.image.cropped.url}
+            onClick={() => this.followedGene(item)} />
+        </ReplaceTransition>
+      </LinkContainer>
+    ))
 
     if (items.length < 1) {
       return <NoResultsContainer>No Results Found</NoResultsContainer>

--- a/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
+++ b/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
@@ -2,8 +2,9 @@ import * as React from "react"
 import { commitMutation, createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
 import { RecordSourceSelectorProxy, SelectorData } from "relay-runtime"
 
+import ReplaceTransition from "../../../Animation/ReplaceTransition"
 import { ContextConsumer, ContextProps } from "../../../Artsy"
-import ItemLink from "../../ItemLink"
+import ItemLink, { LinkContainer } from "../../ItemLink"
 import { FollowProps } from "../../Types"
 
 interface Gene {
@@ -86,20 +87,21 @@ class SuggestedGenesContent extends React.Component<Props, null> {
   }
 
   render() {
-    const items = this.props.suggested_genes.map((item, index) => {
-      return (
-        <ItemLink
-          href="#"
-          item={item}
-          key={index}
-          id={item.id}
-          _id={item._id}
-          name={item.name}
-          image_url={item.image.cropped.url}
-          onClick={() => this.followedGene(item)}
-        />
-      )
-    })
+    const items = this.props.suggested_genes.map((item, index) => (
+      <LinkContainer>
+        <ReplaceTransition key={index} transitionEnterTimeout={1000} transitionLeaveTimeout={400}>
+          <ItemLink
+            href="#"
+            item={item}
+            key={item.id}
+            id={item.id}
+            _id={item._id}
+            name={item.name}
+            image_url={item.image.cropped.url}
+            onClick={() => this.followedGene(item)} />
+        </ReplaceTransition>
+      </LinkContainer>
+    ))
 
     return <div>{items}</div>
   }

--- a/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/__test__/__snapshots__/FeatureHeader.test.tsx.snap
@@ -2748,6 +2748,10 @@ exports[`feature renders superArticle full header properly 1`] = `
   font-size: 32px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c9 {

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -7,6 +7,10 @@ exports[`renders a series properly 1`] = `
   font-size: 32px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c3 {
@@ -1054,6 +1058,10 @@ exports[`renders a sponsored series properly 1`] = `
   font-size: 32px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c7 {

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
@@ -12,6 +12,10 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-size: 32px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c4 {

--- a/src/Components/Publishing/Nav/__test__/__snapshots__/Nav.test.js.snap
+++ b/src/Components/Publishing/Nav/__test__/__snapshots__/Nav.test.js.snap
@@ -7,6 +7,10 @@ exports[`Nav renders a Nav 1`] = `
   font-size: 32px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c2 {
@@ -147,6 +151,10 @@ exports[`Nav renders a sponsored nav 1`] = `
   font-size: 32px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c6 {
@@ -344,6 +352,10 @@ exports[`Nav renders a transparent nav 1`] = `
   font-size: 32px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c2 {

--- a/src/Components/Publishing/Partner/__test__/__snapshots__/PartnerInline.test.tsx.snap
+++ b/src/Components/Publishing/Partner/__test__/__snapshots__/PartnerInline.test.tsx.snap
@@ -7,6 +7,10 @@ exports[`renders the partner inline 1`] = `
   font-size: 32px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c4 {

--- a/src/Components/Publishing/Sections/FullscreenViewer/__test__/__snapshots__/FullscreenViewer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__test__/__snapshots__/FullscreenViewer.test.tsx.snap
@@ -7,6 +7,10 @@ exports[`renders properly 1`] = `
   font-size: 24px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c11 {

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Authors.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Authors.test.tsx.snap
@@ -7,6 +7,10 @@ exports[`renders properly 1`] = `
   font-size: 24px;
   margin: 0 5px;
   display: inline-block;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
 .c2 {

--- a/src/Components/__stories__/Animation.story.tsx
+++ b/src/Components/__stories__/Animation.story.tsx
@@ -1,0 +1,31 @@
+import { storiesOf } from "@storybook/react"
+import * as React from "react"
+import ReplaceTransition from "../Animation/ReplaceTransition"
+import ItemLink, { LinkContainer } from "../Onboarding/ItemLink"
+
+class Animator extends React.Component {
+  state = { count: 0 }
+
+  render() {
+    return (
+      <LinkContainer>
+        <ReplaceTransition
+          transitionEnterTimeout={1000}
+          transitionLeaveTimeout={400}
+          onClick={() => this.setState({ count:  this.state.count + 1 })}>
+          {
+            [
+              <ItemLink id="3141" key="0" name="PABLO PICASSO" image_url="https://www.artsy.net/images/icon-70.png" />,
+              <ItemLink id="2718" key="1" name="ANDY WARHOL" image_url="https://www.artsy.net/images/icon-70.png" />
+            ][this.state.count % 2]
+          }
+        </ReplaceTransition>
+      </LinkContainer>
+    )
+  }
+}
+
+storiesOf("Components/Animations", module).add("All Animations", () =>
+  <div style={{ margin: "40px" }}>
+    <Animator />
+  </div>)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7427,6 +7427,16 @@ react-addons-test-utils@^15.5.1:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
+react-css-transition-replace@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-css-transition-replace/-/react-css-transition-replace-3.0.2.tgz#8c2f8ea556c935f590ec285ed2d3ec247b19271e"
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.2.0"
+    prop-types "^15.6.0"
+    react-transition-group "^1.2.1"
+    warning "^3.0.0"
+
 react-docgen@^2.15.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.16.0.tgz#03c9eba935de8031d791ab62657b7b6606ec5da6"
@@ -7571,6 +7581,16 @@ react-tracking@^4.2.1:
 react-transition-group@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.0.tgz#b51fc921b0c3835a7ef7c571c79fc82c73e9204f"
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.6"
+    warning "^3.0.0"
+
+react-transition-group@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
   dependencies:
     chain-function "^1.0.0"
     dom-helpers "^3.2.0"


### PR DESCRIPTION
This PR adds a `<ReplaceTrnsition>` component. finishes https://github.com/artsy/collector-experience/issues/843

**Jan 22 2018: updated the screenshot**

![2018-01-22 16_20_54](https://user-images.githubusercontent.com/386234/35245029-3c7d6f08-ff90-11e7-8002-a74146fdb05f.gif)

 * Right now, people are moving forward to the `react-transition-group` version 2, which seems to cover many issues. Ideally, we should be using this version.
 * In the master branch, there's already a [`<ReplaceTransition>` component](https://github.com/reactjs/react-transition-group/blob/7a64114/src/ReplaceTransition.js) in `react-transition-group`. However, it requires [exactly two elements](https://github.com/reactjs/react-transition-group/blob/7a641148849fc3aa0aa0acb673da9bc3cc35a7a0/src/ReplaceTransition.js#L10) shown and mounted simultaneously. Unfortunately, this is not the case in our list components such as `<PopularArtists>`. I also tried adding an empty `<div>` just to confirm the interface, but it just transitioned to an empty `<div>` (of course...) or animation wasn't applied at all.
 * There's also another library [`react-css-transition-replace`](https://github.com/marnusw/react-css-transition-replace). While this library works out of the box, it still depends on the old `react-transition-group` v1.

In other words, there's no ideal solution out there at this point. For now, I just sticked to the `react-css-transition-replace` so I could send this PR and show you what's in the branch. There's [another WIP branch](https://github.com/yuki24/reaction/tree/animation-without-dependencies) I'm working on for implementing the same animation but without dependencies. I'm hoping that we'll be able to:

 * Understand how the entire `<ReactCSSTransitionReplace>` component works by reading and converting raw javascript to TypeScript
 * Upgrade the `react-transition-group` to v2 without braking the interface (`<ReplaceTransition>`  takes a single component, fades in/out after `render()`)
 * Propose the entire idea and implementation back to the `react-transition-group`

However, this has been taking a bit longer than it should. I'd like to hear from you before looking into this too deeply. This PR is meant to be a conversation starter for how we are going to implement/maintain animation components rather than just merging immediately. Let me know what you think!