### PR TITLE
@kanaabe => Draft blocks

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -368,12 +368,12 @@ exports[`renders a series properly 1`] = `
 }
 
 .c37 p:first-child,
-.c37 .public-DraftStyleDefault-block:first-child {
+.c37 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c37 p:last-child,
-.c37 .public-DraftStyleDefault-block:last-child {
+.c37 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -1433,12 +1433,12 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 .c42 p:first-child,
-.c42 .public-DraftStyleDefault-block:first-child {
+.c42 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c42 p:last-child,
-.c42 .public-DraftStyleDefault-block:last-child {
+.c42 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
@@ -428,12 +428,12 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 .c49 p:first-child,
-.c49 .public-DraftStyleDefault-block:first-child {
+.c49 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c49 p:last-child,
-.c49 .public-DraftStyleDefault-block:last-child {
+.c49 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -592,12 +592,12 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 .c58 p:first-child,
-.c58 .public-DraftStyleDefault-block:first-child {
+.c58 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c58 p:last-child,
-.c58 .public-DraftStyleDefault-block:last-child {
+.c58 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -50,11 +50,11 @@ export const StyledText = div`
     font-style: ${props => (props.postscript ? "italic" : "inherit")};
   }
   p:first-child,
-  .public-DraftStyleDefault-block:first-child {
+  div[data-block=true]:first-child .public-DraftStyleDefault-block {
     padding-top: 0;
   }
   p:last-child,
-  .public-DraftStyleDefault-block:last-child {
+  div[data-block=true]:last-child .public-DraftStyleDefault-block {
     padding-bottom: 0;
   }
   ul, ol {
@@ -118,7 +118,7 @@ export const StyledText = div`
     word-break: break-word;
   }
   p:first-child:first-letter,
-  .public-DraftStyleDefault-block:first-child:first-letter {
+  div[data-block=true]:first-child .public-DraftStyleDefault-block:first-letter {
     ${props => props.isContentStart && props.layout === "feature" && Fonts.unica("s67", "medium")}
     ${props => props.isContentStart && props.layout === "feature" && `
       float: left;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
@@ -47,12 +47,12 @@ exports[`renders column_width properly 1`] = `
 }
 
 .c1 p:first-child,
-.c1 .public-DraftStyleDefault-block:first-child {
+.c1 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c1 p:last-child,
-.c1 .public-DraftStyleDefault-block:last-child {
+.c1 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -315,12 +315,12 @@ exports[`renders fillwidth properly 1`] = `
 }
 
 .c1 p:first-child,
-.c1 .public-DraftStyleDefault-block:first-child {
+.c1 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c1 p:last-child,
-.c1 .public-DraftStyleDefault-block:last-child {
+.c1 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -583,12 +583,12 @@ exports[`renders overflow_fillwidth properly 1`] = `
 }
 
 .c1 p:first-child,
-.c1 .public-DraftStyleDefault-block:first-child {
+.c1 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c1 p:last-child,
-.c1 .public-DraftStyleDefault-block:last-child {
+.c1 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
@@ -349,12 +349,12 @@ exports[`snapshots renders properly 1`] = `
 }
 
 .c2 p:first-child,
-.c2 .public-DraftStyleDefault-block:first-child {
+.c2 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c2 p:last-child,
-.c2 .public-DraftStyleDefault-block:last-child {
+.c2 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
@@ -36,12 +36,12 @@ exports[`renders classic text properly 1`] = `
 }
 
 .c0 p:first-child,
-.c0 .public-DraftStyleDefault-block:first-child {
+.c0 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c0 p:last-child,
-.c0 .public-DraftStyleDefault-block:last-child {
+.c0 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -284,12 +284,12 @@ exports[`renders feature text properly 1`] = `
 }
 
 .c0 p:first-child,
-.c0 .public-DraftStyleDefault-block:first-child {
+.c0 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c0 p:last-child,
-.c0 .public-DraftStyleDefault-block:last-child {
+.c0 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -522,12 +522,12 @@ exports[`renders standard text properly 1`] = `
 }
 
 .c0 p:first-child,
-.c0 .public-DraftStyleDefault-block:first-child {
+.c0 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c0 p:last-child,
-.c0 .public-DraftStyleDefault-block:last-child {
+.c0 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 

--- a/src/Components/Publishing/Series/__test__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__test__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -73,12 +73,12 @@ exports[`renders a series about properly 1`] = `
 }
 
 .c6 p:first-child,
-.c6 .public-DraftStyleDefault-block:first-child {
+.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c6 p:last-child,
-.c6 .public-DraftStyleDefault-block:last-child {
+.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -472,12 +472,12 @@ exports[`renders a sponsored series about properly 1`] = `
 }
 
 .c9 p:first-child,
-.c9 .public-DraftStyleDefault-block:first-child {
+.c9 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c9 p:last-child,
-.c9 .public-DraftStyleDefault-block:last-child {
+.c9 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -909,12 +909,12 @@ exports[`renders series about with children properly 1`] = `
 }
 
 .c6 p:first-child,
-.c6 .public-DraftStyleDefault-block:first-child {
+.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c6 p:last-child,
-.c6 .public-DraftStyleDefault-block:last-child {
+.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 

--- a/src/Components/Publishing/Video/__test__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__test__/__snapshots__/VideoAbout.test.tsx.snap
@@ -105,12 +105,12 @@ exports[`Video About matches the snapshot 1`] = `
 }
 
 .c4 p:first-child,
-.c4 .public-DraftStyleDefault-block:first-child {
+.c4 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c4 p:last-child,
-.c4 .public-DraftStyleDefault-block:last-child {
+.c4 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
@@ -779,12 +779,12 @@ exports[`Video About matches the snapshot with editable props 1`] = `
 }
 
 .c4 p:first-child,
-.c4 .public-DraftStyleDefault-block:first-child {
+.c4 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
 .c4 p:last-child,
-.c4 .public-DraftStyleDefault-block:last-child {
+.c4 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
Got the selectors slightly wrong for first-child/last-child in draft, this fixes them so spacing is correct in Positron.