### PR TITLE
@alloy => Export component with a QueryRenderer for MarketInsights

### DIFF
--- a/src/Components/Artist/MarketInsights/MarketInsights.tsx
+++ b/src/Components/Artist/MarketInsights/MarketInsights.tsx
@@ -3,10 +3,10 @@ import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 
-import colors from "../../Assets/Colors"
-import { Fonts } from "../Publishing/Fonts"
-import TextLink from "../TextLink"
-import { Tooltip } from "../Tooltip"
+import colors from "../../../Assets/Colors"
+import { Fonts } from "../../Publishing/Fonts"
+import TextLink from "../../TextLink"
+import { Tooltip } from "../../Tooltip"
 
 const MarketInsightsContainer = styled.div`
   ${Fonts.unica("s16", "medium")};
@@ -108,7 +108,7 @@ export class MarketInsights extends React.Component<MarketInsightsProps, null> {
         <div>
           {topAuctionResult.price_realized.display} auction record
           <SubHeadline>
-            {topAuctionResult.organization} {topAuctionResult.date}
+            {topAuctionResult.organization} {topAuctionResult.sale_date}
           </SubHeadline>
         </div>
         <br />
@@ -187,7 +187,7 @@ export default createFragmentContainer(
             price_realized {
               display(format: "0a")
             }
-            date(format: "YYYY")
+            sale_date(format: "YYYY")
           }
         }
       }
@@ -219,7 +219,7 @@ interface RelayProps {
           price_realized: {
             display: string | null
           }
-          date: string | null
+          sale_date: string | null
         } | null
       }> | null
     } | null

--- a/src/Components/Artist/MarketInsights/index.tsx
+++ b/src/Components/Artist/MarketInsights/index.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+
+import { ContextConsumer, ContextProps } from "../../Artsy"
+import MarketInsights from "./MarketInsights"
+
+interface Props extends ContextProps {
+  artistID: string
+}
+
+class MarketInsightsContents extends React.Component<Props, null> {
+  render() {
+    const { artistID, relayEnvironment } = this.props
+    return (
+      <QueryRenderer
+        environment={relayEnvironment}
+        query={graphql`
+          query MarketInsightsContentsQuery($artistID: String!) {
+            artist(id: $artistID) {
+              ...MarketInsights_artist
+            }
+          }
+        `}
+        variables={{ artistID }}
+        render={({ props }) => {
+          if (props) {
+            return <MarketInsights artist={props.artist} />
+          } else {
+            return null
+          }
+        }}
+      />
+    )
+  }
+}
+
+export const Contents = ContextConsumer(MarketInsightsContents)

--- a/src/Components/__stories__/MarketInsights.story.tsx
+++ b/src/Components/__stories__/MarketInsights.story.tsx
@@ -1,44 +1,21 @@
 import { storiesOf } from "@storybook/react"
 import * as React from "react"
-import { graphql } from "react-relay"
 
-import { RootQueryRenderer } from "../../Relay/RootQueryRenderer"
-import MarketInsights from "../Artist/MarketInsights"
+import { Contents } from "../Artist/MarketInsights"
+import { ContextProvider } from "../Artsy"
 
-function ArtistExample(props: { artistID: string }) {
+function RenderMarketInsightsFor(artistID: string) {
   return (
-    <RootQueryRenderer
-      query={graphql`
-        query MarketInsightsQuery($artistID: String!) {
-          artist(id: $artistID) {
-            ...MarketInsights_artist
-          }
-        }
-      `}
-      variables={{ artistID: props.artistID }}
-      render={readyState => {
-        return readyState.props && <MarketInsights artist={readyState.props.artist} />
-      }}
-    />
+    <ContextProvider>
+      <Contents artistID={artistID} />
+    </ContextProvider>
   )
 }
 
 storiesOf("Components/Artist/MarketInsights", module)
-  .add("Pablo Picasso", () => {
-    return <ArtistExample artistID="pablo-picasso" />
-  })
-  .add("Andy Warhol", () => {
-    return <ArtistExample artistID="andy-warhol" />
-  })
-  .add("Damon Zucconi", () => {
-    return <ArtistExample artistID="damon-zucconi" />
-  })
-  .add("Huma Bhabha", () => {
-    return <ArtistExample artistID="huma-bhabha" />
-  })
-  .add("Robert Longo", () => {
-    return <ArtistExample artistID="robert-longo" />
-  })
-  .add("Carla Accardi", () => {
-    return <ArtistExample artistID="carla-accardi" />
-  })
+  .add("Pablo Picasso", () => RenderMarketInsightsFor("pablo-picasso"))
+  .add("Andy Warhol", () => RenderMarketInsightsFor("andy-warhol"))
+  .add("Damon Zucconi", () => RenderMarketInsightsFor("damon-zucconi"))
+  .add("Huma Bhabha", () => RenderMarketInsightsFor("huma-bhabha"))
+  .add("Robert Longo", () => RenderMarketInsightsFor("robert-longo"))
+  .add("Carla Accardi", () => RenderMarketInsightsFor("carla-accardi"))

--- a/src/Components/__tests__/MarketInsights.test.tsx
+++ b/src/Components/__tests__/MarketInsights.test.tsx
@@ -1,7 +1,7 @@
 import "jest-styled-components"
 import React from "react"
 import renderer from "react-test-renderer"
-import MarketInsights from "../Artist/MarketInsights"
+import MarketInsights from "../Artist/MarketInsights/MarketInsights"
 
 describe("MarketInsights", () => {
   it("renders correctly", () => {
@@ -74,7 +74,7 @@ describe("MarketInsights", () => {
             node: {
               organization: "Christie's",
               price_realized: { display: "$63m" },
-              date: "1987",
+              sale_date: "2017",
               __id: "QXVjdGlvblJlc3VsdDoxMDkzOQ==",
             },
           },

--- a/src/Components/__tests__/__snapshots__/MarketInsights.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/MarketInsights.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`MarketInsights renders correctly 1`] = `
       >
         Christie's
          
-        1987
+        2017
       </div>
     </div>
     <br />


### PR DESCRIPTION
I'm still faffing with actually getting this to work in Force, but I _think_ this might work, since we can now use a component that will fetch the data and render.

It cleans up the storybook too, which is akin to how we'll use it in Force.