### PR TITLE
[FIX publishing] Replace news posted by with bullet

### DIFF
--- a/src/Components/Publishing/Byline/AuthorDate.tsx
+++ b/src/Components/Publishing/Byline/AuthorDate.tsx
@@ -97,7 +97,7 @@ const bullet = color => {
   `
 }
 
-const StyledAuthor = Text.extend`
+export const StyledAuthor = Text.extend`
   ${props => (props.withBullet ? bullet(props.color) : "")} ${props =>
       adjustForCondensed(props.condensed)} ${pMedia.sm`
     &:before {

--- a/src/Components/Publishing/Byline/NewsByline.tsx
+++ b/src/Components/Publishing/Byline/NewsByline.tsx
@@ -1,10 +1,9 @@
 import React from "react"
 import styled from "styled-components"
-import { pMedia } from "../../Helpers"
 import { getArticleFullHref, getAuthorByline } from "../Constants"
-import { Fonts } from "../Fonts"
 import { IconShareArrow } from "../Icon/IconShareArrow"
 import { ArticleData } from "../Typings"
+import { StyledAuthor } from "./AuthorDate"
 import { DateSource } from "./DateSource"
 import { Share } from "./Share"
 
@@ -38,7 +37,11 @@ export const NewsByline: React.SFC<NewsBylineProps> = props => {
   return (
     <NewsBylineContainer>
       <AuthorDateContainer>
-        {!isTruncated && <Poster>Posted by {getAuthorByline(authors)}</Poster>}
+        {!isTruncated && (
+          <StyledAuthor condensed withBullet color="black">
+            {getAuthorByline(authors)}
+          </StyledAuthor>
+        )}
         <DateSource article={article} editSource={editSource} />
       </AuthorDateContainer>
       {!isTruncated && shareIcon}
@@ -56,14 +59,6 @@ const NewsBylineContainer = styled.div`
 const AuthorDateContainer = styled.div`
   display: flex;
   flex-direction: column;
-`
-
-const Poster = styled.div`
-  ${Fonts.unica("s14", "medium")};
-
-  ${pMedia.sm`
-    ${Fonts.unica("s12", "medium")}
-  `};
 `
 
 const ShareIconContainer = styled.div`

--- a/src/Components/Publishing/Byline/__tests__/__snapshots__/NewsByline.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__tests__/__snapshots__/NewsByline.test.tsx.snap
@@ -1,6 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`News Byline renders on mobile 1`] = `
+.c2 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 14px;
+  line-height: 1.4em;
+  margin: 10px 30px 0 0;
+}
+
+.c2.date {
+  white-space: nowrap;
+}
+
+.c2:before {
+  content: "";
+  display: inline-block;
+  min-width: 10px;
+  min-height: 10px;
+  border-radius: 50%;
+  margin: 6px 10px 1px 0;
+  background-color: black;
+}
+
+.c2:before {
+  min-width: 8px;
+  min-height: 8px;
+  margin: 0 5px 1px 0;
+}
+
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -45,29 +73,34 @@ exports[`News Byline renders on mobile 1`] = `
   flex-direction: column;
 }
 
-.c2 {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.4em;
-}
-
 .c4:hover {
   opacity: 0.6;
 }
 
 @media (max-width:720px) {
-  .c3 {
-    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  .c2 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 10px 20px 0 0;
   }
 }
 
 @media (max-width:720px) {
-  .c2 {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  .c2:before {
+    min-width: 8px;
+    min-height: 8px;
+  }
+}
+
+@media (max-width:720px) {
+  .c3 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
@@ -82,8 +115,8 @@ exports[`News Byline renders on mobile 1`] = `
   >
     <div
       className="c2"
+      color="black"
     >
-      Posted by 
       Casey Lesser
     </div>
     <div
@@ -214,6 +247,34 @@ exports[`News Byline renders on mobile truncated 1`] = `
 `;
 
 exports[`News Byline renders properly 1`] = `
+.c2 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 14px;
+  line-height: 1.4em;
+  margin: 10px 30px 0 0;
+}
+
+.c2.date {
+  white-space: nowrap;
+}
+
+.c2:before {
+  content: "";
+  display: inline-block;
+  min-width: 10px;
+  min-height: 10px;
+  border-radius: 50%;
+  margin: 6px 10px 1px 0;
+  background-color: black;
+}
+
+.c2:before {
+  min-width: 8px;
+  min-height: 8px;
+  margin: 0 5px 1px 0;
+}
+
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -285,11 +346,25 @@ exports[`News Byline renders properly 1`] = `
   flex-direction: column;
 }
 
-.c2 {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.4em;
+@media (max-width:720px) {
+  .c2 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 12px;
+    line-height: 1.4em;
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 10px 20px 0 0;
+  }
+}
+
+@media (max-width:720px) {
+  .c2:before {
+    min-width: 8px;
+    min-height: 8px;
+  }
 }
 
 @media (max-width:720px) {
@@ -307,15 +382,6 @@ exports[`News Byline renders properly 1`] = `
   }
 }
 
-@media (max-width:720px) {
-  .c2 {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 12px;
-    line-height: 1.4em;
-  }
-}
-
 <div
   className="c0"
 >
@@ -324,8 +390,8 @@ exports[`News Byline renders properly 1`] = `
   >
     <div
       className="c2"
+      color="black"
     >
-      Posted by 
       Casey Lesser
     </div>
     <div
@@ -495,6 +561,34 @@ exports[`News Byline renders properly when truncated 1`] = `
 `;
 
 exports[`News Byline renders without a news source 1`] = `
+.c2 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 14px;
+  line-height: 1.4em;
+  margin: 10px 30px 0 0;
+}
+
+.c2.date {
+  white-space: nowrap;
+}
+
+.c2:before {
+  content: "";
+  display: inline-block;
+  min-width: 10px;
+  min-height: 10px;
+  border-radius: 50%;
+  margin: 6px 10px 1px 0;
+  background-color: black;
+}
+
+.c2:before {
+  min-width: 8px;
+  min-height: 8px;
+  margin: 0 5px 1px 0;
+}
+
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -566,11 +660,25 @@ exports[`News Byline renders without a news source 1`] = `
   flex-direction: column;
 }
 
-.c2 {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.4em;
+@media (max-width:720px) {
+  .c2 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 12px;
+    line-height: 1.4em;
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 10px 20px 0 0;
+  }
+}
+
+@media (max-width:720px) {
+  .c2:before {
+    min-width: 8px;
+    min-height: 8px;
+  }
 }
 
 @media (max-width:720px) {
@@ -588,15 +696,6 @@ exports[`News Byline renders without a news source 1`] = `
   }
 }
 
