### PR TITLE
@eessex => Track "Expand" button once

### DIFF
--- a/src/Components/Publishing/Byline/__tests__/__snapshots__/NewsByline.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__tests__/__snapshots__/NewsByline.test.tsx.snap
@@ -158,7 +158,7 @@ exports[`News Byline renders on mobile 1`] = `
   >
     <a
       className="c6"
-      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined"
+      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
       onClick={[Function]}
       target="_blank"
     >
@@ -184,7 +184,7 @@ exports[`News Byline renders on mobile 1`] = `
     </a>
     <a
       className="c6"
-      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&via=artsy"
+      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
       onClick={[Function]}
       target="_blank"
     >
@@ -210,7 +210,7 @@ exports[`News Byline renders on mobile 1`] = `
     </a>
     <a
       className="c6"
-      href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/undefined"
+      href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
       onClick={[Function]}
     >
       <svg
@@ -483,7 +483,7 @@ exports[`News Byline renders properly 1`] = `
   >
     <a
       className="c6"
-      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined"
+      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
       onClick={[Function]}
       target="_blank"
     >
@@ -509,7 +509,7 @@ exports[`News Byline renders properly 1`] = `
     </a>
     <a
       className="c6"
-      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&via=artsy"
+      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
       onClick={[Function]}
       target="_blank"
     >
@@ -535,7 +535,7 @@ exports[`News Byline renders properly 1`] = `
     </a>
     <a
       className="c6"
-      href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/undefined"
+      href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
       onClick={[Function]}
     >
       <svg
@@ -799,7 +799,7 @@ exports[`News Byline renders without a news source 1`] = `
   >
     <a
       className="c6"
-      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined"
+      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
       onClick={[Function]}
       target="_blank"
     >
@@ -825,7 +825,7 @@ exports[`News Byline renders without a news source 1`] = `
     </a>
     <a
       className="c6"
-      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&via=artsy"
+      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
       onClick={[Function]}
       target="_blank"
     >
@@ -851,7 +851,7 @@ exports[`News Byline renders without a news source 1`] = `
     </a>
     <a
       className="c6"
-      href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/undefined"
+      href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
       onClick={[Function]}
     >
       <svg

--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -821,6 +821,7 @@ export const NewsArticle: ArticleData = {
   id: "594a7e2254c37f00177c0ea9",
   _id: "594a7e2254c37f00177c0ea9",
   layout: "news",
+  slug: "news-article",
   author_id: "57b5fc6acd530e65f8000406",
   author: {
     id: "50f4367051e7956b6e00045d",

--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -6,15 +6,17 @@ import { pMedia } from "../../Helpers"
 import { NewsHeadline } from "../News/NewsHeadline"
 import { NewsSections } from "../News/NewsSections"
 import { ArticleData } from "../Typings"
+import { once } from "lodash"
 import { track } from "../../../Utils/track"
 
 interface Props {
   article: ArticleData
   isMobile?: boolean
+  isHovered?: boolean
   isTruncated?: boolean
   marginTop?: string
   onExpand?: any
-  isHovered?: boolean
+  tracking?: any
 }
 
 interface State {
@@ -39,6 +41,7 @@ export class NewsLayout extends Component<Props, State> {
     }
 
     this.onExpand = this.onExpand.bind(this)
+    this.trackExpand = once(this.trackExpand)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -47,13 +50,23 @@ export class NewsLayout extends Component<Props, State> {
     }
   }
 
-  @track({ action: "Clicked read more" })
   onExpand() {
     const { onExpand } = this.props
+    this.trackExpand()
     if (onExpand) {
       onExpand()
     }
     this.setState({ isTruncated: false })
+  }
+
+  trackExpand = () => {
+    const { article, tracking } = this.props
+    if (tracking) {
+      tracking.trackEvent({
+        action: "Clicked read more",
+        pathname: `/news/${article.slug}`,
+      })
+    }
   }
 
   render() {

--- a/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.js
+++ b/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.js
@@ -5,7 +5,6 @@ import renderer from "react-test-renderer"
 import { NewsArticle } from "../../Fixtures/Articles"
 import { NewsSectionContainer } from "../../News/NewsSections"
 import { ExpandButton, NewsLayout } from "../NewsLayout"
-import { track } from "../../../../Utils/track"
 
 jest.mock("../../../../Utils/track.ts", () => ({
   track: jest.fn(),
@@ -72,12 +71,21 @@ describe("News Layout", () => {
 
   describe("Analytics", () => {
     it("tracks the expand button", () => {
-      const component = mount(<NewsLayout article={NewsArticle} isTruncated />)
-      expect(track.mock.calls[5][0]).toEqual(
-        expect.objectContaining({
-          action: "Clicked read more",
-        })
+      const trackEvent = jest.fn()
+      const component = mount(
+        <NewsLayout
+          article={NewsArticle}
+          isTruncated
+          tracking={{
+            trackEvent,
+          }}
+        />
       )
+      component.find(ExpandButton).simulate("click")
+      expect(trackEvent.mock.calls[0][0]).toEqual({
+        action: "Clicked read more",
+        pathname: "/news/news-article",
+      })
     })
   })
 })

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.js.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.js.snap
@@ -815,7 +815,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
         >
           <a
             className="c20"
-            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined"
+            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
             onClick={[Function]}
             target="_blank"
           >
@@ -841,7 +841,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
           </a>
           <a
             className="c20"
-            href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&via=artsy"
+            href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
             onClick={[Function]}
             target="_blank"
           >
@@ -867,7 +867,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
           </a>
           <a
             className="c20"
-            href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/undefined"
+            href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
             onClick={[Function]}
           >
             <svg
@@ -1724,7 +1724,7 @@ exports[`News Layout renders the news layout properly 1`] = `
         >
           <a
             className="c20"
-            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined"
+            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
             onClick={[Function]}
             target="_blank"
           >
@@ -1750,7 +1750,7 @@ exports[`News Layout renders the news layout properly 1`] = `
           </a>
           <a
             className="c20"
-            href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fundefined&via=artsy"
+            href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
             onClick={[Function]}
             target="_blank"
           >
@@ -1776,7 +1776,7 @@ exports[`News Layout renders the news layout properly 1`] = `
           </a>
           <a
             className="c20"
-            href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/undefined"
+            href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
             onClick={[Function]}
           >
             <svg


### PR DESCRIPTION
This limits the tracking call to only ever fire once. It was firing twice because there is an onClick handler for both the container and the expand button. We also now pass in the pathname to account for a race condition where the url wasn't changing in time for tracking to pick up the right path.

Addresses: https://artsyproduct.atlassian.net/browse/GROW-552
