### PR TITLE
[FIX onboarding] Fixed a bug where the NEXT button doesn't show up on Edge

### DIFF
--- a/src/Components/Onboarding/Steps/Layout.tsx
+++ b/src/Components/Onboarding/Steps/Layout.tsx
@@ -63,7 +63,7 @@ const FixedButttonContainer = styled.div`
  *   https://www.eventbrite.com/engineering/mobile-safari-why/
  **/
 const StickyButtonContainer = styled.div`
-  position: sticky;
+  position: -webkit-sticky;
   bottom: 0px;
   background: linear-gradient(
     rgba(255, 255, 255, 0) 0%,


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/GROW-361

In the previous attempt https://github.com/artsy/reaction/pull/588 I remove the `position: sticky` property entirely, which caused the iOS 9 to push the NEXT button all the way down to the bottom. In this attempt, I replaced it with a prefixed property `-webkit-sticky`, so Edge will only respect `position: fixed` on the `<FixedButttonContainer>` component and the NEXT button will always stay at the bottom of the screen on mobile Safari.