### PR TITLE
adding more options to Tooltip component

### DIFF
--- a/src/Components/Tooltip.tsx
+++ b/src/Components/Tooltip.tsx
@@ -5,7 +5,7 @@ import colors from "../Assets/Colors"
 interface Props extends React.HTMLProps<HTMLDivElement> {
   message: string
   hoverAlign?: string
-  hoverWidth?: Number
+  hoverWidth?: number
 }
 
 const Div: StyledFunction<Props & React.HTMLProps<HTMLDivElement>> = styled.div

--- a/src/Components/Tooltip.tsx
+++ b/src/Components/Tooltip.tsx
@@ -4,6 +4,8 @@ import colors from "../Assets/Colors"
 
 interface Props extends React.HTMLProps<HTMLDivElement> {
   message: string
+  hoverAlign?: string
+  hoverWidth?: Number
 }
 
 const Div: StyledFunction<Props & React.HTMLProps<HTMLDivElement>> = styled.div
@@ -48,13 +50,14 @@ const TooltipContainer = Div`
   &:after {
     display: block;
     top: 0;
-    left: 0;
+    left: ${props => (props.hoverAlign === "right" ? `0` : "auto")}
+    right: ${props => (props.hoverAlign === "left" ? `-7px` : "auto")}
     position: absolute;
     visibility: hidden;
     text-align: left;
     z-index: 1;
     margin: -10px 0 0 -10px;
-    width: 300px;
+    width: ${props => props.hoverWidth + `px`};
     color: ${colors.graySemibold};
     background-color: white;
     padding: 15px 15px 25px 15px;
@@ -72,6 +75,8 @@ export class Tooltip extends React.Component<Props, null> {
     return (
       <TooltipContainer
         message={this.props.message}
+        hoverAlign={this.props.hoverAlign || "right"}
+        hoverWidth={this.props.hoverWidth || 300}
         className={this.props.className}
       >
         {this.props.children}

--- a/src/Components/__stories__/Tooltip.story.tsx
+++ b/src/Components/__stories__/Tooltip.story.tsx
@@ -1,0 +1,31 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+
+import { Tooltip } from "../Tooltip"
+import { Help } from "../../Assets/Icons/Help"
+
+function RenderTooltip(
+  message: string,
+  hoverAlign: string,
+  hoverWidth?: number
+) {
+  return (
+    <div style={{ padding: "20px 0px 0px 300px" }}>
+      <Tooltip
+        message={message}
+        hoverAlign={hoverAlign}
+        hoverWidth={hoverWidth}
+      >
+        <Help />
+      </Tooltip>
+    </div>
+  )
+}
+
+storiesOf("Components/Tooltips", module)
+  .add("Right aligned", () =>
+    RenderTooltip("this is a right aligned tooltip", "right")
+  )
+  .add("Left aligned", () =>
+    RenderTooltip("this is a left aligned tooltip", "left", 200)
+  )

--- a/src/Components/__tests__/__snapshots__/MarketInsights.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/MarketInsights.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`MarketInsights renders correctly 1`] = `
   display: block;
   top: 0;
   left: 0;
+  right: auto;
   position: absolute;
   visibility: hidden;
   text-align: left;
@@ -116,6 +117,7 @@ exports[`MarketInsights renders correctly 1`] = `
   display: block;
   top: 0;
   left: 0;
+  right: auto;
   position: absolute;
   visibility: hidden;
   text-align: left;


### PR DESCRIPTION
I'm planning to reuse this component for the other `?` roll overs in force as requested here: https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=39&projectKey=EV&modal=detail&selectedIssue=EV-96 and made possible by @damassi here: https://github.com/artsy/stitch/pull/8

I need to be able to specify if the roll over should be shown left or right of the question mark. So adding those as props here. The current version will work because those props are optional and defaulted to current values.

Considering that is my first PR - all critique is welcome:)