### PR TITLE
@kanaabe => Slideshow bug

### DIFF
--- a/src/Components/Publishing/Sections/ArtworkCaption.tsx
+++ b/src/Components/Publishing/Sections/ArtworkCaption.tsx
@@ -24,10 +24,11 @@ interface StyledArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {
 export class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
   joinParts(children, delimiter = ", ") {
     const compacted = _.compact(children)
+    const delimSpan = <span>{delimiter}</span>
 
     if (compacted.length) {
       const reduced = compacted.reduce((prev, curr) => {
-        return [prev, delimiter, curr]
+        return [prev, delimSpan, curr]
       })
       return reduced
     } else {
@@ -39,9 +40,10 @@ export class ArtworkCaption extends React.Component<ArtworkCaptionProps, null> {
     if (names.length === 0) {
       return []
     }
+    const delimSpan = <span>{delimiter}</span>
 
     return names.slice(1).reduce((prev, curr, i) => {
-      return prev.concat([delimiter, curr])
+      return prev.concat([delimSpan, curr])
     },
     [names[0]])
   }

--- a/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Caption.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Caption.test.tsx.snap
@@ -209,7 +209,9 @@ exports[`renders an artwork caption properly 1`] = `
                 Nude on the Beach
               </a>
             </span>
-            , 
+            <span>
+              , 
+            </span>
             <span
               className="date"
             >
@@ -225,7 +227,9 @@ exports[`renders an artwork caption properly 1`] = `
             >
               Gary Nader
             </a>
-            . 
+            <span>
+              . 
+            </span>
             <span
               className="credit"
             >

--- a/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/FullscreenViewer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/FullscreenViewer.test.tsx.snap
@@ -338,7 +338,9 @@ exports[`renders properly 1`] = `
                         Nude on the Beach
                       </a>
                     </span>
-                    , 
+                    <span>
+                      , 
+                    </span>
                     <span
                       className="date"
                     >
@@ -354,7 +356,9 @@ exports[`renders properly 1`] = `
                     >
                       Gary Nader
                     </a>
-                    . 
+                    <span>
+                      . 
+                    </span>
                     <span
                       className="credit"
                     >

--- a/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Slide.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Slide.test.tsx.snap
@@ -273,7 +273,9 @@ exports[`renders properly 1`] = `
                     Nude on the Beach
                   </a>
                 </span>
-                , 
+                <span>
+                  , 
+                </span>
                 <span
                   className="date"
                 >
@@ -289,7 +291,9 @@ exports[`renders properly 1`] = `
                 >
                   Gary Nader
                 </a>
-                . 
+                <span>
+                  . 
+                </span>
                 <span
                   className="credit"
                 >

--- a/src/Components/Publishing/Sections/__tests__/ArtworkCaption.test.js
+++ b/src/Components/Publishing/Sections/__tests__/ArtworkCaption.test.js
@@ -54,7 +54,9 @@ describe("ArtworkCaption", () => {
     it("joins two items", () => {
       const component = getWrapper()
       const joined = component.instance().joinParts(["Title", "Date"])
-      expect(joined.join("")).toEqual("Title, Date")
+
+      expect(joined[0]).toEqual("Title")
+      expect(joined[2]).toEqual("Date")
     })
 
     it("joins three items into a nested array", () => {
@@ -88,8 +90,8 @@ describe("ArtworkCaption", () => {
           artists: [{ name: "Andy Warhol" }, { name: "Botero" }],
         }),
       })
-      expect(component.html()).toMatch(
-        '<span class="name">Andy Warhol</span>, <span class="name">Botero</span></span>'
+      expect(component.text()).toMatch(
+        'Andy Warhol, Botero'
       )
     })
 
@@ -97,15 +99,15 @@ describe("ArtworkCaption", () => {
       const component = getWrapper({
         artwork: ArtworkRegular,
       })
-      expect(component.html()).toMatch(
-        '<span class="title">Nude on the Beach</span>, <span class="date">2000</span></span>'
+      expect(component.text()).toMatch(
+        'Nude on the Beach, 2000'
       )
     })
 
     it("renders partner + credit", () => {
       const component = getWrapper()
-      expect(component.html()).toMatch(
-        '<span>Gary Nader. <span class="credit">Courtesy of Gary Nader</span></span>'
+      expect(component.text()).toMatch(
+        'Gary Nader. Courtesy of Gary Nader'
       )
     })
   })

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Artwork.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Artwork.test.tsx.snap
@@ -214,7 +214,9 @@ exports[`renders properly 1`] = `
                   Nude on the Beach
                 </file__StyledTextLink>
               </span>
-              , 
+              <span>
+                , 
+              </span>
               <span
                 className="date"
               >
@@ -235,7 +237,9 @@ exports[`renders properly 1`] = `
               >
                 Gary Nader
               </file__StyledTextLink>
-              . 
+              <span>
+                . 
+              </span>
               <span
                 className="credit"
               >

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/ArtworkCaption.test.js.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/ArtworkCaption.test.js.snap
@@ -30,7 +30,7 @@ exports[`ArtworkCaption snapshot renders a classic caption properly 1`] = `
   <div
     dangerouslySetInnerHTML={
       Object {
-        "__html": "<span><span class=\\"file__ArtistNames-yu39to-0 cwiqgm\\"><span class=\\"name\\">Fernando Botero</span></span><span class=\\"title\\">Nude on the Beach</span>, <span class=\\"date\\">2000</span>. Gary Nader</span>",
+        "__html": "<span><span class=\\"file__ArtistNames-yu39to-0 cwiqgm\\"><span class=\\"name\\">Fernando Botero</span></span><span class=\\"title\\">Nude on the Beach</span><span>, </span><span class=\\"date\\">2000</span>. Gary Nader</span>",
       }
     }
   />
@@ -111,7 +111,9 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
       >
         Nude on the Beach
       </span>
-      , 
+      <span>
+        , 
+      </span>
       <span
         className="date"
       >
@@ -122,7 +124,9 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
       className="c1"
     >
       Gary Nader
-      . 
+      <span>
+        . 
+      </span>
       <span
         className="credit"
       >
@@ -190,14 +194,14 @@ exports[`ArtworkCaption snapshot renders a standard caption properly 1`] = `
     <div
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<span><span class=\\"title\\">Nude on the Beach</span>, <span class=\\"date\\">2000</span></span>",
+          "__html": "<span><span class=\\"title\\">Nude on the Beach</span><span>, </span><span class=\\"date\\">2000</span></span>",
         }
       }
     />
     <div
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<span>Gary Nader. <span class=\\"credit\\">Courtesy of Gary Nader</span></span>",
+          "__html": "<span>Gary Nader<span>. </span><span class=\\"credit\\">Courtesy of Gary Nader</span></span>",
         }
       }
     />

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/ImageCollection.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/ImageCollection.test.tsx.snap
@@ -252,7 +252,9 @@ exports[`renders a single image properly 1`] = `
                       Nude on the Beach
                     </file__StyledTextLink>
                   </span>
-                  , 
+                  <span>
+                    , 
+                  </span>
                   <span
                     className="date"
                   >
@@ -273,7 +275,9 @@ exports[`renders a single image properly 1`] = `
                   >
                     Gary Nader
                   </file__StyledTextLink>
