### PR TITLE
@damassi => Skip images-loaded fade if editing

### DIFF
--- a/src/Components/Publishing/Sections/Artwork.tsx
+++ b/src/Components/Publishing/Sections/Artwork.tsx
@@ -8,6 +8,7 @@ import { ImageWrapper } from "./ImageWrapper"
 
 interface ArtworkProps {
   artwork: any
+  editing?: boolean
   layout?: ArticleLayout
   sectionLayout?: SectionLayout
   linked?: boolean
@@ -23,7 +24,15 @@ export class Artwork extends React.PureComponent<ArtworkProps, null> {
   }
 
   render() {
-    const { artwork, children, linked, height, width, layout } = this.props
+    const {
+      artwork,
+      children,
+      editing,
+      linked,
+      height,
+      width,
+      layout,
+    } = this.props
     const src = resize(artwork.image, {
       width: 1200,
       quality: GLOBAL_IMAGE_QUALITY,
@@ -31,6 +40,7 @@ export class Artwork extends React.PureComponent<ArtworkProps, null> {
 
     const Image = () => (
       <ImageWrapper
+        editing={editing}
         layout={layout}
         linked={linked}
         src={src}

--- a/src/Components/Publishing/Sections/Image.tsx
+++ b/src/Components/Publishing/Sections/Image.tsx
@@ -7,6 +7,7 @@ import { ImageWrapper } from "./ImageWrapper"
 
 interface ImageProps extends React.HTMLProps<HTMLDivElement> {
   editCaption?: any
+  editing?: boolean
   image?: any
   layout?: ArticleLayout
   linked?: boolean
@@ -18,6 +19,7 @@ interface ImageProps extends React.HTMLProps<HTMLDivElement> {
 export const Image: React.SFC<ImageProps> = props => {
   const {
     children,
+    editing,
     editCaption,
     height,
     image,
@@ -40,6 +42,7 @@ export const Image: React.SFC<ImageProps> = props => {
         height={height}
         alt={alt}
         index={image.index}
+        editing={editCaption || editing}
       />
 
       <Caption caption={caption} layout={layout} sectionLayout={sectionLayout}>

--- a/src/Components/Publishing/Sections/ImageWrapper.tsx
+++ b/src/Components/Publishing/Sections/ImageWrapper.tsx
@@ -12,6 +12,7 @@ interface Props extends React.HTMLProps<HTMLImageElement> {
   width?: string | number
   height?: string | number
   alt?: string
+  editing?: boolean
   index?: number
 }
 
@@ -55,10 +56,10 @@ export class ImageWrapper extends React.PureComponent<Props, any> {
   }
 
   render() {
-    const { layout, linked, index, ...blockImageProps }: any = this.props
+    const { editing, layout, linked, index, ...imageProps }: any = this.props
     let className = "BlockImage__container"
 
-    if (this.state.isLoaded) {
+    if (this.state.isLoaded || editing) {
       className = className + " image-loaded"
     }
 
@@ -67,7 +68,7 @@ export class ImageWrapper extends React.PureComponent<Props, any> {
         <BlockImage
           className={className}
           ref={ref => (this.image = ref)}
-          {...blockImageProps}
+          {...imageProps}
         />
 
         {layout !== "classic" &&

--- a/src/Components/Publishing/Sections/__tests__/Artwork.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Artwork.test.tsx
@@ -8,12 +8,12 @@ import { Artwork } from "../Artwork"
 import { ViewFullscreen } from "../ViewFullscreen"
 
 jest.mock("react-lines-ellipsis/lib/html", () => {
-  const React = require('react')
+  const React = require("react")
   return () => <div />
 })
 
-jest.mock('react-dom/server', () => ({
-  renderToStaticMarkup: (x) => x
+jest.mock("react-dom/server", () => ({
+  renderToStaticMarkup: x => x,
 }))
 
 it("renders properly", () => {
@@ -22,27 +22,28 @@ it("renders properly", () => {
 })
 
 it("renders a fullscreen button if linked", () => {
-  const component = mount(
-    <Artwork artwork={Images[0]} linked />
-  )
+  const component = mount(<Artwork artwork={Images[0]} linked />)
   expect(component.find(ViewFullscreen).length).toBe(1)
 })
 
 it("does not render a fullscreen button if not linked", () => {
-  const component = mount(
-    <Artwork
-      artwork={Images[0]}
-      linked={false}
-    />
-  )
+  const component = mount(<Artwork artwork={Images[0]} linked={false} />)
   expect(component.find(ViewFullscreen).length).toBe(0)
 })
 
 it("renders a child if present", () => {
   const component = mount(
-    <Artwork artwork={Images[0]}>
-      {EditableChild('A React child.')}
-    </Artwork>
+    <Artwork artwork={Images[0]}>{EditableChild("A React child.")}</Artwork>
   )
-  expect(component.text()).toMatch('A React child.')
+  expect(component.text()).toMatch("A React child.")
+})
+
+it("adds imagesLoaded class if props.editing", () => {
+  const component = mount(<Artwork artwork={Images[0]} editing />)
+  expect(component.html()).toMatch("BlockImage__container image-loaded")
+})
+
+it("does not add imagesLoaded class if props.editing is false", () => {
+  const component = mount(<Artwork artwork={Images[0]} />)
+  expect(component.html()).not.toMatch("BlockImage__container image-loaded")
 })

--- a/src/Components/Publishing/Sections/__tests__/Image.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Image.test.tsx
@@ -19,50 +19,48 @@ it("renders a long caption properly", () => {
 
 it("renders a react child as caption properly", () => {
   const image = renderer
-    .create(
-    <Image image={Images[2]}>
-      {EditableChild('A React child.')}
-    </Image>
-    )
+    .create(<Image image={Images[2]}>{EditableChild("A React child.")}</Image>)
     .toJSON()
   expect(image).toMatchSnapshot()
 })
 
 it("renders a fullscreen button if linked", () => {
-  const component = mount(
-    <Image
-      image={Images[2]}
-      linked
-    />
-  )
+  const component = mount(<Image image={Images[2]} linked />)
   expect(component.find(ViewFullscreen).length).toBe(1)
 })
 
 it("does not render a fullscreen button if not linked", () => {
-  const component = mount(
-    <Image
-      image={Images[2]}
-      linked={false}
-    />
-  )
+  const component = mount(<Image image={Images[2]} linked={false} />)
   expect(component.find(ViewFullscreen).length).toBe(0)
 })
 
 it("renders editCaption if present", () => {
   const component = mount(
-    <Image
-      image={Images[2]}
-      editCaption={() => EditableChild('editCaption')}
-    />
+    <Image image={Images[2]} editCaption={() => EditableChild("editCaption")} />
   )
-  expect(component.text()).toMatch('editCaption')
+  expect(component.text()).toMatch("editCaption")
 })
 
 it("renders a child if present", () => {
   const component = mount(
-    <Image image={Images[2]}>
-      {EditableChild('A React child.')}
-    </Image>
+    <Image image={Images[2]}>{EditableChild("A React child.")}</Image>
   )
-  expect(component.text()).toMatch('A React child.')
+  expect(component.text()).toMatch("A React child.")
+})
+
+it("adds imagesLoaded class if props.editing", () => {
+  const component = mount(<Image image={Images[2]} editing />)
+  expect(component.html()).toMatch("BlockImage__container image-loaded")
+})
+
+it("adds imagesLoaded class if props.editCaption", () => {
+  const component = mount(
+    <Image image={Images[2]} editCaption={() => jest.fn()} />
+  )
+  expect(component.html()).toMatch("BlockImage__container image-loaded")
+})
+
+it("does not add imagesLoaded class if props.editing is false", () => {
+  const component = mount(<Image image={Images[2]} />)
+  expect(component.html()).not.toMatch("BlockImage__container image-loaded")
 })


### PR DESCRIPTION
Adds an optional boolean prop `editing` to images and artworks, which disables the fade in on loading. 

Once we switched to Redux in Positron, changes to the article can trigger re-rendering in the tree, which causes erratic fade-ins that can confuse users. 