### PR TITLE
@eessex => Use article id as injection marker for mobile display

### DIFF
--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -797,6 +797,7 @@ export const SeriesArticle: ArticleData = {
 export const SeriesArticleSponsored = extend(cloneDeep(SeriesArticle), Sponsor)
 
 export const NewsArticle: ArticleData = {
+  id: "594a7e2254c37f00177c0ea9",
   _id: "594a7e2254c37f00177c0ea9",
   layout: "news",
   author_id: "57b5fc6acd530e65f8000406",

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -1,6 +1,6 @@
-import { clone, compact, once, uniqueId } from 'lodash'
+import { clone, compact, once } from "lodash"
 import React, { Component } from "react"
-import ReactDOM from 'react-dom'
+import ReactDOM from "react-dom"
 import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../Helpers"
 import { Layout } from "../Typings"
@@ -15,8 +15,9 @@ import { Video } from "./Video"
 interface Props {
   DisplayPanel?: any
   article: {
-    layout: Layout
     authors?: any
+    id: string
+    layout: Layout
     postscript?: string
     sections?: any
   }
@@ -32,32 +33,27 @@ interface State {
  * article at a specific paragraph index.
  */
 const MOBILE_DISPLAY_INJECT_INDEX = 1
-const MOBILE_DISPLAY_INJECT_ID_PREFIX = '__mobile_display_inject__'
+const MOBILE_DISPLAY_INJECT_ID_PREFIX = "__mobile_display_inject__"
 
 export class Sections extends Component<Props, State> {
   static defaultProps = {
-    isMobile: false
+    isMobile: false,
   }
 
   displayInjectId: string
 
   state = {
-    shouldInjectMobileDisplay: false
+    shouldInjectMobileDisplay: false,
   }
 
   componentWillMount() {
-    const {
-      article: {
-        layout
-      },
-      isMobile
-    } = this.props
+    const { article: { layout }, isMobile } = this.props
 
     this.injectDisplayPanelMarker = once(this.injectDisplayPanelMarker)
-    const shouldInjectMobileDisplay = isMobile && layout !== 'feature'
+    const shouldInjectMobileDisplay = isMobile && layout !== "feature"
 
     this.setState({
-      shouldInjectMobileDisplay
+      shouldInjectMobileDisplay,
     })
   }
 
@@ -71,13 +67,16 @@ export class Sections extends Component<Props, State> {
     const { isMobile } = this.props
 
     if (prevProps.isMobile !== isMobile) {
-      this.setState({
-        shouldInjectMobileDisplay: isMobile
-      }, () => {
-        if (isMobile && this.state.shouldInjectMobileDisplay) {
-          this.mountDisplayToMarker()
+      this.setState(
+        {
+          shouldInjectMobileDisplay: isMobile,
+        },
+        () => {
+          if (isMobile && this.state.shouldInjectMobileDisplay) {
+            this.mountDisplayToMarker()
+          }
         }
-      })
+      )
     }
   }
 
@@ -85,18 +84,19 @@ export class Sections extends Component<Props, State> {
    * Inject DisplayAd after a specific paragraph index
    */
   injectDisplayPanelMarker(body) {
-    const tag = '</p>'
+    const articleId = this.props.article.id
+    const tag = "</p>"
     const updatedBody = compact(body.split(tag))
       .map(p => p + tag)
       .reduce((arr, block, paragraphIndex) => {
         if (paragraphIndex === MOBILE_DISPLAY_INJECT_INDEX) {
-          this.displayInjectId = uniqueId(MOBILE_DISPLAY_INJECT_ID_PREFIX)
+          this.displayInjectId = `${MOBILE_DISPLAY_INJECT_ID_PREFIX}${articleId}`
           return arr.concat([block, `<div id="${this.displayInjectId}"></div>`])
         } else {
           return arr.concat([block])
         }
       }, [])
-      .join('')
+      .join("")
 
     return updatedBody
   }
@@ -109,31 +109,27 @@ export class Sections extends Component<Props, State> {
       ReactDOM.render(<DisplayPanel />, displayMountPoint)
     } else {
       console.error(
-        '(reaction/Sections.tsx) Error mounting Display: DOM node ',
-        'not found', displayMountPoint
+        "(reaction/Sections.tsx) Error mounting Display: DOM node ",
+        "not found",
+        displayMountPoint
       )
     }
   }
 
   getContentStartIndex = () => {
-    const {
-      article: {
-        layout,
-        sections
-      }
-    } = this.props
+    const { article: { layout, sections } } = this.props
 
-    if (layout === 'feature') {
-      const firstText = sections.findIndex(
-        (section) => {
-          return section.type === 'text'
-        }
-      )
+    if (layout === "feature") {
+      const firstText = sections.findIndex(section => {
+        return section.type === "text"
+      })
       return firstText
     }
   }
 
   getSection(section, index) {
+    const { article } = this.props
+
     const sections = {
       image_collection: (
         <ImageCollection
@@ -143,20 +139,17 @@ export class Sections extends Component<Props, State> {
           gutter={10}
         />
       ),
-      image_set:
-        <ImageSetPreview section={section} />,
-      video:
-        <Video section={section} />,
-      embed:
-        <Embed section={section} />,
-      text:
+      image_set: <ImageSetPreview section={section} />,
+      video: <Video section={section} />,
+      embed: <Embed section={section} />,
+      text: (
         <Text
           html={section.body}
-          layout={this.props.article.layout}
+          layout={article.layout}
           isContentStart={index === this.getContentStartIndex()}
-        />,
-      default:
-        false
+        />
+      ),
+      default: false,
     }
 
     const sectionComponent = sections[section.type] || sections.default
@@ -169,9 +162,10 @@ export class Sections extends Component<Props, State> {
     let displayMarkerInjected = false
 
     const renderedSections = article.sections.map((sectionItem, index) => {
-      const shouldInject = shouldInjectMobileDisplay
-        && sectionItem.type === 'text'
-        && !displayMarkerInjected
+      const shouldInject =
+        shouldInjectMobileDisplay &&
+        sectionItem.type === "text" &&
+        !displayMarkerInjected
 
       let section = sectionItem
 
@@ -181,7 +175,10 @@ export class Sections extends Component<Props, State> {
           section.body = this.injectDisplayPanelMarker(section.body)
           displayMarkerInjected = true
         } catch (error) {
-          console.error('(reaction/Sections.jsx) Error injecting Display:', error)
+          console.error(
+            "(reaction/Sections.jsx) Error injecting Display:",
+            error
+          )
         }
       }
 
@@ -205,15 +202,11 @@ export class Sections extends Component<Props, State> {
   }
 
   renderAuthors() {
-    const {
-      article: {
-        authors
-      }
-    } = this.props
+    const { article: { authors } } = this.props
 
     if (authors) {
       return (
-        <SectionContainer type='author'>
+        <SectionContainer type="author">
           <Authors authors={authors} />
         </SectionContainer>
       )
@@ -226,7 +219,7 @@ export class Sections extends Component<Props, State> {
 
     if (postscript) {
       return (
-        <SectionContainer type='text'>
+        <SectionContainer type="text">
           <Text
             html={postscript}
             layout={layout}
@@ -269,7 +262,7 @@ const StyledSections = div`
 
   ${props => pMedia.xl`
     max-width: ${props.layout === "standard" ? "680px" : "auto"};
-    ${props.layout === 'feature' ? "margin: 80px auto 0 auto" : ""}
+    ${props.layout === "feature" ? "margin: 80px auto 0 auto" : ""}
   `}
 
   ${props => pMedia.md`
@@ -277,6 +270,6 @@ const StyledSections = div`
   `}
   ${props => pMedia.xs`
     max-width: ${props.layout === "standard" ? "780px" : "auto"};
-    ${props.layout === 'feature' ? "margin: 30px auto 0 auto" : ""}
+    ${props.layout === "feature" ? "margin: 30px auto 0 auto" : ""}
   `}
 `

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.js
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.js
@@ -1,42 +1,46 @@
-import 'jest-styled-components'
-import React from 'react'
-import renderer from 'react-test-renderer'
-import { Sections } from '../Sections'
-import { StandardArticle } from '../../Fixtures/Articles'
-import { cloneDeep } from 'lodash'
-import { mount } from 'enzyme'
+import "jest-styled-components"
+import React from "react"
+import renderer from "react-test-renderer"
+import { Sections } from "../Sections"
+import { StandardArticle } from "../../Fixtures/Articles"
+import { cloneDeep } from "lodash"
+import { mount } from "enzyme"
 
-
-jest.mock('react-sizeme', () => jest.fn(c => d => d))
-jest.mock('react-lines-ellipsis/lib/html', () => {
-  const React = require('react')
+jest.mock("react-sizeme", () => jest.fn(c => d => d))
+jest.mock("react-lines-ellipsis/lib/html", () => {
+  const React = require("react")
   return () => <div />
 })
 
-jest.mock('react-dom/server', () => ({
-  renderToStaticMarkup: (x) => x
+jest.mock("react-dom/server", () => ({
+  renderToStaticMarkup: x => x,
 }))
 
-describe('snapshots', () => {
-  it('renders properly', () => {
-    const sections = renderer.create(<Sections article={StandardArticle} />).toJSON()
+describe("snapshots", () => {
+  it("renders properly", () => {
+    const sections = renderer
+      .create(<Sections article={StandardArticle} />)
+      .toJSON()
     expect(sections).toMatchSnapshot()
   })
 })
 
-describe('units', () => {
-  it('doesnt throw an error on invalid markup', () => {
-    const spy = jest.spyOn(global.console, 'error')
+describe("units", () => {
+  it("doesnt throw an error on invalid markup", () => {
+    const spy = jest.spyOn(global.console, "error")
 
     expect(() => {
       const article = cloneDeep(StandardArticle)
-      article.sections = [{
-        type: 'text',
-        body: '<p>busted'
-      }]
+      article.sections = [
+        {
+          type: "text",
+          body: "<p>busted",
+        },
+      ]
 
       mount(
-        <Sections isMobile
+        <Sections
+          isMobile
           DisplayPanel={() => <div>hi!</div>}
           article={article}
         />
@@ -45,12 +49,13 @@ describe('units', () => {
     }).not.toThrowError()
   })
 
-  it('does not inject if feature', () => {
+  it("does not inject if feature", () => {
     const article = cloneDeep(StandardArticle)
-    article.layout = 'feature'
-    const spy = jest.spyOn(Sections.prototype, 'mountDisplayToMarker')
+    article.layout = "feature"
+    const spy = jest.spyOn(Sections.prototype, "mountDisplayToMarker")
     const wrapper = mount(
-      <Sections isMobile
+      <Sections
+        isMobile
         DisplayPanel={() => <div>hi!</div>}
         article={article}
       />
@@ -59,10 +64,11 @@ describe('units', () => {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  it('does not inject if desktop', () => {
-    const spy = jest.spyOn(Sections.prototype, 'mountDisplayToMarker')
+  it("does not inject if desktop", () => {
+    const spy = jest.spyOn(Sections.prototype, "mountDisplayToMarker")
     const wrapper = mount(
-      <Sections isMobile={false}
+      <Sections
+        isMobile={false}
         DisplayPanel={() => <div>hi!</div>}
         article={StandardArticle}
       />
@@ -71,13 +77,14 @@ describe('units', () => {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  it('if mobile, sets flag to inject display', () => {
-    const element = document.createElement('div')
-    element.id = '__mobile_display_inject__'
+  it("if mobile, sets flag to inject display", () => {
+    const element = document.createElement("div")
+    element.id = "__mobile_display_inject__"
     document.getElementById = () => element
-    const spy = jest.spyOn(Sections.prototype, 'mountDisplayToMarker')
+    const spy = jest.spyOn(Sections.prototype, "mountDisplayToMarker")
     const wrapper = mount(
-      <Sections isMobile
+      <Sections
+        isMobile
         DisplayPanel={() => <div>hi!</div>}
         article={StandardArticle}
       />
@@ -86,16 +93,19 @@ describe('units', () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  it('injects a display panel marker after the second paragraph', () => {
+  it("injects a display panel marker after the second paragraph", () => {
     const { injectDisplayPanelMarker } = Sections.prototype
-    const scope = () => { this.displayInjectId = '__to_replace__' }
-    const body = injectDisplayPanelMarker.call(scope, ([
-      '<p>hello</p>',
-      '<p>how are you</p>',
-      '<p>how are you</p>'
-    ].join('')))
+    const scope = {
+      displayInjectId: "__to_replace__",
+      props: {
+        article: { id: "234" },
+      },
+    }
+    const body = injectDisplayPanelMarker.call(
+      scope,
+      ["<p>hello</p>", "<p>how are you</p>", "<p>how are you</p>"].join("")
+    )
 
-    expect(body).toContain('__mobile_display_inject__')
+    expect(body).toContain("__mobile_display_inject__234")
   })
 })
-

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -15,6 +15,7 @@ export type SectionLayout =
 
 export type ArticleData = {
   layout: Layout
+  id: string
   sections?: Array<{
     type: string
     layout?: string


### PR DESCRIPTION
`uniqueId()` is problematic for SSR where sometimes the `id` generated on the server doesn't match the client and therefore can't mount the ad unit. Instead, lets use the article id which still works with infinite scroll to account for uniqueness. 