### PR TITLE
@eessex =>  do not render "via" if no source exists

### DIFF
--- a/src/Components/Publishing/Byline/DateSource.tsx
+++ b/src/Components/Publishing/Byline/DateSource.tsx
@@ -15,11 +15,12 @@ export const DateSource: React.SFC<NewsBylineProps & Props> = props => {
   const { news_source, published_at } = article
 
   const getNewsSource = source => {
-    if (!editSource && (!source || !source.url)) return null
+    const hasSource = source && source.url
+    if (!editSource && !hasSource) return null
 
     return (
       <Fragment>
-        {", via"}&nbsp;
+        {hasSource && ", via"}&nbsp;
         {editSource ? editSource : <a href={source.url}>{source.title}</a>}
       </Fragment>
     )

--- a/src/Components/Publishing/Byline/__tests__/DateSource.tsx
+++ b/src/Components/Publishing/Byline/__tests__/DateSource.tsx
@@ -12,4 +12,13 @@ describe("DateSource", () => {
     )
     expect(component.text()).toMatch("Child source")
   })
+
+  it("does not render unnecessary text if it doesn't have a source", () => {
+    const article = NewsArticle
+    article.news_source = {}
+
+    const component = mount(<DateSource article={NewsArticle} />)
+
+    expect(component.html()).not.toContain("via")
+  })
 })


### PR DESCRIPTION
Makes sure 'via' in byline isn't rendered unless there's a source.