### PR TITLE
@kanaabe => Fix in editSource of NewsByline

### DIFF
--- a/src/Components/Publishing/Byline/DateSource.tsx
+++ b/src/Components/Publishing/Byline/DateSource.tsx
@@ -15,7 +15,8 @@ export const DateSource: React.SFC<NewsBylineProps & Props> = props => {
   const { news_source, published_at } = article
 
   const getNewsSource = source => {
-    if (!source || !source.url) return null
+    if (!editSource && (!source || !source.url)) return null
+
     return (
       <Fragment>
         {", via"}&nbsp;


### PR DESCRIPTION
This makes sure `editSource` can still render if `news_source` is null.