### PR TITLE
@kanaabe => Relay Follow button

### DIFF
--- a/src/Components/FollowButton/Button.tsx
+++ b/src/Components/FollowButton/Button.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { unica } from "Assets/Fonts"
 import Colors from "Assets/Colors"
 
-export interface Props {
+interface Props {
   handleFollow?: any
   isFollowed?: boolean
 }

--- a/src/Components/FollowButton/Button.tsx
+++ b/src/Components/FollowButton/Button.tsx
@@ -3,13 +3,9 @@ import React from "react"
 import { unica } from "Assets/Fonts"
 import Colors from "Assets/Colors"
 
-interface Props {
-  item?: {
-    __id: string
-    id: string
-    is_followed: boolean | null
-  }
-  currentUser?: object
+export interface Props {
+  handleFollow?: any
+  isFollowed?: boolean
 }
 
 interface State {
@@ -17,13 +13,18 @@ interface State {
 }
 
 export class FollowButton extends React.Component<Props, State> {
+  static defaultProps = {
+    isFollowed: false,
+  }
+
   state = {
     showUnfollow: false,
   }
 
   render() {
     const { showUnfollow } = this.state
-    const isFollowed = this.props.item ? this.props.item.is_followed : true
+    const { handleFollow, isFollowed } = this.props
+
     const text = isFollowed
       ? showUnfollow
         ? "Unfollow"
@@ -33,6 +34,7 @@ export class FollowButton extends React.Component<Props, State> {
     return (
       <FollowButtonContainer
         isFollowed={isFollowed}
+        onClick={handleFollow}
         onMouseEnter={() => this.setState({ showUnfollow: true })}
         onMouseLeave={() => this.setState({ showUnfollow: false })}
       >
@@ -58,6 +60,7 @@ const FollowButtonContainer = Div`
   justify-content: center;
   align-items: center;
   color: ${props => (props.isFollowed ? Colors.grayMedium : "black")}
+  cursor: pointer;
   &:hover {
     ${props =>
       !props.isFollowed &&

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -7,20 +7,13 @@ import {
 } from "react-relay"
 import { FollowButton } from "./Button"
 import * as Artsy from "../Artsy"
+import { FollowArtistButton_artist } from "../../__generated__/FollowArtistButton_artist.graphql"
 
-export interface Props
-  extends RelayProps,
-    React.HTMLProps<FollowArtistButton>,
+interface Props
+  extends React.HTMLProps<FollowArtistButton>,
     Artsy.ContextProps {
   relay?: RelayProp
-}
-
-interface RelayProps {
-  artist?: {
-    __id: string
-    id: string
-    is_followed: boolean | null
-  }
+  artist?: FollowArtistButton_artist
 }
 
 interface State {
@@ -80,7 +73,7 @@ export class FollowArtistButton extends React.Component<Props, State> {
 }
 
 export default createFragmentContainer(
-  FollowArtistButton,
+  Artsy.ContextConsumer(FollowArtistButton),
   graphql`
     fragment FollowArtistButton_artist on Artist {
       __id

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -1,0 +1,91 @@
+import React from "react"
+import {
+  commitMutation,
+  createFragmentContainer,
+  graphql,
+  RelayProp,
+} from "react-relay"
+import { FollowButton } from "./Button"
+import * as Artsy from "../Artsy"
+
+export interface Props
+  extends RelayProps,
+    React.HTMLProps<FollowArtistButton>,
+    Artsy.ContextProps {
+  relay?: RelayProp
+}
+
+interface RelayProps {
+  artist?: {
+    __id: string
+    id: string
+    is_followed: boolean | null
+  }
+}
+
+interface State {
+  showUnfollow: boolean
+}
+
+export class FollowArtistButton extends React.Component<Props, State> {
+  state = {
+    showUnfollow: false,
+  }
+
+  handleFollow = () => {
+    const { artist, currentUser, relay } = this.props
+
+    if (currentUser && currentUser.id) {
+      commitMutation(relay.environment, {
+        mutation: graphql`
+          mutation FollowArtistButtonMutation($input: FollowArtistInput!) {
+            followArtist(input: $input) {
+              artist {
+                is_followed
+              }
+            }
+          }
+        `,
+        variables: {
+          input: {
+            artist_id: artist.id,
+            unfollow: artist.is_followed,
+          },
+        },
+        optimisticResponse: {
+          followArtist: {
+            artist: {
+              __id: artist.__id,
+              is_followed: !artist.is_followed,
+            },
+          },
+        },
+      })
+    } else {
+      // TODO: trigger signup/login modal
+      window.location.href = "/login"
+    }
+  }
+
+  render() {
+    const { artist } = this.props
+
+    return (
+      <FollowButton
+        isFollowed={artist && artist.is_followed}
+        handleFollow={this.handleFollow}
+      />
+    )
+  }
+}
+
+export default createFragmentContainer(
+  FollowArtistButton,
+  graphql`
+    fragment FollowArtistButton_artist on Artist {
+      __id
+      id
+      is_followed
+    }
+  `
+)

--- a/src/Components/FollowButton/__tests__/Button.test.tsx
+++ b/src/Components/FollowButton/__tests__/Button.test.tsx
@@ -1,0 +1,57 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import { FollowButton } from "../Button"
+
+describe("FollowButton", () => {
+  const getWrapper = props => {
+    return mount(<FollowButton {...props} />)
+  }
+
+  let props
+  beforeEach(() => {
+    props = {
+      handleFollow: jest.fn(),
+      isFollowed: false,
+    }
+  })
+
+  describe("CTA text", () => {
+    it("Reads 'follow' if isFollowed is false", () => {
+      const component = getWrapper(props)
+      expect(component.text()).toMatch("Follow")
+    })
+
+    it("Reads 'Following' if props.isFollowed", () => {
+      props.isFollowed = true
+      const component = getWrapper(props)
+      expect(component.text()).toMatch("Following")
+    })
+
+    it("Reads 'Unfollow' if props.isFollowed and state.showUnfollow", () => {
+      props.isFollowed = true
+      const component = getWrapper(props)
+      component.setState({ showUnfollow: true })
+      expect(component.text()).toMatch("Unfollow")
+    })
+  })
+
+  it("Calls props.handleFollow onClick", () => {
+    const component = getWrapper(props)
+    component.simulate("click")
+    expect(props.handleFollow).toBeCalled()
+  })
+
+  it("Sets state.showUnfollow on onMouseEnter", () => {
+    const component = getWrapper(props)
+    component.simulate("mouseEnter")
+    expect(component.state().showUnfollow).toBe(true)
+  })
+
+  it("Sets state.showUnfollow on onMouseLeave", () => {
+    const component = getWrapper(props)
+    component.setState({ showUnfollow: true })
+    component.simulate("mouseLeave")
+    expect(component.state().showUnfollow).toBeFalsy()
+  })
+})

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1709,11 +1709,11 @@ exports[`renders a sponsored series properly 1`] = `
   margin-right: auto;
 }
 
-.jYRMCd .c14 {
+.kPJXvy .c14 {
   margin-bottom: 90px;
 }
 
-.jYRMCd .c38 {
+.kPJXvy .c38 {
   padding-top: 60px;
 }
 
@@ -2009,7 +2009,7 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media (max-width:900px) {
-  .jYRMCd .c38 {
+  .kPJXvy .c38 {
     padding-top: 60px;
   }
 }

--- a/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
@@ -4,8 +4,8 @@ import { map } from "lodash"
 import { createFragmentContainer, graphql } from "react-relay"
 import { garamond, unica } from "Assets/Fonts"
 import fillwidthDimensions from "../../../Utils/fillwidth"
+import { FollowArtistButton } from "../../FollowButton/FollowArtistButton"
 import { ToolTipDescription } from "./Components/Description"
-import { FollowButton } from "./Components/FollowButton"
 import { NewFeature } from "./Components/NewFeature"
 import { ArtistMarketData } from "./Components/ArtistMarketData"
 import { ArtistToolTip_artist } from "../../../__generated__/ArtistToolTip_artist.graphql"
@@ -50,7 +50,7 @@ export const ArtistToolTip: React.SFC<ArtistToolTipProps> = props => {
               <Date>{formatted_nationality_and_birthday}</Date>
             )}
           </TitleDate>
-          <FollowButton /> {/* TODO: Replace with relay follow */}
+          <FollowArtistButton />
         </Header>
 
         {showMarketData ? (

--- a/src/Components/Publishing/ToolTip/Components/FollowButton.tsx
+++ b/src/Components/Publishing/ToolTip/Components/FollowButton.tsx
@@ -1,13 +1,55 @@
-import styled from "styled-components"
+import styled, { StyledFunction } from "styled-components"
 import React from "react"
 import { unica } from "Assets/Fonts"
 import Colors from "Assets/Colors"
 
-export const FollowButton: React.SFC = () => {
-  return <FollowButtonContainer>Follow</FollowButtonContainer>
+interface Props {
+  item?: {
+    __id: string
+    id: string
+    is_followed: boolean | null
+  }
+  currentUser?: object
 }
 
-const FollowButtonContainer = styled.div`
+interface State {
+  showUnfollow: boolean
+}
+
+export class FollowButton extends React.Component<Props, State> {
+  state = {
+    showUnfollow: false,
+  }
+
+  render() {
+    const { showUnfollow } = this.state
+    const isFollowed = this.props.item ? this.props.item.is_followed : true
+    const text = isFollowed
+      ? showUnfollow
+        ? "Unfollow"
+        : "Following"
+      : "Follow"
+
+    return (
+      <FollowButtonContainer
+        isFollowed={isFollowed}
+        onMouseEnter={() => this.setState({ showUnfollow: true })}
+        onMouseLeave={() => this.setState({ showUnfollow: false })}
+      >
+        {text}
+      </FollowButtonContainer>
+    )
+  }
+}
+
+interface DivProps {
+  isFollowed: boolean
+}
+
+const Div: StyledFunction<DivProps & React.HTMLProps<HTMLDivElement>> =
+  styled.div
+
+const FollowButtonContainer = Div`
   border: 1px solid ${Colors.grayRegular};
   ${unica("s12", "medium")};
   width: 80px;
@@ -15,9 +57,13 @@ const FollowButtonContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  color: ${props => (props.isFollowed ? Colors.grayMedium : "black")}
   &:hover {
-    border-color: black;
-    background: black;
-    color: white;
+    ${props =>
+      !props.isFollowed &&
+      `
+      border-color: black;`}
+    background: ${props => (props.isFollowed ? "white" : "black")}
+    color: ${props => (props.isFollowed ? Colors.redMedium : "white")}
   }
 `

--- a/src/Components/Publishing/ToolTip/GeneToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/GeneToolTip.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components"
 import React from "react"
 import { garamond } from "Assets/Fonts"
+import { FollowButton } from "../../FollowButton/Button"
 import { ToolTipDescription } from "./Components/Description"
-import { FollowButton } from "./Components/FollowButton"
 import { NewFeature, NewFeatureContainer } from "./Components/NewFeature"
 
 export interface GeneProps {

--- a/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
+++ b/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
@@ -44,10 +44,8 @@ describe("ArtistToolTip", () => {
     it("Renders categories if no artist data", () => {
       const artist = Artists[2].artist
       const component = mount(<ArtistToolTip artist={artist} showMarketData />)
-      // TODO: Use categories instead of bio
-      expect(component.text()).toMatch(
-        "Diamond StingilyFollow Emerging ArtThis is a new feature. Tell us what you think."
-      )
+
+      expect(component.text()).toMatch("Emerging Art")
     })
   })
 })

--- a/src/Components/Publishing/ToolTip/__tests__/__snapshots__/ToolTip.test.tsx.snap
+++ b/src/Components/Publishing/ToolTip/__tests__/__snapshots__/ToolTip.test.tsx.snap
@@ -1,13 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ToolTip snapshots Renders a gene properly 1`] = `
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 15px;
-  line-height: 1.25em;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c7 {
   border: 1px solid #e5e5e5;
   font-family: Unica77LLWebMedium,Arial,serif;
@@ -28,12 +21,21 @@ exports[`ToolTip snapshots Renders a gene properly 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  color: black;
+  cursor: pointer;
 }
 
 .c7:hover {
   border-color: black;
   background: black;
   color: white;
+}
+
+.c5 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 15px;
+  line-height: 1.25em;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c9 {
@@ -182,6 +184,9 @@ exports[`ToolTip snapshots Renders a gene properly 1`] = `
     >
       <div
         className="c7"
+        onClick={undefined}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
       >
         Follow
       </div>
@@ -215,13 +220,6 @@ exports[`ToolTip snapshots Renders a gene properly 1`] = `
 `;
 
 exports[`ToolTip snapshots Renders an artist properly 1`] = `
-.c9 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 15px;
-  line-height: 1.25em;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c8 {
   border: 1px solid #e5e5e5;
   font-family: Unica77LLWebMedium,Arial,serif;
@@ -242,12 +240,21 @@ exports[`ToolTip snapshots Renders an artist properly 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  color: black;
+  cursor: pointer;
 }
 
 .c8:hover {
   border-color: black;
   background: black;
   color: white;
+}
+
+.c9 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 15px;
+  line-height: 1.25em;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c10 {
@@ -417,10 +424,12 @@ exports[`ToolTip snapshots Renders an artist properly 1`] = `
         </div>
         <div
           className="c8"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           Follow
         </div>
-         
       </div>
       <div
         className="c9"

--- a/src/__generated__/FollowArtistButtonMutation.graphql.ts
+++ b/src/__generated__/FollowArtistButtonMutation.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime"
+export type FollowArtistButtonMutationVariables = {
+  readonly input: {
+    readonly artist_id: string | null
+    readonly unfollow: boolean | null
+    readonly clientMutationId: string | null
+  }
+}
+export type FollowArtistButtonMutationResponse = {
+  readonly followArtist:
+    | ({
+        readonly artist:
+          | ({
+              readonly is_followed: boolean | null
+            })
+          | null
+      })
+    | null
+}
+
+/*
+mutation FollowArtistButtonMutation(
+  $input: FollowArtistInput!
+) {
+  followArtist(input: $input) {
+    artist {
+      is_followed
+      __id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function() {
+  var v0 = [
+      {
+        kind: "LocalArgument",
+        name: "input",
+        type: "FollowArtistInput!",
+        defaultValue: null,
+      },
+    ],
+    v1 = [
+      {
+        kind: "LinkedField",
+        alias: null,
+        name: "followArtist",
+        storageKey: null,
+        args: [
+          {
+            kind: "Variable",
+            name: "input",
+            variableName: "input",
+            type: "FollowArtistInput!",
+          },
+        ],
+        concreteType: "FollowArtistPayload",
+        plural: false,
+        selections: [
+          {
+            kind: "LinkedField",
+            alias: null,
+            name: "artist",
+            storageKey: null,
+            args: null,
+            concreteType: "Artist",
+            plural: false,
+            selections: [
+              {
+                kind: "ScalarField",
+                alias: null,
+                name: "is_followed",
+                args: null,
+                storageKey: null,
+              },
+              {
+                kind: "ScalarField",
+                alias: null,
+                name: "__id",
+                args: null,
+                storageKey: null,
+              },
+            ],
+          },
+        ],
+      },
+    ]
+  return {
+    kind: "Request",
+    operationKind: "mutation",
+    name: "FollowArtistButtonMutation",
+    id: null,
+    text:
+      "mutation FollowArtistButtonMutation(\n  $input: FollowArtistInput!\n) {\n  followArtist(input: $input) {\n    artist {\n      is_followed\n      __id\n    }\n  }\n}\n",
+    metadata: {},
+    fragment: {
+      kind: "Fragment",
+      name: "FollowArtistButtonMutation",
+      type: "Mutation",
+      metadata: null,
+      argumentDefinitions: v0,
+      selections: v1,
+    },
+    operation: {
+      kind: "Operation",
+      name: "FollowArtistButtonMutation",
+      argumentDefinitions: v0,
+      selections: v1,
+    },
+  }
+})()
+;(node as any).hash = "8e43ee0d3d31c0036df241cef15d1160"
+export default node

--- a/src/__generated__/FollowArtistButton_artist.graphql.ts
+++ b/src/__generated__/FollowArtistButton_artist.graphql.ts
@@ -1,0 +1,41 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime"
+export type FollowArtistButton_artist = {
+  readonly __id: string
+  readonly id: string
+  readonly is_followed: boolean | null
+}
+
+const node: ConcreteFragment = {
+  kind: "Fragment",
+  name: "FollowArtistButton_artist",
+  type: "Artist",
+  metadata: null,
+  argumentDefinitions: [],
+  selections: [
+    {
+      kind: "ScalarField",
+      alias: null,
+      name: "__id",
+      args: null,
+      storageKey: null,
+    },
+    {
+      kind: "ScalarField",
+      alias: null,
+      name: "id",
+      args: null,
+      storageKey: null,
+    },
+    {
+      kind: "ScalarField",
+      alias: null,
+      name: "is_followed",
+      args: null,
+      storageKey: null,
+    },
+  ],
+}
+;(node as any).hash = "872d90fb3feb3ba8549b783b1b5b5643"
+export default node


### PR DESCRIPTION
Moved our tooltip `FollowButton` into the general /Components directory, and added a wrapper component `FollowArtistButton` that can attach Relay props and handle the follow mutation.

Will add another variation in a separate PR for `FollowGeneButton` once https://github.com/artsy/metaphysics/pull/1035 is merged.