### PR TITLE
@kanaabe => News Date headers

### DIFF
--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -69,6 +69,11 @@ export const getAuthorByline = authors => {
 }
 
 export const getDate = (date, format: DateFormat = "default") => {
+  const today = moment()
+  const isToday = today.isSame(moment(date), "day")
+  const isThisYear =
+    moment(date).format("YYYY") === moment(today).format("YYYY")
+
   switch (format) {
     case "monthYear":
       return moment(date)
@@ -79,17 +84,25 @@ export const getDate = (date, format: DateFormat = "default") => {
         .tz("America/New_York")
         .format("MMM D, YYYY")
     case "verbose":
-      const today = moment()
-      const day = today.isSame(moment(date), "day")
+      const day = isToday
         ? "Today"
         : moment(date)
             .tz("America/New_York")
             .format("MMM D, YYYY")
-
       const time = moment(date)
         .tz("America/New_York")
         .format("h:mm a")
       return `${day} at ${time}`
+    case "news":
+      return isToday
+        ? "Today"
+        : isThisYear
+          ? moment(date)
+              .tz("America/New_York")
+              .format("MMM D")
+          : moment(date)
+              .tz("America/New_York")
+              .format("MMM D, YYYY")
     default:
       return moment(date)
         .tz("America/New_York")

--- a/src/Components/Publishing/Nav/NewsNav.tsx
+++ b/src/Components/Publishing/Nav/NewsNav.tsx
@@ -1,8 +1,8 @@
-import moment from "moment"
 import React from "react"
 import styled from "styled-components"
+import colors from "../../../Assets/Colors"
 import { pMedia } from "../../Helpers"
-import { Fonts } from "../Fonts"
+import { NewsDateHeader, NewsText } from "../News/NewsDateHeader"
 
 interface Props {
   date: string
@@ -10,30 +10,17 @@ interface Props {
 
 export const NewsNav: React.SFC<Props> = props => {
   const { date } = props
-  const today = new Date()
-  const hasYear = moment(date).format("YYYY") !== moment(today).format("YYYY")
-  const isToday =
-    moment(date).format("MMM D, YYYY") === moment(today).format("MMM D, YYYY")
-  const format = hasYear ? "MMM D, YYYY" : "MMM D"
-
   return (
     <NewsNavContainer>
       <MaxWidthContainer>
-        <NavText>{isToday ? "Today" : moment(date).format(format)}</NavText>
+        {date && <NewsDateHeader date={date} />}
         <Title>The News</Title>
       </MaxWidthContainer>
     </NewsNavContainer>
   )
 }
 
-const NavText = styled.div`
-  ${Fonts.unica("s25", "medium")};
-  ${pMedia.sm`
-    ${Fonts.unica("s16", "medium")}
-  `};
-`
-
-const Title = NavText.extend`
+const Title = NewsText.extend`
   position: absolute;
   left: 30px;
   ${pMedia.sm`
@@ -47,12 +34,19 @@ const MaxWidthContainer = styled.div`
   margin: auto;
   display: flex;
   justify-content: center;
+  align-items: center;
+  min-height: 26px;
+  ${pMedia.sm`
+    min-height: 16px;
+  `};
 `
 
 const NewsNavContainer = styled.div`
   position: fixed;
-  width: 100%;
-  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.2);
+  top: 52px;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid ${colors.grayRegular};
   padding: 10px 0;
   background: white;
   z-index: 1;

--- a/src/Components/Publishing/Nav/NewsNav.tsx
+++ b/src/Components/Publishing/Nav/NewsNav.tsx
@@ -10,11 +10,16 @@ interface Props {
 
 export const NewsNav: React.SFC<Props> = props => {
   const { date } = props
+  const today = new Date()
+  const hasYear = moment(date).format("YYYY") !== moment(today).format("YYYY")
+  const isToday =
+    moment(date).format("MMM D, YYYY") === moment(today).format("MMM D, YYYY")
+  const format = hasYear ? "MMM D, YYYY" : "MMM D"
 
   return (
     <NewsNavContainer>
       <MaxWidthContainer>
-        <Date>{moment(date).format("MMM MM")}</Date>
+        <NavText>{isToday ? "Today" : moment(date).format(format)}</NavText>
         <Title>The News</Title>
       </MaxWidthContainer>
     </NewsNavContainer>
@@ -23,22 +28,16 @@ export const NewsNav: React.SFC<Props> = props => {
 
 const NavText = styled.div`
   ${Fonts.unica("s25", "medium")};
-  padding: 10px 0;
-
   ${pMedia.sm`
     ${Fonts.unica("s16", "medium")}
   `};
 `
 
-const Date = NavText.extend`
-  position: absolute;
-  width: 100%;
-  text-align: center;
-`
-
 const Title = NavText.extend`
+  position: absolute;
+  left: 30px;
   ${pMedia.sm`
-    margin-left: 20px;
+    left: 20px;
   `};
 `
 
@@ -46,14 +45,15 @@ const MaxWidthContainer = styled.div`
   position: relative;
   max-width: 780px;
   margin: auto;
+  display: flex;
+  justify-content: center;
 `
 
 const NewsNavContainer = styled.div`
   position: fixed;
   width: 100%;
-  height: 45px;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.2);
-  ${pMedia.sm`
-    height: 36px;
-  `};
+  padding: 10px 0;
+  background: white;
+  z-index: 1;
 `

--- a/src/Components/Publishing/Nav/__tests__/__snapshots__/NewsNav.test.tsx.snap
+++ b/src/Components/Publishing/Nav/__tests__/__snapshots__/NewsNav.test.tsx.snap
@@ -6,10 +6,6 @@ exports[`NewsNav renders NewsNav 1`] = `
   -webkit-font-smoothing: antialiased;
   font-size: 25px;
   line-height: 1.1em;
-  padding: 10px 0;
-  position: absolute;
-  width: 100%;
-  text-align: center;
 }
 
 .c3 {
@@ -17,20 +13,38 @@ exports[`NewsNav renders NewsNav 1`] = `
   -webkit-font-smoothing: antialiased;
   font-size: 25px;
   line-height: 1.1em;
-  padding: 10px 0;
+  position: absolute;
+  left: 30px;
 }
 
 .c1 {
   position: relative;
   max-width: 780px;
   margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-height: 26px;
 }
 
 .c0 {
   position: fixed;
-  width: 100%;
-  height: 45px;
-  box-shadow: 0 0 8px 0 rgba(0,0,0,0.2);
+  top: 52px;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid #e5e5e5;
+  padding: 10px 0;
+  background: white;
+  z-index: 1;
 }
 
 @media (max-width:720px) {
@@ -53,13 +67,13 @@ exports[`NewsNav renders NewsNav 1`] = `
 
 @media (max-width:720px) {
   .c3 {
-    margin-left: 20px;
+    left: 20px;
   }
 }
 
 @media (max-width:720px) {
-  .c0 {
-    height: 36px;
+  .c1 {
+    min-height: 16px;
   }
 }
 
@@ -72,7 +86,7 @@ exports[`NewsNav renders NewsNav 1`] = `
     <div
       className="c2"
     >
-      Jun 06
+      Jun 29, 2017
     </div>
     <div
       className="c3"

--- a/src/Components/Publishing/News/NewsDateDivider.tsx
+++ b/src/Components/Publishing/News/NewsDateDivider.tsx
@@ -1,8 +1,7 @@
-import moment from "moment"
 import React from "react"
 import styled from "styled-components"
 import { pMedia } from "../../Helpers"
-import { Fonts } from "../Fonts"
+import { NewsDateHeader } from "./NewsDateHeader"
 
 interface Props {
   date: string
@@ -10,25 +9,13 @@ interface Props {
 
 export const NewsDateDivider: React.SFC<Props> = props => {
   const { date } = props
-  const today = new Date()
-  const isToday =
-    moment(date).format("MMM D, YYYY") === moment(today).format("MMM D, YYYY")
-  const hasYear = moment(date).format("YYYY") !== moment(today).format("YYYY")
-  const format = hasYear ? "MMM D, YYYY" : "MMM D"
 
   return (
     <NewsDateDividerContainer>
-      {date && <Text>{isToday ? "Today" : moment(date).format(format)}</Text>}
+      {date && <NewsDateHeader date={date} />}
     </NewsDateDividerContainer>
   )
 }
-
-const Text = styled.div`
-  ${Fonts.unica("s25", "medium")};
-  ${pMedia.sm`
-    ${Fonts.unica("s16", "medium")}
-  `};
-`
 
 const NewsDateDividerContainer = styled.div`
   margin-top: 80px;

--- a/src/Components/Publishing/News/NewsDateDivider.tsx
+++ b/src/Components/Publishing/News/NewsDateDivider.tsx
@@ -1,0 +1,41 @@
+import moment from "moment"
+import React from "react"
+import styled from "styled-components"
+import { pMedia } from "../../Helpers"
+import { Fonts } from "../Fonts"
+
+interface Props {
+  date: string
+}
+
+export const NewsDateDivider: React.SFC<Props> = props => {
+  const { date } = props
+  const today = new Date()
+  const isToday =
+    moment(date).format("MMM D, YYYY") === moment(today).format("MMM D, YYYY")
+  const hasYear = moment(date).format("YYYY") !== moment(today).format("YYYY")
+  const format = hasYear ? "MMM D, YYYY" : "MMM D"
+
+  return (
+    <NewsDateDividerContainer>
+      {date && <Text>{isToday ? "Today" : moment(date).format(format)}</Text>}
+    </NewsDateDividerContainer>
+  )
+}
+
+const Text = styled.div`
+  ${Fonts.unica("s25", "medium")};
+  ${pMedia.sm`
+    ${Fonts.unica("s16", "medium")}
+  `};
+`
+
+const NewsDateDividerContainer = styled.div`
+  margin-top: 80px;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  ${pMedia.sm`
+    margin-top: 40px;
+`};
+`

--- a/src/Components/Publishing/News/NewsDateHeader.tsx
+++ b/src/Components/Publishing/News/NewsDateHeader.tsx
@@ -1,0 +1,27 @@
+import moment from "moment"
+import React from "react"
+import styled from "styled-components"
+import { pMedia } from "../../Helpers"
+import { Fonts } from "../Fonts"
+
+interface Props {
+  date: string
+}
+
+export const NewsDateHeader: React.SFC<Props> = props => {
+  const { date } = props
+  const today = new Date()
+  const isToday =
+    moment(date).format("MMM D, YYYY") === moment(today).format("MMM D, YYYY")
+  const hasYear = moment(date).format("YYYY") !== moment(today).format("YYYY")
+  const format = hasYear ? "MMM D, YYYY" : "MMM D"
+
+  return <NewsText>{isToday ? "Today" : moment(date).format(format)}</NewsText>
+}
+
+export const NewsText = styled.div`
+  ${Fonts.unica("s25", "medium")};
+  ${pMedia.sm`
+    ${Fonts.unica("s16", "medium")}
+  `};
+`

--- a/src/Components/Publishing/News/NewsDateHeader.tsx
+++ b/src/Components/Publishing/News/NewsDateHeader.tsx
@@ -1,7 +1,7 @@
-import moment from "moment"
 import React from "react"
 import styled from "styled-components"
 import { pMedia } from "../../Helpers"
+import { getDate } from "../Constants"
 import { Fonts } from "../Fonts"
 
 interface Props {
@@ -10,13 +10,8 @@ interface Props {
 
 export const NewsDateHeader: React.SFC<Props> = props => {
   const { date } = props
-  const today = new Date()
-  const isToday =
-    moment(date).format("MMM D, YYYY") === moment(today).format("MMM D, YYYY")
-  const hasYear = moment(date).format("YYYY") !== moment(today).format("YYYY")
-  const format = hasYear ? "MMM D, YYYY" : "MMM D"
 
-  return <NewsText>{isToday ? "Today" : moment(date).format(format)}</NewsText>
+  return <NewsText>{getDate(date, "news")}</NewsText>
 }
 
 export const NewsText = styled.div`

--- a/src/Components/Publishing/News/__tests__/NewsDateDivider.test.tsx
+++ b/src/Components/Publishing/News/__tests__/NewsDateDivider.test.tsx
@@ -1,0 +1,38 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import moment from "moment"
+import React from "react"
+import renderer from "react-test-renderer"
+
+import { NewsArticle } from "../../Fixtures/Articles"
+import { NewsDateDivider } from "../NewsDateDivider"
+
+it("renders a news date header properly", () => {
+  const component = renderer
+    .create(<NewsDateDivider date={NewsArticle.published_at} />)
+    .toJSON()
+  expect(component).toMatchSnapshot()
+})
+
+it("Renders 'today' if date is today", () => {
+  const date = moment().toISOString()
+  const wrapper = mount(<NewsDateDivider date={date} />)
+  expect(wrapper.text()).toMatch("Today")
+})
+
+it("Renders date with no year if in current year", () => {
+  const date = moment()
+    .subtract(1, "week")
+    .toISOString()
+  const wrapper = mount(<NewsDateDivider date={date} />)
+  expect(wrapper.text()).toMatch(moment(date).format("MMM D"))
+  expect(wrapper.text()).not.toMatch(moment(date).format("YYYY"))
+})
+
+it("Renders date with year if not in current year", () => {
+  const date = moment()
+    .subtract(1, "year")
+    .toISOString()
+  const wrapper = mount(<NewsDateDivider date={date} />)
+  expect(wrapper.text()).toMatch(moment(date).format("MMM D, YYYY"))
+})

--- a/src/Components/Publishing/News/__tests__/NewsDateHeader.test.jsx
+++ b/src/Components/Publishing/News/__tests__/NewsDateHeader.test.jsx
@@ -1,0 +1,38 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import moment from "moment"
+import React from "react"
+import renderer from "react-test-renderer"
+
+import { NewsArticle } from "../../Fixtures/Articles"
+import { NewsDateHeader } from "../NewsDateHeader"
+
+it("renders a news date header properly", () => {
+  const component = renderer
+    .create(<NewsDateHeader date={NewsArticle.published_at} />)
+    .toJSON()
+  expect(component).toMatchSnapshot()
+})
+
+it("Renders 'today' if date is today", () => {
+  const date = moment().toISOString()
+  const wrapper = mount(<NewsDateHeader date={date} />)
+  expect(wrapper.text()).toMatch("Today")
+})
+
+it("Renders date with no year if in current year", () => {
+  const date = moment()
+    .subtract(1, "week")
+    .toISOString()
+  const wrapper = mount(<NewsDateHeader date={date} />)
+  expect(wrapper.text()).toMatch(moment(date).format("MMM D"))
+  expect(wrapper.text()).not.toMatch(moment(date).format("YYYY"))
+})
+
+it("Renders date with year if not in current year", () => {
+  const date = moment()
+    .subtract(1, "year")
+    .toISOString()
+  const wrapper = mount(<NewsDateHeader date={date} />)
+  expect(wrapper.text()).toMatch(moment(date).format("MMM D, YYYY"))
+})

--- a/src/Components/Publishing/News/__tests__/__snapshots__/NewsDateDivider.test.tsx.snap
+++ b/src/Components/Publishing/News/__tests__/__snapshots__/NewsDateDivider.test.tsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a news date header properly 1`] = `
+.c1 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 25px;
+  line-height: 1.1em;
+}
+
+.c0 {
+  margin-top: 80px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+}
+
+@media (max-width:720px) {
+  .c1 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+}
+
+@media (max-width:720px) {
+  .c0 {
+    margin-top: 40px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    Jul 19
+  </div>
+</div>
+`;

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -16,7 +16,12 @@ export type SectionLayout =
 
 export type BylineLayout = "fullscreen" | "condensed" | "standard" | "split"
 
-export type DateFormat = "monthYear" | "condensed" | "verbose" | "default"
+export type DateFormat =
+  | "monthYear"
+  | "condensed"
+  | "verbose"
+  | "news"
+  | "default"
 
 // TODO: Make some of these non-optional ;)
 export type ArticleData = {


### PR DESCRIPTION
- Adds NewsDateHeader component to render styled article date or 'today'
- Replaces NavNews date with NewsDateHeader component
- Adds NewsDateDivider, for displaying date between articles in list
- Minor updates to NavNews styling

<img width="808" alt="screen shot 2018-03-28 at 9 53 45 am" src="https://user-images.githubusercontent.com/1497424/38033688-8f3eaf3e-326e-11e8-9f65-aa8cc765d3a0.png">
<img width="781" alt="screen shot 2018-03-28 at 9 56 35 am" src="https://user-images.githubusercontent.com/1497424/38033689-8f506116-326e-11e8-933a-55d1598b3aaa.png">
<img width="779" alt="screen shot 2018-03-28 at 9 57 48 am" src="https://user-images.githubusercontent.com/1497424/38033690-8f606bb0-326e-11e8-939b-5fb26b662543.png">
