### PR TITLE
[FIX onboarding] Fixed a bug where the NEXT button doesn't show up on Edge

### DIFF
--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -51,20 +51,11 @@ const ItemContainer = styled.div`
   padding-bottom: 50px;
 `
 
-/* MS IE11 and Edge don't support for the sticky position property */
-const FixedButttonContainer = styled.div`
+const StickyButtonContainer = styled.div`
   width: 100%;
   position: fixed;
-  bottom: 0px;
-  left: 0px;
-`
-
-/* Mobile safari doesn't support for the fixed position property:
- *   https://www.eventbrite.com/engineering/mobile-safari-why/
- **/
-const StickyButtonContainer = styled.div`
-  position: sticky;
-  bottom: 0px;
+  left: 0;
+  bottom: 0;
   background: linear-gradient(
     rgba(255, 255, 255, 0) 0%,
     rgba(255, 255, 255, 0.5) 17%,
@@ -100,17 +91,15 @@ export class Layout extends React.Component<Props, null> {
         <Subtitle titleSize="xxsmall">{this.props.subtitle}</Subtitle>
         <ItemContainer>{this.props.children}</ItemContainer>
 
-        <FixedButttonContainer>
-          <StickyButtonContainer>
-            <NextButton
-              disabled={disabled}
-              onClick={this.props.onNextButtonPressed}
-              state={this.props.buttonState}
-            >
-              {buttonText}
-            </NextButton>
-          </StickyButtonContainer>
-        </FixedButttonContainer>
+        <StickyButtonContainer>
+          <NextButton
+            disabled={disabled}
+            onClick={this.props.onNextButtonPressed}
+            state={this.props.buttonState}
+          >
+            {buttonText}
+          </NextButton>
+        </StickyButtonContainer>
       </Container>
     )
   }


### PR DESCRIPTION
I believe [the original issue](https://artsyproduct.atlassian.net/browse/GROWTH-361) I was looking into was fixed by https://github.com/artsy/force/pull/2291, but even with that fix there are many other issues in MS Edge or IE 11, and this PR fixes one of them.

The issue this PR addresses is that on the onboarding screen the NEXT button does not show up. This PR removes the `position: sticky;` property that seems to fix the issue. I was worried about mobile safari not respecting `position: fixed`. I tested it on iOS 9 and 11, and apparently that is no longer an issue. See the screenshots below:

## Before

<img width="1500" alt="edge-next-button" src="https://user-images.githubusercontent.com/386234/37929661-95b4105e-310e-11e8-95c3-01dc46cb48e5.png">


## After

<img width="559" alt="screen shot 2018-03-23 at 2 56 18 pm" src="https://user-images.githubusercontent.com/386234/37853594-c3f56bbe-2ebd-11e8-9925-6bc9124adc13.png"> <img width="559" alt="screen shot 2018-03-23 at 2 56 15 pm" src="https://user-images.githubusercontent.com/386234/37853596-c5e8fd00-2ebd-11e8-98f7-18fc244d0523.png">

<img width="1344" alt="screen shot 2018-03-23 at 2 56 51 pm" src="https://user-images.githubusercontent.com/386234/37853598-c897a736-2ebd-11e8-994a-d5ea626d0ed9.png">
