### PR TITLE
@kanaabe => Minor ui tweaks

### DIFF
--- a/src/Components/Onboarding/ItemLink.tsx
+++ b/src/Components/Onboarding/ItemLink.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components"
 
 import Colors from "../../Assets/Colors"
 import * as fonts from "../../Assets/Fonts"
-import CircleIcon from "../CircleIcon";
+import CircleIcon from "../CircleIcon"
 import Icon from "../Icon"
 
 const Link = styled.a`
@@ -19,7 +19,7 @@ const Link = styled.a`
 `
 
 const Avatar = styled.img`
-  padding: 10px 15px 10px 10px;
+  margin: 10px 15px 10px 10px;
 `
 
 const FullWidthCol = styled.div`
@@ -77,7 +77,11 @@ export default class ItemLink extends React.Component<Props, State> {
         <Col>
           {
             <Avatar
-              src={this.props.image_url ? this.props.image_url : "https://www.artsy.net/images/icon-70.png"}
+              src={
+                this.props.image_url
+                  ? this.props.image_url
+                  : "https://www.artsy.net/images/icon-70.png"
+              }
               width={50}
               height={50}
             />
@@ -85,13 +89,22 @@ export default class ItemLink extends React.Component<Props, State> {
         </Col>
         <FullWidthCol>{this.props.name}</FullWidthCol>
         <Col>
-          {
-            this.state.selected ?
-              <Icon name="follow-circle.is-following" color="black" fontSize="39px" /> :
-              <CircleIconContainer>
-                <CircleIcon name="close" color="black" fontSize="21px" style={{ transform: 'rotate(45deg)' }} />
-              </CircleIconContainer>
-          }
+          {this.state.selected ? (
+            <Icon
+              name="follow-circle.is-following"
+              color="black"
+              fontSize="39px"
+            />
+          ) : (
+            <CircleIconContainer>
+              <CircleIcon
+                name="close"
+                color="black"
+                fontSize="21px"
+                style={{ transform: "rotate(45deg)" }}
+              />
+            </CircleIconContainer>
+          )}
         </Col>
       </Link>
     )

--- a/src/Components/Onboarding/Steps/Budget.tsx
+++ b/src/Components/Onboarding/Steps/Budget.tsx
@@ -68,9 +68,7 @@ class Budget extends React.Component<StepProps & ContextProps, State> {
       },
     })
 
