### PR TITLE
@kanaabe => Prefix draft selector

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -356,7 +356,7 @@ exports[`renders a series properly 1`] = `
 .c37 p,
 .c37 ul,
 .c37 ol,
-.c37 .public-DraftStyleDefault-block {
+.c37 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -728,7 +728,7 @@ exports[`renders a series properly 1`] = `
   .c37 p,
   .c37 ul,
   .c37 ol,
-  .c37 .public-DraftStyleDefault-block {
+  .c37 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -1421,7 +1421,7 @@ exports[`renders a sponsored series properly 1`] = `
 .c42 p,
 .c42 ul,
 .c42 ol,
-.c42 .public-DraftStyleDefault-block {
+.c42 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -1827,7 +1827,7 @@ exports[`renders a sponsored series properly 1`] = `
   .c42 p,
   .c42 ul,
   .c42 ol,
-  .c42 .public-DraftStyleDefault-block {
+  .c42 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.js.snap
@@ -416,7 +416,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 .c49 p,
 .c49 ul,
 .c49 ol,
-.c49 .public-DraftStyleDefault-block {
+.c49 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -580,7 +580,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 .c58 p,
 .c58 ul,
 .c58 ol,
-.c58 .public-DraftStyleDefault-block {
+.c58 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -1404,7 +1404,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   .c49 p,
   .c49 ul,
   .c49 ol,
-  .c49 .public-DraftStyleDefault-block {
+  .c49 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -1463,7 +1463,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   .c58 p,
   .c58 ul,
   .c58 ol,
-  .c58 .public-DraftStyleDefault-block {
+  .c58 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -42,7 +42,7 @@ export const StyledText = div`
     }
   }
   p, ul, ol,
-  .public-DraftStyleDefault-block {
+  div[data-block=true] .public-DraftStyleDefault-block {
     ${props => (props.layout === "classic" ? Fonts.garamond("s19") : Fonts.garamond("s23"))}
     padding-top: ${props => (props.layout === "classic" ? ".75em" : "1em")};
     padding-bottom: ${props => (props.layout === "classic" ? ".75em" : "1em")};
@@ -157,7 +157,7 @@ export const StyledText = div`
   }
   ${props => pMedia.xs`
     p, ul, ol,
-    .public-DraftStyleDefault-block {
+    div[data-block=true] .public-DraftStyleDefault-block {
       ${Fonts.garamond("s19")}
     }
     li {

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/SectionContainer.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`renders column_width properly 1`] = `
 .c1 p,
 .c1 ul,
 .c1 ol,
-.c1 .public-DraftStyleDefault-block {
+.c1 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -194,7 +194,7 @@ exports[`renders column_width properly 1`] = `
   .c1 p,
   .c1 ul,
   .c1 ol,
-  .c1 .public-DraftStyleDefault-block {
+  .c1 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -303,7 +303,7 @@ exports[`renders fillwidth properly 1`] = `
 .c1 p,
 .c1 ul,
 .c1 ol,
-.c1 .public-DraftStyleDefault-block {
+.c1 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -462,7 +462,7 @@ exports[`renders fillwidth properly 1`] = `
   .c1 p,
   .c1 ul,
   .c1 ol,
-  .c1 .public-DraftStyleDefault-block {
+  .c1 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -571,7 +571,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
 .c1 p,
 .c1 ul,
 .c1 ol,
-.c1 .public-DraftStyleDefault-block {
+.c1 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -730,7 +730,7 @@ exports[`renders overflow_fillwidth properly 1`] = `
   .c1 p,
   .c1 ul,
   .c1 ol,
-  .c1 .public-DraftStyleDefault-block {
+  .c1 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Sections.test.js.snap
@@ -337,7 +337,7 @@ exports[`snapshots renders properly 1`] = `
 .c2 p,
 .c2 ul,
 .c2 ol,
-.c2 .public-DraftStyleDefault-block {
+.c2 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -669,7 +669,7 @@ exports[`snapshots renders properly 1`] = `
   .c2 p,
   .c2 ul,
   .c2 ol,
-  .c2 .public-DraftStyleDefault-block {
+  .c2 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__test__/__snapshots__/Text.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`renders classic text properly 1`] = `
 .c0 p,
 .c0 ul,
 .c0 ol,
-.c0 .public-DraftStyleDefault-block {
+.c0 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -178,7 +178,7 @@ exports[`renders classic text properly 1`] = `
   .c0 p,
   .c0 ul,
   .c0 ol,
-  .c0 .public-DraftStyleDefault-block {
+  .c0 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -272,7 +272,7 @@ exports[`renders feature text properly 1`] = `
 .c0 p,
 .c0 ul,
 .c0 ol,
-.c0 .public-DraftStyleDefault-block {
+.c0 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -417,7 +417,7 @@ exports[`renders feature text properly 1`] = `
   .c0 p,
   .c0 ul,
   .c0 ol,
-  .c0 .public-DraftStyleDefault-block {
+  .c0 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -510,7 +510,7 @@ exports[`renders standard text properly 1`] = `
 .c0 p,
 .c0 ul,
 .c0 ol,
-.c0 .public-DraftStyleDefault-block {
+.c0 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -655,7 +655,7 @@ exports[`renders standard text properly 1`] = `
   .c0 p,
   .c0 ul,
   .c0 ol,
-  .c0 .public-DraftStyleDefault-block {
+  .c0 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Series/__test__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__test__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`renders a series about properly 1`] = `
 .c6 p,
 .c6 ul,
 .c6 ol,
-.c6 .public-DraftStyleDefault-block {
+.c6 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -282,7 +282,7 @@ exports[`renders a series about properly 1`] = `
   .c6 p,
   .c6 ul,
   .c6 ol,
-  .c6 .public-DraftStyleDefault-block {
+  .c6 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -460,7 +460,7 @@ exports[`renders a sponsored series about properly 1`] = `
 .c9 p,
 .c9 ul,
 .c9 ol,
-.c9 .public-DraftStyleDefault-block {
+.c9 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -696,7 +696,7 @@ exports[`renders a sponsored series about properly 1`] = `
   .c9 p,
   .c9 ul,
   .c9 ol,
-  .c9 .public-DraftStyleDefault-block {
+  .c9 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -897,7 +897,7 @@ exports[`renders series about with children properly 1`] = `
 .c6 p,
 .c6 ul,
 .c6 ol,
-.c6 .public-DraftStyleDefault-block {
+.c6 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -1118,7 +1118,7 @@ exports[`renders series about with children properly 1`] = `
   .c6 p,
   .c6 ul,
   .c6 ol,
-  .c6 .public-DraftStyleDefault-block {
+  .c6 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;

--- a/src/Components/Publishing/Video/__test__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__test__/__snapshots__/VideoAbout.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`Video About matches the snapshot 1`] = `
 .c4 p,
 .c4 ul,
 .c4 ol,
-.c4 .public-DraftStyleDefault-block {
+.c4 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -339,7 +339,7 @@ exports[`Video About matches the snapshot 1`] = `
   .c4 p,
   .c4 ul,
   .c4 ol,
-  .c4 .public-DraftStyleDefault-block {
+  .c4 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -767,7 +767,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
 .c4 p,
 .c4 ul,
 .c4 ol,
-.c4 .public-DraftStyleDefault-block {
+.c4 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
   -webkit-font-smoothing: antialiased;
   font-size: 23px;
@@ -1013,7 +1013,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   .c4 p,
   .c4 ul,
   .c4 ol,
-  .c4 .public-DraftStyleDefault-block {
+  .c4 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 19px;


### PR DESCRIPTION
One more small change to the classes for Draft -- prefix selector with `div[data-block=true]` so it does not apply to div's inside an `h2` or other kind of block.