### PR TITLE
@xtina-starr => Remove use of internal _debugID in Impression tracking

### DIFF
--- a/src/Components/Publishing/Display/track-once.ts
+++ b/src/Components/Publishing/Display/track-once.ts
@@ -21,12 +21,12 @@ const trackOnce = (unitLayout, action) => {
   return (target, name, descriptor) => {
     const decoratedFn = descriptor.value
     // tslint:disable-next-line:only-arrow-functions
-    descriptor.value = function () {
+    descriptor.value = function() {
       const key = [
         this.props.campaign.name,
         unitLayout(this.props),
         action,
-        (this.props.article && this.props.article.id) || this._reactInternalInstance._debugID,
+        (this.props.article && this.props.article.id) || "",
       ].join(":")
       if (alreadyFired[key]) return decoratedFn.apply(this, arguments)
       this.props.tracking &&


### PR DESCRIPTION
This was introduced to account for impression tracking that didn't provide an article id (right now that's Instant Articles). But using the internal `_reactInternalInstance` as the `||` is probably not a good idea since it's meant to be used internally by React. And now this line is broken with React 16 because they've switched to using a different node internally called `_reactInternalFiber `. 

If an article id isn't provided, it can be assumed that this is a one-off ad (Instant Article) which doesn't need to keep a cache of display units.

Sorry a lot of words here, so I'm happy to explain in person if that's easier. 