### PR TITLE
@kanaabe => Draft default class

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -355,7 +355,8 @@ exports[`renders a series properly 1`] = `
 
 .c37 p,
 .c37 ul,
-.c37 ol {
+.c37 ol,
+.c37 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -366,11 +367,13 @@ exports[`renders a series properly 1`] = `
   font-style: inherit;
 }
 
-.c37 p:first-child {
+.c37 p:first-child,
+.c37 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c37 p:last-child {
+.c37 p:last-child,
+.c37 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -724,7 +727,8 @@ exports[`renders a series properly 1`] = `
 @media (max-width:600px) {
   .c37 p,
   .c37 ul,
-  .c37 ol {
+  .c37 ol,
+  .c37 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -1416,7 +1420,8 @@ exports[`renders a sponsored series properly 1`] = `
 
 .c42 p,
 .c42 ul,
-.c42 ol {
+.c42 ol,
+.c42 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -1427,11 +1432,13 @@ exports[`renders a sponsored series properly 1`] = `
   font-style: inherit;
 }
 
-.c42 p:first-child {
+.c42 p:first-child,
+.c42 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c42 p:last-child {
+.c42 p:last-child,
+.c42 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -1819,7 +1826,8 @@ exports[`renders a sponsored series properly 1`] = `
 @media (max-width:600px) {
   .c42 p,
   .c42 ul,
-  .c42 ol {
+  .c42 ol,
+  .c42 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
@@ -415,7 +415,8 @@ exports[`Video Layout matches the snapshot 1`] = `
 
 .c49 p,
 .c49 ul,
-.c49 ol {
+.c49 ol,
+.c49 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -426,11 +427,13 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-style: inherit;
 }
 
-.c49 p:first-child {
+.c49 p:first-child,
+.c49 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c49 p:last-child {
+.c49 p:last-child,
+.c49 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -576,7 +579,8 @@ exports[`Video Layout matches the snapshot 1`] = `
 
 .c58 p,
 .c58 ul,
-.c58 ol {
+.c58 ol,
+.c58 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -587,11 +591,13 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-style: inherit;
 }
 
-.c58 p:first-child {
+.c58 p:first-child,
+.c58 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c58 p:last-child {
+.c58 p:last-child,
+.c58 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -1397,7 +1403,8 @@ exports[`Video Layout matches the snapshot 1`] = `
 @media (max-width:600px) {
   .c49 p,
   .c49 ul,
-  .c49 ol {
+  .c49 ol,
+  .c49 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -1455,7 +1462,8 @@ exports[`Video Layout matches the snapshot 1`] = `
 @media (max-width:600px) {
   .c58 p,
   .c58 ul,
-  .c58 ol {
+  .c58 ol,
+  .c58 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Sections/Caption.tsx
+++ b/src/Components/Publishing/Sections/Caption.tsx
@@ -51,7 +51,9 @@ const Figcaption = div`
   width: 100%;
   word-break: break-word;
 
-  & > p, p, .public-DraftEditorPlaceholder-root {
+  & > p, p,
+  .public-DraftEditorPlaceholder-root,
+  .public-DraftStyleDefault-block {
     ${props => (props.layout === "classic" ? Fonts.garamond("s15") : Fonts.unica("s14"))}
     color: ${props => (props.layout === "classic" ? "#666" : "#999")};
     margin: 0;

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -41,17 +41,20 @@ export const StyledText = div`
       opacity:  ${props => props.color === "black" ? "1" : ".65"};
     }
   }
-  p, ul, ol {
+  p, ul, ol,
+  .public-DraftStyleDefault-block {
     ${props => (props.layout === "classic" ? Fonts.garamond("s19") : Fonts.garamond("s23"))}
     padding-top: ${props => (props.layout === "classic" ? ".75em" : "1em")};
     padding-bottom: ${props => (props.layout === "classic" ? ".75em" : "1em")};
     margin: 0;
     font-style: ${props => (props.postscript ? "italic" : "inherit")};
   }
-  p:first-child {
+  p:first-child,
+  .public-DraftStyleDefault-block:first-child {
     padding-top: 0;
   }
-  p:last-child {
+  p:last-child,
+  .public-DraftStyleDefault-block:last-child {
     padding-bottom: 0;
   }
   ul, ol {
@@ -114,7 +117,8 @@ export const StyledText = div`
     margin: 0;
     word-break: break-word;
   }
-  p:first-child:first-letter {
+  p:first-child:first-letter,
+  .public-DraftStyleDefault-block:first-child:first-letter {
     ${props => props.isContentStart && props.layout === "feature" && Fonts.unica("s67", "medium")}
     ${props => props.isContentStart && props.layout === "feature" && `
       float: left;
@@ -152,7 +156,8 @@ export const StyledText = div`
     }
   }
   ${props => pMedia.xs`
-    p, ul, ol {
+    p, ul, ol,
+    .public-DraftStyleDefault-block {
       ${Fonts.garamond("s19")}
     }
     li {

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Caption.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Caption.test.tsx.snap
@@ -21,7 +21,8 @@ exports[`renders a child even if a caption is provided 1`] = `
 
 .c1 > p,
 .c1 p,
-.c1 .public-DraftEditorPlaceholder-root {
+.c1 .public-DraftEditorPlaceholder-root,
+.c1 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -86,7 +87,8 @@ exports[`renders a saved caption properly 1`] = `
 
 .c1 > p,
 .c1 p,
-.c1 .public-DraftEditorPlaceholder-root {
+.c1 .public-DraftEditorPlaceholder-root,
+.c1 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Image.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Image.test.tsx.snap
@@ -21,7 +21,8 @@ exports[`renders a long caption properly 1`] = `
 
 .c6 > p,
 .c6 p,
-.c6 .public-DraftEditorPlaceholder-root {
+.c6 .public-DraftEditorPlaceholder-root,
+.c6 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -210,7 +211,8 @@ exports[`renders a react child as caption properly 1`] = `
 
 .c6 > p,
 .c6 p,
-.c6 .public-DraftEditorPlaceholder-root {
+.c6 .public-DraftEditorPlaceholder-root,
+.c6 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -403,7 +405,8 @@ exports[`renders properly 1`] = `
 
 .c6 > p,
 .c6 p,
-.c6 .public-DraftEditorPlaceholder-root {
+.c6 .public-DraftEditorPlaceholder-root,
+.c6 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/ImageCollection.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/ImageCollection.test.tsx.snap
@@ -374,7 +374,8 @@ exports[`renders properly 1`] = `
 
 .c12 > p,
 .c12 p,
-.c12 .public-DraftEditorPlaceholder-root {
+.c12 .public-DraftEditorPlaceholder-root,
+.c12 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
@@ -34,7 +34,8 @@ exports[`renders column_width properly 1`] = `
 
 .c1 p,
 .c1 ul,
-.c1 ol {
+.c1 ol,
+.c1 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -45,11 +46,13 @@ exports[`renders column_width properly 1`] = `
   font-style: inherit;
 }
 
-.c1 p:first-child {
+.c1 p:first-child,
+.c1 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c1 p:last-child {
+.c1 p:last-child,
+.c1 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -190,7 +193,8 @@ exports[`renders column_width properly 1`] = `
 @media (max-width:600px) {
   .c1 p,
   .c1 ul,
-  .c1 ol {
+  .c1 ol,
+  .c1 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -298,7 +302,8 @@ exports[`renders fillwidth properly 1`] = `
 
 .c1 p,
 .c1 ul,
-.c1 ol {
+.c1 ol,
+.c1 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -309,11 +314,13 @@ exports[`renders fillwidth properly 1`] = `
   font-style: inherit;
 }
 
-.c1 p:first-child {
+.c1 p:first-child,
+.c1 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c1 p:last-child {
+.c1 p:last-child,
+.c1 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -454,7 +461,8 @@ exports[`renders fillwidth properly 1`] = `
 @media (max-width:600px) {
   .c1 p,
   .c1 ul,
-  .c1 ol {
+  .c1 ol,
+  .c1 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -562,7 +570,8 @@ exports[`renders overflow_fillwidth properly 1`] = `
 
 .c1 p,
 .c1 ul,
-.c1 ol {
+.c1 ol,
+.c1 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -573,11 +582,13 @@ exports[`renders overflow_fillwidth properly 1`] = `
   font-style: inherit;
 }
 
-.c1 p:first-child {
+.c1 p:first-child,
+.c1 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c1 p:last-child {
+.c1 p:last-child,
+.c1 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -718,7 +729,8 @@ exports[`renders overflow_fillwidth properly 1`] = `
 @media (max-width:600px) {
   .c1 p,
   .c1 ul,
-  .c1 ol {
+  .c1 ol,
+  .c1 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
@@ -335,7 +335,8 @@ exports[`snapshots renders properly 1`] = `
 
 .c2 p,
 .c2 ul,
-.c2 ol {
+.c2 ol,
+.c2 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -346,11 +347,13 @@ exports[`snapshots renders properly 1`] = `
   font-style: inherit;
 }
 
-.c2 p:first-child {
+.c2 p:first-child,
+.c2 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c2 p:last-child {
+.c2 p:last-child,
+.c2 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -664,7 +667,8 @@ exports[`snapshots renders properly 1`] = `
 @media (max-width:600px) {
   .c2 p,
   .c2 ul,
-  .c2 ol {
+  .c2 ol,
+  .c2 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
@@ -111,7 +111,8 @@ exports[`snapshots renders properly 1`] = `
 
 .c13 > p,
 .c13 p,
-.c13 .public-DraftEditorPlaceholder-root {
+.c13 .public-DraftEditorPlaceholder-root,
+.c13 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
@@ -23,7 +23,8 @@ exports[`renders classic text properly 1`] = `
 
 .c0 p,
 .c0 ul,
-.c0 ol {
+.c0 ol,
+.c0 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -34,11 +35,13 @@ exports[`renders classic text properly 1`] = `
   font-style: inherit;
 }
 
-.c0 p:first-child {
+.c0 p:first-child,
+.c0 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c0 p:last-child {
+.c0 p:last-child,
+.c0 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -174,7 +177,8 @@ exports[`renders classic text properly 1`] = `
 @media (max-width:600px) {
   .c0 p,
   .c0 ul,
-  .c0 ol {
+  .c0 ol,
+  .c0 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -267,7 +271,8 @@ exports[`renders feature text properly 1`] = `
 
 .c0 p,
 .c0 ul,
-.c0 ol {
+.c0 ol,
+.c0 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -278,11 +283,13 @@ exports[`renders feature text properly 1`] = `
   font-style: inherit;
 }
 
-.c0 p:first-child {
+.c0 p:first-child,
+.c0 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c0 p:last-child {
+.c0 p:last-child,
+.c0 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -409,7 +416,8 @@ exports[`renders feature text properly 1`] = `
 @media (max-width:600px) {
   .c0 p,
   .c0 ul,
-  .c0 ol {
+  .c0 ol,
+  .c0 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -501,7 +509,8 @@ exports[`renders standard text properly 1`] = `
 
 .c0 p,
 .c0 ul,
-.c0 ol {
+.c0 ol,
+.c0 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -512,11 +521,13 @@ exports[`renders standard text properly 1`] = `
   font-style: inherit;
 }
 
-.c0 p:first-child {
+.c0 p:first-child,
+.c0 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c0 p:last-child {
+.c0 p:last-child,
+.c0 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -643,7 +654,8 @@ exports[`renders standard text properly 1`] = `
 @media (max-width:600px) {
   .c0 p,
   .c0 ul,
-  .c0 ol {
+  .c0 ol,
+  .c0 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Video.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Video.test.tsx.snap
@@ -21,7 +21,8 @@ exports[`renders properly 1`] = `
 
 .c6 > p,
 .c6 p,
-.c6 .public-DraftEditorPlaceholder-root {
+.c6 .public-DraftEditorPlaceholder-root,
+.c6 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular , 'Arial', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 14px;

--- a/src/Components/Publishing/Series/__test__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__test__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -60,7 +60,8 @@ exports[`renders a series about properly 1`] = `
 
 .c6 p,
 .c6 ul,
-.c6 ol {
+.c6 ol,
+.c6 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -71,11 +72,13 @@ exports[`renders a series about properly 1`] = `
   font-style: inherit;
 }
 
-.c6 p:first-child {
+.c6 p:first-child,
+.c6 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c6 p:last-child {
+.c6 p:last-child,
+.c6 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -278,7 +281,8 @@ exports[`renders a series about properly 1`] = `
 @media (max-width:600px) {
   .c6 p,
   .c6 ul,
-  .c6 ol {
+  .c6 ol,
+  .c6 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -455,7 +459,8 @@ exports[`renders a sponsored series about properly 1`] = `
 
 .c9 p,
 .c9 ul,
-.c9 ol {
+.c9 ol,
+.c9 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -466,11 +471,13 @@ exports[`renders a sponsored series about properly 1`] = `
   font-style: inherit;
 }
 
-.c9 p:first-child {
+.c9 p:first-child,
+.c9 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c9 p:last-child {
+.c9 p:last-child,
+.c9 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -688,7 +695,8 @@ exports[`renders a sponsored series about properly 1`] = `
 @media (max-width:600px) {
   .c9 p,
   .c9 ul,
-  .c9 ol {
+  .c9 ol,
+  .c9 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -888,7 +896,8 @@ exports[`renders series about with children properly 1`] = `
 
 .c6 p,
 .c6 ul,
-.c6 ol {
+.c6 ol,
+.c6 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -899,11 +908,13 @@ exports[`renders series about with children properly 1`] = `
   font-style: inherit;
 }
 
-.c6 p:first-child {
+.c6 p:first-child,
+.c6 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c6 p:last-child {
+.c6 p:last-child,
+.c6 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -1106,7 +1117,8 @@ exports[`renders series about with children properly 1`] = `
 @media (max-width:600px) {
   .c6 p,
   .c6 ul,
-  .c6 ol {
+  .c6 ol,
+  .c6 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Video/__test__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__test__/__snapshots__/VideoAbout.test.tsx.snap
@@ -92,7 +92,8 @@ exports[`Video About matches the snapshot 1`] = `
 
 .c4 p,
 .c4 ul,
-.c4 ol {
+.c4 ol,
+.c4 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -103,11 +104,13 @@ exports[`Video About matches the snapshot 1`] = `
   font-style: inherit;
 }
 
-.c4 p:first-child {
+.c4 p:first-child,
+.c4 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c4 p:last-child {
+.c4 p:last-child,
+.c4 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -335,7 +338,8 @@ exports[`Video About matches the snapshot 1`] = `
 @media (max-width:600px) {
   .c4 p,
   .c4 ul,
-  .c4 ol {
+  .c4 ol,
+  .c4 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -762,7 +766,8 @@ exports[`Video About matches the snapshot with editable props 1`] = `
 
 .c4 p,
 .c4 ul,
-.c4 ol {
+.c4 ol,
+.c4 .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -773,11 +778,13 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   font-style: inherit;
 }
 
-.c4 p:first-child {
+.c4 p:first-child,
+.c4 .public-DraftStyleDefault-block:first-child {
   padding-top: 0;
 }
 
-.c4 p:last-child {
+.c4 p:last-child,
+.c4 .public-DraftStyleDefault-block:last-child {
   padding-bottom: 0;
 }
 
@@ -1005,7 +1012,8 @@ exports[`Video About matches the snapshot with editable props 1`] = `
 @media (max-width:600px) {
   .c4 p,
   .c4 ul,
-  .c4 ol {
+  .c4 ol,
+  .c4 .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;


### PR DESCRIPTION
One half of https://github.com/artsy/positron/issues/1531

Adds Draft's default block (equivalent to paragraph) to StyledText classes.