### PR TITLE
@l2succes => Artist tooltip can show genes

### DIFF
--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -738,6 +738,38 @@ export const Artists: ArtistProps[] = [
         },
       ],
     },
+    genes: [
+      {
+        name: "United States",
+      },
+      {
+        name: "Abstract Art",
+      },
+      {
+        name: "21st Century",
+      },
+      {
+        name: "1970–present",
+      },
+      {
+        name: "Use of Common Materials",
+      },
+      {
+        name: "Drawing",
+      },
+      {
+        name: "Painting",
+      },
+      {
+        name: "Immersive",
+      },
+      {
+        name: "Ceramic",
+      },
+      {
+        name: "Mixed-Media",
+      },
+    ],
   },
   {
     name: "Jutta Koether",
@@ -805,6 +837,7 @@ export const Artists: ArtistProps[] = [
       },
     },
     auctionResults: null,
+    genes: [],
   },
   {
     name: "Diamond Stingily",
@@ -839,6 +872,11 @@ export const Artists: ArtistProps[] = [
       },
     },
     auctionResults: null,
+    genes: [
+      {
+        name: "Emerging Art",
+      },
+    ],
   },
   {
     name: "Anni Albers",
@@ -966,5 +1004,6 @@ export const Artists: ArtistProps[] = [
       },
     },
     auctionResults: null,
+    genes: [],
   },
 ]

--- a/src/Components/Publishing/ToolTip/Artist.tsx
+++ b/src/Components/Publishing/ToolTip/Artist.tsx
@@ -21,6 +21,9 @@ export interface ArtistProps {
   blurb?: string
   collections?: string[]
   formatted_nationality_and_birthday?: string
+  genes?: Array<{
+    name: string
+  }>
   highlights?: {
     partners?: {
       edges?: Array<{
@@ -178,5 +181,8 @@ const Images = styled.div`
 //         }
 //       }
 //     }
+//   }
+//   genes {
+//     name
 //   }
 // }

--- a/src/Components/Publishing/ToolTip/Components/ArtistMarketData.tsx
+++ b/src/Components/Publishing/ToolTip/Components/ArtistMarketData.tsx
@@ -80,8 +80,13 @@ export class ArtistMarketData extends React.Component<ArtistProps> {
   }
 
   renderArtistGenes = () => {
-    // TODO: Artist genes
-    return <ToolTipDescription text={this.props.blurb} />
+    const { genes } = this.props
+    if (genes.length) {
+      const formattedGenes = map(genes, "name").join(", ")
+      return <div>{formattedGenes}</div>
+    } else {
+      return <ToolTipDescription text={this.props.blurb} />
+    }
   }
 
   render() {

--- a/src/Components/Publishing/ToolTip/Components/ArtistMarketData.tsx
+++ b/src/Components/Publishing/ToolTip/Components/ArtistMarketData.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import { countBy, intersection, flatten, map } from "lodash"
 import { unica } from "Assets/Fonts"
 import { ArtistProps } from "../Artist"
-import { ToolTipDescription } from "./Description"
 import { Truncator } from "../../Sections/Truncator"
 
 const ALLOWED_CATEGORIES = ["blue-chip", "top-established", "top-emerging"]
@@ -84,8 +83,6 @@ export class ArtistMarketData extends React.Component<ArtistProps> {
     if (genes.length) {
       const formattedGenes = map(genes, "name").join(", ")
       return <div>{formattedGenes}</div>
-    } else {
-      return <ToolTipDescription text={this.props.blurb} />
     }
   }
 

--- a/src/Components/Publishing/ToolTip/__tests__/Artist.test.tsx
+++ b/src/Components/Publishing/ToolTip/__tests__/Artist.test.tsx
@@ -44,10 +44,7 @@ describe("ArtistToolTip", () => {
     it("Renders categories if no artist data", () => {
       const artist = Artists[2]
       const component = mount(<ArtistToolTip {...artist} showMarketData />)
-      // TODO: Use categories instead of bio
-      expect(component.text()).toMatch(
-        "Diamond Stingily is an American artist whose work"
-      )
+      expect(component.text()).toMatch("Emerging Art")
     })
   })
 })

--- a/src/Components/Publishing/ToolTip/__tests__/ArtistMarketData.test.js
+++ b/src/Components/Publishing/ToolTip/__tests__/ArtistMarketData.test.js
@@ -17,13 +17,11 @@ describe("Artist Market Data", () => {
       expect(component.text()).toMatch('Emerging Art')
     })
 
-    it("renders description if no market data or genes", () => {
+    it("renders nothing if no market data or genes", () => {
       const artist = cloneDeep(Artists[2])
       artist.genes = []
       const component = mount(<ArtistMarketData {...artist} />)
-      expect(component.text()).toMatch(
-        "Diamond Stingily is an American artist whose work"
-      )
+      expect(component.text()).toBe('')
     })
   })
 

--- a/src/Components/Publishing/ToolTip/__tests__/ArtistMarketData.test.js
+++ b/src/Components/Publishing/ToolTip/__tests__/ArtistMarketData.test.js
@@ -1,10 +1,32 @@
 import { mount } from "enzyme"
+import { cloneDeep } from "lodash"
 import "jest-styled-components"
 import React from "react"
 import { Artists } from "../../Fixtures/Components"
 import { ArtistMarketData } from "../Components/ArtistMarketData"
 
 describe("Artist Market Data", () => {
+  describe("rendering", () => {
+    it("renders market data if present", () => {
+      const component = mount(<ArtistMarketData {...Artists[0]} />)
+      expect(component.text()).toMatch('Represented by a blue chip gallery')
+    })
+
+    it("renders genes if present and no market data", () => {
+      const component = mount(<ArtistMarketData {...Artists[2]} />)
+      expect(component.text()).toMatch('Emerging Art')
+    })
+
+    it("renders description if no market data or genes", () => {
+      const artist = cloneDeep(Artists[2])
+      artist.genes = []
+      const component = mount(<ArtistMarketData {...artist} />)
+      expect(component.text()).toMatch(
+        "Diamond Stingily is an American artist whose work"
+      )
+    })
+  })
+
   it("#hasGalleryData is true if artist has gallery in allowed category", () => {
     const hasData = mount(<ArtistMarketData {...Artists[0]} />)
     const noData = mount(<ArtistMarketData {...Artists[2]} />)


### PR DESCRIPTION
Adds list of artist genes as fallback if no market data is present.  Displays nothing if no genes or market data are present.