### PR TITLE
@eessex => Adds back read more tracking

### DIFF
--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -6,6 +6,7 @@ import { Fonts } from "../Fonts"
 import { NewsHeadline } from "../News/NewsHeadline"
 import { NewsSections } from "../News/NewsSections"
 import { ArticleData } from "../Typings"
+import { track } from "../../../Utils/track"
 
 interface Props {
   article: ArticleData
@@ -27,6 +28,7 @@ interface NewsContainerProps {
   isHovered: boolean
 }
 
+@track()
 export class NewsLayout extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
@@ -45,6 +47,7 @@ export class NewsLayout extends Component<Props, State> {
     }
   }
 
+  @track({ action: "Clicked read more" })
   onExpand() {
     const { onExpand } = this.props
     if (onExpand) {

--- a/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.js
+++ b/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.js
@@ -69,4 +69,15 @@ describe("News Layout", () => {
 
     expect(component).toMatchSnapshot()
   })
+
+  describe("Analytics", () => {
+    it("tracks the expand button", () => {
+      const component = mount(<NewsLayout article={NewsArticle} isTruncated />)
+      expect(track.mock.calls[5][0]).toEqual(
+        expect.objectContaining({
+          action: "Clicked read more",
+        })
+      )
+    })
+  })
 })


### PR DESCRIPTION
Oops! I removed this before thinking we don't need it since we don't want to make a track call, but instead we should keep this and omit it here so we still get a pageview: https://github.com/artsy/force/blob/e69298df7f9f9a321ee75142e7fc7bce3d62b733/src/desktop/assets/analytics.coffee#L17