### PR TITLE
@sarahscott => News Nav

### DIFF
--- a/src/Components/Publishing/Fonts.tsx
+++ b/src/Components/Publishing/Fonts.tsx
@@ -73,6 +73,10 @@ const textSizesForUnica = {
     size: "19px",
     height: "1.5em",
   },
+  s25: {
+    size: "25px",
+    height: "1.1em",
+  },
   s32: {
     size: "32px",
     height: "1.1em",

--- a/src/Components/Publishing/Nav/NewsNav.tsx
+++ b/src/Components/Publishing/Nav/NewsNav.tsx
@@ -1,0 +1,59 @@
+import moment from "moment"
+import React from "react"
+import styled from "styled-components"
+import { pMedia } from "../../Helpers"
+import { Fonts } from "../Fonts"
+
+interface Props {
+  date: string
+}
+
+export const NewsNav: React.SFC<Props> = props => {
+  const { date } = props
+
+  return (
+    <NewsNavContainer>
+      <MaxWidthContainer>
+        <Date>{moment(date).format("MMM MM")}</Date>
+        <Title>The News</Title>
+      </MaxWidthContainer>
+    </NewsNavContainer>
+  )
+}
+
+const NavText = styled.div`
+  ${Fonts.unica("s25", "medium")};
+  padding: 10px 0;
+
+  ${pMedia.sm`
+    ${Fonts.unica("s16", "medium")}
+  `};
+`
+
+const Date = NavText.extend`
+  position: absolute;
+  width: 100%;
+  text-align: center;
+`
+
+const Title = NavText.extend`
+  ${pMedia.sm`
+    margin-left: 20px;
+  `};
+`
+
+const MaxWidthContainer = styled.div`
+  position: relative;
+  max-width: 780px;
+  margin: auto;
+`
+
+const NewsNavContainer = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 45px;
+  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.2);
+  ${pMedia.sm`
+    height: 36px;
+  `};
+`

--- a/src/Components/Publishing/Nav/__tests__/NewsNav.test.tsx
+++ b/src/Components/Publishing/Nav/__tests__/NewsNav.test.tsx
@@ -1,0 +1,11 @@
+import "jest-styled-components"
+import React from "react"
+import renderer from "react-test-renderer"
+import { NewsNav } from "../NewsNav"
+
+describe("NewsNav", () => {
+  it("renders NewsNav", () => {
+    const nav = renderer.create(<NewsNav date="2017-06-29T15:00:00.000Z" />)
+    expect(nav).toMatchSnapshot()
+  })
+})

--- a/src/Components/Publishing/Nav/__tests__/__snapshots__/NewsNav.test.tsx.snap
+++ b/src/Components/Publishing/Nav/__tests__/__snapshots__/NewsNav.test.tsx.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewsNav renders NewsNav 1`] = `
+.c2 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 25px;
+  line-height: 1.1em;
+  padding: 10px 0;
+  position: absolute;
+  width: 100%;
+  text-align: center;
+}
+
+.c3 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 25px;
+  line-height: 1.1em;
+  padding: 10px 0;
+}
+
+.c1 {
+  position: relative;
+  max-width: 780px;
+  margin: auto;
+}
+
+.c0 {
+  position: fixed;
+  width: 100%;
+  height: 45px;
+  box-shadow: 0 0 8px 0 rgba(0,0,0,0.2);
+}
+
+@media (max-width:720px) {
+  .c2 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+}
+
+@media (max-width:720px) {
+  .c3 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+}
+
+@media (max-width:720px) {
+  .c3 {
+    margin-left: 20px;
+  }
+}
+
+@media (max-width:720px) {
+  .c0 {
+    height: 36px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      Jun 06
+    </div>
+    <div
+      className="c3"
+    >
+      The News
+    </div>
+  </div>
+</div>
+`;

--- a/src/Components/Publishing/__stories__/Nav.story.tsx
+++ b/src/Components/Publishing/__stories__/Nav.story.tsx
@@ -2,6 +2,7 @@ import { storiesOf } from "@storybook/react"
 import React from "react"
 import { SponsoredArticle } from "../Fixtures/Articles"
 import { Nav } from "../Nav/Nav"
+import { NewsNav } from "../Nav/NewsNav"
 
 storiesOf("Publishing/Nav", module)
   .add("Regular", () => {
@@ -29,9 +30,13 @@ storiesOf("Publishing/Nav", module)
       </div>
     )
   })
+  .add("News", () => {
+    return <NewsNav date="2017-06-29T15:00:00.000Z" />
+  })
 
 const backgroundStyle: React.CSSProperties = {
-  background: "url(https://artsy-media-uploads.s3.amazonaws.com/ZR0wtJhg5Nez7Vm8uCP8Nw%2FDSC_0720-Edit-2.jpg)",
+  background:
+    "url(https://artsy-media-uploads.s3.amazonaws.com/ZR0wtJhg5Nez7Vm8uCP8Nw%2FDSC_0720-Edit-2.jpg)",
   color: "white",
   position: "relative",
   height: "50px",


### PR DESCRIPTION
Fairly simple nav for News. Haven't added it to the Article because I think this should exist one level up, when we have an InfiniteScroll. Addresses https://artsyproduct.atlassian.net/browse/GROWTH-278

Desktop:
![image](https://user-images.githubusercontent.com/2236794/37231246-7808be64-23b8-11e8-8264-46eed2963565.png)


Mobile:
![image](https://user-images.githubusercontent.com/2236794/37231272-85e7491a-23b8-11e8-8a8f-fdc5c8251edf.png)