-                  . 
+                  <span>
+                    . 
+                  </span>
                   <span
                     className="credit"
                   >
@@ -616,7 +620,9 @@ exports[`renders properly 1`] = `
                       Nude on the Beach
                     </file__StyledTextLink>
                   </span>
-                  , 
+                  <span>
+                    , 
+                  </span>
                   <span
                     className="date"
                   >
@@ -637,7 +643,9 @@ exports[`renders properly 1`] = `
                   >
                     Gary Nader
                   </file__StyledTextLink>
-                  . 
+                  <span>
+                    . 
+                  </span>
                   <span
                     className="credit"
                   >

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.js.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.js.snap
@@ -1189,7 +1189,9 @@ exports[`snapshots renders properly 1`] = `
                           Brass Tax
                         </file__StyledTextLink>
                       </span>
-                      , 
+                      <span>
+                        , 
+                      </span>
                       <span
                         className="date"
                       >
@@ -1210,7 +1212,9 @@ exports[`snapshots renders properly 1`] = `
                       >
                         Joanne Artman Gallery
                       </file__StyledTextLink>
-                      . 
+                      <span>
+                        . 
+                      </span>
                       <span
                         className="credit"
                       >


### PR DESCRIPTION
Wraps comma delimiter in JSX span when joining artist names. The `react-lines-ellipsis` library was breaking when plain strings were passed to it, all items sent to the library need a DOM wrapper.

Addresses [GROW-515](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-515)