### PR TITLE
[Prettier] Update column setting to default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "**/node_modules": true,
     "dist/": true
   },
+  "editor.rulers": [80],
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "[json]": {

--- a/package.json
+++ b/package.json
@@ -41,13 +41,6 @@
     "type-check": "tsc --noEmit --pretty",
     "watch": "gulp watch"
   },
-  "prettier": {
-    "printWidth": 120,
-    "semi": false,
-    "singleQuote": false,
-    "trailingComma": "es5",
-    "bracketSpacing": true
-  },
   "devDependencies": {
     "@playlyfe/gql": "^2.3.2",
     "@storybook/addon-options": "^3.2.1",
@@ -131,6 +124,12 @@
   },
   "graphql": {
     "file": "data/schema.json"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": false,
+    "trailingComma": "es5",
+    "bracketSpacing": true
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
This updates Prettier column settings to the default (80) per the [RFC outcome](https://github.com/artsy/potential/issues/127#issuecomment-358997987). In favor of an incremental approach (while acknowledging existing PRs in the wild), it does _not_ reformat the codebase. Existing code will remain the same until touched at which point our git precommit hook (or VSCode editor settings) will rewrite. 