### PR TITLE
[FIX button] Fix the color for the hover state for <MultiStateButton>

### DIFF
--- a/src/Components/Buttons/MultiStateButton.tsx
+++ b/src/Components/Buttons/MultiStateButton.tsx
@@ -68,6 +68,7 @@ export const StyledButton = styled(Button)`
   text-decoration: none;
 
   &:hover:not(:disabled) {
+    color: white;
     cursor: pointer;
     background: ${colors.purpleRegular};
   }


### PR DESCRIPTION
According to the spec, the font color for the hover state should be white: https://artsyproduct.atlassian.net/browse/AR-211

## Before

![screen shot 2018-02-23 at 3 43 48 pm](https://user-images.githubusercontent.com/386234/36616219-f1fe249c-18b0-11e8-9233-96845e9bc90b.png)

## After

![screen shot 2018-02-23 at 3 44 11 pm](https://user-images.githubusercontent.com/386234/36616221-f4601f88-18b0-11e8-8976-65f5877d7db9.png)

