### PR TITLE
[FIX onboarding] Make <PopularArtist> defensive about null values

### DIFF
--- a/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
+++ b/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
@@ -47,7 +47,7 @@ class PopularArtistsContent extends React.Component<Props, null> {
   constructor(props: Props, context: any) {
     super(props, context)
     this.excludedArtistIds = new Set(
-      this.props.popular_artists.artists.map(item => item._id)
+      this.props.popular_artists.artists.filter(Boolean).map(item => item._id)
     )
   }
 
@@ -154,8 +154,9 @@ class PopularArtistsContent extends React.Component<Props, null> {
   }
 
   render() {
-    const artistItems = this.props.popular_artists.artists.map(
-      (artist, index) => (
+    const artistItems = this.props.popular_artists.artists
+      .filter(Boolean)
+      .map((artist, index) => (
         <LinkContainer>
           <ReplaceTransition
             key={index}
@@ -173,8 +174,7 @@ class PopularArtistsContent extends React.Component<Props, null> {
             />
           </ReplaceTransition>
         </LinkContainer>
-      )
-    )
+      ))
 
     return <div>{artistItems}</div>
   }


### PR DESCRIPTION
As of writing https://www.artsy.net/personalize/artists is broken:

<img width="1616" alt="screen shot 2018-03-30 at 16 10 36" src="https://user-images.githubusercontent.com/386234/38152266-f2965dd0-3434-11e8-92e3-142fa7642682.png">

This was caused by a `null` value in a response from MP:

<img width="829" alt="screen_shot_2018-03-30_at_15_46_24" src="https://user-images.githubusercontent.com/386234/38152282-0df01512-3435-11e8-8590-0147b6903463.png">

And here is the whole query:

```graphql
query {
  popular_artists(exclude_followed_artists: true) {
    artists {
      id
      _id
      __id
      name	
      image {
        cropped(width: 100, height: 100) {
          url
        }
      }
    }
  }
}
```

We are also working on fixing the roo cause on the server-side, but to get the onboarding back quickly let's just make it defensive about `null` values.