### PR TITLE
@yuki24 => Fixes static variables on HOC

### DIFF
--- a/src/Components/Onboarding/Steps/Budget.tsx
+++ b/src/Components/Onboarding/Steps/Budget.tsx
@@ -99,4 +99,8 @@ export class BudgetComponent extends React.Component<
   }
 }
 
-export default ContextConsumer(BudgetComponent)
+const Budget = ContextConsumer(BudgetComponent)
+// tslint:disable:no-string-literal
+Budget["slug"] = BudgetComponent.slug
+
+export default Budget

--- a/src/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -113,4 +113,8 @@ export class CollectorIntentComponent extends React.Component<Props, State> {
   }
 }
 
-export default ContextConsumer(CollectorIntentComponent)
+const CollectorIntent = ContextConsumer(CollectorIntentComponent)
+// tslint:disable:no-string-literal
+CollectorIntent["slug"] = CollectorIntentComponent.slug
+
+export default CollectorIntent


### PR DESCRIPTION
We need to pass the slug onto the HOC that wraps BudgetComponent. The preferred way is to do `Budget.slug = BudgetComponent.slug` but that returns a TS error on `ContextConsumer` for not having defined slug. However, we probably don't want to litter the `ContextConsumer` types to do this so this works around the error by using string literals to set the variable.

I don't know if this is controversial to people, but it works 😄 

Ref: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over