### PR TITLE
@yuki24 => [Onboarding] Be able to force a step to start on

### DIFF
--- a/src/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/Components/Onboarding/Steps/Artists/index.tsx
@@ -28,7 +28,7 @@ interface State {
 }
 
 export default class Artists extends React.Component<StepProps, State> {
-  static slug = "artists"
+  static slug: "artists" = "artists"
 
   state = {
     inputText: "",

--- a/src/Components/Onboarding/Steps/Budget.tsx
+++ b/src/Components/Onboarding/Steps/Budget.tsx
@@ -25,8 +25,11 @@ interface State {
   selection: number | null
 }
 
-class Budget extends React.Component<StepProps & ContextProps, State> {
-  static slug = "budget"
+export class BudgetComponent extends React.Component<
+  StepProps & ContextProps,
+  State
+> {
+  static slug: "budget" = "budget"
 
   options = {
     "UNDER $500": 500,
@@ -96,4 +99,4 @@ class Budget extends React.Component<StepProps & ContextProps, State> {
   }
 }
 
-export default ContextConsumer(Budget)
+export default ContextConsumer(BudgetComponent)

--- a/src/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -29,8 +29,8 @@ interface State {
   error?: string
 }
 
-class CollectorIntent extends React.Component<Props, State> {
-  static slug = "interests"
+export class CollectorIntentComponent extends React.Component<Props, State> {
+  static slug: "interests" = "interests"
 
   static intentEnum = {
     "buy art & design": "BUY_ART_AND_DESIGN",
@@ -50,18 +50,22 @@ class CollectorIntent extends React.Component<Props, State> {
     }
   }
 
-  onOptionSelected = (index) => {
+  onOptionSelected = index => {
     const selectedOptions = Object.assign({}, this.state.selectedOptions)
     selectedOptions[index] = !selectedOptions[index]
 
     this.setState({
       selectedOptions,
-      selectedCount: Object.values(selectedOptions).filter(isSelected => isSelected).length
+      selectedCount: Object.values(selectedOptions).filter(
+        isSelected => isSelected
+      ).length,
     })
   }
 
   submit() {
-    const intents = Object.values(CollectorIntent.intentEnum).filter((_, index) => this.state.selectedOptions[index])
+    const intents = Object.values(CollectorIntentComponent.intentEnum).filter(
+      (_, index) => this.state.selectedOptions[index]
+    )
 
     commitMutation(this.props.relayEnvironment, {
       mutation: graphql`
@@ -84,7 +88,9 @@ class CollectorIntent extends React.Component<Props, State> {
   }
 
   render() {
-    const options = Object.keys(CollectorIntent.intentEnum).map((text, index) => (
+    const options = Object.keys(
+      CollectorIntentComponent.intentEnum
+    ).map((text, index) => (
       <SelectableToggle
         key={index}
         text={text}
@@ -107,4 +113,4 @@ class CollectorIntent extends React.Component<Props, State> {
   }
 }
 
-export default ContextConsumer(CollectorIntent)
+export default ContextConsumer(CollectorIntentComponent)

--- a/src/Components/Onboarding/Types.ts
+++ b/src/Components/Onboarding/Types.ts
@@ -12,3 +12,5 @@ export interface StepComponent extends React.ComponentClass<StepProps> {
 export interface FollowProps {
   updateFollowCount: (count: number) => void
 }
+
+export type StepSlugs = "artists" | "budget" | "categories" | "interests" | null

--- a/src/Components/Onboarding/Types.ts
+++ b/src/Components/Onboarding/Types.ts
@@ -1,3 +1,8 @@
+import Artists from "./Steps/Artists"
+import { BudgetComponent as Budget } from "./Steps/Budget"
+import { CollectorIntentComponent as CollectorIntent } from "./Steps/CollectorIntent"
+import Genes from "./Steps/Genes"
+
 /**
  * The props interface that the step needs to implement for the wizard.
  */
@@ -13,4 +18,9 @@ export interface FollowProps {
   updateFollowCount: (count: number) => void
 }
 
-export type StepSlugs = "artists" | "budget" | "categories" | "interests" | null
+export type StepSlugs =
+  | typeof Budget.slug
+  | typeof Artists.slug
+  | typeof Genes.slug
+  | typeof CollectorIntent.slug
+  | null

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -1,10 +1,10 @@
 import React from "react"
-import { StepComponent } from "./Types"
+import { StepComponent, StepSlugs } from "./Types"
 
 interface Props {
   stepComponents: StepComponent[]
   redirectTo?: string
-  forceStep?: string
+  forceStep?: StepSlugs
 }
 
 interface State {

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -15,7 +15,7 @@ interface State {
 class Wizard extends React.Component<Props, State> {
   static defaultProps = {
     redirectTo: "/",
-    forceStep: "",
+    forceStep: null,
   }
 
   constructor(props) {

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -4,6 +4,7 @@ import { StepComponent } from "./Types"
 interface Props {
   stepComponents: StepComponent[]
   redirectTo?: string
+  forceStep?: string
 }
 
 interface State {
@@ -14,11 +15,36 @@ interface State {
 class Wizard extends React.Component<Props, State> {
   static defaultProps = {
     redirectTo: "/",
+    forceStep: "",
   }
 
-  state = {
-    currentStep: 0,
-    nextButtonEnabled: false,
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      currentStep: this.getForceStep(),
+      nextButtonEnabled: false,
+    }
+  }
+
+  getForceStep = () => {
+    const { forceStep } = this.props
+    const stepSlugs = this.props.stepComponents.map(step => step.slug)
+    if (forceStep && stepSlugs.includes(forceStep)) {
+      return stepSlugs.indexOf(forceStep)
+    } else {
+      return 0
+    }
+  }
+
+  componentDidMount() {
+    const { stepComponents } = this.props
+    const { currentStep } = this.state
+    window.history.pushState(
+      {},
+      "",
+      `/personalize/${stepComponents[currentStep].slug}`
+    )
   }
 
   getCurrentStep(): JSX.Element | null {

--- a/src/Components/Onboarding/__stories__/Wizard.story.tsx
+++ b/src/Components/Onboarding/__stories__/Wizard.story.tsx
@@ -8,15 +8,29 @@ import CollectorIntent from "../Steps/CollectorIntent"
 import Genes from "../Steps/Genes"
 import Wizard from "../Wizard"
 
-storiesOf("Onboarding", module).add("Wizard", () => {
-  return (
-    <div>
-      <ContextProvider>
-        <Wizard
-          stepComponents={[CollectorIntent, Artists, Genes, Budget]}
-          redirectTo={"/"}
-        />
-      </ContextProvider>
-    </div>
-  )
-})
+storiesOf("Onboarding", module)
+  .add("Wizard", () => {
+    return (
+      <div>
+        <ContextProvider>
+          <Wizard
+            stepComponents={[CollectorIntent, Artists, Genes, Budget]}
+            redirectTo={"/"}
+          />
+        </ContextProvider>
+      </div>
+    )
+  })
+  .add("Wizard - Force Step", () => {
+    return (
+      <div>
+        <ContextProvider>
+          <Wizard
+            stepComponents={[CollectorIntent, Artists, Genes, Budget]}
+            redirectTo="/"
+            forceStep="artists"
+          />
+        </ContextProvider>
+      </div>
+    )
+  })


### PR DESCRIPTION
Forgot that we need this piece of logic to get the Force side working! This allows you to pass a prop called `forceStep` which sets `state.currentStep` to be the one we ask for based on the slug. It can handle slugs that doesn't exist as a step (defaults to the first step) and updates the url.

Adds a story to represent forceStep: 
![image](https://user-images.githubusercontent.com/2236794/35882549-95414d94-0b52-11e8-91b8-a9d6ff998953.png)
