### PR TITLE
@xtina-starr => [Onboarding][AR-74] Autofocus on the artist step 

### DIFF
--- a/src/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/Components/Onboarding/Steps/Artists/index.tsx
@@ -87,6 +87,7 @@ export default class Artists extends React.Component<StepProps, State> {
             onInput={this.searchTextChanged.bind(this)}
             onPaste={this.searchTextChanged.bind(this)}
             onCut={this.searchTextChanged.bind(this)}
+            autoFocus
           />
           <div style={{ marginBottom: "35px" }} />
           <ArtistList


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=AR&modal=detail&selectedIssue=AR-74

It looks like the Gene step already has autofocus on, so it's only the artist step. 