### PR TITLE
Move the <RoutesWithProgressBar> component from Force to Reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "react-markdown": "^2.5.0",
     "react-relay": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/react-relay-1.5.0-artsy.3.tgz",
     "react-responsive-decorator": "^0.0.1",
+    "react-router": "4.1.1",
     "react-sizeme": "^2.3.2",
     "react-slick": "^0.14.11",
     "react-styled-flexboxgrid": "^2.0.0",

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -1,108 +1,74 @@
 import React from "react"
+import { Redirect, Route } from 'react-router'
+
 import Events from "../../Utils/Events"
 import { track } from "../../Utils/track"
 import { ProgressIndicator } from "./ProgressIndicator"
-import { StepComponent, StepSlugs } from "./Types"
 
-interface Props {
-  stepComponents: StepComponent[]
-  redirectTo?: string
-  forceStep?: StepSlugs
+import Artists from './Steps/Artists'
+import { BudgetComponent as Budget } from "./Steps/Budget"
+import { CollectorIntentComponent as CollectorIntent } from "./Steps/CollectorIntent"
+import Genes from './Steps/Genes'
+
+const STEPS = [
+  `/personalize/${CollectorIntent.slug}`,
+  `/personalize/${Artists.slug}`,
+  `/personalize/${Genes.slug}`,
+  `/personalize/${Budget.slug}`
+]
+
+export interface Props {
   tracking?: any
 }
 
-interface State {
-  currentStep: number
-  nextButtonEnabled: boolean
-  percentComplete: number
+export interface State {
+  finished: boolean
 }
 
 @track({}, { dispatch: data => Events.postEvent(data) })
-class Wizard extends React.Component<Props, State> {
-  static defaultProps = {
-    redirectTo: "/",
-    forceStep: null,
-  }
-
+export class Wizard extends React.Component<Props, State> {
   constructor(props) {
     super(props)
-
     this.state = {
-      currentStep: this.getForceStep(),
-      nextButtonEnabled: false,
-      percentComplete: 0,
+      finished: false,
     }
   }
 
-  getForceStep = () => {
-    const { forceStep } = this.props
-    const stepSlugs = this.props.stepComponents.map(step => step.slug)
-    if (forceStep && stepSlugs.includes(forceStep)) {
-      return stepSlugs.indexOf(forceStep)
-    } else {
-      return 0
-    }
+  onNextButtonPressed = (increaseBy, history) => {
+    history.push(STEPS[STEPS.indexOf(location.pathname) + increaseBy])
   }
 
-  componentDidMount() {
-    const { stepComponents } = this.props
-    const { currentStep } = this.state
-    window.history.pushState(
-      {},
-      "",
-      `/personalize/${stepComponents[currentStep].slug}`
-    )
-  }
-
-  getCurrentStep(): JSX.Element | null {
-    const currentStep = this.state.currentStep
-
-    if (currentStep > this.props.stepComponents.length - 1) {
-      return null
-    }
-
-    const CurrentStep = this.props.stepComponents[currentStep]
-    return <CurrentStep onNextButtonPressed={this.onNextButtonPressed} />
-  }
-
-  onFinish = () => {
-    const { redirectTo } = this.props
-    this.setState({ percentComplete: 1 })
-    setTimeout(() => {
-      window.location.href = redirectTo
-    }, 500)
+  onFinish = redirectTo => {
+    this.setState({ finished: true })
+    setTimeout(() => (window.location.href = redirectTo || "/"), 500)
 
     this.props.tracking.trackEvent({
       action: "Completed Onboarding",
     })
   }
 
-  onNextButtonPressed = (increaseBy = 1) => {
-    const { currentStep } = this.state
-    const { stepComponents } = this.props
-
-    if (currentStep >= stepComponents.length - 1) {
-      this.onFinish()
-    } else {
-      const stepIndex = currentStep + increaseBy
-      const nextComponent = stepComponents[stepIndex]
-      window.history.pushState({}, "", `/personalize/${nextComponent.slug}`)
-      this.setState({
-        currentStep: stepIndex,
-        percentComplete: stepIndex / stepComponents.length,
-      })
-    }
-  }
-
   render() {
-    const step = this.getCurrentStep()
     return (
       <div>
-        <ProgressIndicator percentComplete={this.state.percentComplete} />
-        {step}
+        <Route path='/personalize/*' render={() =>
+          <ProgressIndicator percentComplete={ this.state.finished ? 1 : STEPS.indexOf(location.pathname) / STEPS.length } />
+        } />
+
+        <Route path={`/personalize/${CollectorIntent.slug}`} render={props =>
+          <CollectorIntent {...props} onNextButtonPressed={(increaseBy = 1) => this.onNextButtonPressed(increaseBy, props.history)} />
+        } />
+        <Route path={`/personalize/${Artists.slug}`} render={props =>
+          <Artists {...props} onNextButtonPressed={(increaseBy = 1) => this.onNextButtonPressed(increaseBy, props.history)} />
+        } />
+        <Route path={`/personalize/${Genes.slug}`} render={props =>
+          <Genes {...props} onNextButtonPressed={(increaseBy = 1) => this.onNextButtonPressed(increaseBy, props.history)} />
+        } />
+        <Route path={`/personalize/${Budget.slug}`} render={props =>
+          <Budget {...props} onNextButtonPressed={() => this.onFinish(props.redirectTo)} />
+        } />
+
+        {new RegExp("/personalize(/*)$").exec(location.pathname) && <Redirect to={`/personalize/${CollectorIntent.slug}`} />}
       </div>
     )
   }
 }
-
-export default Wizard

--- a/src/Components/Onboarding/__stories__/Wizard.story.tsx
+++ b/src/Components/Onboarding/__stories__/Wizard.story.tsx
@@ -2,34 +2,14 @@ import { storiesOf } from "@storybook/react"
 import React from "react"
 
 import { ContextProvider } from "../../Artsy"
-import Artists from "../Steps/Artists"
-import Budget from "../Steps/Budget"
-import CollectorIntent from "../Steps/CollectorIntent"
-import Genes from "../Steps/Genes"
-import Wizard from "../Wizard"
+import { Wizard } from "../Wizard"
 
 storiesOf("Onboarding", module)
   .add("Wizard", () => {
     return (
       <div>
         <ContextProvider>
-          <Wizard
-            stepComponents={[CollectorIntent, Artists, Genes, Budget]}
-            redirectTo={"/"}
-          />
-        </ContextProvider>
-      </div>
-    )
-  })
-  .add("Wizard - Force Step", () => {
-    return (
-      <div>
-        <ContextProvider>
-          <Wizard
-            stepComponents={[CollectorIntent, Artists, Genes, Budget]}
-            redirectTo="/"
-            forceStep="artists"
-          />
+          <Wizard />
         </ContextProvider>
       </div>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -4662,6 +4662,16 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
+history@^4.6.0:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 history@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.6.1.tgz#911cf8eb65728555a94f2b12780a0c531a14d2fd"
@@ -7077,6 +7087,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.5.3:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -7729,6 +7745,18 @@ react-responsive-decorator@^0.0.1:
     enquire.js "^2.1.1"
     json2mq "^0.2.0"
 
+react-router@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.1.1.tgz#d448f3b7c1b429a6fbb03395099949c606b1fe95"
+  dependencies:
+    history "^4.6.0"
+    hoist-non-react-statics "^1.2.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.5.3"
+    prop-types "^15.5.4"
+    warning "^3.0.0"
+
 react-sizeme@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.3.2.tgz#3ad87541e96371403a1d3468d885164b98452862"
@@ -8187,6 +8215,10 @@ resolve-from@^3.0.0:
 resolve-pathname@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.1.0.tgz#e8358801b86b83b17560d4e3c382d7aef2100944"
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
 resolve-url@^0.2.1, resolve-url@~0.2.1:
   version "0.2.1"
@@ -9480,6 +9512,10 @@ validate-npm-package-license@^3.0.1:
 value-equal@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.2.1.tgz#c220a304361fce6994dbbedaa3c7e1a1b895871d"
+
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## WIP: Do not merge this yet

_When I tried to test this staging was missing popular artists data, which caused the `<PopularArtists>` component to fail to load._

This brings the `<RoutesWithProgressBar>` component (currently in Force) onto Reaction. We wanted to use the `@track` decorator in Force, but it turns out that not everything is set up properly and it seems a bit too early to adopt it. For now, it may make more sense to maintain TS classes and components in Reaction.