-    if (this.props.redirectTo) {
-      window.location.href = this.props.redirectTo
-    }
+    this.props.onNextButtonPressed()
   }
 
   render() {

--- a/src/Components/Onboarding/Steps/Budget.tsx
+++ b/src/Components/Onboarding/Steps/Budget.tsx
@@ -50,7 +50,9 @@ class Budget extends React.Component<StepProps & ContextProps, State> {
 
     commitMutation(this.props.relayEnvironment, {
       mutation: graphql`
-        mutation BudgetUpdateMyUserProfileMutation($input: UpdateMyProfileInput!) {
+        mutation BudgetUpdateMyUserProfileMutation(
+          $input: UpdateMyProfileInput!
+        ) {
           updateMyUserProfile(input: $input) {
             user {
               name
@@ -65,6 +67,10 @@ class Budget extends React.Component<StepProps & ContextProps, State> {
         },
       },
     })
+
+    if (this.props.redirectTo) {
+      window.location.href = this.props.redirectTo
+    }
   }
 
   render() {

--- a/src/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -83,7 +83,9 @@ class CollectorIntent extends React.Component<Props, State> {
 
     commitMutation(this.props.relayEnvironment, {
       mutation: graphql`
-        mutation CollectorIntentUpdateCollectorProfileMutation($input: UpdateCollectorProfileInput!) {
+        mutation CollectorIntentUpdateCollectorProfileMutation(
+          $input: UpdateCollectorProfileInput!
+        ) {
           updateCollectorProfile(input: $input) {
             intents
           }
@@ -101,13 +103,19 @@ class CollectorIntent extends React.Component<Props, State> {
 
   render() {
     const options = this.options.map((text, index) => (
-      <SelectableLink key={index} text={text} onSelect={this.onOptionSelected.bind(this, index)} />
+      <SelectableLink
+        key={index}
+        text={text}
+        onSelect={this.onOptionSelected.bind(this, index)}
+      />
     ))
     return (
       <Layout
         title="Get started on Artsy, what are you most interested in doing?"
         subtitle="Select all that apply"
-        onNextButtonPressed={this.state.selectedCount > 0 ? this.submit.bind(this) : null}
+        onNextButtonPressed={
+          this.state.selectedCount > 0 ? this.submit.bind(this) : null
+        }
       >
         <OptionsContainer>{options}</OptionsContainer>
       </Layout>

--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -21,17 +21,18 @@ const Container = styled.div`
   `};
 `
 
-const MainTitle = styled(StyledTitle) `
+const MainTitle = styled(StyledTitle)`
   text-align: center;
   line-height: normal;
   ${media.sm`
     text-align: left;
   `};
 `
-const Subtitle = styled(StyledTitle) `
+const Subtitle = styled(StyledTitle)`
   color: ${Colors.grayDark};
   margin-bottom: 100px;
   text-align: center;
+  line-height: normal;
   ${media.sm`
     text-align: left;
     margin-bottom: 15px;
@@ -39,7 +40,7 @@ const Subtitle = styled(StyledTitle) `
   `};
 `
 
-const ButtonContainer = styled(Button) `
+const ButtonContainer = styled(Button)`
   margin: 0 auto 50px;
   display: block;
   width: 250px;
@@ -56,7 +57,10 @@ export class Layout extends React.Component<Props, null> {
         <MainTitle titleSize="xlarge">{this.props.title} </MainTitle>
         <Subtitle titleSize="xlarge">{this.props.subtitle}</Subtitle>
         <div>{this.props.children}</div>
-        <ButtonContainer disabled={disabled} onClick={this.props.onNextButtonPressed}>
+        <ButtonContainer
+          disabled={disabled}
+          onClick={this.props.onNextButtonPressed}
+        >
           Next
         </ButtonContainer>
       </Container>

--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -23,6 +23,7 @@ const Container = styled.div`
 
 const MainTitle = styled(StyledTitle) `
   text-align: center;
+  line-height: normal;
   ${media.sm`
     text-align: left;
   `};

--- a/src/Components/Onboarding/Types.ts
+++ b/src/Components/Onboarding/Types.ts
@@ -3,6 +3,7 @@
  */
 export interface StepProps {
   onNextButtonPressed: (increaseBy?) => void
+  redirectTo?: string
 }
 
 export interface FollowProps {

--- a/src/Components/Onboarding/Types.ts
+++ b/src/Components/Onboarding/Types.ts
@@ -3,7 +3,6 @@
  */
 export interface StepProps {
   onNextButtonPressed: (increaseBy?) => void
-  redirectTo?: string
 }
 
 export interface FollowProps {

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -4,6 +4,7 @@ import { StepProps } from "./Types"
 
 interface Props {
   stepComponents: Array<React.ComponentClass<StepProps>>
+  redirectTo?: string
 }
 
 interface State {
@@ -28,7 +29,12 @@ class Wizard extends React.Component<Props, State> {
     }
 
     const CurrentStep = this.props.stepComponents[currentStep]
-    return <CurrentStep onNextButtonPressed={this.onNextButtonPressed.bind(this)} />
+    return (
+      <CurrentStep
+        onNextButtonPressed={this.onNextButtonPressed.bind(this)}
+        redirectTo={this.props.redirectTo}
+      />
+    )
   }
 
   onNextButtonPressed(increaseBy = 1) {

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -13,6 +13,10 @@ interface State {
 }
 
 class Wizard extends React.Component<Props, State> {
+  static defaultProps = {
+    redirectTo: "/",
+  }
+
   constructor(props, state) {
     super(props, state)
 
@@ -24,21 +28,20 @@ class Wizard extends React.Component<Props, State> {
 
   getCurrentStep(): JSX.Element | null {
     const currentStep = this.state.currentStep
+
     if (currentStep > this.props.stepComponents.length - 1) {
       return null
     }
 
     const CurrentStep = this.props.stepComponents[currentStep]
     return (
-      <CurrentStep
-        onNextButtonPressed={this.onNextButtonPressed.bind(this)}
-        redirectTo={this.props.redirectTo}
-      />
+      <CurrentStep onNextButtonPressed={this.onNextButtonPressed.bind(this)} />
     )
   }
 
   onNextButtonPressed(increaseBy = 1) {
-    if (this.props.stepComponents.length <= this.state.currentStep) {
+    if (this.state.currentStep >= this.props.stepComponents.length - 1) {
+      window.location.href = this.props.redirectTo
       return
     }
 

--- a/src/Components/Onboarding/__stories__/Wizard.story.tsx
+++ b/src/Components/Onboarding/__stories__/Wizard.story.tsx
@@ -12,7 +12,10 @@ storiesOf("Onboarding", module).add("Wizard", () => {
   return (
     <div>
       <ContextProvider>
-        <Wizard stepComponents={[CollectorIntent, Artists, Genes, Budget]} />
+        <Wizard
+          stepComponents={[CollectorIntent, Artists, Genes, Budget]}
+          redirectTo={"/"}
+        />
       </ContextProvider>
     </div>
   )


### PR DESCRIPTION
This fixes the minor CSS items we saw related to the `line-height` in the titles as well the resizing that was happening to the images. In addition, it also supports a `redirectTo` prop to be passed Wizard component and down to the Budget component so that we can support redirecting the user to their entry point before account creation/onboarding after onboarding steps are completed.