### PR TITLE
Revert "[FIX onboarding] Fixed a bug where the NEXT button doesn't show up on Edge"

### DIFF
--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -51,11 +51,20 @@ const ItemContainer = styled.div`
   padding-bottom: 50px;
 `
 
-const StickyButtonContainer = styled.div`
+/* MS IE11 and Edge don't support for the sticky position property */
+const FixedButttonContainer = styled.div`
   width: 100%;
   position: fixed;
-  left: 0;
-  bottom: 0;
+  bottom: 0px;
+  left: 0px;
+`
+
+/* Mobile safari doesn't support for the fixed position property:
+ *   https://www.eventbrite.com/engineering/mobile-safari-why/
+ **/
+const StickyButtonContainer = styled.div`
+  position: sticky;
+  bottom: 0px;
   background: linear-gradient(
     rgba(255, 255, 255, 0) 0%,
     rgba(255, 255, 255, 0.5) 17%,
@@ -91,15 +100,17 @@ export class Layout extends React.Component<Props, null> {
         <Subtitle titleSize="xxsmall">{this.props.subtitle}</Subtitle>
         <ItemContainer>{this.props.children}</ItemContainer>
 
-        <StickyButtonContainer>
-          <NextButton
-            disabled={disabled}
-            onClick={this.props.onNextButtonPressed}
-            state={this.props.buttonState}
-          >
-            {buttonText}
-          </NextButton>
-        </StickyButtonContainer>
+        <FixedButttonContainer>
+          <StickyButtonContainer>
+            <NextButton
+              disabled={disabled}
+              onClick={this.props.onNextButtonPressed}
+              state={this.props.buttonState}
+            >
+              {buttonText}
+            </NextButton>
+          </StickyButtonContainer>
+        </FixedButttonContainer>
       </Container>
     )
   }


### PR DESCRIPTION
Reverts artsy/reaction#588

For some reason, the NEXT button is completely gone on the iOS (see screenshot below). I'll have to look into it more deeply.

<img width="559" alt="next-button-gone" src="https://user-images.githubusercontent.com/386234/37934266-a216d36a-311b-11e8-8d1f-84e60ce9e52a.png">
