### PR TITLE
@xtina-starr => SeriesAbout supports custom sub_title and editing sub_title

### DIFF
--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -803,10 +803,20 @@ export const SeriesArticle: ArticleData = {
   },
   series_description:
     "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+  series: {
+    description:
+      "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+  },
   related_articles: ["594a7e2254c37f00177c0ea9", "597b9f652d35b80017a2a6a7"],
 }
 
 export const SeriesArticleSponsored = extend(cloneDeep(SeriesArticle), Sponsor)
+
+export const SeriesArticleCustomSubTitle = extend(cloneDeep(SeriesArticle), {
+  series: {
+    sub_title: "About this Feature",
+  },
+})
 
 export const NewsArticle: ArticleData = {
   id: "594a7e2254c37f00177c0ea9",

--- a/src/Components/Publishing/Series/SeriesAbout.tsx
+++ b/src/Components/Publishing/Series/SeriesAbout.tsx
@@ -6,11 +6,13 @@ import { media } from "../../Helpers"
 import { Fonts } from "../Fonts"
 import { PartnerBlock, PartnerBlockContainer } from "../Partner/PartnerBlock"
 import { Text } from "../Sections/Text"
+import { ArticleData } from "../Typings"
 
 interface Props {
-  article?: any
+  article?: ArticleData
   color?: string
   editDescription?: any
+  editSubTitle?: any
   tracking?: any
 }
 
@@ -35,8 +37,13 @@ export class SeriesAbout extends Component<Props, null> {
   }
 
   render() {
-    const { article, color, editDescription } = this.props
-    const { series_description, sponsor } = article
+    const {
+      article: { series, series_description, sponsor },
+      color,
+      editDescription,
+      editSubTitle,
+    } = this.props
+
     const sponsorLogo =
       sponsor &&
       (color === "black"
@@ -46,7 +53,11 @@ export class SeriesAbout extends Component<Props, null> {
     return (
       <SeriesAboutContainer color={color}>
         <StyledCol xs={12} sm={4}>
-          <Title>About the Series</Title>
+          <Title>
+            {editSubTitle
+              ? editSubTitle
+              : (series && series.sub_title) || "About the Series"}
+          </Title>
           {sponsor && (
             <PartnerBlock
               logo={sponsorLogo}
@@ -65,7 +76,11 @@ export class SeriesAbout extends Component<Props, null> {
             </Text>
           ) : (
             <div className="SeriesAbout__description">
-              <Text layout="standard" color={color} html={series_description} />
+              <Text
+                layout="standard"
+                color={color}
+                html={series_description || series.description}
+              />
             </div>
           )}
           {sponsor && (

--- a/src/Components/Publishing/Series/__tests__/SeriesAbout.test.js
+++ b/src/Components/Publishing/Series/__tests__/SeriesAbout.test.js
@@ -2,7 +2,7 @@ import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import renderer from "react-test-renderer"
-import { SeriesArticle, SeriesArticleSponsored } from "../../Fixtures/Articles"
+import { SeriesArticle, SeriesArticleSponsored, SeriesArticleCustomSubTitle } from "../../Fixtures/Articles"
 import { EditableChild } from "../../Fixtures/Helpers"
 import { SeriesAbout } from "../SeriesAbout"
 
@@ -12,21 +12,21 @@ jest.mock("../../../../Utils/track", () => ({
 
 describe("SeriesAbout", () => {
   describe("snapshots", () => {
-    it("renders a series about properly", () => {
+    it("Renders properly", () => {
       const component = renderer
         .create(<SeriesAbout article={SeriesArticle} />)
         .toJSON()
       expect(component).toMatchSnapshot()
     })
 
-    it("renders a sponsored series about properly", () => {
+    it("Renders with sponsor", () => {
       const component = renderer
         .create(<SeriesAbout article={SeriesArticleSponsored} />)
         .toJSON()
       expect(component).toMatchSnapshot()
     })
 
-    it("renders series about with children properly", () => {
+    it("Renders with editDescription", () => {
       const component = renderer
         .create(
           <SeriesAbout
@@ -37,20 +37,32 @@ describe("SeriesAbout", () => {
         .toJSON()
       expect(component).toMatchSnapshot()
     })
+
+    it("Renders with editSubTitle", () => {
+      const component = renderer
+        .create(
+          <SeriesAbout
+            article={SeriesArticle}
+            editSubTitle={EditableChild("sub_title")}
+          />
+        )
+        .toJSON()
+      expect(component).toMatchSnapshot()
+    })
   })
 
   describe("unit", () => {
-    it("Renders partner block for a sponsored series", () => {
+    it("Renders PartnerBlock for a sponsored series", () => {
       const component = mount(<SeriesAbout article={SeriesArticleSponsored} />)
       expect(component.find(".PartnerBlock").length).not.toBe(0)
     })
 
-    it("Does not render partner block for an unsponsored series", () => {
+    it("Does not render PartnerBlock for an unsponsored series", () => {
       const component = mount(<SeriesAbout article={SeriesArticle} />)
       expect(component.find(".PartnerBlock").length).toBe(0)
     })
 
-    it("Renders children if present", () => {
+    it("Renders editDescription if present", () => {
       const component = mount(
         <SeriesAbout
           article={SeriesArticle}
@@ -58,6 +70,30 @@ describe("SeriesAbout", () => {
         />
       )
       expect(component.text()).toMatch("Child description")
+    })
+
+    it("Renders editSubTitle if present", () => {
+      const component = mount(
+        <SeriesAbout
+          article={SeriesArticle}
+          editSubTitle={EditableChild("sub_title")}
+        />
+      )
+      expect(component.text()).toMatch("Child sub_title")
+    })
+
+    it("Renders a custom series.sub_title if present", () => {
+      const component = mount(
+        <SeriesAbout article={SeriesArticleCustomSubTitle} />
+      )
+      expect(component.text()).toMatch("About this Feature")
+    })
+
+    it("Renders 'About the Series' by default", () => {
+      const component = mount(
+        <SeriesAbout article={SeriesArticle} />
+      )
+      expect(component.text()).toMatch("About the Series")
     })
 
     it("Tracks click on link in footer", () => {

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.js.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SeriesAbout snapshots renders a series about properly 1`] = `
+exports[`SeriesAbout snapshots Renders properly 1`] = `
 .c1 {
   box-sizing: border-box;
   display: -webkit-box;
@@ -391,7 +391,785 @@ exports[`SeriesAbout snapshots renders a series about properly 1`] = `
 </div>
 `;
 
-exports[`SeriesAbout snapshots renders a sponsored series about properly 1`] = `
+exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
+.c1 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+}
+
+.c3 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c6 a {
+  color: black;
+  text-decoration: none;
+  position: relative;
+  background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
+  background-size: 1.25px 4px;
+  background-repeat: repeat-x;
+  background-position: bottom;
+}
+
+.c6 a:hover {
+  color: #999;
+  opacity: 1;
+}
+
+.c6 p,
+.c6 ul,
+.c6 ol,
+.c6 div[data-block=true] .public-DraftStyleDefault-block {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 23px;
+  line-height: 1.5em;
+  padding-top: 1em;
+  padding-bottom: 1em;
+  margin: 0;
+  font-style: inherit;
+}
+
+.c6 p:first-child,
+.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+  padding-top: 0;
+}
+
+.c6 p:last-child,
+.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+  padding-bottom: 0;
+}
+
+.c6 ul,
+.c6 ol {
+  padding-left: 1em;
+}
+
+.c6 li {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 23px;
+  line-height: 1.5em;
+  padding-top: .5em;
+  padding-bottom: .5em;
+}
+
+.c6 h1 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  font-weight: normal;
+  padding-top: 107px;
+  padding-bottom: 46px;
+  margin: 0;
+  position: relative;
+  text-align: center;
+}
+
+.c6 h1:before {
+  content: "";
+  width: 15px;
+  height: 15px;
+  background: black;
+  border-radius: 50%;
+  position: absolute;
+  top: 69px;
+  right: calc(50% - 7.5px);
+}
+
+.c6 h2 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+  font-weight: normal;
+  margin: 0;
+}
+
+.c6 h2 a {
+  background-size: 1.25px 1px;
+}
+
+.c6 h3 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+  font-weight: normal;
+  padding-top: 23px;
+  margin: 0;
+}
+
+.c6 h3 strong {
+  font-weight: normal;
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+}
+
+.c6 h3 a {
+  background-size: 1.25px 1px;
+}
+
+.c6 blockquote {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  text-align: left;
+  font-weight: normal;
+  padding-top: 46px;
+  padding-bottom: 46px;
+  margin: 0;
+  word-break: break-word;
+}
+
+.c6 .content-end {
+  display: inline-block;
+  content: "";
+  width: 12px;
+  height: 12px;
+  background: black;
+  border-radius: 50%;
+  margin-left: 12px;
+}
+
+.c6 .artist-follow {
+  vertical-align: middle;
+  margin-left: 10px;
+  cursor: pointer;
+  background: none transparent;
+}
+
+.c6 .artist-follow:before {
+  font-family: "artsy-icons";
+  content: "";
+  vertical-align: -8.5px;
+  line-height: 32px;
+  font-size: 32px;
+}
+
+.c6 .artist-follow:after {
+  content: "Follow";
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 17px;
+  line-height: 1.1em;
+  text-transform: none;
+}
+
+.c0 {
+  color: black;
+  max-width: 1200px;
+  width: 100%;
+}
+
+.c2 .file__PartnerBlockContainer-yu39to-0 {
+  display: none;
+}
+
+.c2:first-of-type {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2:first-of-type .file__PartnerBlockContainer-yu39to-0 {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+}
+
+@media only screen and (min-width:0em) {
+  .c3 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-preferred-size: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c3 {
+    -webkit-flex-basis: 33.333333333333336%;
+    -ms-flex-preferred-size: 33.333333333333336%;
+    flex-basis: 33.333333333333336%;
+    max-width: 33.333333333333336%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:0em) {
+  .c5 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-preferred-size: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c5 {
+    -webkit-flex-basis: 66.66666666666667%;
+    -ms-flex-preferred-size: 66.66666666666667%;
+    flex-basis: 66.66666666666667%;
+    max-width: 66.66666666666667%;
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c6 p,
+  .c6 ul,
+  .c6 ol,
+  .c6 div[data-block=true] .public-DraftStyleDefault-block {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 19px;
+    line-height: 1.5em;
+  }
+
+  .c6 li {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 19px;
+    line-height: 1.5em;
+  }
+
+  .c6 h1 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+  }
+
+  .c6 h2 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 32px;
+    line-height: 1.1em;
+  }
+
+  .c6 h3 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+    line-height: 1.5em;
+  }
+
+  .c6 h3 strong {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+
+  .c6 blockquote {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+    margin: 0;
+  }
+
+  .c6 .content-start {
+    font-size: 55px;
+  }
+}
+
+@media (max-width:48em) {
+  .c2:first-of-type .file__PartnerBlockContainer-yu39to-0 {
+    display: none;
+  }
+
+  .c2 .file__PartnerBlockContainer-yu39to-0 {
+    margin-top: 60px;
+    display: block;
+  }
+}
+
+@media (max-width:48em) {
+  .c4 {
+    margin-bottom: 20px;
+  }
+}
+
+<div
+  className="c0 c1"
+  color="black"
+>
+  <div
+    className="c2 c3"
+  >
+    <div
+      className="c4"
+    >
+      About the Series
+    </div>
+  </div>
+  <div
+    className="c2 c5"
+  >
+    <div
+      className="article__text-section c6"
+      color="black"
+    >
+      <div>
+        Child 
+        description
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
+.c1 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+}
+
+.c3 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c6 a {
+  color: black;
+  text-decoration: none;
+  position: relative;
+  background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
+  background-size: 1.25px 4px;
+  background-repeat: repeat-x;
+  background-position: bottom;
+}
+
+.c6 a:hover {
+  color: #999;
+  opacity: 1;
+}
+
+.c6 p,
+.c6 ul,
+.c6 ol,
+.c6 div[data-block=true] .public-DraftStyleDefault-block {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 23px;
+  line-height: 1.5em;
+  padding-top: 1em;
+  padding-bottom: 1em;
+  margin: 0;
+  font-style: inherit;
+}
+
+.c6 p:first-child,
+.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+  padding-top: 0;
+}
+
+.c6 p:last-child,
+.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+  padding-bottom: 0;
+}
+
+.c6 ul,
+.c6 ol {
+  padding-left: 1em;
+}
+
+.c6 li {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 23px;
+  line-height: 1.5em;
+  padding-top: .5em;
+  padding-bottom: .5em;
+}
+
+.c6 h1 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  font-weight: normal;
+  padding-top: 107px;
+  padding-bottom: 46px;
+  margin: 0;
+  position: relative;
+  text-align: center;
+}
+
+.c6 h1:before {
+  content: "";
+  width: 15px;
+  height: 15px;
+  background: black;
+  border-radius: 50%;
+  position: absolute;
+  top: 69px;
+  right: calc(50% - 7.5px);
+}
+
+.c6 h2 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+  font-weight: normal;
+  margin: 0;
+}
+
+.c6 h2 a {
+  background-size: 1.25px 1px;
+}
+
+.c6 h3 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+  font-weight: normal;
+  padding-top: 23px;
+  margin: 0;
+}
+
+.c6 h3 strong {
+  font-weight: normal;
+  font-family: Unica77LLWebMedium , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+}
+
+.c6 h3 a {
+  background-size: 1.25px 1px;
+}
+
+.c6 blockquote {
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  text-align: left;
+  font-weight: normal;
+  padding-top: 46px;
+  padding-bottom: 46px;
+  margin: 0;
+  word-break: break-word;
+}
+
+.c6 .content-end {
+  display: inline-block;
+  content: "";
+  width: 12px;
+  height: 12px;
+  background: black;
+  border-radius: 50%;
+  margin-left: 12px;
+}
+
+.c6 .artist-follow {
+  vertical-align: middle;
+  margin-left: 10px;
+  cursor: pointer;
+  background: none transparent;
+}
+
+.c6 .artist-follow:before {
+  font-family: "artsy-icons";
+  content: "";
+  vertical-align: -8.5px;
+  line-height: 32px;
+  font-size: 32px;
+}
+
+.c6 .artist-follow:after {
+  content: "Follow";
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 17px;
+  line-height: 1.1em;
+  text-transform: none;
+}
+
+.c0 {
+  color: black;
+  max-width: 1200px;
+  width: 100%;
+}
+
+.c2 .file__PartnerBlockContainer-yu39to-0 {
+  display: none;
+}
+
+.c2:first-of-type {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2:first-of-type .file__PartnerBlockContainer-yu39to-0 {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular , 'Arial', 'serif';
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+}
+
+@media only screen and (min-width:0em) {
+  .c3 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-preferred-size: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c3 {
+    -webkit-flex-basis: 33.333333333333336%;
+    -ms-flex-preferred-size: 33.333333333333336%;
+    flex-basis: 33.333333333333336%;
+    max-width: 33.333333333333336%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:0em) {
+  .c5 {
+    -webkit-flex-basis: 100%;
+    -ms-flex-preferred-size: 100%;
+    flex-basis: 100%;
+    max-width: 100%;
+    display: block;
+  }
+}
+
+@media only screen and (min-width:48em) {
+  .c5 {
+    -webkit-flex-basis: 66.66666666666667%;
+    -ms-flex-preferred-size: 66.66666666666667%;
+    flex-basis: 66.66666666666667%;
+    max-width: 66.66666666666667%;
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c6 p,
+  .c6 ul,
+  .c6 ol,
+  .c6 div[data-block=true] .public-DraftStyleDefault-block {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 19px;
+    line-height: 1.5em;
+  }
+
+  .c6 li {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 19px;
+    line-height: 1.5em;
+  }
+
+  .c6 h1 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+  }
+
+  .c6 h2 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 32px;
+    line-height: 1.1em;
+  }
+
+  .c6 h3 {
+    font-family: Unica77LLWebRegular , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+    line-height: 1.5em;
+  }
+
+  .c6 h3 strong {
+    font-family: Unica77LLWebMedium , 'Arial', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+
+  .c6 blockquote {
+    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+    margin: 0;
+  }
+
+  .c6 .content-start {
+    font-size: 55px;
+  }
+}
+
+@media (max-width:48em) {
+  .c2:first-of-type .file__PartnerBlockContainer-yu39to-0 {
+    display: none;
+  }
+
+  .c2 .file__PartnerBlockContainer-yu39to-0 {
+    margin-top: 60px;
+    display: block;
+  }
+}
+
+@media (max-width:48em) {
+  .c4 {
+    margin-bottom: 20px;
+  }
+}
+
+<div
+  className="c0 c1"
+  color="black"
+>
+  <div
+    className="c2 c3"
+  >
+    <div
+      className="c4"
+    >
+      <div>
+        Child 
+        sub_title
+      </div>
+    </div>
+  </div>
+  <div
+    className="c2 c5"
+  >
+    <div
+      className="SeriesAbout__description"
+    >
+      <div
+        className="article__text-section c6"
+        color="black"
+      >
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
 .c1 {
   box-sizing: border-box;
   display: -webkit-box;
@@ -840,390 +1618,6 @@ exports[`SeriesAbout snapshots renders a sponsored series about properly 1`] = `
           src="https://artsy-media-uploads.s3.amazonaws.com/AjncVmjZHFM4Z-0b6nPz8A%2FGUCCI.png"
         />
       </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`SeriesAbout snapshots renders series about with children properly 1`] = `
-.c1 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
-}
-
-.c3 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c5 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c6 {
-  position: relative;
-  width: 100%;
-}
-
-.c6 a {
-  color: black;
-  text-decoration: none;
-  position: relative;
-  background-image: linear-gradient(to bottom,transparent 0,#333 1px,transparent 0);
-  background-size: 1.25px 4px;
-  background-repeat: repeat-x;
-  background-position: bottom;
-}
-
-.c6 a:hover {
-  color: #999;
-  opacity: 1;
-}
-
-.c6 p,
-.c6 ul,
-.c6 ol,
-.c6 div[data-block=true] .public-DraftStyleDefault-block {
-  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 23px;
-  line-height: 1.5em;
-  padding-top: 1em;
-  padding-bottom: 1em;
-  margin: 0;
-  font-style: inherit;
-}
-
-.c6 p:first-child,
-.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
-  padding-top: 0;
-}
-
-.c6 p:last-child,
-.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
-  padding-bottom: 0;
-}
-
-.c6 ul,
-.c6 ol {
-  padding-left: 1em;
-}
-
-.c6 li {
-  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 23px;
-  line-height: 1.5em;
-  padding-top: .5em;
-  padding-bottom: .5em;
-}
-
-.c6 h1 {
-  font-family: Unica77LLWebRegular , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 40px;
-  line-height: 1.1em;
-  font-weight: normal;
-  padding-top: 107px;
-  padding-bottom: 46px;
-  margin: 0;
-  position: relative;
-  text-align: center;
-}
-
-.c6 h1:before {
-  content: "";
-  width: 15px;
-  height: 15px;
-  background: black;
-  border-radius: 50%;
-  position: absolute;
-  top: 69px;
-  right: calc(50% - 7.5px);
-}
-
-.c6 h2 {
-  font-family: Unica77LLWebRegular , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
-  font-weight: normal;
-  margin: 0;
-}
-
-.c6 h2 a {
-  background-size: 1.25px 1px;
-}
-
-.c6 h3 {
-  font-family: Unica77LLWebRegular , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 19px;
-  line-height: 1.5em;
-  font-weight: normal;
-  padding-top: 23px;
-  margin: 0;
-}
-
-.c6 h3 strong {
-  font-weight: normal;
-  font-family: Unica77LLWebMedium , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 19px;
-  line-height: 1.5em;
-}
-
-.c6 h3 a {
-  background-size: 1.25px 1px;
-}
-
-.c6 blockquote {
-  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 40px;
-  line-height: 1.1em;
-  text-align: left;
-  font-weight: normal;
-  padding-top: 46px;
-  padding-bottom: 46px;
-  margin: 0;
-  word-break: break-word;
-}
-
-.c6 .content-end {
-  display: inline-block;
-  content: "";
-  width: 12px;
-  height: 12px;
-  background: black;
-  border-radius: 50%;
-  margin-left: 12px;
-}
-
-.c6 .artist-follow {
-  vertical-align: middle;
-  margin-left: 10px;
-  cursor: pointer;
-  background: none transparent;
-}
-
-.c6 .artist-follow:before {
-  font-family: "artsy-icons";
-  content: "";
-  vertical-align: -8.5px;
-  line-height: 32px;
-  font-size: 32px;
-}
-
-.c6 .artist-follow:after {
-  content: "Follow";
-  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 17px;
-  line-height: 1.1em;
-  text-transform: none;
-}
-
-.c0 {
-  color: black;
-  max-width: 1200px;
-  width: 100%;
-}
-
-.c2 .file__PartnerBlockContainer-yu39to-0 {
-  display: none;
-}
-
-.c2:first-of-type {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2:first-of-type .file__PartnerBlockContainer-yu39to-0 {
-  display: block;
-  margin-bottom: 10px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular , 'Arial', 'serif';
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
-}
-
-@media only screen and (min-width:0em) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c3 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c5 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
-  }
-}
-
-@media (max-width:600px) {
-  .c6 p,
-  .c6 ul,
-  .c6 ol,
-  .c6 div[data-block=true] .public-DraftStyleDefault-block {
-    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 19px;
-    line-height: 1.5em;
-  }
-
-  .c6 li {
-    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 19px;
-    line-height: 1.5em;
-  }
-
-  .c6 h1 {
-    font-family: Unica77LLWebRegular , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 34px;
-    line-height: 1.1em;
-  }
-
-  .c6 h2 {
-    font-family: Unica77LLWebRegular , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-
-  .c6 h3 {
-    font-family: Unica77LLWebRegular , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 16px;
-    line-height: 1.1em;
-    line-height: 1.5em;
-  }
-
-  .c6 h3 strong {
-    font-family: Unica77LLWebMedium , 'Arial', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 16px;
-    line-height: 1.1em;
-  }
-
-  .c6 blockquote {
-    font-family: 'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
-    -webkit-font-smoothing: antialiased;
-    font-size: 34px;
-    line-height: 1.1em;
-    margin: 0;
-  }
-
-  .c6 .content-start {
-    font-size: 55px;
-  }
-}
-
-@media (max-width:48em) {
-  .c2:first-of-type .file__PartnerBlockContainer-yu39to-0 {
-    display: none;
-  }
-
-  .c2 .file__PartnerBlockContainer-yu39to-0 {
-    margin-top: 60px;
-    display: block;
-  }
-}
-
-@media (max-width:48em) {
-  .c4 {
-    margin-bottom: 20px;
-  }
-}
-
-<div
-  className="c0 c1"
-  color="black"
->
-  <div
-    className="c2 c3"
-  >
-    <div
-      className="c4"
-    >
-      About the Series
-    </div>
-  </div>
-  <div
-    className="c2 c5"
-  >
-    <div
-      className="article__text-section c6"
-      color="black"
-    >
-      <div>
-        Child 
-        description
-      </div>
     </div>
   </div>
 </div>

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -33,6 +33,10 @@ export type ArticleData = {
   date?: string
   published_at?: string
   sections?: SectionData[]
+  series?: {
+    description?: string
+    sub_title?: string
+  }
   news_source?: {
     title?: string
     url?: string

--- a/src/Components/Publishing/__stories__/Series.story.tsx
+++ b/src/Components/Publishing/__stories__/Series.story.tsx
@@ -7,6 +7,7 @@ import { SeriesTitle } from "../Series/SeriesTitle"
 import {
   SeriesArticle,
   SeriesArticleSponsored,
+  SeriesArticleCustomSubTitle,
   StandardArticle,
   VideoArticle,
   VideoArticleUnpublished,
@@ -87,13 +88,21 @@ storiesOf("Publishing/Series", module)
       </div>
     )
   })
-  .add("Series About with children", () => {
+  .add("Series About with editable children", () => {
     return (
       <div>
         <SeriesAbout
           article={SeriesArticle}
           editDescription={EditableChild("description")}
+          editSubTitle={EditableChild("sub_title")}
         />
+      </div>
+    )
+  })
+  .add("Series About with custom sub_title", () => {
+    return (
+      <div>
+        <SeriesAbout article={SeriesArticleCustomSubTitle} />
       </div>
     )
   })


### PR DESCRIPTION
Follows up on this API change - https://github.com/artsy/positron/pull/1683

- Adds support for `series` object to `SeriesAbout` component
- Adds support for editSubTitle prop in `SeriesAbout` component
- Adds `series` object to `ArticleData` typing
- Adds `series` object to series fixtures

TODO: once the Positron PR is merged and data is backfilled, the old `series_description` field should be removed from Reaction.