### PR TITLE
[FIX onboarding] fixed a bug where <PopularArtists> didn't update the <ItemLink> with the suggested artist

### DIFF
--- a/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
@@ -14,6 +14,18 @@ import { ContextConsumer, ContextProps } from "../../../Artsy"
 import ItemLink, { LinkContainer } from "../../ItemLink"
 import { FollowProps } from "../../Types"
 
+interface Artist {
+  id: string | null
+  _id: string | null
+  __id: string | null
+  name: string | null
+  image: {
+    cropped: {
+      url: string | null
+    }
+  } | null
+}
+
 export interface Props extends FollowProps {
   term: string
   tracking?: any
@@ -22,7 +34,7 @@ export interface Props extends FollowProps {
 interface RelayProps extends React.HTMLProps<HTMLAnchorElement>, Props {
   relay?: RelayProp
   viewer: {
-    match_artist: any[]
+    match_artist: Artist[]
   }
 }
 
@@ -39,7 +51,7 @@ class ArtistSearchResultsContent extends React.Component<RelayProps, null> {
   }
 
   onArtistFollowed(
-    artist: any,
+    artist: Artist,
     store: RecordSourceSelectorProxy,
     data: SelectorData
   ): void {
@@ -79,7 +91,7 @@ class ArtistSearchResultsContent extends React.Component<RelayProps, null> {
     })
   }
 
-  onFollowedArtist(artist: any) {
+  onFollowedArtist(artist: Artist) {
     commitMutation(this.props.relay.environment, {
       mutation: graphql`
         mutation ArtistSearchResultsArtistMutation(

--- a/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
@@ -106,6 +106,7 @@ class ArtistSearchResultsContent extends React.Component<RelayProps, null> {
             ) {
               artists {
                 id
+                _id
                 __id
                 name
                 image {

--- a/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
+++ b/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
@@ -104,6 +104,7 @@ class PopularArtistsContent extends React.Component<Props, null> {
             ) {
               artists {
                 id
+                _id
                 __id
                 name
                 image {

--- a/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
+++ b/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
@@ -14,11 +14,23 @@ import { ContextConsumer, ContextProps } from "../../../Artsy"
 import ItemLink, { LinkContainer } from "../../ItemLink"
 import { FollowProps } from "../../Types"
 
+interface Artist {
+  id: string | null
+  _id: string | null
+  __id: string | null
+  name: string | null
+  image: {
+    cropped: {
+      url: string | null
+    }
+  } | null
+}
+
 export interface RelayProps {
   tracking?: any
   relay?: RelayProp
   popular_artists: {
-    artists?: any[]
+    artists?: Artist[]
   }
 }
 
@@ -40,7 +52,7 @@ class PopularArtistsContent extends React.Component<Props, null> {
   }
 
   onArtistFollowed(
-    artist: any,
+    artist: Artist,
     store: RecordSourceSelectorProxy,
     data: SelectorData
   ): void {
@@ -77,7 +89,7 @@ class PopularArtistsContent extends React.Component<Props, null> {
     })
   }
 
-  onFollowedArtist(artist: any) {
+  onFollowedArtist(artist: Artist) {
     commitMutation(this.props.relay.environment, {
       mutation: graphql`
         mutation PopularArtistsFollowArtistMutation(
@@ -136,7 +148,7 @@ class PopularArtistsContent extends React.Component<Props, null> {
         excludedArtistIds: Array.from(this.excludedArtistIds),
       },
       updater: (store: RecordSourceSelectorProxy, data: SelectorData) =>
-        this.onArtistFollowed(artist.__id, store, data),
+        this.onArtistFollowed(artist, store, data),
     })
   }
 

--- a/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
@@ -19,6 +19,7 @@ import { FollowProps } from "../../Types"
 interface Gene {
   id: string | null
   _id: string | null
+  __id: string | null
   name: string | null
   image: {
     cropped: {
@@ -60,7 +61,7 @@ class GeneSearchResultsContent extends React.Component<RelayProps, null> {
   }
 
   onGeneFollowed(
-    gene: any,
+    gene: Gene,
     store: RecordSourceSelectorProxy,
     data: SelectorData
   ): void {
@@ -76,7 +77,7 @@ class GeneSearchResultsContent extends React.Component<RelayProps, null> {
     )
     const updatedSuggestedGenes = suggestedGenes.map(
       geneItem =>
-        geneItem.getValue("id") === gene.__id ? suggestedGene : geneItem
+        geneItem.getValue("id") === gene.id ? suggestedGene : geneItem
     )
 
     suggestedGenesRootField.setLinkedRecords(

--- a/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
+++ b/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
@@ -17,6 +17,7 @@ import { FollowProps } from "../../Types"
 interface Gene {
   id: string | null
   _id: string | null
+  __id: string | null
   name: string | null
   image: {
     cropped: {
@@ -50,7 +51,7 @@ class SuggestedGenesContent extends React.Component<Props, null> {
   }
 
   onGeneFollowed(
-    gene: any,
+    gene: Gene,
     store: RecordSourceSelectorProxy,
     data: SelectorData
   ): void {
@@ -65,7 +66,7 @@ class SuggestedGenesContent extends React.Component<Props, null> {
     )
     const updatedSuggestedGenes = suggestedGenes.map(
       geneItem =>
-        geneItem.getValue("id") === gene.__id ? suggestedGene : geneItem
+        geneItem.getValue("id") === gene.id ? suggestedGene : geneItem
     )
 
     suggestedGenesRootField.setLinkedRecords(


### PR DESCRIPTION
This fixes a bug and also adds a type as a guard against potential type mismatch. Regarding the bug, we were passing an `artistId` to `onArtistFollowed` when it was expecting an artist object. This passes that artist and adds the artist type check so we can catch something like this in the future.