### PR TITLE
@sarahscott => [Newsfeed] The News/Date header

### DIFF
--- a/src/Components/Publishing/News/NewsDateHeader.tsx
+++ b/src/Components/Publishing/News/NewsDateHeader.tsx
@@ -1,0 +1,57 @@
+import moment from "moment"
+import React from "react"
+import styled from "styled-components"
+import { pMedia } from "../../Helpers"
+import { Fonts } from "../Fonts"
+
+interface NewsDateHeaderProps {
+  date: any
+}
+
+export const NewsDateHeader: React.SFC<NewsDateHeaderProps> = props => {
+  const { date } = props
+  const hasYear =
+    moment(date).format("YYYY") !== moment(new Date()).format("YYYY")
+  const isToday =
+    moment(date).format("MMM D, YYYY") ===
+    moment(new Date()).format("MMM D, YYYY")
+  const format = hasYear ? "MMM D, YYYY" : "MMM D"
+
+  return (
+    <NewsDateHeaderParent>
+      <NewsDateHeaderContainer>
+        <Title>The News</Title>
+        {date && <Text>{isToday ? "Today" : moment(date).format(format)}</Text>}
+      </NewsDateHeaderContainer>
+    </NewsDateHeaderParent>
+  )
+}
+
+const NewsDateHeaderParent = styled.div`
+  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2);
+  padding: 10px 20px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+`
+
+const NewsDateHeaderContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  max-width: 780px;
+  margin: 0 auto;
+  position: relative;
+`
+
+const Text = styled.div`
+  ${Fonts.unica("s25", "medium")};
+  ${pMedia.sm`
+    ${Fonts.unica("s16", "medium")}
+  `};
+`
+
+const Title = Text.extend`
+  position: absolute;
+  left: 0;
+`

--- a/src/Components/Publishing/News/__tests__/NewsDateHeader.test.tsx
+++ b/src/Components/Publishing/News/__tests__/NewsDateHeader.test.tsx
@@ -1,0 +1,38 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import moment from "moment"
+import React from "react"
+import renderer from "react-test-renderer"
+
+import { NewsArticle } from "../../Fixtures/Articles"
+import { NewsDateHeader } from "../NewsDateHeader"
+
+it("renders a news date header properly", () => {
+  const component = renderer
+    .create(<NewsDateHeader date={NewsArticle.published_at} />)
+    .toJSON()
+  expect(component).toMatchSnapshot()
+})
+
+it("Renders 'today' if date is today", () => {
+  const date = moment().toISOString()
+  const wrapper = mount(<NewsDateHeader date={date} />)
+  expect(wrapper.text()).toMatch("Today")
+})
+
+it("Renders date with no year if in current year", () => {
+  const date = moment()
+    .subtract(1, "week")
+    .toISOString()
+  const wrapper = mount(<NewsDateHeader date={date} />)
+  expect(wrapper.text()).toMatch(moment(date).format("MMM D"))
+  expect(wrapper.text()).not.toMatch(moment(date).format("YYYY"))
+})
+
+it("Renders date with year if not in current year", () => {
+  const date = moment()
+    .subtract(1, "year")
+    .toISOString()
+  const wrapper = mount(<NewsDateHeader date={date} />)
+  expect(wrapper.text()).toMatch(moment(date).format("MMM D, YYYY"))
+})

--- a/src/Components/Publishing/News/__tests__/__snapshots__/NewsDateHeader.test.tsx.snap
+++ b/src/Components/Publishing/News/__tests__/__snapshots__/NewsDateHeader.test.tsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a news date header properly 1`] = `
+.c0 {
+  box-shadow: 0 0 5px 0 rgba(0,0,0,0.2);
+  padding: 10px 20px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 780px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.c3 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 25px;
+  line-height: 1.1em;
+}
+
+.c2 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 25px;
+  line-height: 1.1em;
+  position: absolute;
+  left: 0;
+}
+
+@media (max-width:720px) {
+  .c3 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+}
+
+@media (max-width:720px) {
+  .c2 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      The News
+    </div>
+    <div
+      className="c3"
+    >
+      Jul 19
+    </div>
+  </div>
+</div>
+`;

--- a/src/Components/Publishing/__stories__/News.story.tsx
+++ b/src/Components/Publishing/__stories__/News.story.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
+import { NewsDateHeader } from "../News/NewsDateHeader"
 import { NewsHeadline } from "../News/NewsHeadline"
 
 import { NewsArticle } from "../Fixtures/Articles"
@@ -10,6 +11,13 @@ storiesOf("Publishing/News", module)
     return (
       <div>
         <NewsHeadline article={NewsArticle} />
+      </div>
+    )
+  })
+  .add("News Date Header", () => {
+    return (
+      <div>
+        <NewsDateHeader date={NewsArticle.published_at} />
       </div>
     )
   })


### PR DESCRIPTION
Adds `NewsDateHeader` component for sticky header in News articles. Related to [GROWTH-371](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROWTH&modal=detail&selectedIssue=GROWTH-371)

Desktop:
![screen shot 2018-03-26 at 1 07 01 pm](https://user-images.githubusercontent.com/1497424/37921084-c1bb6912-30f6-11e8-81e8-ba2f0222210c.png)

Mobile:
![screen shot 2018-03-26 at 1 07 15 pm](https://user-images.githubusercontent.com/1497424/37921085-c1c905e0-30f6-11e8-8e11-25208fe0e22d.png)
