### PR TITLE
@mzikherman => [ArtworkBrick] Add `useRelay` bool flag

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -61,11 +61,17 @@ export class Details extends React.Component<Props, null> {
 
   partnerLine() {
     if (this.props.artwork.collecting_institution) {
-      return <TruncatedLine>{this.props.artwork.collecting_institution}</TruncatedLine>
+      return (
+        <TruncatedLine>
+          {this.props.artwork.collecting_institution}
+        </TruncatedLine>
+      )
     } else if (this.props.artwork.partner) {
       return (
         <TruncatedLine>
-          <TextLink href={this.props.artwork.partner.href}>{this.props.artwork.partner.name}</TextLink>
+          <TextLink href={this.props.artwork.partner.href}>
+            {this.props.artwork.partner.name}
+          </TextLink>
         </TruncatedLine>
       )
     }
@@ -73,7 +79,8 @@ export class Details extends React.Component<Props, null> {
 
   saleLine() {
     const artwork = this.props.artwork
-    const hasSaleMessage = artwork.sale_message && artwork.sale_message !== "Contact For Price"
+    const hasSaleMessage =
+      artwork.sale_message && artwork.sale_message !== "Contact For Price"
     const notInAuction = !(artwork.sale && artwork.sale.is_auction)
     if (hasSaleMessage && notInAuction) {
       return <div>{artwork.sale_message}</div>

--- a/src/Components/Artwork/Fillwidth.tsx
+++ b/src/Components/Artwork/Fillwidth.tsx
@@ -5,7 +5,7 @@ import sizeMe from "react-sizeme"
 import styled from "styled-components"
 
 import fillwidthDimensions from "../../Utils/fillwidth"
-import FillwidthItem from "./FillwidthItem"
+import RelayFillwidthItem, { FillwidthItem } from "./FillwidthItem"
 
 import { find } from "lodash"
 
@@ -17,26 +17,32 @@ interface RelayProps {
   }
 }
 
-interface Props extends RelayProps, React.HTMLAttributes<Fillwidth> {
+interface Props extends RelayProps, React.HTMLAttributes<FillwidthContainer> {
   targetHeight?: number
   gutter?: number
   size?: any
+  useRelay?: boolean
 }
 
-export class Fillwidth extends React.Component<Props, null> {
-  public static defaultProps: Partial<Props>
+class FillwidthContainer extends React.Component<Props, null> {
+  public static defaultProps: Partial<Props> = {
+    useRelay: true,
+  }
 
   renderArtwork(artwork, dimensions, i) {
-    const { gutter } = this.props
+    const { gutter, useRelay } = this.props
     const artworkSize = find(dimensions, ["__id", artwork.__id])
+    const FillWidthItemBlock = useRelay ? RelayFillwidthItem : FillwidthItem
+
     return (
-      <FillwidthItem
+      <FillWidthItemBlock
         artwork={artwork as any}
         key={"artwork--" + artwork.__id}
         targetHeight={artworkSize.height}
         imageHeight={artworkSize.height}
         width={artworkSize.width}
         margin={i === dimensions.length - 1 ? 0 : gutter}
+        useRelay={useRelay}
       />
     )
   }
@@ -51,13 +57,15 @@ export class Fillwidth extends React.Component<Props, null> {
     )
     return (
       <div className={this.props.className}>
-        {artworks.map((artwork, i) => this.renderArtwork(artwork.node, dimensions, i))}
+        {artworks.map((artwork, i) =>
+          this.renderArtwork(artwork.node, dimensions, i)
+        )}
       </div>
     )
   }
 }
 
-const StyledFillwidth = styled(Fillwidth)`
+const StyledFillwidth = styled(FillwidthContainer)`
   margin-bottom: 50px;
 `
 
@@ -72,10 +80,12 @@ const sizeMeOptions = {
   refreshMode: "debounce",
 }
 
-const FillwidthDimensions = sizeMe(sizeMeOptions)(StyledFillwidth) as React.StatelessComponent<Props>
+export const Fillwidth = sizeMe(sizeMeOptions)(
+  StyledFillwidth
+) as React.StatelessComponent<Props>
 
 export default createFragmentContainer(
-  FillwidthDimensions,
+  Fillwidth,
   graphql`
     fragment Fillwidth_artworks on ArtworkConnection {
       edges {

--- a/src/Components/Artwork/FillwidthItem.tsx
+++ b/src/Components/Artwork/FillwidthItem.tsx
@@ -2,8 +2,8 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 
-import Metadata from "./Metadata"
-import Save from "./Save"
+import RelayMetadata, { Metadata } from "./Metadata"
+import RelaySaveButton, { SaveButton } from "./Save"
 
 const Image = styled.img`
   width: 100%;
@@ -21,35 +21,51 @@ const Placeholder = styled.div`
   width: 100%;
 `
 
-interface Props extends RelayProps, React.HTMLProps<FillwidthItem> {
+interface Props extends RelayProps, React.HTMLProps<FillwidthItemContainer> {
   targetHeight?: number
   imageHeight?: number
   width?: number
   margin?: number
+  useRelay?: boolean
 }
 
-export class FillwidthItem extends React.Component<Props, null> {
+class FillwidthItemContainer extends React.Component<Props, null> {
+  static defaultProps = {
+    useRelay: true,
+  }
+
   render() {
-    const { artwork, className, targetHeight, imageHeight } = this.props
+    const {
+      artwork,
+      className,
+      targetHeight,
+      imageHeight,
+      useRelay,
+    } = this.props
+
+    const SaveButtonBlock = useRelay ? RelaySaveButton : SaveButton
+    const MetadataBlock = useRelay ? RelayMetadata : Metadata
+
     return (
       <div className={className}>
         <Placeholder style={{ height: targetHeight }}>
           <ImageLink href={artwork.href}>
             <Image src={artwork.image.url} height={imageHeight} />
           </ImageLink>
-          <Save
+          <SaveButtonBlock
             className="artwork-save"
             artwork={artwork as any}
             style={{ position: "absolute", right: "5px", bottom: "5px" }}
+            useRelay={useRelay}
           />
         </Placeholder>
-        <Metadata artwork={artwork} extended />
+        <MetadataBlock artwork={artwork} useRelay={useRelay} extended />
       </div>
     )
   }
 }
 
-const StyledFillwidthItem = styled(FillwidthItem)`
+export const FillwidthItem = styled(FillwidthItemContainer)`
   display: inline-block;
   width: ${props => props.width}px;
   vertical-align: top;
@@ -63,7 +79,7 @@ const StyledFillwidthItem = styled(FillwidthItem)`
 `
 
 export default createFragmentContainer(
-  StyledFillwidthItem,
+  FillwidthItem,
   graphql`
     fragment FillwidthItem_artwork on Artwork {
       image {

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -3,8 +3,8 @@ import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 
 import colors from "../../Assets/Colors"
-import Metadata from "./Metadata"
-import Save from "./Save"
+import RelayMetadata, { Metadata } from "./Metadata"
+import RelaySaveButton, { SaveButton } from "./Save"
 
 const Image = styled.img`
   width: 100%;
@@ -16,35 +16,44 @@ const Image = styled.img`
 const Placeholder = styled.div`
   background-color: ${colors.grayMedium};
   position: relative;
-  width 100%;
+  width: 100%;
 `
 
-interface Props extends RelayProps, React.HTMLProps<ArtworkGridItem> {
+interface Props extends RelayProps, React.HTMLProps<ArtworkGridItemContainer> {
+  useRelay?: boolean
   style?: any
 }
 
-export class ArtworkGridItem extends React.Component<Props, null> {
+class ArtworkGridItemContainer extends React.Component<Props, null> {
+  static defaultProps = {
+    useRelay: true,
+  }
+
   render() {
-    const { style, className, artwork } = this.props
+    const { style, className, artwork, useRelay } = this.props
+    const SaveButtonBlock = useRelay ? RelaySaveButton : SaveButton
+    const MetadataBlock = useRelay ? RelayMetadata : Metadata
+
     return (
       <div className={className} style={style}>
         <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
           <a href={artwork.href}>
             <Image src={artwork.image.url} />
           </a>
-          <Save
+          <SaveButtonBlock
             className="artwork-save"
             artwork={artwork as any}
             style={{ position: "absolute", right: "10px", bottom: "10px" }}
+            useRelay={useRelay}
           />
         </Placeholder>
-        <Metadata artwork={artwork} />
+        <MetadataBlock artwork={artwork} useRelay={useRelay} />
       </div>
     )
   }
 }
 
-const StyledArtworkGridItem = styled(ArtworkGridItem)`
+export const ArtworkGridItem = styled(ArtworkGridItemContainer)`
   .artwork-save {
     opacity: 0;
   }
@@ -54,7 +63,7 @@ const StyledArtworkGridItem = styled(ArtworkGridItem)`
 `
 
 export default createFragmentContainer(
-  StyledArtworkGridItem,
+  ArtworkGridItem,
   graphql`
     fragment GridItem_artwork on Artwork {
       image {

--- a/src/Components/Artwork/Metadata.tsx
+++ b/src/Components/Artwork/Metadata.tsx
@@ -4,30 +4,36 @@ import styled from "styled-components"
 import colors from "../../Assets/Colors"
 import * as fonts from "../../Assets/Fonts"
 
-import Contact from "./Contact"
-import Details from "./Details"
+import RelayContact, { Contact } from "./Contact"
+import RelayDetails, { Details } from "./Details"
 
-export interface ArtworkMetadataProps extends React.HTMLProps<ArtworkMetadata> {
+export interface MetadataProps extends React.HTMLProps<MetadataContainer> {
   artwork: any
   extended?: boolean
+  useRelay?: boolean
 }
 
-export class ArtworkMetadata extends React.Component<ArtworkMetadataProps, null> {
+export class MetadataContainer extends React.Component<MetadataProps> {
   static defaultProps = {
     extended: true,
+    useRelay: true,
   }
 
   render() {
+    const { artwork, className, extended, useRelay } = this.props
+    const DetailsBlock = useRelay ? RelayDetails : Details
+    const ContactBlock = useRelay ? RelayContact : Contact
+
     return (
-      <div className={this.props.className}>
-        <Details showSaleLine={this.props.extended} artwork={this.props.artwork} />
-        {this.props.extended && <Contact artwork={this.props.artwork} />}
+      <div className={className}>
+        <DetailsBlock showSaleLine={extended} artwork={artwork} />
+        {extended && <ContactBlock artwork={artwork} />}
       </div>
     )
   }
 }
 
-export const StyledMetadata = styled(ArtworkMetadata)`
+export const Metadata = styled(MetadataContainer)`
   ${fonts.secondary.style};
   color: ${colors.graySemibold};
   margin-top: 12px;
@@ -37,7 +43,7 @@ export const StyledMetadata = styled(ArtworkMetadata)`
 `
 
 export default createFragmentContainer(
-  StyledMetadata,
+  Metadata,
   graphql`
     fragment Metadata_artwork on Artwork {
       ...Details_artwork

--- a/src/Components/Artwork/Save.tsx
+++ b/src/Components/Artwork/Save.tsx
@@ -1,5 +1,10 @@
 import React from "react"
-import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
+import {
+  commitMutation,
+  createFragmentContainer,
+  graphql,
+  RelayProp,
+} from "react-relay"
 
 import Icon from "../Icon"
 
@@ -10,15 +15,23 @@ import * as Artsy from "../../Components/Artsy"
 
 const SIZE = 40
 
-export interface Props extends RelayProps, React.HTMLProps<SaveButton>, Artsy.ContextProps {
+export interface Props
+  extends RelayProps,
+    React.HTMLProps<SaveButtonContainer>,
+    Artsy.ContextProps {
   style?: any
   relay?: RelayProp
+  useRelay?: boolean
 }
 
-export class SaveButton extends React.Component<Props, null> {
+export class SaveButtonContainer extends React.Component<Props, null> {
+  static defaultProps = {
+    useRelay: true,
+  }
+
   handleSave() {
-    const { currentUser, artwork, relay } = this.props
-    if (currentUser && currentUser.id) {
+    const { currentUser, artwork, relay, useRelay } = this.props
+    if (useRelay && currentUser && currentUser.id) {
       commitMutation(relay.environment, {
         mutation: graphql`
           mutation SaveArtworkMutation($input: SaveArtworkInput!) {
@@ -45,6 +58,9 @@ export class SaveButton extends React.Component<Props, null> {
           },
         },
       })
+
+      // FIXME: Add non-relay based favorite mechanism
+      // } else {
     } else {
       window.location.href = "/login"
     }
@@ -59,13 +75,18 @@ export class SaveButton extends React.Component<Props, null> {
         onClick={() => this.handleSave()}
         data-saved={artwork.is_saved}
       >
-        <Icon name="heart" height={SIZE} color="white" style={{ verticalAlign: "middle" }} />
+        <Icon
+          name="heart"
+          height={SIZE}
+          color="white"
+          style={{ verticalAlign: "middle" }}
+        />
       </div>
     )
   }
 }
 
-export const StyledSaveButton = styled(SaveButton)`
+export const SaveButton = styled(SaveButtonContainer)`
   width: ${SIZE}px;
   height: ${SIZE}px;
   text-align: center;
@@ -88,7 +109,7 @@ export const StyledSaveButton = styled(SaveButton)`
 `
 
 export default createFragmentContainer(
-  Artsy.ContextConsumer(StyledSaveButton),
+  Artsy.ContextConsumer(SaveButton),
   graphql`
     fragment Save_artwork on Artwork {
       __id

--- a/src/Components/Artwork/index.tsx
+++ b/src/Components/Artwork/index.tsx
@@ -3,7 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import styled, { css } from "styled-components"
 
 import theme from "../../Assets/Theme"
-import Metadata from "./Metadata"
+import RelayMetadata, { Metadata } from "./Metadata"
 
 const Container = styled.div`
   width: 100%;
@@ -59,11 +59,13 @@ const Image = styled.img`
 
 export interface OverlayProps {
   selected: boolean
+  useRelay?: boolean
 }
 
 export interface ArtworkProps extends RelayProps {
   extended?: boolean
   Overlay?: React.SFC<OverlayProps>
+  useRelay?: boolean
   onSelect?: (selected: boolean) => void
   showOverlayOnHover?: boolean
 }
@@ -76,6 +78,7 @@ export class Artwork extends React.Component<ArtworkProps, ArtworkState> {
   static defaultProps = {
     extended: true,
     overlay: null,
+    useRelay: true,
     showOverlayOnHover: false,
   }
 
@@ -98,19 +101,29 @@ export class Artwork extends React.Component<ArtworkProps, ArtworkState> {
   }
 
   render() {
-    const { artwork, Overlay, showOverlayOnHover } = this.props
+    const { artwork, Overlay, useRelay, showOverlayOnHover } = this.props
     let overlayClasses = "overlay-container"
 
     overlayClasses += showOverlayOnHover ? " hovered" : ""
     overlayClasses += this.state.isSelected ? " selected" : ""
 
+    const MetadataBlock = useRelay ? RelayMetadata : Metadata
+
     return (
       <Container onClick={this.onSelected}>
         <ImageContainer>
           <Image src={artwork.image.url} />
-          <div className={overlayClasses}>{Overlay && <Overlay selected={this.state.isSelected} />}</div>
+          <div className={overlayClasses}>
+            {Overlay && (
+              <Overlay selected={this.state.isSelected} useRelay={useRelay} />
+            )}
+          </div>
         </ImageContainer>
-        <Metadata extended={this.props.extended} artwork={artwork} />
+        <MetadataBlock
+          extended={this.props.extended}
+          artwork={artwork}
+          useRelay={useRelay}
+        />
       </Container>
     )
   }

--- a/src/Components/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid.tsx
@@ -3,13 +3,14 @@ import ReactDOM from "react-dom"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 
-import GridItem from "./Artwork/GridItem"
+import RelayGridItem, { ArtworkGridItem } from "./Artwork/GridItem"
 
-interface Props extends RelayProps, React.HTMLProps<ArtworkGrid> {
+interface Props extends RelayProps, React.HTMLProps<ArtworkGridContainer> {
   columnCount?: number
   sectionMargin?: number
   itemMargin?: number
   onLoadMore?: () => any
+  useRelay?: boolean
 }
 
 interface State {
@@ -17,8 +18,13 @@ interface State {
   interval: any
 }
 
-export class ArtworkGrid extends React.Component<Props, State> {
-  public static defaultProps: Partial<Props>
+class ArtworkGridContainer extends React.Component<Props, State> {
+  static defaultProps = {
+    columnCount: 3,
+    sectionMargin: 20,
+    itemMargin: 20,
+    useRelay: true,
+  }
 
   state = {
     interval: null,
@@ -101,17 +107,27 @@ export class ArtworkGrid extends React.Component<Props, State> {
       const artworkComponents = []
       for (let j = 0; j < sectionedArtworks[i].length; j++) {
         const artwork = sectionedArtworks[i][j]
-        artworkComponents.push(<GridItem artwork={artwork as any} key={"artwork-" + j + "-" + artwork.__id} />)
+        const GridItem = this.props.useRelay ? RelayGridItem : ArtworkGridItem
+        artworkComponents.push(
+          <GridItem
+            artwork={artwork as any}
+            key={"artwork-" + j + "-" + artwork.__id}
+            useRelay={this.props.useRelay}
+          />
+        )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
         if (j < sectionedArtworks[i].length - 1) {
-          artworkComponents.push(<div style={spacerStyle} key={"spacer-" + j + "-" + artwork.__id} />)
+          artworkComponents.push(
+            <div style={spacerStyle} key={"spacer-" + j + "-" + artwork.__id} />
+          )
         }
       }
 
       const sectionSpecificStyle = {
         flex: 1,
         minWidth: 0,
-        marginRight: i === this.props.columnCount - 1 ? 0 : this.props.sectionMargin,
+        marginRight:
+          i === this.props.columnCount - 1 ? 0 : this.props.sectionMargin,
       }
 
       sections.push(
@@ -129,20 +145,14 @@ export class ArtworkGrid extends React.Component<Props, State> {
   }
 }
 
-ArtworkGrid.defaultProps = {
-  columnCount: 3,
-  sectionMargin: 20,
-  itemMargin: 20,
-}
-
-const StyledGrid = styled(ArtworkGrid) `
+export const ArtworkGrid = styled(ArtworkGridContainer)`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
 `
 
 export default createFragmentContainer(
-  StyledGrid,
+  ArtworkGrid,
   graphql`
     fragment ArtworkGrid_artworks on ArtworkConnection {
       edges {

--- a/src/Components/Auctions/RailSlider/index.tsx
+++ b/src/Components/Auctions/RailSlider/index.tsx
@@ -36,7 +36,7 @@ const SliderContainer = ContextConsumer((props: Props) => {
 export const RailSlider: SFC = () => {
   return (
     <ContextProvider>
-      <SliderContainer saleID="phillips-evening-and-day-editions-3" />
+      <SliderContainer saleID="shared-live-mocktion" />
     </ContextProvider>
   )
 }

--- a/src/Components/__stories__/Artwork.story.tsx
+++ b/src/Components/__stories__/Artwork.story.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { graphql } from "react-relay"
 
 import { RootQueryRenderer } from "../../Relay/RootQueryRenderer"
-import Artwork from "../Artwork"
+import RelayArtwork, { Artwork } from "../Artwork"
 
 function ArtworkExample(props: { artworkID: string }) {
   return (
@@ -16,14 +16,52 @@ function ArtworkExample(props: { artworkID: string }) {
         }
       `}
       variables={{ artworkID: props.artworkID }}
-      render={readyState => readyState.props && <Artwork {...readyState.props as any} />}
+      render={readyState =>
+        readyState.props && <RelayArtwork {...readyState.props as any} />}
     />
   )
 }
 
 storiesOf("Components/Artwork/Singular", module)
-  .add("A square artwork", () => <ArtworkExample artworkID="christopher-burkett-coastal-storm-oregon" />)
-  .add("A landscape artwork", () => <ArtworkExample artworkID="andrew-moore-puente-de-bacunayagua-via-blanca" />)
-  .add("A landscape artwork (extra wide)", () => <ArtworkExample artworkID="brian-kosoff-bay-of-islands" />)
-  .add("A portrait artwork", () => <ArtworkExample artworkID="ester-curini-my-eyes-my-soul" />)
-  .add("A portrait artwork (extra tall)", () => <ArtworkExample artworkID="snik-untitled-vertical" />)
+  .add("A square artwork", () => (
+    <ArtworkExample artworkID="christopher-burkett-coastal-storm-oregon" />
+  ))
+  .add("A landscape artwork", () => (
+    <ArtworkExample artworkID="andrew-moore-puente-de-bacunayagua-via-blanca" />
+  ))
+  .add("A landscape artwork (extra wide)", () => (
+    <ArtworkExample artworkID="brian-kosoff-bay-of-islands" />
+  ))
+  .add("A portrait artwork", () => (
+    <ArtworkExample artworkID="helen-frankenthaler-madame-de-pompadour-2" />
+  ))
+  .add("A portrait artwork (extra tall)", () => (
+    <ArtworkExample artworkID="snik-untitled-vertical" />
+  ))
+  .add("Without Relay", () => {
+    const artwork = {
+      id: "mikael-olson-some-kind-of-dinosaur",
+      title: "Some Kind of Dinosaur",
+      date: "2015",
+      sale_message: "$875",
+      is_in_auction: false,
+      image: {
+        url:
+          "https://d32dm0rphc51dk.cloudfront.net/WhROiQBIHoXNIBr2zW3RUw/larger.jpg",
+        aspect_ratio: 0.74,
+        placeholder: "134.6445824706694%",
+      },
+      artists: [
+        {
+          __id: "mikael-olson",
+          name: "Mikael Olson",
+        },
+      ],
+      partner: {
+        name: "Gallery 1261",
+      },
+      href: "/artwork/mikael-olson-some-kind-of-dinosaur",
+    }
+
+    return <Artwork artwork={artwork as any} useRelay={false} />
+  })

--- a/src/Components/__stories__/ArtworkGrid.story.tsx
+++ b/src/Components/__stories__/ArtworkGrid.story.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { graphql } from "react-relay"
 
 import { RootQueryRenderer } from "../../Relay/RootQueryRenderer"
-import ArtworkGrid from "../ArtworkGrid"
+import RelayArtworkGrid, { ArtworkGrid } from "../ArtworkGrid"
 
 function GridExample(props: { artistID: string }) {
   return (
@@ -19,12 +19,169 @@ function GridExample(props: { artistID: string }) {
       `}
       variables={{ artistID: props.artistID }}
       render={readyState => {
-        return readyState.props && <ArtworkGrid {...readyState.props.artist as any} />
+        return (
+          readyState.props && (
+            <RelayArtworkGrid {...readyState.props.artist as any} />
+          )
+        )
       }}
     />
   )
 }
 
-storiesOf("Components/Artworks/ArtworkGrid", module).add("A typical grid", () => {
-  return <GridExample artistID="banksy" />
-})
+storiesOf("Components/Artworks/ArtworkGrid", module)
+  .add("A typical grid", () => {
+    return <GridExample artistID="banksy" />
+  })
+  .add("Without Relay", () => {
+    return <ArtworkGrid artworks={artworks as any} useRelay={false} />
+  })
+
+const artworks = {
+  edges: [
+    {
+      node: {
+        __id: "QXJ0d29yazpiYW5rc3ktd2UtbG92ZS15b3Utc28tbG92ZS11cw==",
+        image: {
+          aspect_ratio: 1,
+          placeholder: "100%",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/hoFocUdpgF4mazPIgekpZA/large.jpg",
+        },
+        href: "/artwork/banksy-we-love-you-so-love-us",
+        title: "We Love You So Love Us",
+        date: "2000",
+        sale_message: "Contact For Price",
+        cultural_maker: null,
+        artists: [
+          {
+            __id: "QXJ0aXN0OmJhbmtzeQ==",
+            href: "/artist/banksy",
+            name: "Banksy",
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: "EHC Fine Art",
+          href: "/ehc-fine-art",
+          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
+          type: "Gallery",
+        },
+        sale: null,
+        _id: "58e1a19d275b247d353ff0d9",
+        is_inquireable: true,
+        sale_artwork: null,
+        id: "banksy-we-love-you-so-love-us",
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: "QXJ0d29yazpiYW5rc3ktcmFkYXItcmF0LWRpcnR5LWZ1bmtlci1scA==",
+        image: {
+          aspect_ratio: 1,
+          placeholder: "100%",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/NQvnb87U8oGDm6kpdJ9jLA/large.jpg",
+        },
+        href: "/artwork/banksy-radar-rat-dirty-funker-lp",
+        title: "Radar Rat (Dirty Funker LP)",
+        date: "2008",
+        sale_message: "$950",
+        cultural_maker: null,
+        artists: [
+          {
+            __id: "QXJ0aXN0OmJhbmtzeQ==",
+            href: "/artist/banksy",
+            name: "Banksy",
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: "EHC Fine Art",
+          href: "/ehc-fine-art",
+          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
+          type: "Gallery",
+        },
+        sale: null,
+        _id: "58e1a19ecd530e4d612cb07f",
+        is_inquireable: true,
+        sale_artwork: null,
+        id: "banksy-radar-rat-dirty-funker-lp",
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: "QXJ0d29yazpiYW5rc3ktZmxvd2VyLWJvbWJlci1ieS1icmFuZGFsaXNt",
+        image: {
+          aspect_ratio: 1.5,
+          placeholder: "66.66666666666666%",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/88LaQZxzQdksn76f0LGFoQ/large.jpg",
+        },
+        href: "/artwork/banksy-flower-bomber-by-brandalism",
+        title: "Flower Bomber (by Brandalism)",
+        date: "ca. 2017",
+        sale_message: "Contact For Price",
+        cultural_maker: null,
+        artists: [
+          {
+            __id: "QXJ0aXN0OmJhbmtzeQ==",
+            href: "/artist/banksy",
+            name: "Banksy",
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: "EHC Fine Art",
+          href: "/ehc-fine-art",
+          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
+          type: "Gallery",
+        },
+        sale: null,
+        _id: "58e1a19f275b247d353ff0e2",
+        is_inquireable: true,
+        sale_artwork: null,
+        id: "banksy-flower-bomber-by-brandalism",
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: "QXJ0d29yazpiYW5rc3ktZ2lybC13aXRoLWJhbGxvb24tMTQ=",
+        image: {
+          aspect_ratio: 0.75,
+          placeholder: "132.9%",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/RRGE9Ild18_IPghZXT6wuQ/large.jpg",
+        },
+        href: "/artwork/banksy-girl-with-balloon-14",
+        title: "Girl With Balloon",
+        date: "2004",
+        sale_message: "Contact For Price",
+        cultural_maker: null,
+        artists: [
+          {
+            __id: "QXJ0aXN0OmJhbmtzeQ==",
+            href: "/artist/banksy",
+            name: "Banksy",
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: "Graffik Gallery / Banksy Editions",
+          href: "/graffik-gallery-slash-banksy-editions",
+          __id: "UGFydG5lcjpncmFmZmlrLWdhbGxlcnktc2xhc2gtYmFua3N5LWVkaXRpb25z",
+          type: "Gallery",
+        },
+        sale: null,
+        _id: "58e370659c18db774f25ed5b",
+        is_inquireable: true,
+        sale_artwork: null,
+        id: "banksy-girl-with-balloon-14",
+        is_saved: null,
+      },
+    },
+  ],
+}

--- a/src/Components/__stories__/ArtworkMetadata.story.tsx
+++ b/src/Components/__stories__/ArtworkMetadata.story.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { graphql } from "react-relay"
 
 import { RootQueryRenderer } from "../../Relay/RootQueryRenderer"
-import Metadata from "../Artwork/Metadata"
+import RelayMetadata, { Metadata } from "../Artwork/Metadata"
 
 function ArtworkExample(props: { artworkID: string }) {
   return (
@@ -16,11 +16,41 @@ function ArtworkExample(props: { artworkID: string }) {
         }
       `}
       variables={{ artworkID: props.artworkID }}
-      render={readyState => readyState.props && <Metadata {...readyState.props as any} />}
+      render={readyState =>
+        readyState.props && <RelayMetadata {...readyState.props as any} />}
     />
   )
 }
 
 storiesOf("Components/Artwork/Metadata", module)
-  .add("A not-for-sale artwork", () => <ArtworkExample artworkID="andy-warhol-skull" />)
-  .add("A for-sale artwork with exact price", () => <ArtworkExample artworkID="stephen-berkman-a-history-of-dread" />)
+  .add("A not-for-sale artwork", () => (
+    <ArtworkExample artworkID="andy-warhol-skull" />
+  ))
+  .add("A for-sale artwork with exact price", () => (
+    <ArtworkExample artworkID="stephen-berkman-a-history-of-dread" />
+  ))
+  .add("Without Relay", () => <Metadata artwork={artwork} useRelay={false} />)
+
+const artwork = {
+  id: "mikael-olson-some-kind-of-dinosaur",
+  title: "Some Kind of Dinosaur",
+  date: "2015",
+  sale_message: "$875",
+  is_in_auction: false,
+  image: {
+    url:
+      "https://d32dm0rphc51dk.cloudfront.net/WhROiQBIHoXNIBr2zW3RUw/larger.jpg",
+    aspect_ratio: 0.74,
+    placeholder: "134.6445824706694%",
+  },
+  artists: [
+    {
+      __id: "mikael-olson",
+      name: "Mikael Olson",
+    },
+  ],
+  partner: {
+    name: "Gallery 1261",
+  },
+  href: "/artwork/mikael-olson-some-kind-of-dinosaur",
+}

--- a/src/Components/__stories__/Fillwidth.story.tsx
+++ b/src/Components/__stories__/Fillwidth.story.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { graphql } from "react-relay"
 
 import { RootQueryRenderer } from "../../Relay/RootQueryRenderer"
-import Fillwidth from "../Artwork/Fillwidth"
+import RelayFillwidth, { Fillwidth } from "../Artwork/Fillwidth"
 
 function FillwidthExample(props: { artistID: string }) {
   return (
@@ -19,12 +19,169 @@ function FillwidthExample(props: { artistID: string }) {
       `}
       variables={{ artistID: props.artistID }}
       render={readyState => {
-        return readyState.props && <Fillwidth {...readyState.props.artist as any} />
+        return (
+          readyState.props && (
+            <RelayFillwidth {...readyState.props.artist as any} />
+          )
+        )
       }}
     />
   )
 }
 
-storiesOf("Components/Artworks/Fillwidth", module).add("A typical fillwidth", () => {
-  return <FillwidthExample artistID="stephen-willats" />
-})
+storiesOf("Components/Artworks/Fillwidth", module)
+  .add("A typical fillwidth", () => {
+    return <FillwidthExample artistID="stephen-willats" />
+  })
+  .add("Without Relay", () => {
+    return <Fillwidth artworks={artworks} useRelay={false} />
+  })
+
+const artworks = {
+  edges: [
+    {
+      node: {
+        __id: "QXJ0d29yazpiYW5rc3ktd2UtbG92ZS15b3Utc28tbG92ZS11cw==",
+        image: {
+          aspect_ratio: 1,
+          placeholder: "100%",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/hoFocUdpgF4mazPIgekpZA/large.jpg",
+        },
+        href: "/artwork/banksy-we-love-you-so-love-us",
+        title: "We Love You So Love Us",
+        date: "2000",
+        sale_message: "Contact For Price",
+        cultural_maker: null,
+        artists: [
+          {
+            __id: "QXJ0aXN0OmJhbmtzeQ==",
+            href: "/artist/banksy",
+            name: "Banksy",
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: "EHC Fine Art",
+          href: "/ehc-fine-art",
+          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
+          type: "Gallery",
+        },
+        sale: null,
+        _id: "58e1a19d275b247d353ff0d9",
+        is_inquireable: true,
+        sale_artwork: null,
+        id: "banksy-we-love-you-so-love-us",
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: "QXJ0d29yazpiYW5rc3ktcmFkYXItcmF0LWRpcnR5LWZ1bmtlci1scA==",
+        image: {
+          aspect_ratio: 1,
+          placeholder: "100%",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/NQvnb87U8oGDm6kpdJ9jLA/large.jpg",
+        },
+        href: "/artwork/banksy-radar-rat-dirty-funker-lp",
+        title: "Radar Rat (Dirty Funker LP)",
+        date: "2008",
+        sale_message: "$950",
+        cultural_maker: null,
+        artists: [
+          {
+            __id: "QXJ0aXN0OmJhbmtzeQ==",
+            href: "/artist/banksy",
+            name: "Banksy",
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: "EHC Fine Art",
+          href: "/ehc-fine-art",
+          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
+          type: "Gallery",
+        },
+        sale: null,
+        _id: "58e1a19ecd530e4d612cb07f",
+        is_inquireable: true,
+        sale_artwork: null,
+        id: "banksy-radar-rat-dirty-funker-lp",
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: "QXJ0d29yazpiYW5rc3ktZmxvd2VyLWJvbWJlci1ieS1icmFuZGFsaXNt",
+        image: {
+          aspect_ratio: 1.5,
+          placeholder: "66.66666666666666%",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/88LaQZxzQdksn76f0LGFoQ/large.jpg",
+        },
+        href: "/artwork/banksy-flower-bomber-by-brandalism",
+        title: "Flower Bomber (by Brandalism)",
+        date: "ca. 2017",
+        sale_message: "Contact For Price",
+        cultural_maker: null,
+        artists: [
+          {
+            __id: "QXJ0aXN0OmJhbmtzeQ==",
+            href: "/artist/banksy",
+            name: "Banksy",
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: "EHC Fine Art",
+          href: "/ehc-fine-art",
+          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
+          type: "Gallery",
+        },
+        sale: null,
+        _id: "58e1a19f275b247d353ff0e2",
+        is_inquireable: true,
+        sale_artwork: null,
+        id: "banksy-flower-bomber-by-brandalism",
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: "QXJ0d29yazpiYW5rc3ktZ2lybC13aXRoLWJhbGxvb24tMTQ=",
+        image: {
+          aspect_ratio: 0.75,
+          placeholder: "132.9%",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/RRGE9Ild18_IPghZXT6wuQ/large.jpg",
+        },
+        href: "/artwork/banksy-girl-with-balloon-14",
+        title: "Girl With Balloon",
+        date: "2004",
+        sale_message: "Contact For Price",
+        cultural_maker: null,
+        artists: [
+          {
+            __id: "QXJ0aXN0OmJhbmtzeQ==",
+            href: "/artist/banksy",
+            name: "Banksy",
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: "Graffik Gallery / Banksy Editions",
+          href: "/graffik-gallery-slash-banksy-editions",
+          __id: "UGFydG5lcjpncmFmZmlrLWdhbGxlcnktc2xhc2gtYmFua3N5LWVkaXRpb25z",
+          type: "Gallery",
+        },
+        sale: null,
+        _id: "58e370659c18db774f25ed5b",
+        is_inquireable: true,
+        sale_artwork: null,
+        id: "banksy-girl-with-balloon-14",
+        is_saved: null,
+      },
+    },
+  ],
+}


### PR DESCRIPTION
To make our ArtworkBrick compatible with old force code I wen't through and added a new flag (`useRelay`) to the relevant pieces that determines if relay should be used. By default this is true.

Patterns introduced (using `GridItem` as an example): 

1. Relay-related fragments are imported from a default exports and named `RelayGridItem`
1. Inner components (before being passed to Relay HOC) have `GridItemContainer`
1. Often inner components are wrapped by Styled Components before being passed to Relay wrapper. These components are named exports and named as they'd typically be imported, eg, `GridItem`
1. If `useRelay` is true, the inner container component uses the `RelayGridItem` component
1. If `useRelay` is false, it uses the named export -- `GridItem`

#### Example

```javascript
// GridItem.js

class GridItemContainer extends Component {
  ... 
}

export class GridItem = styled(GridItemContainer)` ... ` 

export default createRelayFragment(GridItem, ...)

// Usecase.js 

import RelayGridItem, { GridItem } from './GridItem'

<QueryRenderer
  render={props => <RelayGridItem {...props} />}
/>

// Plain JS object
<GridItem artwork={artwork} />
```