### PR TITLE
@kanaabe => Content end bug

### DIFF
--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -43,11 +43,11 @@ export class Text extends Component<Props, State> {
       const paragraphs = doc.getElementsByTagName("P")
       const lastParagraph =
         paragraphs.length && paragraphs[paragraphs.length - 1]
-
-      // insert content-end in last paragraph
-      lastParagraph.innerHTML =
-        lastParagraph.innerHTML + "<span class='content-end'> </span>"
-
+      if (lastParagraph) {
+        // insert content-end in last paragraph
+        lastParagraph.innerHTML =
+          lastParagraph.innerHTML + "<span class='content-end'> </span>"
+      }
       return doc.innerHTML
     }
     return cleanedHtml


### PR DESCRIPTION
A bug in 'content-end' spans came up today for an article that has not had text added yet-- content-end placement has been updated to check if a paragraph exists in the text section before attempting to add a 'content-end' span to it.

Fixes [GROW-451](https://artsyproduct.atlassian.net/browse/GROW-451)