### PR TITLE
@yuki24 => [Onboarding] Throttled search

### DIFF
--- a/src/Components/Onboarding/SelectableLink.tsx
+++ b/src/Components/Onboarding/SelectableLink.tsx
@@ -38,11 +38,12 @@ const Link = styled.a`
   font-size: 14px;
   color: black;
   text-decoration: none;
-  ${fonts.primary.style}
+  ${fonts.primary.style};
   padding: 30px 0 30px 15px;
   border-top: 1px solid ${Colors.grayRegular};
   &:hover {
     background-color: ${Colors.gray};
+    cursor: pointer;
   }
   &:hover ${IconContainer} {
     display: inline-flex;
@@ -77,7 +78,12 @@ class SelectableLink extends React.Component<SelectableLinkProps, LinkState> {
           {this.props.text}
 
           <IconContainer isSelected={this.state.selected}>
-            <Icon name="follow-circle.is-following" color="white" fontSize="39px" style={{ alignSelf: "center" }} />
+            <Icon
+              name="follow-circle.is-following"
+              color="white"
+              fontSize="39px"
+              style={{ alignSelf: "center" }}
+            />
           </IconContainer>
         </Link>
       </div>

--- a/src/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/Components/Onboarding/Steps/Artists/index.tsx
@@ -1,3 +1,4 @@
+import { throttle } from "lodash"
 import React from "react"
 import styled from "styled-components"
 
@@ -23,11 +24,13 @@ const OnboardingSearchBox = styled.div`
 interface State {
   inputText: string
   followCount: number
+  inputTextQuery: string
 }
 
 export default class Artists extends React.Component<StepProps, State> {
   state = {
     inputText: "",
+    inputTextQuery: "",
     followCount: 0,
   }
 
@@ -39,13 +42,30 @@ export default class Artists extends React.Component<StepProps, State> {
 
   submit() {
     const increaseBy = this.state.followCount >= 4 ? 2 : 1
-
     this.props.onNextButtonPressed(increaseBy)
   }
 
-  searchTextChanged(e) {
+  componentDidMount() {
+    this.throttledTextChange = throttle(this.throttledTextChange, 500, {
+      leading: true,
+    })
+  }
+
+  searchTextChanged = e => {
     const updatedInputText = e.target.value
     this.setState({ inputText: updatedInputText })
+    this.throttledTextChange(updatedInputText)
+  }
+
+  throttledTextChange = inputText => {
+    this.setState({ inputTextQuery: inputText })
+  }
+
+  clearSearch(e) {
+    this.setState({
+      inputText: "",
+      inputTextQuery: "",
+    })
   }
 
   render() {
@@ -68,7 +88,7 @@ export default class Artists extends React.Component<StepProps, State> {
           />
           <div style={{ marginBottom: "35px" }} />
           <ArtistList
-            searchQuery={this.state.inputText}
+            searchQuery={this.state.inputTextQuery}
             updateFollowCount={this.updateFollowCount.bind(this)}
           />
         </OnboardingSearchBox>

--- a/src/Components/Onboarding/Steps/Genes/index.tsx
+++ b/src/Components/Onboarding/Steps/Genes/index.tsx
@@ -1,3 +1,4 @@
+import { throttle } from "lodash"
 import * as React from "react"
 import styled from "styled-components"
 
@@ -23,11 +24,13 @@ const OnboardingSearchBox = styled.div`
 interface State {
   inputText: string
   followCount: number
+  inputTextQuery: string
 }
 
 export default class Genes extends React.Component<StepProps, State> {
   state = {
     inputText: "",
+    inputTextQuery: "",
     followCount: 0,
   }
 
@@ -35,9 +38,20 @@ export default class Genes extends React.Component<StepProps, State> {
     this.setState({ followCount: count })
   }
 
-  searchTextChanged(e) {
+  componentDidMount() {
+    this.throttledTextChange = throttle(this.throttledTextChange, 500, {
+      leading: true,
+    })
+  }
+
+  searchTextChanged = e => {
     const updatedInputText = e.target.value
     this.setState({ inputText: updatedInputText })
+    this.throttledTextChange(updatedInputText)
+  }
+
+  throttledTextChange = inputText => {
+    this.setState({ inputTextQuery: inputText })
   }
 
   clearSearch(e) {
@@ -65,14 +79,18 @@ export default class Genes extends React.Component<StepProps, State> {
               ) : null
             }
             block
-            onInput={this.searchTextChanged.bind(this)}
-            onPaste={this.searchTextChanged.bind(this)}
-            onCut={this.searchTextChanged.bind(this)}
+            onInput={this.searchTextChanged}
+            onPaste={this.searchTextChanged}
+            onCut={this.searchTextChanged}
             value={this.state.inputText}
             autoFocus
           />
           <div style={{ marginBottom: "35px" }} />
+<<<<<<< HEAD
           {<GeneList searchQuery={this.state.inputText} updateFollowCount={this.updateFollowCount.bind(this)} />}
+=======
+          {<GeneList searchQuery={this.state.inputTextQuery} />}
+>>>>>>> a487c894... Adds throttled Gene search
         </OnboardingSearchBox>
       </Layout>
     )

--- a/src/Components/Onboarding/Steps/Genes/index.tsx
+++ b/src/Components/Onboarding/Steps/Genes/index.tsx
@@ -55,7 +55,10 @@ export default class Genes extends React.Component<StepProps, State> {
   }
 
   clearSearch(e) {
-    this.setState({ inputText: "" })
+    this.setState({
+      inputText: "",
+      inputTextQuery: "",
+    })
   }
 
   clickedNext() {
@@ -67,7 +70,9 @@ export default class Genes extends React.Component<StepProps, State> {
       <Layout
         title="Follow art categories that interest you most"
         subtitle="Follow one or more"
-        onNextButtonPressed={this.state.followCount > 0 ? this.clickedNext.bind(this) : null}
+        onNextButtonPressed={
+          this.state.followCount > 0 ? this.clickedNext.bind(this) : null
+        }
       >
         <OnboardingSearchBox>
           <Input
@@ -75,7 +80,11 @@ export default class Genes extends React.Component<StepProps, State> {
             leftView={<Icon name="search" color={Colors.graySemibold} />}
             rightView={
               this.state.inputText.length ? (
-                <Icon name="close" color={Colors.graySemibold} onClick={this.clearSearch.bind(this)} />
+                <Icon
+                  name="close"
+                  color={Colors.graySemibold}
+                  onClick={this.clearSearch.bind(this)}
+                />
               ) : null
             }
             block
@@ -86,11 +95,12 @@ export default class Genes extends React.Component<StepProps, State> {
             autoFocus
           />
           <div style={{ marginBottom: "35px" }} />
-<<<<<<< HEAD
-          {<GeneList searchQuery={this.state.inputText} updateFollowCount={this.updateFollowCount.bind(this)} />}
-=======
-          {<GeneList searchQuery={this.state.inputTextQuery} />}
->>>>>>> a487c894... Adds throttled Gene search
+          {
+            <GeneList
+              searchQuery={this.state.inputTextQuery}
+              updateFollowCount={this.updateFollowCount.bind(this)}
+            />
+          }
         </OnboardingSearchBox>
       </Layout>
     )


### PR DESCRIPTION
Addresses https://github.com/artsy/collector-experience/issues/847 by decoupling text input from query + throttles the query state change.

Noticed there weren't any tests in this project yet so I was going to add one but got a little stuck on an error with `ContextProvider` and mocking the Relay side. I'll follow up with tests but didn't want to hold back on the PR.

This uses 500 millisecond throttle which was a little nicer than 1 second which felt pretty slow.
![throttle-search](https://user-images.githubusercontent.com/2236794/35175139-5443936c-fd40-11e7-97bf-360433f3238d.gif)
