### PR TITLE
@kanaabe => [PATCH news] Make isHovered available on Article

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -14,6 +14,7 @@ export interface ArticleProps {
   relatedArticlesForPanel?: any
   relatedArticlesForCanvas?: any
   seriesArticle?: ArticleData
+  isHovered?: boolean
   isMobile?: boolean
   isSuper?: boolean
   isTruncated?: boolean

--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -41,6 +41,12 @@ export class NewsLayout extends Component<Props, State> {
     this.onExpand = this.onExpand.bind(this)
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.isHovered !== this.props.isHovered) {
+      this.setState({ isHovered: nextProps.isHovered })
+    }
+  }
+
   @track({ action: "Clicked read more" })
   onExpand() {
     const { onExpand } = this.props


### PR DESCRIPTION
Makes `isHovered` available on `<Article>` to allow activating News articles on mobile. #minor