### PR TITLE
@kanaabe => Add ErrorBoundary component

### DIFF
--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+
+interface Props {
+  children?: any
+}
+
+export class ErrorBoundary extends React.Component<Props, null> {
+  componentDidCatch(error, errorInfo) {
+    console.error(error)
+  }
+
+  render() {
+    return this.props.children
+  }
+}

--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -4,7 +4,7 @@ interface Props {
   children?: any
 }
 
-export class ErrorBoundary extends React.Component<Props, null> {
+export class ErrorBoundary extends React.Component<Props> {
   componentDidCatch(error, errorInfo) {
     console.error(error)
   }

--- a/src/Components/Publishing/Sections/Truncator.tsx
+++ b/src/Components/Publishing/Sections/Truncator.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import ReactDOM from "react-dom/server"
+import { ErrorBoundary } from "../../ErrorBoundary"
 
 interface Props {
   maxLineCount?: number
@@ -24,11 +25,13 @@ export const Truncator: React.SFC<Props> = ({ children, maxLineCount }) => {
   }
 
   return (
-    <HTMLEllipsis
-      unsafeHTML={html}
-      trimRight={false}
-      maxLine={maxLineCount || 2}
-      ellipsis="..."
-    />
+    <ErrorBoundary>
+      <HTMLEllipsis
+        unsafeHTML={html}
+        trimRight={false}
+        maxLine={maxLineCount || 2}
+        ellipsis="..."
+      />
+    </ErrorBoundary>
   )
 }


### PR DESCRIPTION
The caption component seems to bug out differently based on the caption it gets -- I'm going to make a separate ticket for looking at this more closely. 

For expediencies sake on the Emerging Artists feature/slideshow bug, this PR adds an ErrorBoundary component, and wraps the Truncator component in it to prevent irregular captions from breaking their parent components. 

This is the same bug that is causing articles not to render [referenced in this ticket](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-529)