### PR TITLE
@sarahscott => Handle non-valid links in SocialEmbed

### DIFF
--- a/src/Components/Publishing/Sections/SocialEmbed.tsx
+++ b/src/Components/Publishing/Sections/SocialEmbed.tsx
@@ -23,15 +23,19 @@ export class SocialEmbed extends React.Component<
   SocialEmbedProps,
   SocialEmbedState
 > {
-  state = { html: "", error: "" }
+  state = { html: "" }
 
   componentDidMount() {
-    jsonp(this.getEmbedUrl(), (err, data) => {
-      if (err) {
-        return
-      }
-      this.setState({ html: data.html })
-    })
+    const url = this.getEmbedUrl()
+
+    if (url) {
+      jsonp(url, (err, data) => {
+        if (err) {
+          return
+        }
+        this.setState({ html: data.html })
+      })
+    }
   }
 
   getEmbedUrl = () => {

--- a/src/Components/Publishing/Sections/__tests__/SocialEmbed.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/SocialEmbed.test.tsx
@@ -6,11 +6,15 @@ import {
   SocialEmbedInstagram,
   SocialEmbedTwitter,
 } from "../../Fixtures/Components"
-import { SocialEmbed } from "../SocialEmbed"
+import { SocialEmbed, SocialEmbedProps } from "../SocialEmbed"
 
 jest.mock("jsonp", () => jest.fn())
 
 describe("Social Embed", () => {
+  beforeEach(() => {
+    jsonp.mockClear()
+  })
+
   it("fetches and embeds instagram html", () => {
     const response = {
       html: "<blockquote>Instagram</blockquote>",
@@ -24,8 +28,19 @@ describe("Social Embed", () => {
   it("fetches and embeds twitter html", () => {
     const response = { html: "<blockquote>Twitter</blockquote>" }
     const component = mount(<SocialEmbed section={SocialEmbedTwitter} />)
-    expect(jsonp.mock.calls[1][0]).toMatch("publish.twitter.com")
-    jsonp.mock.calls[1][1](null, response)
+    expect(jsonp.mock.calls[0][0]).toMatch("publish.twitter.com")
+    jsonp.mock.calls[0][1](null, response)
     expect(component.find(SocialEmbed).html()).toMatch(response.html)
+  })
+
+  it("renders nothing if url is invalid", () => {
+    const section: SocialEmbedProps["section"] = {
+      url: "",
+      type: "social_embed",
+      layout: "column_width",
+    }
+    const component = mount(<SocialEmbed section={section} />)
+    expect(jsonp.mock.calls.length).toEqual(0)
+    expect(component.find(SocialEmbed).html()).toBeNull()
   })
 })


### PR DESCRIPTION
Handles the error we were seeing earlier -- we should not fetch anything if the url is null. 