-@media (max-width:720px) {
-  .c2 {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 12px;
-    line-height: 1.4em;
-  }
-}
-
 <div
   className="c0"
 >
@@ -605,8 +704,8 @@ exports[`News Byline renders without a news source 1`] = `
   >
     <div
       className="c2"
+      color="black"
     >
-      Posted by 
       Casey Lesser
     </div>
     <div

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
@@ -29,6 +29,34 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   padding-left: 0.5rem;
 }
 
+.c19 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 14px;
+  line-height: 1.4em;
+  margin: 10px 30px 0 0;
+}
+
+.c19.date {
+  white-space: nowrap;
+}
+
+.c19:before {
+  content: "";
+  display: inline-block;
+  min-width: 10px;
+  min-height: 10px;
+  border-radius: 50%;
+  margin: 6px 10px 1px 0;
+  background-color: black;
+}
+
+.c19:before {
+  min-width: 8px;
+  min-height: 8px;
+  margin: 0 5px 1px 0;
+}
+
 .c20 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -71,13 +99,6 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c19 {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.4em;
 }
 
 .c21:hover {
@@ -422,17 +443,29 @@ exports[`News Layout renders the news layout on mobile 1`] = `
 }
 
 @media (max-width:720px) {
-  .c20 {
-    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  .c19 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 10px 20px 0 0;
   }
 }
 
 @media (max-width:720px) {
-  .c19 {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  .c19:before {
+    min-width: 8px;
+    min-height: 8px;
+  }
+}
+
+@media (max-width:720px) {
+  .c20 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
     line-height: 1.4em;
@@ -762,8 +795,8 @@ exports[`News Layout renders the news layout on mobile 1`] = `
         >
           <div
             className="c19"
+            color="black"
           >
-            Posted by 
             Casey Lesser
           </div>
           <div
@@ -869,6 +902,34 @@ exports[`News Layout renders the news layout properly 1`] = `
   padding-left: 0.5rem;
 }
 
+.c19 {
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 14px;
+  line-height: 1.4em;
+  margin: 10px 30px 0 0;
+}
+
+.c19.date {
+  white-space: nowrap;
+}
+
+.c19:before {
+  content: "";
+  display: inline-block;
+  min-width: 10px;
+  min-height: 10px;
+  border-radius: 50%;
+  margin: 6px 10px 1px 0;
+  background-color: black;
+}
+
+.c19:before {
+  min-width: 8px;
+  min-height: 8px;
+  margin: 0 5px 1px 0;
+}
+
 .c20 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -938,13 +999,6 @@ exports[`News Layout renders the news layout properly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c19 {
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.4em;
 }
 
 .c10 {
@@ -1285,6 +1339,27 @@ exports[`News Layout renders the news layout properly 1`] = `
 }
 
 @media (max-width:720px) {
+  .c19 {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 12px;
+    line-height: 1.4em;
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 10px 20px 0 0;
+  }
+}
+
+@media (max-width:720px) {
+  .c19:before {
+    min-width: 8px;
+    min-height: 8px;
+  }
+}
+
+@media (max-width:720px) {
   .c20 {
     font-family: Unica77LLWebRegular , 'Arial', 'serif';
     -webkit-font-smoothing: antialiased;
@@ -1296,15 +1371,6 @@ exports[`News Layout renders the news layout properly 1`] = `
 @media (max-width:600px) {
   .c21 {
     margin-top: 15px;
-  }
-}
-
-@media (max-width:720px) {
-  .c19 {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 12px;
-    line-height: 1.4em;
   }
 }
 
@@ -1631,8 +1697,8 @@ exports[`News Layout renders the news layout properly 1`] = `
         >
           <div
             className="c19"
+            color="black"
           >
-            Posted by 
             Casey Lesser
           </div>
           <div


### PR DESCRIPTION
Addresses [GROW-400](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-400)

Replaces 'Posted by' with bullet in news byline.

<img width="208" alt="screen shot 2018-03-30 at 10 17 35 am" src="https://user-images.githubusercontent.com/1497424/38140839-aafacec4-3403-11e8-960c-e84997240d22.png">
