### PR TITLE
[Onboarding] UI QA: fixes the title size, correct margan b/t title and serach, and sticky footer

### DIFF
--- a/src/Components/Onboarding/Steps/Budget.tsx
+++ b/src/Components/Onboarding/Steps/Budget.tsx
@@ -86,6 +86,7 @@ class Budget extends React.Component<StepProps & ContextProps, State> {
         title="What's your budget?"
         subtitle="Select one"
         onNextButtonPressed={this.state.selection && this.submit.bind(this)}
+        isLastStep
       >
         <OptionsContainer>{options}</OptionsContainer>
       </Layout>

--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -41,12 +41,32 @@ const Subtitle = styled(StyledTitle)`
   `};
 `
 
-const ButtonContainer = styled(Button)`
-  margin: 0 auto 50px;
+/* MS IE11 and Edge don't support for the sticky position property */
+const FixedButttonContainer = styled.div`
+  width: 100%;
+  position: fixed;
+  bottom: 0px;
+  left: 0px;
+`
+
+/* Mobile safari doesn't support for the fixed position property:
+ *   https://www.eventbrite.com/engineering/mobile-safari-why/
+ **/
+const StickyButtonContainer = styled.div`
+  position: sticky;
+  bottom: 0px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, white, white);
+  display: flex;
+  justify-content: center;
+`
+
+const NextButton = styled(Button)`
+  margin: 50px 0px;
   display: block;
   width: 250px;
   ${media.sm`
     width: 100%;
+    margin: 25px 0px;
   `};
 `
 
@@ -59,12 +79,16 @@ export class Layout extends React.Component<Props, null> {
         <MainTitle>{this.props.title} </MainTitle>
         <Subtitle>{this.props.subtitle}</Subtitle>
         <div>{this.props.children}</div>
-        <ButtonContainer
-          disabled={disabled}
-          onClick={this.props.onNextButtonPressed}
-        >
-          {buttonText}
-        </ButtonContainer>
+        <FixedButttonContainer>
+          <StickyButtonContainer>
+            <NextButton
+              disabled={disabled}
+              onClick={this.props.onNextButtonPressed}
+            >
+              {buttonText}
+            </NextButton>
+          </StickyButtonContainer>
+        </FixedButttonContainer>
       </Container>
     )
   }

--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -31,7 +31,7 @@ const MainTitle = styled(StyledTitle)`
 `
 const Subtitle = styled(StyledTitle)`
   color: ${Colors.grayDark};
-  margin-bottom: 100px;
+  margin-bottom: 30px;
   text-align: center;
   line-height: normal;
   ${media.sm`

--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -10,6 +10,7 @@ interface Props {
   title: string
   subtitle: string
   onNextButtonPressed?: () => void
+  isLastStep?: boolean | null
 }
 
 const Container = styled.div`
@@ -52,6 +53,7 @@ const ButtonContainer = styled(Button)`
 export class Layout extends React.Component<Props, null> {
   render() {
     const disabled = !this.props.onNextButtonPressed
+    const buttonText = this.props.isLastStep ? "finished" : "next"
     return (
       <Container>
         <MainTitle>{this.props.title} </MainTitle>
@@ -61,7 +63,7 @@ export class Layout extends React.Component<Props, null> {
           disabled={disabled}
           onClick={this.props.onNextButtonPressed}
         >
-          Next
+          {buttonText}
         </ButtonContainer>
       </Container>
     )

--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 
 import Colors from "../../../Assets/Colors"
-import Button from "../../Buttons/Ghost"
+import InvertedButton from "../../Buttons/Inverted"
 import { media } from "../../Helpers"
 import StyledTitle from "../../Title"
 
@@ -60,10 +60,17 @@ const StickyButtonContainer = styled.div`
   justify-content: center;
 `
 
-const NextButton = styled(Button)`
+const NextButton = styled(InvertedButton)`
   margin: 50px 0px;
   display: block;
   width: 250px;
+
+  &:disabled {
+    background: white;
+    border: 1px solid ${Colors.grayRegular};
+    color: ${Colors.grayMedium};
+  }
+
   ${media.sm`
     width: 100%;
     margin: 25px 0px;

--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -54,8 +54,8 @@ export class Layout extends React.Component<Props, null> {
     const disabled = !this.props.onNextButtonPressed
     return (
       <Container>
-        <MainTitle titleSize="xlarge">{this.props.title} </MainTitle>
-        <Subtitle titleSize="xlarge">{this.props.subtitle}</Subtitle>
+        <MainTitle>{this.props.title} </MainTitle>
+        <Subtitle>{this.props.subtitle}</Subtitle>
         <div>{this.props.children}</div>
         <ButtonContainer
           disabled={disabled}


### PR DESCRIPTION
fixes [AR-70](https://artsyproduct.atlassian.net/browse/AR-70), [AR-71](https://artsyproduct.atlassian.net/browse/AR-71), and [AR-72](https://artsyproduct.atlassian.net/browse/AR-72). This is the first step to address [AR-69](https://artsyproduct.atlassian.net/browse/AR-69) and we'll be working on [AR-73](https://artsyproduct.atlassian.net/browse/AR-73) and [AR-75](https://artsyproduct.atlassian.net/browse/AR-75) next.

tested on Firefox, Safari, Chrome, IE Edge, IE11 and mobile safari.

![screen_shot_2018-02-01_at_4_58_35_pm](https://user-images.githubusercontent.com/386234/35705791-754bde80-0771-11e8-9e32-ded606937709.png)

### Button state:

![2018-02-01 17_38_23](https://user-images.githubusercontent.com/386234/35707177-c42f550e-0776-11e8-9309-fc8164fb3975.gif)
