### PR TITLE
[DOC readme] Update with yarn watch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@
           $ yarn start
           $ open http://localhost:9001/
 
+-   When working between Reaction and [Force](https://github.com/artsy/force):
+          $ yarn link && yarn watch
+          $ cd ../force && yarn link @artsy/reaction && yarn start
+
 -   Run the tests:
 
           $ yarn test


### PR DESCRIPTION
Adds docs around 

```
yarn link
cd ../force && yarn link @artsy/reaction && yarn start
```

(I'm still thinking about how I'd like to wrap all of these commands up)