### PR TITLE
Add a <Checkbox> component

### DIFF
--- a/src/Assets/Colors.tsx
+++ b/src/Assets/Colors.tsx
@@ -1,10 +1,12 @@
 export default {
+  white: "#ffffff",
   gray: "#f8f8f8",
   grayMedium: "#cccccc",
   grayRegular: "#e5e5e5",
   grayDark: "#999999",
   graySemibold: "#666666",
   grayBold: "#333333",
+  black: "#000000",
   purpleLight: "#e2d2ff",
   purpleRegular: "#6e1fff",
   redRegular: "#FFEFED",

--- a/src/Components/ArtworkFilter/ForSaleCheckbox.tsx
+++ b/src/Components/ArtworkFilter/ForSaleCheckbox.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Component, HTMLProps } from "react"
 
 import Checkbox from "../Checkbox"
 
@@ -6,54 +6,25 @@ import styled from "styled-components"
 import colors from "../../Assets/Colors"
 import { primary } from "../../Assets/Fonts"
 
-interface Props extends React.HTMLProps<ForSaleCheckbox> {
-  onChange?: any
-}
-
-interface State {
-  isChecked: boolean
-}
-
-export class ForSaleCheckbox extends React.Component<Props, State> {
-  state = {
-    isChecked: false,
-  }
-
-  onClick() {
-    this.setState({
-      isChecked: !this.state.isChecked,
-    })
-    this.props.onChange()
-  }
-
+export class ForSaleCheckbox extends Component<HTMLProps<Checkbox>, null> {
   render() {
-    const { isChecked } = this.state
-    const { checked } = this.props
     return (
-      <div className={this.props.className} onClick={() => this.onClick()}>
-        <StyledCheckbox checked={isChecked || checked} />
-        <label>Only for Sale</label>
-      </div>
+      <CheckboxContainer>
+        <Checkbox {...this.props}>Only for Sale</Checkbox>
+      </CheckboxContainer>
     )
   }
 }
 
-const StyledCheckbox = styled(Checkbox)`
-  margin-right: 15px
-`
-
-const StyledForSaleCheckbox = styled(ForSaleCheckbox)`
-  display: inline-block;
+const CheckboxContainer = styled.div`
   border: 1px solid ${colors.grayRegular};
-  font-size: 13px;
-  line-height: 160%;
   padding: 15px 18px;
   font-size: 13px;
   vertical-align: middle;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  ${primary.style}
+  ${primary.style};
 `
 
-export default StyledForSaleCheckbox
+export default ForSaleCheckbox

--- a/src/Components/Authorization/commonElements.tsx
+++ b/src/Components/Authorization/commonElements.tsx
@@ -47,10 +47,9 @@ export const StyledInput = styled(Input)`
 `
 
 export const TOSCheckbox = ({ error, errorMessage, value, ...props }) => (
-  <div>
-    <Checkbox id="accepted-tos" {...{ error, errorMessage, checked: value }} />
-    <label htmlFor="accepted-tos">{props.children} - I don't work :(</label>
-  </div>
+  <Checkbox {...{ error, errorMessage, checked: value }}>
+    {props.children} - I don't work :(
+  </Checkbox>
 )
 
 interface ModeSelectorProps {

--- a/src/Components/Checkbox.tsx
+++ b/src/Components/Checkbox.tsx
@@ -1,71 +1,114 @@
-import React from "react"
-
+import React, { Component, HTMLProps } from "react"
 import styled from "styled-components"
 import colors from "../Assets/Colors"
 
-interface Props extends React.HTMLProps<Checkbox> {
+interface CheckboxState {
   checked: boolean
 }
 
-export class Checkbox extends React.Component<Props, null> {
-  static defaultProps = {
-    checked: true,
+export class Checkbox extends Component<HTMLProps<Checkbox>, CheckboxState> {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      checked: props.checked || false,
+    }
+  }
+
+  onChange = event => {
+    if (this.props.onChange) {
+      this.props.onChange(event)
+    }
+
+    this.setState({
+      checked: event.currentTarget.checked,
+    })
   }
 
   render() {
-    const { checked } = this.props
+    const { children, className, ...propsForCheckbox } = this.props
 
     return (
-      <div className={this.props.className}>
+      <Label className={className}>
         <CheckboxInput
-          onChange={() => null}
           type="checkbox"
-          checked={checked}
+          {...propsForCheckbox as any}
+          onChange={this.onChange}
+          checked={this.state.checked}
         />
-        <Label />
-      </div>
+
+        {children}
+      </Label>
     )
   }
 }
 
-const StyledCheckbox = styled(Checkbox)`
+const CheckboxInput = styled.input`
   width: 20px;
   height: 20px;
   position: relative;
-  user-select: none;
-  background: ${colors.grayMedium};
-  display: inline-block;
-`
+  top: -1px;
+  margin: 0 0.5rem 0 0;
 
-const CheckboxInput = styled.input`
-  visibility: hidden;
-  &:checked + label:after {
-    opacity: 1 !important;
+  // The before represents the check mark
+  &:before {
+    transform: rotate(-45deg);
+    content: "";
+    position: absolute;
+    z-index: 1;
+    top: 5px;
+    left: 4px;
+    width: 0.6rem;
+    height: 0.3rem;
+    border: 2px solid ${colors.black};
+    border-top-style: none;
+    border-right-style: none;
+    transition: opacity 0.25s;
+    opacity: 0;
+  }
+
+  &:hover:before {
+    opacity: 0.1;
+  }
+
+  &:checked:before {
+    opacity: 1;
+  }
+
+  // The after represents the square box
+  &:after {
+    content: "";
+    position: absolute;
+    left: 0;
+    width: 1rem;
+    height: 1rem;
+    background: ${colors.white};
+    border: 2px solid ${colors.grayRegular};
+  }
+
+  &:disabled {
+    &:hover:before {
+      border-color: transparent;
+    }
+
+    &:checked {
+      &:before {
+        border-color: ${colors.grayDark};
+      }
+    }
+
+    &:after {
+      background-color: ${colors.grayRegular};
+    }
   }
 `
 
 const Label = styled.label`
-  cursor: pointer
-  position: absolute
-  top: 2px;
-  right: 2px;
-  bottom: 2px;
-  left: 2px;
-  background-color: white;
-  &:after {
-    content: '';
-    position: absolute;
-    top: 3px;
-    right: 2px;
-    bottom: 7px;
-    left: 2px;
-    border: 2px solid black;
-    border-top: none;
-    border-right: none;
-    opacity: 0;
-    transform: rotate(-45deg) translateZ(0);
-    transition: opacity 0.25s;
-  }
+  position: relative;
+  line-height: 135%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
 `
 
-export default StyledCheckbox
+export default Checkbox

--- a/src/Components/__stories__/Input.story.tsx
+++ b/src/Components/__stories__/Input.story.tsx
@@ -3,6 +3,7 @@ import React from "react"
 
 import colors from "../../Assets/Colors"
 import Button from "../Buttons/Inverted"
+import { Checkbox } from "../Checkbox"
 import Icon from "../Icon"
 import Input from "../Input"
 import TextArea from "../TextArea"
@@ -47,6 +48,24 @@ storiesOf("Components/Input", module)
       <TextArea placeholder="Your Message" />
       <TextArea placeholder="Your Message" error />
       <TextArea placeholder="Your Message" disabled />
+    </div>
+  ))
+  .add("Check Boxes", () => (
+    <div>
+      <div style={{ padding: 10 }}>
+        <Checkbox>Remember me</Checkbox>
+      </div>
+      <div style={{ padding: 10 }}>
+        <Checkbox checked>Remember me</Checkbox>
+      </div>
+      <div style={{ padding: 10 }}>
+        <Checkbox disabled>Remember me</Checkbox>
+      </div>
+      <div style={{ padding: 10 }}>
+        <Checkbox checked disabled>
+          Remember me
+        </Checkbox>
+      </div>
     </div>
   ))
   .add("Form", () => (


### PR DESCRIPTION
This updates the existing `<Checkbox>` component:

<img width="176" alt="screen shot 2018-04-02 at 18 43 58" src="https://user-images.githubusercontent.com/386234/38219930-efde61aa-36a5-11e8-9186-391bb55d728e.png">

And here is how to use it:

```tsx
<Checkbox onChange={event => console.log("I'll remember you!", event)}>
  Remember me
</Checkbox>

<Checkbox checked>
  Remember me
</Checkbox>

<Checkbox disabled>
  Remember me
</Checkbox>

<Checkbox checked disabled>
  Remember me
</Checkbox>
```

This is an existing component, so the interface for `props` are unchagend, but now it can take a `children` prop to show the label for a checkbox input.

This also updates the styling, so for example, the  `<FilterBar>` in the `<GeneArtworks>` component would look slightly different:

### Before:

<img width="767" alt="screen shot 2018-04-02 at 18 44 35" src="https://user-images.githubusercontent.com/386234/38219946-07b10c88-36a6-11e8-8572-7881ecae2166.png">

### After:

<img width="762" alt="screen shot 2018-04-02 at 18 43 44" src="https://user-images.githubusercontent.com/386234/38219952-09bb6262-36a6-11e8-94f4-45574f8682b5.png">
