### PR TITLE
@xtina-starr => Signup tracking on article pages

### DIFF
--- a/src/Components/Publishing/Email/EmailPanel.tsx
+++ b/src/Components/Publishing/Email/EmailPanel.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { StyledFunction } from "styled-components"
 import request from "superagent"
 import Colors from "../../../Assets/Colors"
+import { track } from "../../../Utils/track"
 import InvertedButton from "../../Buttons/Inverted"
 import { borderedInput } from "../../Mixins"
 import { EMAIL_REGEX } from "../Constants"
@@ -9,6 +10,7 @@ import { Fonts } from "../Fonts"
 
 interface EmailPanelProps {
   signupUrl: string
+  tracking?: any
 }
 
 interface EmailPanelState {
@@ -24,7 +26,11 @@ interface InputProps {
   isReadOnly: boolean
 }
 
-export class EmailPanel extends React.Component<EmailPanelProps, EmailPanelState> {
+@track()
+export class EmailPanel extends React.Component<
+  EmailPanelProps,
+  EmailPanelState
+> {
   constructor(props) {
     super(props)
     this.state = {
@@ -34,18 +40,28 @@ export class EmailPanel extends React.Component<EmailPanelProps, EmailPanelState
       disabled: false,
       message: "",
     }
+
+    this.onClick = this.onClick.bind(this)
   }
 
-  onClick = () => {
+  onClick() {
     this.setState({ disabled: true })
     if (this.state.value.match(EMAIL_REGEX)) {
-      request.post(this.props.signupUrl).send({ email: this.state.value }).set("accept", "json").end((err, res) => {
-        if (err) {
-          this.flashMessage("Error. Please try again", true, false)
-        } else {
-          this.flashMessage("Thank you!", false, true)
-        }
-      })
+      request
+        .post(this.props.signupUrl)
+        .send({ email: this.state.value })
+        .set("accept", "json")
+        .end((err, res) => {
+          if (err) {
+            this.flashMessage("Error. Please try again", true, false)
+          } else {
+            this.flashMessage("Thank you!", false, true)
+            this.props.tracking.trackEvent({
+              action: "Click",
+              label: "Editorial signup",
+            })
+          }
+        })
     } else {
       this.flashMessage("Invalid Email... Please try again", true, false)
     }
@@ -89,7 +105,8 @@ export class EmailPanel extends React.Component<EmailPanelProps, EmailPanelState
   }
 }
 
-const input: StyledFunction<InputProps & React.HTMLProps<HTMLInputElement>> = styled.input
+const input: StyledFunction<InputProps & React.HTMLProps<HTMLInputElement>> =
+  styled.input
 const Input = input`
   ${borderedInput}
   width: 100%;
@@ -104,15 +121,14 @@ const EmailPanelContainer = styled.div`
   width: 100%;
 `
 const Title = styled.div`
-  ${Fonts.unica("s16", "medium")}
-  margin-bottom: 10px;
+  ${Fonts.unica("s16", "medium")} margin-bottom: 10px;
 `
 const StyledButton = InvertedButton.extend`
   border-radius: 2px;
   height: 30px;
   width: 80px;
   margin-left: -100px;
-  ${Fonts.avantgarde("s11")}
+  ${Fonts.avantgarde("s11")};
 `
 const Form = styled.div`
   display: flex;

--- a/src/Components/Publishing/Email/EmailPanel.tsx
+++ b/src/Components/Publishing/Email/EmailPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import styled, { StyledFunction } from "styled-components"
+import styled from "styled-components"
 import request from "superagent"
 import Colors from "../../../Assets/Colors"
 import Events from "../../../Utils/Events"
@@ -22,7 +22,7 @@ interface EmailPanelState {
   message: string
 }
 
-interface InputProps {
+interface InputProps extends React.HTMLProps<HTMLInputElement> {
   isError: boolean
   isReadOnly: boolean
 }
@@ -106,14 +106,12 @@ export class EmailPanel extends React.Component<
   }
 }
 
-const input: StyledFunction<InputProps & React.HTMLProps<HTMLInputElement>> =
-  styled.input
-const Input = input`
-  ${borderedInput}
+const Input = styled.input`
   width: 100%;
   border-width: 1px;
-  color: ${props => (props.isError ? Colors.redMedium : "black")};
-  ${props => (props.isReadOnly ? Fonts.unica("s16") : "")}
+  color: ${(props: InputProps) => (props.isError ? Colors.redMedium : "black")};
+  ${(props: InputProps) => (props.isReadOnly ? Fonts.unica("s16") : "")};
+  ${borderedInput};
 `
 const EmailPanelContainer = styled.div`
   display: flex;

--- a/src/Components/Publishing/Email/EmailPanel.tsx
+++ b/src/Components/Publishing/Email/EmailPanel.tsx
@@ -37,20 +37,15 @@ export class EmailPanel extends React.Component<
   EmailPanelProps,
   EmailPanelState
 > {
-  constructor(props) {
-    super(props)
-    this.state = {
-      value: "",
-      error: false,
-      submitted: false,
-      disabled: false,
-      message: "",
-    }
-
-    this.onClick = this.onClick.bind(this)
+  state = {
+    value: "",
+    error: false,
+    submitted: false,
+    disabled: false,
+    message: "",
   }
 
-  onClick() {
+  onClick = () => {
     this.setState({ disabled: true })
     if (this.state.value.match(EMAIL_REGEX)) {
       request
@@ -127,7 +122,8 @@ const EmailPanelContainer = styled.div`
   width: 100%;
 `
 const Title = styled.div`
-  ${Fonts.unica("s16", "medium")} margin-bottom: 10px;
+  ${Fonts.unica("s16", "medium")};
+  margin-bottom: 10px;
 `
 const StyledButton = InvertedButton.extend`
   border-radius: 2px;

--- a/src/Components/Publishing/Email/EmailPanel.tsx
+++ b/src/Components/Publishing/Email/EmailPanel.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import styled, { StyledFunction } from "styled-components"
 import request from "superagent"
 import Colors from "../../../Assets/Colors"
+import Events from "../../../Utils/Events"
 import { track } from "../../../Utils/track"
 import InvertedButton from "../../Buttons/Inverted"
 import { borderedInput } from "../../Mixins"
@@ -26,7 +27,12 @@ interface InputProps {
   isReadOnly: boolean
 }
 
-@track()
+@track(
+  { page: "Article" },
+  {
+    dispatch: data => Events.postEvent(data),
+  }
+)
 export class EmailPanel extends React.Component<
   EmailPanelProps,
   EmailPanelState
@@ -57,8 +63,8 @@ export class EmailPanel extends React.Component<
           } else {
             this.flashMessage("Thank you!", false, true)
             this.props.tracking.trackEvent({
-              action: "Click",
-              label: "Editorial signup",
+              action: "Sign up for editorial email",
+              context_type: "article_fixed",
             })
           }
         })

--- a/src/Components/Publishing/Email/__test__/__snapshots__/EmailPanel.test.tsx.snap
+++ b/src/Components/Publishing/Email/__test__/__snapshots__/EmailPanel.test.tsx.snap
@@ -44,6 +44,9 @@ exports[`EmailSignup renders an email signup 1`] = `
 }
 
 .c3 {
+  width: 100%;
+  border-width: 1px;
+  color: black;
   padding: 10px;
   box-shadow: none;
   font-size: 17px;
@@ -56,9 +59,6 @@ exports[`EmailSignup renders an email signup 1`] = `
   border: 2px solid #e5e5e5;
   -webkit-transition: border-color .25s;
   transition: border-color .25s;
-  width: 100%;
-  border-width: 1px;
-  color: black;
 }
 
 .c3:focus,


### PR DESCRIPTION
We were missing a track call on the fixed email signup in articles. Talking about this guy on the side bar:

![image](https://user-images.githubusercontent.com/2236794/35363069-34d85ebe-0136-11e8-95f4-e6a395c14847.png)


This adds a track call to the success callback. Hope this is helpful to read through for implementing analytics for Onboarding!

