### PR TITLE
@l2success => Go back to development for npm version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction",
-  "version": "1.2.1",
+  "version": "0.0.0-development",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",


### PR DESCRIPTION
Had to change this today to get our NPM and github versions back in sync, this goes back to the "0.0.0-development" version for semantic-release