### PR TITLE
@damassi => Don't alert slack for gh-pages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,3 +39,5 @@ experimental:
     branches:
       only:
         - master
+      ignore:
+        - gh-pages


### PR DESCRIPTION
Ignores gh-pages branch for slack alerts to #front-end channel.

Removes messages like this:
![screen shot 2018-02-20 at 1 48 17 pm](https://user-images.githubusercontent.com/1497424/36442751-c601baca-1644-11e8-9be5-bbc72cebfe21.png)
 