### PR TITLE
@joeyAghion => Last market insights QA

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -271,7 +271,7 @@ type ArtistEdge {
 }
 
 type ArtistHighlights {
-  partners(represented_by: Boolean, partner_category: [String], after: String, first: Int, before: String, last: Int): PartnerArtistConnection
+  partners(represented_by: Boolean, partner_category: [String], display_on_partner_profile: Boolean, after: String, first: Int, before: String, last: Int): PartnerArtistConnection
 }
 
 type ArtistItem implements Node {
@@ -787,6 +787,7 @@ type ArtworkContextAuction implements Node {
   # Returns a live auctions url if the sale is open and start time is after now
   live_url_if_open: String
   profile: Profile
+  promoted_sale: Sale
   registration_ends_at(
     convert_to_utc: Boolean
     format: String
@@ -1023,6 +1024,7 @@ type ArtworkContextSale implements Node {
   # Returns a live auctions url if the sale is open and start time is after now
   live_url_if_open: String
   profile: Profile
+  promoted_sale: Sale
   registration_ends_at(
     convert_to_utc: Boolean
     format: String
@@ -3325,6 +3327,7 @@ type HomePageModuleContextSale implements Node {
   # Returns a live auctions url if the sale is open and start time is after now
   live_url_if_open: String
   profile: Profile
+  promoted_sale: Sale
   registration_ends_at(
     convert_to_utc: Boolean
     format: String
@@ -4791,6 +4794,7 @@ type Sale implements Node {
   # Returns a live auctions url if the sale is open and start time is after now
   live_url_if_open: String
   profile: Profile
+  promoted_sale: Sale
   registration_ends_at(
     convert_to_utc: Boolean
     format: String

--- a/data/schema.json
+++ b/data/schema.json
@@ -12690,6 +12690,18 @@
               "deprecationReason": null
             },
             {
+              "name": "promoted_sale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sale",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "registration_ends_at",
               "description": null,
               "args": [
@@ -14610,6 +14622,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "display_on_partner_profile",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "after",
                   "description": null,
                   "type": {
@@ -15248,6 +15270,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Profile",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "promoted_sale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sale",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -17117,6 +17151,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Profile",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "promoted_sale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sale",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -24736,6 +24782,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Profile",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "promoted_sale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sale",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/src/Components/Artist/MarketInsights/MarketInsights.tsx
+++ b/src/Components/Artist/MarketInsights/MarketInsights.tsx
@@ -166,7 +166,7 @@ export class MarketInsights extends React.Component<MarketInsightsProps, null> {
         <TextLink
           color={colors.graySemibold}
           underline
-          href="mailto:productfeedback@artsy.net?subject=Feedback+on+About+the+Artist+Information"
+          href="mailto:productfeedback@artsy.net?subject=Feedback+on+%22About+the+Artist%22+information"
         >
           Tell us what you think.
         </TextLink>

--- a/src/Components/Artist/MarketInsights/MarketInsights.tsx
+++ b/src/Components/Artist/MarketInsights/MarketInsights.tsx
@@ -196,7 +196,12 @@ export default createFragmentContainer(
       _id
       collections
       highlights {
-        partners(first: 10, represented_by: true, partner_category: $partner_category) {
+        partners(
+          first: 10
+          display_on_partner_profile: true
+          represented_by: true
+          partner_category: $partner_category
+        ) {
           edges {
             node {
               name

--- a/src/Components/__tests__/__snapshots__/MarketInsights.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/MarketInsights.test.tsx.snap
@@ -312,7 +312,7 @@ exports[`MarketInsights renders correctly 1`] = `
     This is a new feature. 
     <a
       className="c6"
-      href="mailto:productfeedback@artsy.net?subject=Feedback+on+About+the+Artist+Information"
+      href="mailto:productfeedback@artsy.net?subject=Feedback+on+%22About+the+Artist%22+information"
     >
       Tell us what you think.
     </a>


### PR DESCRIPTION
Addresses last couple of bullet points for https://github.com/artsy/collector-experience/issues/872.

Depends on https://github.com/artsy/metaphysics/pull/898

There'll be one last PR in Force, to bring in the latest Reaction module, as well as a `z-index` fix for the tooltip bug, and then Force `master` will be ready to go with these final QA pieces!

One last pass at QA to verify final fixes, and then we can merge https://github.com/artsy/force/pull/2070 , which replaces the admin-only guard with the actual AB test (next Tuesday).