### PR TITLE
@damassi => Rename NPM package 'Reaction'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 -   **State:** development
 -   **Demo:** <https://artsy.github.io/reaction>
 -   **CI:** [![CircleCI](https://circleci.com/gh/artsy/reaction.svg?style=shield)](https://circleci.com/gh/artsy/reaction)
--   **NPM:** [![npm version](https://badge.fury.io/js/%40artsy%2Freaction-force.svg)](https://www.npmjs.com/package/@artsy/reaction-force)
+-   **NPM:** [![npm version](https://badge.fury.io/js/%40artsy%2Freaction.svg)](https://www.npmjs.com/package/@artsy/reaction)
 -   **Point People:** [@alloy](https://github.com/alloy) & [@l2succes](https://github.com/l2succes)
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction",
-  "version": "0.23.4",
+  "version": "0.0.0-development",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction",
-  "version": "0.23.6",
+  "version": "0.23.4",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@artsy/reaction-force",
+  "name": "@artsy/reaction",
   "version": "0.0.0-development",
   "description": "Force’s React Components",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
     "react-waypoint": "^7.3.3",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-runtime-1.5.0-artsy.3.tgz",
     "sharify": "^0.1.6",
-    "superagent": "^3.6.3"
+    "superagent": "^3.6.3",
+    "yarn": "^1.3.2"
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction",
-  "version": "0.23.4",
+  "version": "0.23.6",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction",
-  "version": "0.0.0-development",
+  "version": "0.23.4",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",
@@ -186,11 +186,26 @@
     "analyzeCommits": {
       "preset": "ember",
       "releaseRules": [
-        {"tag": "DOC", "release": "patch"},
-        {"tag": "FIX", "release": "patch"},
-        {"tag": "PATCH", "release": "patch"},
-        {"tag": "FEATURE", "release": "minor"},
-        {"tag": "BREAKING", "release": "major"}
+        {
+          "tag": "DOC",
+          "release": "patch"
+        },
+        {
+          "tag": "FIX",
+          "release": "patch"
+        },
+        {
+          "tag": "PATCH",
+          "release": "patch"
+        },
+        {
+          "tag": "FEATURE",
+          "release": "minor"
+        },
+        {
+          "tag": "BREAKING",
+          "release": "major"
+        }
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10662,3 +10662,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yarn@^1.3.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.4.0.tgz#d54fa1e2db761c3527983ff40cf1442e69642abd"


### PR DESCRIPTION
Renames package to 'reaction' in package.json -- the new version is now published here and up to date with the existing version: https://www.npmjs.com/package/@artsy/reaction

Will update consumers next 🎉 

TODO: add 'deprecated' message to reaction-force