### PR TITLE
@kanaabe => Refactor ArticleLayout

### DIFF
--- a/src/Components/Publishing/Layouts/ArticleLayout.tsx
+++ b/src/Components/Publishing/Layouts/ArticleLayout.tsx
@@ -11,7 +11,6 @@ import { StandardLayout } from "./StandardLayout"
 
 export interface ArticleProps {
   article: ArticleData
-  seriesArticle?: ArticleData
   closeViewer?: () => void
   display?: {
     name: string

--- a/src/Components/Publishing/Layouts/ArticleLayout.tsx
+++ b/src/Components/Publishing/Layouts/ArticleLayout.tsx
@@ -1,30 +1,17 @@
-import { get } from "lodash"
-import { cloneDeep, includes, map, omit } from "lodash"
+import { cloneDeep, extend, includes, map } from "lodash"
 import React from "react"
 import styled, { StyledFunction } from "styled-components"
-import Colors from "../../../Assets/Colors"
 import Events from "../../../Utils/Events"
-import { Responsive } from "../../../Utils/Responsive"
 import track from "../../../Utils/track"
-import { pMedia } from "../../Helpers"
-import { DisplayCanvas } from "../Display/Canvas"
-import { DisplayPanel } from "../Display/DisplayPanel"
-import { EmailPanel } from "../Email/EmailPanel"
-import { Header } from "../Header/Header"
-import { ReadMore } from "../ReadMore/ReadMoreButton"
-import { ReadMoreWrapper } from "../ReadMore/ReadMoreWrapper"
-import { RelatedArticlesCanvas } from "../RelatedArticles/RelatedArticlesCanvas"
-import { RelatedArticlesPanel } from "../RelatedArticles/RelatedArticlesPanel"
 import { FullscreenViewer } from "../Sections/FullscreenViewer/FullscreenViewer"
 import { withFullScreen } from "../Sections/FullscreenViewer/withFullScreen"
-import { Sections } from "../Sections/Sections"
 import { ArticleData } from "../Typings"
-import { Sidebar } from "./Components/Sidebar"
 import { FeatureLayout } from "./FeatureLayout"
-import { StandardLayout, StandardLayoutParent } from "./StandardLayout"
+import { StandardLayout } from "./StandardLayout"
 
 export interface ArticleProps {
   article: ArticleData
+  seriesArticle?: ArticleData
   closeViewer?: () => void
   display?: {
     name: string
@@ -45,8 +32,7 @@ export interface ArticleProps {
 
 interface ArticleState {
   fullscreenImages: any
-  article: any
-  isTruncated: boolean
+  article: ArticleData
 }
 
 interface ArticleContainerProps {
@@ -80,18 +66,14 @@ export class ArticleLayout extends React.Component<ArticleProps, ArticleState> {
     this.state = {
       fullscreenImages,
       article,
-      isTruncated: props.isTruncated || false,
     }
-  }
-
-  removeTruncation = () => {
-    this.setState({ isTruncated: false })
   }
 
   indexAndExtractImages = () => {
     const article = cloneDeep(this.props.article)
     const fullscreenImages = []
     let sectionIndex = 0
+
     const newSections = map(article.sections, section => {
       if (includes(["image_collection", "image_set"], section.type)) {
         const newImages = map(section.images, image => {
@@ -109,187 +91,24 @@ export class ArticleLayout extends React.Component<ArticleProps, ArticleState> {
     return { fullscreenImages, article }
   }
 
-  renderFeatureArticle() {
-    const {
-      headerHeight,
-      isMobile,
-      isSuper,
-      relatedArticlesForCanvas,
-    } = this.props
-    const { article } = this.state
-
-    return (
-      <div>
-        <Header article={article} height={headerHeight} isMobile={isMobile} />
-
-        <FeatureLayout className="article-content">
-          <Sections article={article} isMobile={isMobile} />
-        </FeatureLayout>
-
-        {relatedArticlesForCanvas &&
-          !isSuper && (
-            <RelatedArticlesCanvas
-              articles={relatedArticlesForCanvas}
-              vertical={article.vertical}
-            />
-          )}
-      </div>
-    )
-  }
-
-  renderStandardArticle() {
-    const {
-      display,
-      relatedArticlesForCanvas,
-      relatedArticlesForPanel,
-    } = this.props
-
-    const { article } = this.state
-
-    const hasPanel = get(display, "panel", false)
-    const campaign = omit(display, "panel", "canvas")
-    const displayOverflows = display && display.canvas.layout === "slideshow"
-
-    return (
-      <Responsive initialState={{ isMobile: this.props.isMobile }}>
-        {({ isMobile, xs, sm, md }) => {
-          const isMobileAd = Boolean(isMobile || xs || sm || md)
-
-          const DisplayPanelAd = () => {
-            return (
-              hasPanel && (
-                <DisplayPanel
-                  isMobile={isMobileAd}
-                  unit={this.props.display.panel}
-                  campaign={campaign}
-                  article={article}
-                />
-              )
-            )
-          }
-
-          return (
-            <div>
-              <ReadMoreWrapper
-                isTruncated={this.state.isTruncated}
-                hideButton={this.removeTruncation}
-              >
-                {/*
-                  Header
-                */}
-                <Header article={article} isMobile={isMobile} />
-
-                <StandardLayoutParent>
-                  <StandardLayout>
-                    {/*
-                      Body Content
-                    */}
-                    <Sections
-                      DisplayPanel={DisplayPanelAd}
-                      article={article}
-                      isMobile={isMobile}
-                    />
-
-                    {/*
-                      Sidebar
-                    */}
-                    <Sidebar>
-                      {this.props.emailSignupUrl && (
-                        <SidebarItem>
-                          <EmailPanel signupUrl={this.props.emailSignupUrl} />
-                        </SidebarItem>
-                      )}
-
-                      {/*
-                        Related Articles
-                      */}
-                      {relatedArticlesForPanel && (
-                        <SidebarItem>
-                          <RelatedArticlesPanel
-                            label={"Related Stories"}
-                            articles={relatedArticlesForPanel}
-                          />
-                        </SidebarItem>
-                      )}
-
-                      {/*
-                        Display Ad
-                      */}
-                      {!isMobileAd && this.props.display && <DisplayPanelAd />}
-                    </Sidebar>
-                  </StandardLayout>
-                </StandardLayoutParent>
-
-                {/*
-                  Canvas: Related Articles
-                */}
-                {relatedArticlesForCanvas && (
-                  <div>
-                    <LineBreak />
-                    <RelatedArticlesCanvas
-                      articles={relatedArticlesForCanvas}
-                      isMobile={isMobile}
-                      vertical={article.vertical}
-                    />
-                  </div>
-                )}
-              </ReadMoreWrapper>
-
-              {/*
-                Read More Button
-              */}
-              {this.state.isTruncated && (
-                <ReadMore onClick={this.removeTruncation} />
-              )}
-
-              {/*
-                Footer
-              */}
-              {this.props.display && (
-                <div>
-                  <LineBreak />
-
-                  {displayOverflows ? (
-                    <div>
-                      <DisplayCanvas
-                        unit={this.props.display.canvas}
-                        campaign={campaign}
-                        article={article}
-                      />
-                    </div>
-                  ) : (
-                    <FooterContainer>
-                      <DisplayCanvas
-                        unit={this.props.display.canvas}
-                        campaign={campaign}
-                        article={article}
-                      />
-                    </FooterContainer>
-                  )}
-                </div>
-              )}
-            </div>
-          )
-        }}
-      </Responsive>
-    )
-  }
-
   render() {
-    const { article } = this.state
-    const { marginTop } = this.props
+    const { article, fullscreenImages } = this.state
+    const { closeViewer, marginTop, slideIndex, viewerIsOpen } = this.props
+
+    const articleProps = extend(cloneDeep(this.props), { article, slideIndex })
 
     return (
       <ArticleContainer marginTop={marginTop}>
-        {article.layout === "feature"
-          ? this.renderFeatureArticle()
-          : this.renderStandardArticle()}
-
+        {article.layout === "feature" ? (
+          <FeatureLayout {...articleProps} />
+        ) : (
+          <StandardLayout {...articleProps} />
+        )}
         <FullscreenViewer
-          onClose={this.props.closeViewer}
-          show={this.props.viewerIsOpen}
-          slideIndex={this.props.slideIndex}
-          images={this.state.fullscreenImages}
+          onClose={closeViewer}
+          show={viewerIsOpen}
+          slideIndex={slideIndex}
+          images={fullscreenImages}
         />
       </ArticleContainer>
     )
@@ -303,20 +122,4 @@ const ArticleDiv: StyledFunction<
 
 const ArticleContainer = ArticleDiv`
   margin-top: ${props => props.marginTop || "50px"};
-`
-
-const LineBreak = styled.div`
-  border-top: 1px solid ${Colors.grayRegular};
-  width: 100%;
-`
-
-const SidebarItem = styled.div`
-  margin-bottom: 40px;
-`
-
-const FooterContainer = styled.div`
-  margin: 0 40px;
-  ${pMedia.sm`
-    margin: 0 20px;
-  `};
 `

--- a/src/Components/Publishing/Layouts/Components/Sidebar.tsx
+++ b/src/Components/Publishing/Layouts/Components/Sidebar.tsx
@@ -31,8 +31,6 @@ export const Sidebar: React.SFC<ArticleProps> = props => {
       )}
 
       {DisplayPanel && <DisplayPanel />}
-
-      {props.children}
     </SidebarContainer>
   )
 }

--- a/src/Components/Publishing/Layouts/Components/Sidebar.tsx
+++ b/src/Components/Publishing/Layouts/Components/Sidebar.tsx
@@ -1,9 +1,40 @@
 import React from "react"
 import styled from "styled-components"
 import { pMedia } from "../../../Helpers"
+import { EmailPanel } from "../../Email/EmailPanel"
+import { RelatedArticlesPanel } from "../../RelatedArticles/RelatedArticlesPanel"
 
-export const Sidebar: React.SFC<React.HTMLProps<HTMLDivElement>> = props => {
-  return <SidebarContainer>{props.children}</SidebarContainer>
+export interface ArticleProps {
+  emailSignupUrl?: string
+  DisplayPanel?: any
+  relatedArticlesForPanel?: any
+}
+
+export const Sidebar: React.SFC<ArticleProps> = props => {
+  const { emailSignupUrl, DisplayPanel, relatedArticlesForPanel } = props
+
+  return (
+    <SidebarContainer>
+      {emailSignupUrl && (
+        <SidebarItem>
+          <EmailPanel signupUrl={emailSignupUrl} />
+        </SidebarItem>
+      )}
+
+      {relatedArticlesForPanel && (
+        <SidebarItem>
+          <RelatedArticlesPanel
+            label={"Related Stories"}
+            articles={relatedArticlesForPanel}
+          />
+        </SidebarItem>
+      )}
+
+      {DisplayPanel && <DisplayPanel />}
+
+      {props.children}
+    </SidebarContainer>
+  )
 }
 
 const SidebarContainer = styled.div`
@@ -13,8 +44,11 @@ const SidebarContainer = styled.div`
   min-width: 280px;
   ${pMedia.xl`
     margin-left: 40px;
-  `}
-  ${pMedia.lg`
+  `} ${pMedia.lg`
     display: none;
-  `}
+  `};
+`
+
+const SidebarItem = styled.div`
+  margin-bottom: 40px;
 `

--- a/src/Components/Publishing/Layouts/FeatureLayout.tsx
+++ b/src/Components/Publishing/Layouts/FeatureLayout.tsx
@@ -1,6 +1,50 @@
+import React from "react"
 import styled from "styled-components"
+import { Header } from "../Header/Header"
+import { RelatedArticlesCanvas } from "../RelatedArticles/RelatedArticlesCanvas"
+import { Sections } from "../Sections/Sections"
+import { ArticleData } from "../Typings"
 
-export const FeatureLayout = styled.div`
+export interface ArticleProps {
+  article: ArticleData
+  headerHeight?: string
+  isMobile?: boolean
+  isSuper?: boolean
+  marginTop?: string
+  relatedArticlesForCanvas?: any
+}
+
+export class FeatureLayout extends React.Component<ArticleProps> {
+  render() {
+    const {
+      article,
+      headerHeight,
+      isMobile,
+      isSuper,
+      relatedArticlesForCanvas,
+    } = this.props
+
+    return (
+      <div>
+        <Header article={article} height={headerHeight} isMobile={isMobile} />
+
+        <FeatureLayoutContent className="article-content">
+          <Sections article={article} isMobile={isMobile} />
+        </FeatureLayoutContent>
+
+        {relatedArticlesForCanvas &&
+          !isSuper && (
+            <RelatedArticlesCanvas
+              articles={relatedArticlesForCanvas}
+              vertical={article.vertical}
+            />
+          )}
+      </div>
+    )
+  }
+}
+
+const FeatureLayoutContent = styled.div`
   display: flex;
   width: 100%;
 `

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -6,12 +6,10 @@ import { Responsive } from "../../../Utils/Responsive"
 import { pMedia } from "../../Helpers"
 import { DisplayCanvas } from "../Display/Canvas"
 import { DisplayPanel } from "../Display/DisplayPanel"
-import { EmailPanel } from "../Email/EmailPanel"
 import { Header } from "../Header/Header"
 import { ReadMore } from "../ReadMore/ReadMoreButton"
 import { ReadMoreWrapper } from "../ReadMore/ReadMoreWrapper"
 import { RelatedArticlesCanvas } from "../RelatedArticles/RelatedArticlesCanvas"
-import { RelatedArticlesPanel } from "../RelatedArticles/RelatedArticlesPanel"
 import { Sections } from "../Sections/Sections"
 import { ArticleData } from "../Typings"
 import { Sidebar } from "./Components/Sidebar"
@@ -63,24 +61,6 @@ export class StandardLayout extends React.Component<
     this.setState({ isTruncated: false })
   }
 
-  displayPanelAd = isMobileAd => {
-    const { article, display } = this.props
-
-    const hasPanel = get(display, "panel", false)
-    const campaign = omit(display, "panel", "canvas")
-
-    if (hasPanel) {
-      return (
-        <DisplayPanel
-          isMobile={isMobileAd}
-          unit={display.panel}
-          campaign={campaign}
-          article={article}
-        />
-      )
-    }
-  }
-
   render() {
     const {
       article,
@@ -97,8 +77,21 @@ export class StandardLayout extends React.Component<
     return (
       <Responsive initialState={{ isMobile: this.props.isMobile }}>
         {({ isMobile, xs, sm, md }) => {
+          const hasPanel = get(display, "panel", false)
           const isMobileAd = Boolean(isMobile || xs || sm || md)
 
+          const DisplayPanelAd = () => {
+            return (
+              hasPanel && (
+                <DisplayPanel
+                  isMobile={isMobileAd}
+                  unit={display.panel}
+                  campaign={campaign}
+                  article={article}
+                />
+              )
+            )
+          }
           return (
             <div>
               <ReadMoreWrapper
@@ -110,34 +103,15 @@ export class StandardLayout extends React.Component<
                 <StandardLayoutParent>
                   <StandardLayoutContainer>
                     <Sections
-                      DisplayPanel={this.displayPanelAd(isMobileAd)}
+                      DisplayPanel={DisplayPanelAd}
                       article={article}
                       isMobile={isMobile}
                     />
-
-                    <Sidebar>
-                      {emailSignupUrl && (
-                        <SidebarItem>
-                          <EmailPanel signupUrl={emailSignupUrl} />
-                        </SidebarItem>
-                      )}
-
-                      {relatedArticlesForPanel && (
-                        <SidebarItem>
-                          <RelatedArticlesPanel
-                            label={"Related Stories"}
-                            articles={relatedArticlesForPanel}
-                          />
-                        </SidebarItem>
-                      )}
-
-                      {/*
-                        Display Ad
-                      */}
-                      {!isMobileAd &&
-                        display &&
-                        this.displayPanelAd(isMobileAd)}
-                    </Sidebar>
+                    <Sidebar
+                      emailSignupUrl={emailSignupUrl}
+                      DisplayPanel={DisplayPanelAd}
+                      relatedArticlesForPanel={relatedArticlesForPanel}
+                    />
                   </StandardLayoutContainer>
                 </StandardLayoutParent>
 
@@ -212,10 +186,6 @@ const StandardLayoutContainer = styled.div`
 const LineBreak = styled.div`
   border-top: 1px solid ${Colors.grayRegular};
   width: 100%;
-`
-
-const SidebarItem = styled.div`
-  margin-bottom: 40px;
 `
 
 const FooterContainer = styled.div`

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -1,16 +1,226 @@
+import { get, omit } from "lodash"
+import React from "react"
 import styled from "styled-components"
+import Colors from "../../../Assets/Colors"
+import { Responsive } from "../../../Utils/Responsive"
 import { pMedia } from "../../Helpers"
+import { DisplayCanvas } from "../Display/Canvas"
+import { DisplayPanel } from "../Display/DisplayPanel"
+import { EmailPanel } from "../Email/EmailPanel"
+import { Header } from "../Header/Header"
+import { ReadMore } from "../ReadMore/ReadMoreButton"
+import { ReadMoreWrapper } from "../ReadMore/ReadMoreWrapper"
+import { RelatedArticlesCanvas } from "../RelatedArticles/RelatedArticlesCanvas"
+import { RelatedArticlesPanel } from "../RelatedArticles/RelatedArticlesPanel"
+import { Sections } from "../Sections/Sections"
+import { ArticleData } from "../Typings"
+import { Sidebar } from "./Components/Sidebar"
+
+export interface ArticleProps {
+  article: ArticleData
+  seriesArticle?: ArticleData
+  closeViewer?: () => void
+  display?: {
+    name: string
+    panel: object
+    canvas: any
+  }
+  emailSignupUrl?: string
+  headerHeight?: string
+  isMobile?: boolean
+  isSuper?: boolean
+  isTruncated?: boolean
+  marginTop?: string
+  relatedArticlesForCanvas?: any
+  relatedArticlesForPanel?: any
+  slideIndex?: number
+  viewerIsOpen?: boolean
+}
+
+interface ArticleState {
+  isTruncated: boolean
+}
+
+export class StandardLayout extends React.Component<
+  ArticleProps,
+  ArticleState
+> {
+  static defaultProps = {
+    isMobile: false,
+    isSuper: false,
+    article: {},
+    isTruncated: false,
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      isTruncated: props.isTruncated || false,
+    }
+  }
+
+  removeTruncation = () => {
+    this.setState({ isTruncated: false })
+  }
+
+  displayPanelAd = isMobileAd => {
+    const { article, display } = this.props
+
+    const hasPanel = get(display, "panel", false)
+    const campaign = omit(display, "panel", "canvas")
+
+    if (hasPanel) {
+      return (
+        <DisplayPanel
+          isMobile={isMobileAd}
+          unit={display.panel}
+          campaign={campaign}
+          article={article}
+        />
+      )
+    }
+  }
+
+  render() {
+    const {
+      article,
+      display,
+      emailSignupUrl,
+      relatedArticlesForCanvas,
+      relatedArticlesForPanel,
+    } = this.props
+    const { isTruncated } = this.state
+
+    const campaign = omit(display, "panel", "canvas")
+    const displayOverflows = display && display.canvas.layout === "slideshow"
+
+    return (
+      <Responsive initialState={{ isMobile: this.props.isMobile }}>
+        {({ isMobile, xs, sm, md }) => {
+          const isMobileAd = Boolean(isMobile || xs || sm || md)
+
+          return (
+            <div>
+              <ReadMoreWrapper
+                isTruncated={isTruncated}
+                hideButton={this.removeTruncation}
+              >
+                <Header article={article} isMobile={isMobile} />
+
+                <StandardLayoutParent>
+                  <StandardLayoutContainer>
+                    <Sections
+                      DisplayPanel={this.displayPanelAd(isMobileAd)}
+                      article={article}
+                      isMobile={isMobile}
+                    />
+
+                    <Sidebar>
+                      {emailSignupUrl && (
+                        <SidebarItem>
+                          <EmailPanel signupUrl={emailSignupUrl} />
+                        </SidebarItem>
+                      )}
+
+                      {relatedArticlesForPanel && (
+                        <SidebarItem>
+                          <RelatedArticlesPanel
+                            label={"Related Stories"}
+                            articles={relatedArticlesForPanel}
+                          />
+                        </SidebarItem>
+                      )}
+
+                      {/*
+                        Display Ad
+                      */}
+                      {!isMobileAd &&
+                        display &&
+                        this.displayPanelAd(isMobileAd)}
+                    </Sidebar>
+                  </StandardLayoutContainer>
+                </StandardLayoutParent>
+
+                {/*
+                  Canvas: Related Articles
+                */}
+                {relatedArticlesForCanvas && (
+                  <div>
+                    <LineBreak />
+                    <RelatedArticlesCanvas
+                      articles={relatedArticlesForCanvas}
+                      isMobile={isMobile}
+                      vertical={article.vertical}
+                    />
+                  </div>
+                )}
+              </ReadMoreWrapper>
+
+              {/*
+                Read More Button
+              */}
+              {isTruncated && <ReadMore onClick={this.removeTruncation} />}
+
+              {/*
+                Footer
+              */}
+              {display && (
+                <div>
+                  <LineBreak />
+
+                  {displayOverflows ? (
+                    <div>
+                      <DisplayCanvas
+                        unit={display.canvas}
+                        campaign={campaign}
+                        article={article}
+                      />
+                    </div>
+                  ) : (
+                    <FooterContainer>
+                      <DisplayCanvas
+                        unit={display.canvas}
+                        campaign={campaign}
+                        article={article}
+                      />
+                    </FooterContainer>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        }}
+      </Responsive>
+    )
+  }
+}
 
 export const StandardLayoutParent = styled.div`
   margin: 0 40px 100px 40px;
   ${pMedia.sm`
     margin: 0 0 100px 0;
-  `}
+  `};
 `
 
-export const StandardLayout = styled.div`
+const StandardLayoutContainer = styled.div`
   max-width: 1250px;
   display: flex;
   margin: auto;
   justify-content: space-between;
+`
+
+const LineBreak = styled.div`
+  border-top: 1px solid ${Colors.grayRegular};
+  width: 100%;
+`
+
+const SidebarItem = styled.div`
+  margin-bottom: 40px;
+`
+
+const FooterContainer = styled.div`
+  margin: 0 40px;
+  ${pMedia.sm`
+    margin: 0 20px;
+  `};
 `

--- a/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
@@ -1,0 +1,33 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import { FeatureArticle } from "../../Fixtures/Articles"
+import { RelatedCanvas } from "../../Fixtures/Components"
+import { RelatedArticlesCanvas } from "../../RelatedArticles/RelatedArticlesCanvas"
+import { FeatureLayout } from "../FeatureLayout"
+
+jest.mock("react-sizeme", () => jest.fn(c => d => d))
+jest.mock("../../Sections/FullscreenViewer/withFullScreen", () => ({
+  withFullScreen: x => x,
+}))
+
+it("renders RelatedArticlesCanvas", () => {
+  const article = mount(
+    <FeatureLayout
+      article={FeatureArticle}
+      relatedArticlesForCanvas={RelatedCanvas}
+    />
+  )
+  expect(article.find(RelatedArticlesCanvas).length).toBe(1)
+})
+
+it("Does not render RelatedArticlesCanvas if isSuper", () => {
+  const article = mount(
+    <FeatureLayout
+      article={FeatureArticle}
+      relatedArticlesForCanvas={RelatedCanvas}
+      isSuper
+    />
+  )
+  expect(article.find(RelatedArticlesCanvas).length).toBe(0)
+})

--- a/src/Components/Publishing/Layouts/__tests__/Sidebar.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/Sidebar.test.tsx
@@ -1,0 +1,29 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import { RelatedPanel } from "../../Fixtures/Components"
+import { RelatedArticlesPanel } from "../../RelatedArticles/RelatedArticlesPanel"
+import { EmailPanel } from "../../Email/EmailPanel"
+import { Sidebar } from "../Components/Sidebar"
+
+jest.mock("../../Sections/FullscreenViewer/withFullScreen", () => ({
+  withFullScreen: x => x,
+}))
+
+const DisplayPanel = () => {
+  return <div>Display Panel</div>
+}
+it("renders display panel", () => {
+  const sidebar = mount(<Sidebar DisplayPanel={DisplayPanel} />)
+  expect(sidebar.find(DisplayPanel).length).toBe(1)
+})
+
+it("renders related articles", () => {
+  const sidebar = mount(<Sidebar relatedArticlesForPanel={RelatedPanel} />)
+  expect(sidebar.find(RelatedArticlesPanel).length).toBe(1)
+})
+
+it("renders email signup", () => {
+  const sidebar = mount(<Sidebar emailSignupUrl="artsy.net" />)
+  expect(sidebar.find(EmailPanel).length).toBe(1)
+})

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -1,0 +1,25 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import { StandardArticle } from "../../Fixtures/Articles"
+import { Display, RelatedCanvas, RelatedPanel } from "../../Fixtures/Components"
+import { RelatedArticlesCanvas } from "../../RelatedArticles/RelatedArticlesCanvas"
+import { RelatedArticlesPanel } from "../../RelatedArticles/RelatedArticlesPanel"
+import { StandardLayout } from "../StandardLayout"
+
+jest.mock("../../Sections/FullscreenViewer/withFullScreen", () => ({
+  withFullScreen: x => x,
+}))
+
+it("renders related articles in standard layout", () => {
+  const article = mount(
+    <StandardLayout
+      article={StandardArticle}
+      display={Display("standard")}
+      relatedArticlesForCanvas={RelatedCanvas}
+      relatedArticlesForPanel={RelatedPanel}
+    />
+  )
+  expect(article.find(RelatedArticlesPanel).length).toBe(1)
+  expect(article.find(RelatedArticlesCanvas).length).toBe(1)
+})

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -3,15 +3,31 @@ import "jest-styled-components"
 import React from "react"
 import { StandardArticle } from "../../Fixtures/Articles"
 import { Display, RelatedCanvas, RelatedPanel } from "../../Fixtures/Components"
+import { DisplayCanvas } from "../../Display/Canvas"
+import { DisplayPanel } from "../../Display/DisplayPanel"
+import { ReadMore } from "../../ReadMore/ReadMoreButton"
 import { RelatedArticlesCanvas } from "../../RelatedArticles/RelatedArticlesCanvas"
 import { RelatedArticlesPanel } from "../../RelatedArticles/RelatedArticlesPanel"
 import { StandardLayout } from "../StandardLayout"
+import { Sidebar } from "../Components/Sidebar"
 
 jest.mock("../../Sections/FullscreenViewer/withFullScreen", () => ({
   withFullScreen: x => x,
 }))
 
-it("renders related articles in standard layout", () => {
+it("renders sidebar", () => {
+  const article = mount(
+    <StandardLayout
+      article={StandardArticle}
+      display={Display("standard")}
+      relatedArticlesForCanvas={RelatedCanvas}
+      relatedArticlesForPanel={RelatedPanel}
+    />
+  )
+  expect(article.find(Sidebar).length).toBe(1)
+})
+
+it("renders related articles", () => {
   const article = mount(
     <StandardLayout
       article={StandardArticle}
@@ -22,4 +38,48 @@ it("renders related articles in standard layout", () => {
   )
   expect(article.find(RelatedArticlesPanel).length).toBe(1)
   expect(article.find(RelatedArticlesCanvas).length).toBe(1)
+})
+
+it("renders display", () => {
+  const article = mount(
+    <StandardLayout
+      article={StandardArticle}
+      display={Display("standard")}
+      relatedArticlesForCanvas={RelatedCanvas}
+      relatedArticlesForPanel={RelatedPanel}
+    />
+  )
+  expect(article.find(DisplayPanel).length).toBe(1)
+  expect(article.find(DisplayCanvas).length).toBe(1)
+})
+
+it("shows read more if truncated", () => {
+  const article = mount(
+    <StandardLayout
+      article={StandardArticle}
+      display={Display("standard")}
+      relatedArticlesForCanvas={RelatedCanvas}
+      relatedArticlesForPanel={RelatedPanel}
+      isTruncated
+    />
+  )
+  expect(article.find(ReadMore).length).toBe(1)
+})
+
+it("Can remove truncation on click", () => {
+  const article = mount(
+    <StandardLayout
+      article={StandardArticle}
+      display={Display("standard")}
+      relatedArticlesForCanvas={RelatedCanvas}
+      relatedArticlesForPanel={RelatedPanel}
+      isTruncated
+    />
+  )
+  article
+    .find(ReadMore)
+    .at(0)
+    .props()
+    .onClick()
+  expect(article.state().isTruncated).toBeFalsy()
 })

--- a/src/Components/Publishing/__stories__/Article.story.tsx
+++ b/src/Components/Publishing/__stories__/Article.story.tsx
@@ -141,17 +141,6 @@ story
       />
     )
   })
-  .add("Feature in series", () => {
-    return <Article article={FeatureArticle} seriesArticle={SeriesArticle} />
-  })
-  .add("Feature in sponsored series", () => {
-    return (
-      <Article
-        article={FeatureArticle}
-        seriesArticle={SeriesArticleSponsored}
-      />
-    )
-  })
   .add("Basic Feature", () => {
     const article = clone({
       ...BasicArticle,

--- a/src/Components/Publishing/__stories__/Article.story.tsx
+++ b/src/Components/Publishing/__stories__/Article.story.tsx
@@ -141,6 +141,17 @@ story
       />
     )
   })
+  .add("Feature in series", () => {
+    return <Article article={FeatureArticle} seriesArticle={SeriesArticle} />
+  })
+  .add("Feature in sponsored series", () => {
+    return (
+      <Article
+        article={FeatureArticle}
+        seriesArticle={SeriesArticleSponsored}
+      />
+    )
+  })
   .add("Basic Feature", () => {
     const article = clone({
       ...BasicArticle,

--- a/src/Components/Publishing/__tests__/Article.test.tsx
+++ b/src/Components/Publishing/__tests__/Article.test.tsx
@@ -22,12 +22,12 @@ jest.mock("react-slick", () => {
 jest.mock("react-sizeme", () => jest.fn(c => d => d))
 jest.mock("react-tracking", () => jest.fn(c => d => d))
 
-it("renders standard articles in default layout", () => {
+it("renders standard articles in fullscreen layout", () => {
   const article = mount(<Article article={StandardArticle} />)
   expect(article.find(ArticleLayout).length).toBe(1)
 })
 
-it("renders feature articles in default layout", () => {
+it("renders feature articles in fullscreen layout", () => {
   const article = mount(<Article article={FeatureArticle} />)
   expect(article.find(ArticleLayout).length).toBe(1)
 })

--- a/src/Components/Publishing/__tests__/Article.test.tsx
+++ b/src/Components/Publishing/__tests__/Article.test.tsx
@@ -22,12 +22,12 @@ jest.mock("react-slick", () => {
 jest.mock("react-sizeme", () => jest.fn(c => d => d))
 jest.mock("react-tracking", () => jest.fn(c => d => d))
 
-it("renders standard articles in fullscreen layout", () => {
+it("renders standard articles in default layout", () => {
   const article = mount(<Article article={StandardArticle} />)
   expect(article.find(ArticleLayout).length).toBe(1)
 })
 
-it("renders feature articles in fullscreen layout", () => {
+it("renders feature articles in default layout", () => {
   const article = mount(<Article article={FeatureArticle} />)
   expect(article.find(ArticleLayout).length).toBe(1)
 })
@@ -37,7 +37,7 @@ it("renders series articles in series layout", () => {
   expect(article.find(SeriesLayout).length).toBe(1)
 })
 
-it("renders series articles in series layout", () => {
+it("renders video articles in video layout", () => {
   const article = mount(<Article article={VideoArticle} />)
   expect(article.find(VideoLayout).length).toBe(1)
 })


### PR DESCRIPTION
While looking into adding series/sponsor components to Features, I realized that a lot of non-overlapping logic was housed in the `ArticleLayout` component, making it pretty difficult to follow. This PR separates some of these concerns into separate components, so that we can more easily add to feature and standard articles independently.  No significant changes were made in logic, mostly just moving things around.

- Moves the body of features into the already existing `FeatureLayout`
- Moves the body of standard articles into the already existing `StandardLayout`
- Moves sidebar content into the `Sidebar` component
- Adds more unit tests for each layout and sidebar

The `ArticleLayout` file might better be described as `ArticleWithFullscreenViewer` -- however renaming it meant the changes were not side-by-side, making it harder to review.  We might consider renaming this later.