### PR TITLE
@damassi => Semantic release qa

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,8 @@ test:
 deployment:
   release:
     branch: master
-      - yarn run semantic-release
+    commands:
+      - yarn semantic-release
   demo:
     branch: master
     commands:


### PR DESCRIPTION
- Adds `commands` prefix to deployment for semantic-release
- Use command from package json rather than run