### PR TITLE
@sarahscott => News text / Fixtures updates

### DIFF
--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -776,7 +776,7 @@ export const SeriesArticle: ArticleData = {
 
 export const SeriesArticleSponsored = extend({}, SeriesArticle, Sponsor)
 
-export const NewsArticle = {
+export const NewsArticle: ArticleData = {
   _id: "594a7e2254c37f00177c0ea9",
   layout: "news",
   author_id: "57b5fc6acd530e65f8000406",
@@ -829,7 +829,7 @@ export const NewsArticle = {
     {
       type: "text",
       layout: "blockquote",
-      body: "<blockquote><a href='#'>The Guardian</blockquote>",
+      body: "<blockquote><a href='#'>The Guardian</a></blockquote>",
     },
     {
       type: "text",

--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -1,6 +1,12 @@
-import { extend } from "lodash"
+import { cloneDeep, extend } from "lodash"
 import { ArticleData } from "../Typings"
-import { Media, Sponsor } from "./Components"
+import {
+  ArticleText,
+  FeatureText,
+  Media,
+  Sponsor,
+  StandardText,
+} from "./Components"
 
 export const ClassicArticle: ArticleData = {
   _id: "597b9f652d35b80017a2a6a7",
@@ -723,6 +729,17 @@ export const ShortStandardArticle = extend({}, StandardArticle, {
 
 export const MissingVerticalStandardArticle = extend({}, StandardArticle, {
   vertical: null,
+})
+
+// Articles with only text sections
+export const TextClassicArticle = extend(cloneDeep(ClassicArticle), {
+  sections: ArticleText,
+})
+export const TextStandardArticle = extend(cloneDeep(StandardArticle), {
+  sections: StandardText,
+})
+export const TextFeatureArticle = extend(cloneDeep(FeatureArticle), {
+  sections: FeatureText,
 })
 
 export const VideoArticle: ArticleData = {

--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -1,7 +1,7 @@
 import { cloneDeep, extend } from "lodash"
 import { ArticleData } from "../Typings"
 import {
-  ArticleText,
+  ClassicText,
   FeatureText,
   Media,
   Sponsor,
@@ -640,9 +640,9 @@ export const FeatureArticle: ArticleData = {
   slug: "artsy-editorial-path-winning-art-prize",
 }
 
-export const SponsoredArticle = extend({}, FeatureArticle, Sponsor)
+export const SponsoredArticle = extend(cloneDeep(FeatureArticle), Sponsor)
 
-export const SuperArticle = extend({}, FeatureArticle, {
+export const SuperArticle = extend(cloneDeep(FeatureArticle), {
   is_super_article: true,
   super_article: {
     footer_blurb:
@@ -669,7 +669,7 @@ export const SuperArticle = extend({}, FeatureArticle, {
   },
 })
 
-export const ImageHeavyStandardArticle = extend({}, StandardArticle, {
+export const ImageHeavyStandardArticle = extend(cloneDeep(StandardArticle), {
   sections: [
     {
       type: "image_collection",
@@ -717,7 +717,7 @@ export const ImageHeavyStandardArticle = extend({}, StandardArticle, {
   ],
 })
 
-export const ShortStandardArticle = extend({}, StandardArticle, {
+export const ShortStandardArticle = extend(cloneDeep(StandardArticle), {
   sections: [
     {
       type: "text",
@@ -727,13 +727,16 @@ export const ShortStandardArticle = extend({}, StandardArticle, {
   ],
 })
 
-export const MissingVerticalStandardArticle = extend({}, StandardArticle, {
-  vertical: null,
-})
+export const MissingVerticalStandardArticle = extend(
+  cloneDeep(StandardArticle),
+  {
+    vertical: null,
+  }
+)
 
 // Articles with only text sections
 export const TextClassicArticle = extend(cloneDeep(ClassicArticle), {
-  sections: ArticleText,
+  sections: ClassicText,
 })
 export const TextStandardArticle = extend(cloneDeep(StandardArticle), {
   sections: StandardText,
@@ -761,7 +764,7 @@ export const VideoArticle: ArticleData = {
   media: Media[0],
 }
 
-export const VideoArticleUnpublished = extend({}, VideoArticle, {
+export const VideoArticleUnpublished = extend(cloneDeep(VideoArticle), {
   media: {
     title: "Trevor Paglan",
     url: "",
@@ -775,7 +778,7 @@ export const VideoArticleUnpublished = extend({}, VideoArticle, {
   },
 })
 
-export const VideoArticleSponsored = extend({}, VideoArticle, Sponsor)
+export const VideoArticleSponsored = extend(cloneDeep(VideoArticle), Sponsor)
 
 export const SeriesArticle: ArticleData = {
   _id: "594a7e2254c37f00177c0ea9",
@@ -791,7 +794,7 @@ export const SeriesArticle: ArticleData = {
   related_articles: ["594a7e2254c37f00177c0ea9", "597b9f652d35b80017a2a6a7"],
 }
 
-export const SeriesArticleSponsored = extend({}, SeriesArticle, Sponsor)
+export const SeriesArticleSponsored = extend(cloneDeep(SeriesArticle), Sponsor)
 
 export const NewsArticle: ArticleData = {
   _id: "594a7e2254c37f00177c0ea9",

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -1,6 +1,5 @@
-import { compact, map } from "lodash"
+import { flatten } from "lodash"
 import { Props as ImageSetPreviewProps } from "../Sections/ImageSetPreview"
-import { NewsArticle } from "./Articles"
 
 export const ArtworkMissingInfo = {
   type: "artwork",
@@ -557,45 +556,75 @@ export const Videos = [
   },
 ]
 
-const textElements = [
-  // classic elements
-  [
-    "<p>Rines is a part of a recent migration that has galleries gravitating to the <a href='https://www.artsy.net/'>Lower East Side and Chinatown</a>. The new gallery sits on a stretch of Henry Street that also includes Chapter NY, Cuevas Tilleard, and newcomer Shrine, and is just blocks from:</p>",
-    "<ul><li>Chinatown stalwart Reena Spaulings Fine Art</li><li>The shiny new <span style='text-decoration: line-through;'>Foxy Production</span></li><li>Freshly launched programs like Erin Goldberger’s New Release</li><li>Angelo Lanza’s gallery Jeffrey Stark in the basement of the East Broadway Mall</li></ul>",
-    "<p>And <em>not a stone’s throw away</em> are the southern bounds of the Lower East Side, where <strong>hundreds</strong> of more galleries gather.</p>",
-    "<blockquote>Hardly a week goes by without murmurings that yet another gallery is opening</blockquote>",
-    "<h3><strong>Galleries Section, Booth 10221</strong></h3><h2>neugerriemschneider</h2>",
-    "<h3><em>With works by</em> Franz Ackermann, Ai Weiwei, Pawel Althamer, Billy Childish, Keith Edmier, Olafur Eliasson, Andreas Eriksson, Noa Eshkol, Mario García Torres, Renata Lucas, Michel Majerus, Mike Nelson, Jorge Pardo, Elizabeth Peyton, Tobias Rehberger, Thaddeus Strode, Rirkrit Tiravanija, Pae White</h3>",
-  ],
-  // feature elements
-  [
-    "<h1>Standard Header</h1>",
-    "<p><span class='content-start'>R</span>ines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building. The new gallery sits on a stretch of Henry Street that also includes Chapter NY, Cuevas Tilleard, and newcomer Shrine, and is just blocks from:</p>",
-  ],
-  // classic close
-  [
-    "<p>The resultant work allows Salley the chance to recount her experiences of the aftermath of her scandal in her own words. In the film, Fujiwara and Salley are shown meeting professionals from public relations, advertising, and fashion companies as they seek to construct a new public image for her. Alongside the film, light boxes display fashion photographer Andreas Larsson’s pictures of Salley, which were taken as part of the project to rebuild her profile. While the show tackles public identity, female iconography, and Salley’s voice as an artist, the pair’s close working relationship—one in which the conventional power relationship has been overturned—no doubt aided their collaboration.</p>",
-    "<ol><li>Chinatown stalwart Reena Spaulings Fine Art</li><li>The shiny new Foxy Production</li><li>Freshly launched programs like Erin Goldberger’s New Release</li><li>Angelo Lanza’s gallery Jeffrey Stark in the basement of the East Broadway Mall</li></ol>",
-    "<p>Rines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building.</p>",
-    "<h2><a href='https://www.artsy.net/artist/ej-hill' class='is-follow-link' name='EJ_Hill'>EJ Hill</a><a data-id='ej-hill' class='entity-follow artist-follow'></a></h2>",
-    "<p><a href='https://www.artsy.net/artist/ej-hill' class='is-follow-link' name='EJ_Hill'>EJ Hill</a><a data-id='ej-hill' class='entity-follow artist-follow'></a></p>",
-  ],
-  // standard & feature close
-  [
-    "<p>Rines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building.<span class='content-end'></span></p>",
-  ],
+export const ArticleText: Object[] = [
+  {
+    type: "text",
+    body:
+      "<p>Rines is a part of a recent migration that has galleries gravitating to the <a href='https://www.artsy.net/'>Lower East Side and Chinatown</a>. The new gallery sits on a stretch of Henry Street that also includes Chapter NY, Cuevas Tilleard, and newcomer Shrine, and is just blocks from:</p>",
+  },
+  {
+    type: "text",
+    body:
+      "<ul><li>Chinatown stalwart Reena Spaulings Fine Art</li><li>The shiny new <span style='text-decoration: line-through;'>Foxy Production</span></li><li>Freshly launched programs like Erin Goldberger’s New Release</li><li>Angelo Lanza’s gallery Jeffrey Stark in the basement of the East Broadway Mall</li></ul>",
+  },
+  {
+    type: "text",
+    body:
+      "<p>And <em>not a stone’s throw away</em> are the southern bounds of the Lower East Side, where <strong>hundreds</strong> of more galleries gather.</p>",
+  },
+  {
+    type: "text",
+    layout: "blockquote",
+    body:
+      "<blockquote>Hardly a week goes by without murmurings that yet another gallery is opening</blockquote>",
+  },
+  {
+    type: "text",
+    body:
+      "<h3><strong>Galleries Section, Booth 10221</strong></h3><h2>neugerriemschneider</h2>",
+  },
+  {
+    type: "text",
+    body:
+      "<h3><em>With works by</em> Franz Ackermann, Ai Weiwei, Pawel Althamer, Billy Childish, Keith Edmier, Olafur Eliasson, Andreas Eriksson, Noa Eshkol, Mario García Torres, Renata Lucas, Michel Majerus, Mike Nelson, Jorge Pardo, Elizabeth Peyton, Tobias Rehberger, Thaddeus Strode, Rirkrit Tiravanija, Pae White</h3>",
+  },
+  {
+    type: "text",
+    body:
+      "<p>The resultant work allows Salley the chance to recount her experiences of the aftermath of her scandal in her own words. In the film, Fujiwara and Salley are shown meeting professionals from public relations, advertising, and fashion companies as they seek to construct a new public image for her. Alongside the film, light boxes display fashion photographer Andreas Larsson’s pictures of Salley, which were taken as part of the project to rebuild her profile. While the show tackles public identity, female iconography, and Salley’s voice as an artist, the pair’s close working relationship—one in which the conventional power relationship has been overturned—no doubt aided their collaboration.</p>",
+  },
+  {
+    type: "text",
+    body:
+      "<ol><li>Chinatown stalwart Reena Spaulings Fine Art</li><li>The shiny new Foxy Production</li><li>Freshly launched programs like Erin Goldberger’s New Release</li><li>Angelo Lanza’s gallery Jeffrey Stark in the basement of the East Broadway Mall</li></ol>",
+  },
+  {
+    type: "text",
+    body:
+      "<p>Rines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building.</p>",
+  },
+  {
+    type: "text",
+    body:
+      "<h2><a href='https://www.artsy.net/artist/ej-hill' class='is-follow-link' name='EJ_Hill'>EJ Hill</a><a data-id='ej-hill' class='entity-follow artist-follow'></a></h2>",
+  },
+  {
+    type: "text",
+    body:
+      "<p><a href='https://www.artsy.net/artist/ej-hill' class='is-follow-link' name='EJ_Hill'>EJ Hill</a><a data-id='ej-hill' class='entity-follow artist-follow'></a></p>",
+  },
 ]
 
-const classicText = textElements[0].concat(textElements[2])
-const standardText = classicText.concat(textElements[3])
-const featureText = textElements[1].concat(standardText)
+export const StandardText = flatten([
+  ArticleText,
+  {
+    type: "text",
+    body:
+      "<p>Rines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building.<span class='content-end'></span></p>",
+  },
+])
 
-export const newsArticleText = () => {
-  return compact(map(NewsArticle.sections, "body")).join("")
-}
-
-export const SectionText = {
-  classic: classicText.join(""),
-  feature: featureText.join(""),
-  standard: standardText.join(""),
-}
+export const FeatureText = flatten([
+  { type: "text", body: "<h1>Standard Header</h1>" },
+  StandardText,
+])

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -556,7 +556,7 @@ export const Videos = [
   },
 ]
 
-export const ArticleText: Object[] = [
+export const ClassicText: Object[] = [
   {
     type: "text",
     body:
@@ -616,7 +616,7 @@ export const ArticleText: Object[] = [
 ]
 
 export const StandardText = flatten([
-  ArticleText,
+  ClassicText,
   {
     type: "text",
     body:

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -1,4 +1,6 @@
+import { compact, map } from "lodash"
 import { Props as ImageSetPreviewProps } from "../Sections/ImageSetPreview"
+import { NewsArticle } from "./Articles"
 
 export const ArtworkMissingInfo = {
   type: "artwork",
@@ -587,6 +589,10 @@ const textElements = [
 const classicText = textElements[0].concat(textElements[2])
 const standardText = classicText.concat(textElements[3])
 const featureText = textElements[1].concat(standardText)
+
+export const newsArticleText = () => {
+  return compact(map(NewsArticle.sections, "body")).join("")
+}
 
 export const SectionText = {
   classic: classicText.join(""),

--- a/src/Components/Publishing/Fixtures/Helpers.tsx
+++ b/src/Components/Publishing/Fixtures/Helpers.tsx
@@ -1,5 +1,10 @@
+import { compact, map } from "lodash"
 import React from "react"
 
-export const EditableChild = (type) => {
+export const EditableChild = type => {
   return <div>Child {type}</div>
+}
+
+export const TextFromArticle = article => {
+  return compact(map(article.sections, "body")).join("")
 }

--- a/src/Components/Publishing/Sections/SectionContainer.tsx
+++ b/src/Components/Publishing/Sections/SectionContainer.tsx
@@ -16,7 +16,10 @@ const chooseWidth = (layout, articleLayout, media = null) => {
     if (media && media === "lg" && articleLayout === "standard") {
       return "680px"
     }
-    if (layout === "blockquote" && articleLayout !== "classic") {
+    if (
+      layout === "blockquote" &&
+      ["feature", "standard"].includes(articleLayout)
+    ) {
       const sectionWidth = articleLayout === "feature" ? "900px" : "780px"
       return sectionWidth
     } else if (layout === "overflow_fillwidth" || layout === "blockquote") {
@@ -28,7 +31,7 @@ const chooseWidth = (layout, articleLayout, media = null) => {
   return "680px"
 }
 
-const chooseMobilePadding = (type) => {
+const chooseMobilePadding = type => {
   switch (type) {
     case "author":
     case "blockquote":

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -11,17 +11,25 @@ interface StyledTextProps {
   postscript?: Boolean
 }
 
-const div: StyledFunction<StyledTextProps & React.HTMLProps<HTMLDivElement>> = styled.div
+const div: StyledFunction<StyledTextProps & React.HTMLProps<HTMLDivElement>> =
+  styled.div
 
 function getBlockquoteSize(layout, size) {
-  let font
   const desktop = size === "lg"
-  if (layout === "feature") {
-    font = desktop ? Fonts.unica("s40") : Fonts.unica("s34")
-  } else {
-    font = desktop ? Fonts.garamond("s40") : Fonts.garamond("s34")
+
+  switch (layout) {
+    case "feature": {
+      return desktop ? Fonts.unica("s40") : Fonts.unica("s34")
+    }
+    case "news": {
+      return desktop
+        ? Fonts.unica("s19", "medium")
+        : Fonts.unica("s16", "medium")
+    }
+    default: {
+      return desktop ? Fonts.garamond("s40") : Fonts.garamond("s34")
+    }
   }
-  return font
 }
 
 export const StyledText = div`
@@ -32,18 +40,22 @@ export const StyledText = div`
     color: ${props => props.color};
     text-decoration: none;
     position: relative;
-    background-image: linear-gradient(to bottom,transparent 0, ${props => props.color === "black" ? "#333" : props.color} 1px,transparent 0);
+    background-image: linear-gradient(to bottom,transparent 0, ${props =>
+      props.color === "black" ? "#333" : props.color} 1px,transparent 0);
     background-size: 1.25px 4px;
     background-repeat: repeat-x;
     background-position: bottom;
     &:hover {
-      color: ${props => props.color === "black" ? "#999" : props.color};
-      opacity:  ${props => props.color === "black" ? "1" : ".65"};
+      color: ${props => (props.color === "black" ? "#999" : props.color)};
+      opacity:  ${props => (props.color === "black" ? "1" : ".65")};
     }
   }
   p, ul, ol,
   div[data-block=true] .public-DraftStyleDefault-block {
-    ${props => (props.layout === "classic" ? Fonts.garamond("s19") : Fonts.garamond("s23"))}
+    ${props =>
+      props.layout === "classic"
+        ? Fonts.garamond("s19")
+        : Fonts.garamond("s23")}
     padding-top: ${props => (props.layout === "classic" ? ".75em" : "1em")};
     padding-bottom: ${props => (props.layout === "classic" ? ".75em" : "1em")};
     margin: 0;
@@ -61,7 +73,10 @@ export const StyledText = div`
     padding-left: 1em;
   }
   li {
-    ${props => (props.layout === "classic" ? Fonts.garamond("s19") : Fonts.garamond("s23"))}
+    ${props =>
+      props.layout === "classic"
+        ? Fonts.garamond("s19")
+        : Fonts.garamond("s23")}
     padding-top: .5em;
     padding-bottom: .5em;
   }
@@ -85,7 +100,8 @@ export const StyledText = div`
     }
   }
   h2 {
-    ${props => (props.layout === "classic" ? Fonts.garamond("s28") : Fonts.unica("s32"))}
+    ${props =>
+      props.layout === "classic" ? Fonts.garamond("s28") : Fonts.unica("s32")}
     font-weight: normal;
     margin: 0;
     a {
@@ -93,13 +109,15 @@ export const StyledText = div`
     }
   }
   h3 {
-    ${props => (props.layout === "classic" ? Fonts.avantgarde("s13") : Fonts.unica("s19"))}
+    ${props =>
+      props.layout === "classic" ? Fonts.avantgarde("s13") : Fonts.unica("s19")}
     font-weight: normal;
     padding-top: 23px;
     margin: 0;
     strong {
       font-weight: normal;
-      ${props => (props.layout !== "classic" ? Fonts.unica("s19", "medium") : "")}
+      ${props =>
+        props.layout !== "classic" ? Fonts.unica("s19", "medium") : ""}
     }
     em {
       font-style: ${props => (props.layout === "classic" ? "normal" : "")};
@@ -112,15 +130,28 @@ export const StyledText = div`
     ${props => getBlockquoteSize(props.layout, "lg")}
     text-align: ${props => (props.layout === "classic" ? "center" : "left")};
     font-weight: normal;
-    padding-top: 46px;
-    padding-bottom: 46px;
+    padding-top: ${props => (props.layout === "news" ? "10px" : "46px")};
+    padding-bottom: ${props => (props.layout === "news" ? "10px" : "46px")};
     margin: 0;
     word-break: break-word;
+    a {
+      ${props =>
+        props.layout === "news" &&
+        `
+        background-size: 1.25px 1px;
+      `}
+    }
   }
   p:first-child:first-letter,
   div[data-block=true]:first-child .public-DraftStyleDefault-block:first-letter {
-    ${props => props.isContentStart && props.layout === "feature" && Fonts.unica("s67", "medium")}
-    ${props => props.isContentStart && props.layout === "feature" && `
+    ${props =>
+      props.isContentStart &&
+      props.layout === "feature" &&
+      Fonts.unica("s67", "medium")}
+    ${props =>
+      props.isContentStart &&
+      props.layout === "feature" &&
+      `
       float: left;
       line-height: .5em;
       margin-right: 10px;
@@ -170,7 +201,9 @@ export const StyledText = div`
       ${props.layout === "classic" ? Fonts.garamond("s28") : Fonts.unica("s32")}
     }
     h3 {
-      ${props.layout === "classic" ? Fonts.avantgarde("s11") : Fonts.unica("s16")}
+      ${props.layout === "classic"
+        ? Fonts.avantgarde("s11")
+        : Fonts.unica("s16")}
       line-height: ${props.layout !== "classic" ? "1.5em" : ""};
     }
     h3 strong {
@@ -186,5 +219,5 @@ export const StyledText = div`
 `
 
 StyledText.defaultProps = {
-  color: 'black'
+  color: "black",
 }

--- a/src/Components/Publishing/Sections/__tests__/Text.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Text.test.tsx
@@ -1,20 +1,45 @@
 import "jest-styled-components"
 import React from "react"
 import renderer from "react-test-renderer"
-import { SectionText } from "../../Fixtures/Components"
+import {
+  NewsArticle,
+  TextClassicArticle,
+  TextFeatureArticle,
+  TextStandardArticle,
+} from "../../Fixtures/Articles"
+import { TextFromArticle } from "../../Fixtures/Helpers"
 import { Text } from "../Text"
 
 it("renders classic text properly", () => {
-  const text = renderer.create(<Text html={SectionText.classic} layout="classic" />).toJSON()
+  const text = renderer
+    .create(
+      <Text html={TextFromArticle(TextClassicArticle)} layout="classic" />
+    )
+    .toJSON()
   expect(text).toMatchSnapshot()
 })
 
 it("renders feature text properly", () => {
-  const text = renderer.create(<Text html={SectionText.feature} layout="feature" />).toJSON()
+  const text = renderer
+    .create(
+      <Text html={TextFromArticle(TextFeatureArticle)} layout="feature" />
+    )
+    .toJSON()
   expect(text).toMatchSnapshot()
 })
 
 it("renders standard text properly", () => {
-  const text = renderer.create(<Text html={SectionText.standard} layout="standard" />).toJSON()
+  const text = renderer
+    .create(
+      <Text html={TextFromArticle(TextStandardArticle)} layout="standard" />
+    )
+    .toJSON()
+  expect(text).toMatchSnapshot()
+})
+
+it("renders news text properly", () => {
+  const text = renderer
+    .create(<Text html={TextFromArticle(NewsArticle)} layout="standard" />)
+    .toJSON()
   expect(text).toMatchSnapshot()
 })

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Text.test.tsx.snap
@@ -479,7 +479,245 @@ exports[`renders feature text properly 1`] = `
   <div
     dangerouslySetInnerHTML={
       Object {
-        "__html": "<h1>Standard Header</h1><p><span class='content-start'>R</span>ines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building. The new gallery sits on a stretch of Henry Street that also includes Chapter NY, Cuevas Tilleard, and newcomer Shrine, and is just blocks from:</p><p>Rines is a part of a recent migration that has galleries gravitating to the <a href='https://www.artsy.net/'>Lower East Side and Chinatown</a>. The new gallery sits on a stretch of Henry Street that also includes Chapter NY, Cuevas Tilleard, and newcomer Shrine, and is just blocks from:</p><ul><li>Chinatown stalwart Reena Spaulings Fine Art</li><li>The shiny new <span style='text-decoration: line-through;'>Foxy Production</span></li><li>Freshly launched programs like Erin Goldberger’s New Release</li><li>Angelo Lanza’s gallery Jeffrey Stark in the basement of the East Broadway Mall</li></ul><p>And <em>not a stone’s throw away</em> are the southern bounds of the Lower East Side, where <strong>hundreds</strong> of more galleries gather.</p><blockquote>Hardly a week goes by without murmurings that yet another gallery is opening</blockquote><h3><strong>Galleries Section, Booth 10221</strong></h3><h2>neugerriemschneider</h2><h3><em>With works by</em> Franz Ackermann, Ai Weiwei, Pawel Althamer, Billy Childish, Keith Edmier, Olafur Eliasson, Andreas Eriksson, Noa Eshkol, Mario García Torres, Renata Lucas, Michel Majerus, Mike Nelson, Jorge Pardo, Elizabeth Peyton, Tobias Rehberger, Thaddeus Strode, Rirkrit Tiravanija, Pae White</h3><p>The resultant work allows Salley the chance to recount her experiences of the aftermath of her scandal in her own words. In the film, Fujiwara and Salley are shown meeting professionals from public relations, advertising, and fashion companies as they seek to construct a new public image for her. Alongside the film, light boxes display fashion photographer Andreas Larsson’s pictures of Salley, which were taken as part of the project to rebuild her profile. While the show tackles public identity, female iconography, and Salley’s voice as an artist, the pair’s close working relationship—one in which the conventional power relationship has been overturned—no doubt aided their collaboration.</p><ol><li>Chinatown stalwart Reena Spaulings Fine Art</li><li>The shiny new Foxy Production</li><li>Freshly launched programs like Erin Goldberger’s New Release</li><li>Angelo Lanza’s gallery Jeffrey Stark in the basement of the East Broadway Mall</li></ol><p>Rines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building.</p><h2><a href='https://www.artsy.net/artist/ej-hill' class='is-follow-link' name='EJ_Hill'>EJ Hill</a><a data-id='ej-hill' class='entity-follow artist-follow'></a></h2><p><a href='https://www.artsy.net/artist/ej-hill' class='is-follow-link' name='EJ_Hill'>EJ Hill</a><a data-id='ej-hill' class='entity-follow artist-follow'></a></p><p>Rines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building.<span class='content-end'></span></p>",
+        "__html": "<h1>Standard Header</h1><p>Rines is a part of a recent migration that has galleries gravitating to the <a href='https://www.artsy.net/'>Lower East Side and Chinatown</a>. The new gallery sits on a stretch of Henry Street that also includes Chapter NY, Cuevas Tilleard, and newcomer Shrine, and is just blocks from:</p><ul><li>Chinatown stalwart Reena Spaulings Fine Art</li><li>The shiny new <span style='text-decoration: line-through;'>Foxy Production</span></li><li>Freshly launched programs like Erin Goldberger’s New Release</li><li>Angelo Lanza’s gallery Jeffrey Stark in the basement of the East Broadway Mall</li></ul><p>And <em>not a stone’s throw away</em> are the southern bounds of the Lower East Side, where <strong>hundreds</strong> of more galleries gather.</p><blockquote>Hardly a week goes by without murmurings that yet another gallery is opening</blockquote><h3><strong>Galleries Section, Booth 10221</strong></h3><h2>neugerriemschneider</h2><h3><em>With works by</em> Franz Ackermann, Ai Weiwei, Pawel Althamer, Billy Childish, Keith Edmier, Olafur Eliasson, Andreas Eriksson, Noa Eshkol, Mario García Torres, Renata Lucas, Michel Majerus, Mike Nelson, Jorge Pardo, Elizabeth Peyton, Tobias Rehberger, Thaddeus Strode, Rirkrit Tiravanija, Pae White</h3><p>The resultant work allows Salley the chance to recount her experiences of the aftermath of her scandal in her own words. In the film, Fujiwara and Salley are shown meeting professionals from public relations, advertising, and fashion companies as they seek to construct a new public image for her. Alongside the film, light boxes display fashion photographer Andreas Larsson’s pictures of Salley, which were taken as part of the project to rebuild her profile. While the show tackles public identity, female iconography, and Salley’s voice as an artist, the pair’s close working relationship—one in which the conventional power relationship has been overturned—no doubt aided their collaboration.</p><ol><li>Chinatown stalwart Reena Spaulings Fine Art</li><li>The shiny new Foxy Production</li><li>Freshly launched programs like Erin Goldberger’s New Release</li><li>Angelo Lanza’s gallery Jeffrey Stark in the basement of the East Broadway Mall</li></ol><p>Rines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building.</p><h2><a href='https://www.artsy.net/artist/ej-hill' class='is-follow-link' name='EJ_Hill'>EJ Hill</a><a data-id='ej-hill' class='entity-follow artist-follow'></a></h2><p><a href='https://www.artsy.net/artist/ej-hill' class='is-follow-link' name='EJ_Hill'>EJ Hill</a><a data-id='ej-hill' class='entity-follow artist-follow'></a></p><p>Rines is a part of a recent migration that has galleries gravitating to the Lower East Side and Chinatown. She opened 56 Henry in December 2015, just four months after being forced to shutter her previous microgallery 55 Gansevoort—an elevator shaft a block east of the Whitney—after Restoration Hardware bought its building.<span class='content-end'></span></p>",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`renders news text properly 1`] = `
+.c0 {
+  position: relative;
+  width: 100%;
+}
+
+.c0 a {
+  color: black;
+  text-decoration: none;
+  position: relative;
+  background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
+  background-size: 1.25px 4px;
+  background-repeat: repeat-x;
+  background-position: bottom;
+}
+
+.c0 a:hover {
+  color: #999;
+  opacity: 1;
+}
+
+.c0 p,
+.c0 ul,
+.c0 ol,
+.c0 div[data-block=true] .public-DraftStyleDefault-block {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 23px;
+  line-height: 1.5em;
+  padding-top: 1em;
+  padding-bottom: 1em;
+  margin: 0;
+  font-style: inherit;
+}
+
+.c0 p:first-child,
+.c0 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+  padding-top: 0;
+}
+
+.c0 p:last-child,
+.c0 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+  padding-bottom: 0;
+}
+
+.c0 ul,
+.c0 ol {
+  padding-left: 1em;
+}
+
+.c0 li {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 23px;
+  line-height: 1.5em;
+  padding-top: .5em;
+  padding-bottom: .5em;
+}
+
+.c0 h1 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  font-weight: normal;
+  padding-top: 107px;
+  padding-bottom: 46px;
+  margin: 0;
+  position: relative;
+  text-align: center;
+}
+
+.c0 h1:before {
+  content: "";
+  width: 15px;
+  height: 15px;
+  background: black;
+  border-radius: 50%;
+  position: absolute;
+  top: 69px;
+  right: calc(50% - 7.5px);
+}
+
+.c0 h2 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+  font-weight: normal;
+  margin: 0;
+}
+
+.c0 h2 a {
+  background-size: 1.25px 1px;
+}
+
+.c0 h3 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+  font-weight: normal;
+  padding-top: 23px;
+  margin: 0;
+}
+
+.c0 h3 strong {
+  font-weight: normal;
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+}
+
+.c0 h3 a {
+  background-size: 1.25px 1px;
+}
+
+.c0 blockquote {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  text-align: left;
+  font-weight: normal;
+  padding-top: 46px;
+  padding-bottom: 46px;
+  margin: 0;
+  word-break: break-word;
+}
+
+.c0 .content-end {
+  display: inline-block;
+  content: "";
+  width: 12px;
+  height: 12px;
+  background: black;
+  border-radius: 50%;
+  margin-left: 12px;
+}
+
+.c0 .artist-follow {
+  vertical-align: middle;
+  margin-left: 10px;
+  cursor: pointer;
+  background: none transparent;
+}
+
+.c0 .artist-follow:before {
+  font-family: "artsy-icons";
+  content: "";
+  vertical-align: -8.5px;
+  line-height: 32px;
+  font-size: 32px;
+}
+
+.c0 .artist-follow:after {
+  content: "Follow";
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 17px;
+  line-height: 1.1em;
+  text-transform: none;
+}
+
+@media (max-width:600px) {
+  .c0 p,
+  .c0 ul,
+  .c0 ol,
+  .c0 div[data-block=true] .public-DraftStyleDefault-block {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 19px;
+    line-height: 1.5em;
+  }
+
+  .c0 li {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 19px;
+    line-height: 1.5em;
+  }
+
+  .c0 h1 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+  }
+
+  .c0 h2 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 32px;
+    line-height: 1.1em;
+  }
+
+  .c0 h3 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+    line-height: 1.5em;
+  }
+
+  .c0 h3 strong {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+
+  .c0 blockquote {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+  }
+
+  .c0 .content-start {
+    font-size: 55px;
+  }
+}
+
+<div
+  className="article__text-section c0"
+  color="black"
+>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p><strong>The design for the as-yet-uncompleted sculpture</strong>, <span style='text-decoration:line-through;'><em>Bouquet of Tulips</em></span>, was donated by Koons to the French capital in November 2016 as a memorial to the recent terrorist attacks that have taken place in the city. But Koons, <a href='#'>one of the world’s richest living artists</a>, didn’t donate the $4.3 million needed to create 40-foot-tall sculpture, which was raised separately via donations. And the work, slated for installation in front of the Palais de Tokyo and Paris’s Museum of Modern Art, has attracted opposition. In a letter published in the French newspaper Libération on Sunday, signatories—including Frédéric Mitterrand, the country’s former culture minister—demanded that the city halt its plans to install the sculpture, calling it “shocking.” </p><blockquote>It is understood the [British Museum] has been in talks about a possible loan of the tapestry for several years, but there will be other contenders to host it.</blockquote><blockquote>The bookmaker Ladbrokes is offering odds on where it might go, with the British Museum evens favourite, followed by Westminster Cathedral at 3/1, Canterbury Cathedral at 5/1 and Hastings at 8/1.</blockquote><blockquote><a href='#'>The Guardian</a></blockquote><p>It further criticized Koons for using the opportunity as a publicity stunt, as the sculpture’s planned location is in a tourist-heavy area far from where the 2015 terrorist attacks actually took place. “We appreciate gifts, [but ones that are] free, unconditional, and without ulterior motives,” the letter said. In any case, Parisian officials have not yet granted authorization to install the sculpture, according to the <em>New York Times</em>.</p><h3><strong>Takeaway</strong></h3><h3>Should Prince lose at trial and on appeal the resulting precedent would reign in the broader <em>fair use interpretations</em> now afforded to artists.</h3>",
       }
     }
   />

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -1,5 +1,17 @@
-export type Layout = "classic" | "feature" | "series" | "standard" | "video"
-export type SectionLayout = "blockquote" | "column_width" | "fillwidth" | "full" | "mini" | "overflow_fillwidth"
+export type Layout =
+  | "classic"
+  | "feature"
+  | "series"
+  | "standard"
+  | "video"
+  | "news"
+export type SectionLayout =
+  | "blockquote"
+  | "column_width"
+  | "fillwidth"
+  | "full"
+  | "mini"
+  | "overflow_fillwidth"
 
 export type ArticleData = {
   layout: Layout

--- a/src/Components/Publishing/__stories__/Text.story.tsx
+++ b/src/Components/Publishing/__stories__/Text.story.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
-import { SectionText } from "../Fixtures/Components"
+import { newsArticleText, SectionText } from "../Fixtures/Components"
 import { Text } from "../Sections/Text"
 
 storiesOf("Publishing/Text", module)
@@ -22,6 +22,13 @@ storiesOf("Publishing/Text", module)
     return (
       <div style={{ maxWidth: 680, margin: "0 auto" }}>
         <Text layout="standard" html={SectionText.standard} />
+      </div>
+    )
+  })
+  .add("News", () => {
+    return (
+      <div style={{ maxWidth: 680, margin: "0 auto" }}>
+        <Text layout="news" html={newsArticleText()} />
       </div>
     )
   })

--- a/src/Components/Publishing/__stories__/Text.story.tsx
+++ b/src/Components/Publishing/__stories__/Text.story.tsx
@@ -1,34 +1,40 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
-import { newsArticleText, SectionText } from "../Fixtures/Components"
+import {
+  NewsArticle,
+  TextClassicArticle,
+  TextFeatureArticle,
+  TextStandardArticle,
+} from "../Fixtures/Articles"
+import { TextFromArticle } from "../Fixtures/Helpers"
 import { Text } from "../Sections/Text"
 
 storiesOf("Publishing/Text", module)
   .add("Classic", () => {
     return (
       <div style={{ maxWidth: 580, margin: "0 auto" }}>
-        <Text layout="classic" html={SectionText.classic} />
+        <Text layout="classic" html={TextFromArticle(TextClassicArticle)} />
       </div>
     )
   })
   .add("Feature", () => {
     return (
       <div style={{ maxWidth: 680, margin: "0 auto" }}>
-        <Text layout="feature" html={SectionText.feature} />
+        <Text layout="feature" html={TextFromArticle(TextFeatureArticle)} />
       </div>
     )
   })
   .add("Standard", () => {
     return (
       <div style={{ maxWidth: 680, margin: "0 auto" }}>
-        <Text layout="standard" html={SectionText.standard} />
+        <Text layout="standard" html={TextFromArticle(TextStandardArticle)} />
       </div>
     )
   })
   .add("News", () => {
     return (
       <div style={{ maxWidth: 680, margin: "0 auto" }}>
-        <Text layout="news" html={newsArticleText()} />
+        <Text layout="news" html={TextFromArticle(NewsArticle)} />
       </div>
     )
   })


### PR DESCRIPTION
- Adds styles for News articles to `StyledText` component
- Adds 'news' layout to article typings
- Adds helper function `TextFromArticle` to get all html from text sections
- Reworks text fixtures to conform to section modeling, adds fixture articles with only text sections
- Uses cloneDeep in fixtures when duplicating articles

*** blockquote width is determined in sectionContainer, so will not show up in this screenshot 

![screen shot 2018-02-27 at 11 58 06 am](https://user-images.githubusercontent.com/1497424/36742400-87c512ea-1bb5-11e8-98f8-0cb3a030177d.png)
