### PR TITLE
@yuki24 => [Onboarding] Wizard progress indicator

### DIFF
--- a/src/Components/Onboarding/ProgressIndicator.tsx
+++ b/src/Components/Onboarding/ProgressIndicator.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import styled from "styled-components"
+
+interface Props {
+  percentComplete: number
+}
+
+export class ProgressIndicator extends React.Component<Props, null> {
+  static defaultProps = {
+    percentComplete: 0,
+  }
+
+  render() {
+    const { percentComplete } = this.props
+
+    return (
+      <ProgressIndicatorContainer>
+        <CompletionBar percentComplete={percentComplete} />
+      </ProgressIndicatorContainer>
+    )
+  }
+}
+
+const ProgressIndicatorContainer = styled.div`
+  width: 100%;
+  height: 6px;
+  background-image: linear-gradient(
+    45deg,
+    gray 25%,
+    transparent 25%,
+    transparent 50%,
+    gray 50%,
+    gray 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 4px 4px;
+`
+
+const CompletionBar = styled.div`
+  width: ${(props: Props) => `calc(100% * ${props.percentComplete})`};
+  height: 100%;
+  background-color: black;
+  transition: width 0.25s ease-in;
+`
+
+CompletionBar.displayName = "CompletionBar"

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -66,7 +66,12 @@ class Wizard extends React.Component<Props, State> {
     const { stepComponents, redirectTo } = this.props
 
     if (currentStep >= stepComponents.length - 1) {
-      window.location.href = redirectTo
+      this.setState({
+        percentComplete: 1,
+      })
+      setTimeout(() => {
+        window.location.href = redirectTo
+      }, 500)
     } else {
       const stepIndex = currentStep + increaseBy
       const nextComponent = stepComponents[stepIndex]

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ProgressIndicator } from "./ProgressIndicator"
 import { StepComponent, StepSlugs } from "./Types"
 
 interface Props {
@@ -10,6 +11,7 @@ interface Props {
 interface State {
   currentStep: number
   nextButtonEnabled: boolean
+  percentComplete: number
 }
 
 class Wizard extends React.Component<Props, State> {
@@ -24,6 +26,7 @@ class Wizard extends React.Component<Props, State> {
     this.state = {
       currentStep: this.getForceStep(),
       nextButtonEnabled: false,
+      percentComplete: 0,
     }
   }
 
@@ -68,13 +71,21 @@ class Wizard extends React.Component<Props, State> {
       const stepIndex = currentStep + increaseBy
       const nextComponent = stepComponents[stepIndex]
       window.history.pushState({}, "", `/personalize/${nextComponent.slug}`)
-      this.setState({ currentStep: stepIndex })
+      this.setState({
+        currentStep: stepIndex,
+        percentComplete: stepIndex / stepComponents.length,
+      })
     }
   }
 
   render() {
     const step = this.getCurrentStep()
-    return <div>{step}</div>
+    return (
+      <div>
+        <ProgressIndicator percentComplete={this.state.percentComplete} />
+        {step}
+      </div>
+    )
   }
 }
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=AR&modal=detail&selectedIssue=AR-91

Wasn't too sure about the stripes in the background of the indicator bc the comps were a little fuzzy but this is what I came up with:
![image](https://user-images.githubusercontent.com/2236794/36040519-aadde728-0d93-11e8-8607-f8e7a598e62b.png)

Also the animation here uses ease-in but we can configure that to whatever.

![onboarding-progress](https://user-images.githubusercontent.com/2236794/36040349-2e9a611e-0d93-11e8-8355-692e606ee41d.gif)
