### PR TITLE
[FIX lib] Downgrade styled-components 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "relay-compiler": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-compiler-1.5.0-artsy.3.tgz",
     "relay-compiler-language-typescript": "^0.9.0",
     "semantic-release": "^12.4.1",
-    "styled-components": "^2.5.0-1",
+    "styled-components": "2.4.0",
     "ts-loader": "^3.5.0",
     "tslint": "^4.5.0",
     "tslint-config-prettier": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8926,9 +8926,9 @@ style-loader@^0.19.1:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-styled-components@^2.5.0-1:
-  version "2.5.0-1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.5.0-1.tgz#0de96a5a6a07e78f620d6106cdcd10cc932425f7"
+styled-components@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.4.0.tgz#086d0fd483d54638837fca3ea546a030b94adf75"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"


### PR DESCRIPTION
Try this one more time. Looks like 2.5 ships with flat bundles, which breaks jest-styled-components. 