### PR TITLE
@eessex => Social embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "repository": "https://github.com/artsy/reaction.git",
   "author": "Eloy Durán <eloy.de.enige@gmail.com>",
   "license": "MIT",
-  "files": ["assets", "data", "dist", "docs"],
+  "files": [
+    "assets",
+    "data",
+    "dist",
+    "docs"
+  ],
   "engines": {
     "node": "8.x.x",
     "npm": "5.4.x"
@@ -119,6 +124,7 @@
   "dependencies": {
     "history": "^4.6.1",
     "isomorphic-fetch": "^2.2.1",
+    "jsonp": "^0.2.1",
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.13",
     "numeral": "^2.0.4",
@@ -127,6 +133,7 @@
     "react-css-transition-replace": "^3.0.2",
     "react-lines-ellipsis": "^0.8.0",
     "react-markdown": "^2.5.0",
+    "react-oembed-container": "^0.3.0",
     "react-relay": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/react-relay-1.5.0-artsy.3.tgz",
     "react-responsive-decorator": "^0.0.1",
     "react-router": "4.1.1",
@@ -151,14 +158,32 @@
       ".(ts|tsx)": "typescript-babel-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js|jsx)$",
-    "testPathIgnorePatterns": ["<rootDir>/dist/", "<rootDir>/externals/"],
-    "moduleFileExtensions": ["ts", "tsx", "js"],
-    "modulePathIgnorePatterns": ["<rootDir>/dist/*"],
-    "setupFiles": ["raf/polyfill", "./src/setup_jest.ts"]
+    "testPathIgnorePatterns": [
+      "<rootDir>/dist/",
+      "<rootDir>/externals/"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist/*"
+    ],
+    "setupFiles": [
+      "raf/polyfill",
+      "./src/setup_jest.ts"
+    ]
   },
   "lint-staged": {
-    "*.@(ts|tsx)": ["tslint --fix", "yarn prettier-write --", "git add"],
-    "*.json": ["yarn prettier-write --"]
+    "*.@(ts|tsx)": [
+      "tslint --fix",
+      "yarn prettier-write --",
+      "git add"
+    ],
+    "*.json": [
+      "yarn prettier-write --"
+    ]
   },
   "release": {
     "analyzeCommits": {

--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -4,6 +4,8 @@ import {
   ClassicText,
   FeatureText,
   Media,
+  SocialEmbedInstagram,
+  SocialEmbedTwitter,
   Sponsor,
   StandardText,
 } from "./Components"
@@ -836,6 +838,7 @@ export const NewsArticle: ArticleData = {
       body:
         "<p><strong>The design for the as-yet-uncompleted sculpture</strong>, <span style='text-decoration:line-through;'><em>Bouquet of Tulips</em></span>, was donated by Koons to the French capital in November 2016 as a memorial to the recent terrorist attacks that have taken place in the city. But Koons, <a href='#'>one of the world’s richest living artists</a>, didn’t donate the $4.3 million needed to create 40-foot-tall sculpture, which was raised separately via donations. And the work, slated for installation in front of the Palais de Tokyo and Paris’s Museum of Modern Art, has attracted opposition. In a letter published in the French newspaper Libération on Sunday, signatories—including Frédéric Mitterrand, the country’s former culture minister—demanded that the city halt its plans to install the sculpture, calling it “shocking.” </p>",
     },
+    SocialEmbedInstagram,
     {
       type: "text",
       layout: "blockquote",
@@ -858,6 +861,7 @@ export const NewsArticle: ArticleData = {
       body:
         "<p>It further criticized Koons for using the opportunity as a publicity stunt, as the sculpture’s planned location is in a tourist-heavy area far from where the 2015 terrorist attacks actually took place. “We appreciate gifts, [but ones that are] free, unconditional, and without ulterior motives,” the letter said. In any case, Parisian officials have not yet granted authorization to install the sculpture, according to the <em>New York Times</em>.</p>",
     },
+    SocialEmbedTwitter,
     {
       type: "text",
       body:

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -1,5 +1,6 @@
 import { flatten } from "lodash"
 import { Props as ImageSetPreviewProps } from "../Sections/ImageSetPreview"
+import { SocialEmbedProps } from "../Sections/SocialEmbed"
 
 export const ArtworkMissingInfo = {
   type: "artwork",
@@ -292,13 +293,13 @@ export const Embeds = [
   },
 ]
 
-export const SocialEmbedTwitter = {
+export const SocialEmbedTwitter: SocialEmbedProps["section"] = {
   url: "https://twitter.com/artsy/status/965246051107164160",
   layout: "column_width",
   type: "social_embed",
 }
 
-export const SocialEmbedInstagram = {
+export const SocialEmbedInstagram: SocialEmbedProps["section"] = {
   url: "https://www.instagram.com/p/BfJ2TU9F6sm",
   layout: "column_width",
   type: "social_embed",

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -292,6 +292,18 @@ export const Embeds = [
   },
 ]
 
+export const SocialEmbedTwitter = {
+  url: "https://twitter.com/artsy/status/965246051107164160",
+  layout: "body",
+  type: "social_embed",
+}
+
+export const SocialEmbedInstagram = {
+  url: "https://www.instagram.com/p/BfJ2TU9F6sm/?taken-by=artsy",
+  layout: "body",
+  type: "social_embed",
+}
+
 export const HeroSections = [
   {
     type: "text",

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -299,7 +299,7 @@ export const SocialEmbedTwitter = {
 }
 
 export const SocialEmbedInstagram = {
-  url: "https://www.instagram.com/p/BfJ2TU9F6sm/?taken-by=artsy",
+  url: "https://www.instagram.com/p/BfJ2TU9F6sm",
   layout: "body",
   type: "social_embed",
 }

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -294,13 +294,13 @@ export const Embeds = [
 
 export const SocialEmbedTwitter = {
   url: "https://twitter.com/artsy/status/965246051107164160",
-  layout: "body",
+  layout: "column_width",
   type: "social_embed",
 }
 
 export const SocialEmbedInstagram = {
   url: "https://www.instagram.com/p/BfJ2TU9F6sm",
-  layout: "body",
+  layout: "column_width",
   type: "social_embed",
 }
 

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
@@ -338,10 +338,14 @@ exports[`renders the news layout properly 1`] = `
   line-height: 1.5em;
   text-align: left;
   font-weight: normal;
+  padding-top: 46px;
+  padding-bottom: 46px;
+  margin: 0;
+  word-break: break-word;
   padding-top: 10px;
   padding-bottom: 10px;
-  margin: 0 50px;
-  word-break: break-word;
+  max-width: 560px;
+  margin: auto;
 }
 
 .c15 blockquote a {
@@ -640,6 +644,10 @@ exports[`renders the news layout properly 1`] = `
     </div>
     <div
       className="c14 c7"
+      type="social_embed"
+    />
+    <div
+      className="c14 c7"
       type="text"
     >
       <div
@@ -706,6 +714,10 @@ exports[`renders the news layout properly 1`] = `
         />
       </div>
     </div>
+    <div
+      className="c14 c7"
+      type="social_embed"
+    />
     <div
       className="c14 c7"
       type="text"

--- a/src/Components/Publishing/News/NewsSections.tsx
+++ b/src/Components/Publishing/News/NewsSections.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components"
 import { pMedia } from "../../Helpers"
 import { NewsByline } from "../Byline/NewsByline"
 import { ImageCollection } from "../Sections/ImageCollection"
+import { SocialEmbed } from "../Sections/SocialEmbed"
 import { Text } from "../Sections/Text"
 import { ArticleData } from "../Typings"
 
@@ -29,6 +30,7 @@ export class NewsSections extends Component<Props> {
           gutter={10}
         />
       ),
+      social_embed: <SocialEmbed section={section} />,
       text: <Text html={section.body} layout={this.props.article.layout} />,
       default: false,
     }
@@ -78,12 +80,10 @@ export class NewsSections extends Component<Props> {
 }
 
 const getMaxWidth = type => {
-  if (type === "text") {
-    return "max-width: 660px;"
-  } else if (type === "image_collection") {
+  if (type === "image_collection") {
     return ""
   } else {
-    return "max-width: 560px;"
+    return "max-width: 660px;"
   }
 }
 

--- a/src/Components/Publishing/Sections/SocialEmbed.tsx
+++ b/src/Components/Publishing/Sections/SocialEmbed.tsx
@@ -1,6 +1,7 @@
 import jsonp from "jsonp"
 import React from "react"
 import EmbedContainer from "react-oembed-container"
+import styled from "styled-components"
 
 interface SocialEmbedProps {
   section: any
@@ -43,12 +44,23 @@ export class SocialEmbed extends React.Component<
 
     if (html) {
       return (
-        <EmbedContainer markup={html}>
+        <StyledEmbedContainer markup={html}>
           <div dangerouslySetInnerHTML={{ __html: html }} />
-        </EmbedContainer>
+        </StyledEmbedContainer>
       )
     } else {
       return false
     }
   }
 }
+
+const StyledEmbedContainer = styled(EmbedContainer)`
+  width: 100%;
+  max-width: 560px;
+  margin: auto;
+
+  twitterwidget {
+    margin-left: auto;
+    margin-right: auto;
+  }
+`

--- a/src/Components/Publishing/Sections/SocialEmbed.tsx
+++ b/src/Components/Publishing/Sections/SocialEmbed.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+
+interface SocialEmbedProps {
+  section: any
+}
+
+interface SocialEmbedState {
+  html: string
+}
+
+export class SocialEmbed extends React.Component<
+  SocialEmbedProps,
+  SocialEmbedState
+> {
+  state = { html: "" }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({
+        html: "WHAT UP!",
+      })
+    }, 3000)
+  }
+
+  getEmbedType = () => {
+    const { url } = this.props.section
+
+    if (url.match("twitter")) {
+      return "twitter"
+    } else if (url.match("instagram")) {
+      return "instagram"
+    }
+  }
+
+  render() {
+    if (this.state.html) {
+      return this.state.html
+    } else {
+      return <div>Loading...</div>
+    }
+  }
+}

--- a/src/Components/Publishing/Sections/SocialEmbed.tsx
+++ b/src/Components/Publishing/Sections/SocialEmbed.tsx
@@ -8,7 +8,6 @@ interface SocialEmbedProps {
 
 interface SocialEmbedState {
   html: string
-  error: string
 }
 
 const TWITTER_EMBED_URL = "https://publish.twitter.com/oembed"
@@ -23,9 +22,8 @@ export class SocialEmbed extends React.Component<
   componentDidMount() {
     jsonp(this.getEmbedUrl(), (err, data) => {
       if (err) {
-        return this.setState({ error: "Failed to Load." })
+        return
       }
-
       this.setState({ html: data.html })
     })
   }
@@ -34,14 +32,14 @@ export class SocialEmbed extends React.Component<
     const { url } = this.props.section
 
     if (url.match("twitter")) {
-      return TWITTER_EMBED_URL + `?url=${encodeURIComponent(url)}`
+      return TWITTER_EMBED_URL + `?url=${url}`
     } else if (url.match("insta")) {
-      return INSTAGRAM_EMBED_URL + `?url=${encodeURIComponent(url)}`
+      return INSTAGRAM_EMBED_URL + `?url=${url}`
     }
   }
 
   render() {
-    const { html, error } = this.state
+    const { html } = this.state
 
     if (html) {
       return (
@@ -49,12 +47,8 @@ export class SocialEmbed extends React.Component<
           <div dangerouslySetInnerHTML={{ __html: html }} />
         </EmbedContainer>
       )
-    } else if (error) {
-      return <div>{error}</div>
     } else {
-      return <div>Loading...</div>
+      return false
     }
   }
 }
-
-const failed

--- a/src/Components/Publishing/Sections/SocialEmbed.tsx
+++ b/src/Components/Publishing/Sections/SocialEmbed.tsx
@@ -2,9 +2,14 @@ import jsonp from "jsonp"
 import React from "react"
 import EmbedContainer from "react-oembed-container"
 import styled from "styled-components"
+import { SectionLayout } from "../Typings"
 
-interface SocialEmbedProps {
-  section: any
+export interface SocialEmbedProps {
+  section: {
+    type: string
+    url?: string
+    layout?: SectionLayout
+  }
 }
 
 interface SocialEmbedState {

--- a/src/Components/Publishing/Sections/SocialEmbed.tsx
+++ b/src/Components/Publishing/Sections/SocialEmbed.tsx
@@ -1,4 +1,6 @@
+import jsonp from "jsonp"
 import React from "react"
+import EmbedContainer from "react-oembed-container"
 
 interface SocialEmbedProps {
   section: any
@@ -6,37 +8,53 @@ interface SocialEmbedProps {
 
 interface SocialEmbedState {
   html: string
+  error: string
 }
+
+const TWITTER_EMBED_URL = "https://publish.twitter.com/oembed"
+const INSTAGRAM_EMBED_URL = "https://api.instagram.com/oembed"
 
 export class SocialEmbed extends React.Component<
   SocialEmbedProps,
   SocialEmbedState
 > {
-  state = { html: "" }
+  state = { html: "", error: "" }
 
   componentDidMount() {
-    setTimeout(() => {
-      this.setState({
-        html: "WHAT UP!",
-      })
-    }, 3000)
+    jsonp(this.getEmbedUrl(), (err, data) => {
+      if (err) {
+        return this.setState({ error: "Failed to Load." })
+      }
+
+      this.setState({ html: data.html })
+    })
   }
 
-  getEmbedType = () => {
+  getEmbedUrl = () => {
     const { url } = this.props.section
 
     if (url.match("twitter")) {
-      return "twitter"
-    } else if (url.match("instagram")) {
-      return "instagram"
+      return TWITTER_EMBED_URL + `?url=${encodeURIComponent(url)}`
+    } else if (url.match("insta")) {
+      return INSTAGRAM_EMBED_URL + `?url=${encodeURIComponent(url)}`
     }
   }
 
   render() {
-    if (this.state.html) {
-      return this.state.html
+    const { html, error } = this.state
+
+    if (html) {
+      return (
+        <EmbedContainer markup={html}>
+          <div dangerouslySetInnerHTML={{ __html: html }} />
+        </EmbedContainer>
+      )
+    } else if (error) {
+      return <div>{error}</div>
     } else {
       return <div>Loading...</div>
     }
   }
 }
+
+const failed

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -130,10 +130,18 @@ export const StyledText = div`
     ${props => getBlockquoteSize(props.layout, "lg")}
     text-align: ${props => (props.layout === "classic" ? "center" : "left")};
     font-weight: normal;
-    padding-top: ${props => (props.layout === "news" ? "10px" : "46px")};
-    padding-bottom: ${props => (props.layout === "news" ? "10px" : "46px")};
-    margin: ${props => (props.layout === "news" ? "0 50px;" : "0")};
+    padding-top: 46px;
+    padding-bottom: 46px;
+    margin: 0;
     word-break: break-word;
+    ${props =>
+      props.layout === "news" &&
+      `
+        padding-top: 10px;
+        padding-bottom: 10px;
+        max-width: 560px;
+        margin: auto;
+      `}
     a {
       ${props =>
         props.layout === "news" &&

--- a/src/Components/Publishing/Sections/__tests__/SocialEmbed.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/SocialEmbed.test.tsx
@@ -1,0 +1,31 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import jsonp from "jsonp"
+import React from "react"
+import {
+  SocialEmbedInstagram,
+  SocialEmbedTwitter,
+} from "../../Fixtures/Components"
+import { SocialEmbed } from "../SocialEmbed"
+
+jest.mock("jsonp", () => jest.fn())
+
+describe("Social Embed", () => {
+  it("fetches and embeds instagram html", () => {
+    const response = {
+      html: "<blockquote>Instagram</blockquote>",
+    }
+    const component = mount(<SocialEmbed section={SocialEmbedInstagram} />)
+    expect(jsonp.mock.calls[0][0]).toMatch("api.instagram.com")
+    jsonp.mock.calls[0][1](null, response)
+    expect(component.find(SocialEmbed).html()).toMatch(response.html)
+  })
+
+  it("fetches and embeds twitter html", () => {
+    const response = { html: "<blockquote>Twitter</blockquote>" }
+    const component = mount(<SocialEmbed section={SocialEmbedTwitter} />)
+    expect(jsonp.mock.calls[1][0]).toMatch("publish.twitter.com")
+    jsonp.mock.calls[1][1](null, response)
+    expect(component.find(SocialEmbed).html()).toMatch(response.html)
+  })
+})

--- a/src/Components/Publishing/__stories__/Sections.story.tsx
+++ b/src/Components/Publishing/__stories__/Sections.story.tsx
@@ -1,9 +1,15 @@
 import { storiesOf } from "@storybook/react"
-import React from "react"
-import { Authors, Embeds } from "../Fixtures/Components"
+import React, { Fragment } from "react"
+import {
+  Authors,
+  Embeds,
+  SocialEmbedInstagram,
+  SocialEmbedTwitter,
+} from "../Fixtures/Components"
 import { Videos } from "../Fixtures/Components"
 import { Authors as AuthorInfo } from "../Sections/Authors"
 import { Embed } from "../Sections/Embed"
+import { SocialEmbed } from "../Sections/SocialEmbed"
 import { Video } from "../Sections/Video"
 
 storiesOf("Publishing/Sections", module)
@@ -12,6 +18,18 @@ storiesOf("Publishing/Sections", module)
       <div style={{ width: "100%" }}>
         <Embed section={Embeds[0]} />
       </div>
+    )
+  })
+  .add("Social Embed", () => {
+    return (
+      <Fragment>
+        <div style={{ width: "100%" }}>
+          <SocialEmbed section={SocialEmbedTwitter} />
+        </div>
+        <div style={{ width: "100%" }}>
+          <SocialEmbed section={SocialEmbedInstagram} />
+        </div>
+      </Fragment>
     )
   })
   .add("Author Info", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3577,7 +3577,7 @@ dateformat@^1.0.11:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -5938,6 +5938,12 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  dependencies:
+    debug "^2.1.3"
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -7793,6 +7799,12 @@ react-modal@^3.1.8:
     exenv "^1.2.0"
     prop-types "^15.5.10"
     warning "^3.0.0"
+
+react-oembed-container@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/react-oembed-container/-/react-oembed-container-0.3.0.tgz#6fcfc145d1a392fd27e801d19adcaeeb3f5b6865"
+  dependencies:
+    prop-types "^15.6.0"
 
 "react-relay@https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/react-relay-1.5.0-artsy.3.tgz":
   version "1.5.0-artsy.3"


### PR DESCRIPTION
This adds `jsonp` and `react-oembed-container` packages. In an earlier implementation I started writing the jsonp fetcher and script injection from scratch but in the end these libs were way less flaky and covered more edge cases. If anyone is weary about adding more dependency load let's talk --
 these are both pretty small libs tho. 

- [x] Tests
- [x] NewsArticle integration

See notes here: https://artsyproduct.atlassian.net/browse/GROWTH-268

![social-embeds](https://user-images.githubusercontent.com/2236794/37123968-4989e048-2234-11e8-951a-90051134335b.gif)
