### PR TITLE
Update styling for the checkbox component

### DIFF
--- a/src/Assets/Checkmark.tsx
+++ b/src/Assets/Checkmark.tsx
@@ -1,0 +1,23 @@
+import React, { HTMLProps } from "react"
+
+interface CheckmarkProps extends HTMLProps<SVGElement> {
+  stroke?: string
+}
+
+export class Checkmark extends React.Component<CheckmarkProps> {
+  render() {
+    const { stroke, ...remainderProps } = this.props
+
+    return (
+      <svg width={14} height={11} viewBox="0 0 14 11" {...remainderProps}>
+        <path
+          fill="none"
+          fillRule="evenodd"
+          stroke={stroke || "#FFF"}
+          strokeWidth={2}
+          d="M1 4.743L5.168 9 13 1"
+        />
+      </svg>
+    )
+  }
+}

--- a/src/Assets/Colors.tsx
+++ b/src/Assets/Colors.tsx
@@ -7,6 +7,7 @@ export default {
   graySemibold: "#666666",
   grayBold: "#333333",
   black: "#000000",
+  black30: "#c2c2c2",
   purpleLight: "#e2d2ff",
   purpleRegular: "#6e1fff",
   redRegular: "#FFEFED",

--- a/src/Assets/Fonts.tsx
+++ b/src/Assets/Fonts.tsx
@@ -13,6 +13,10 @@ const GaramondSizes = {
     size: "15px",
     height: "1.25em",
   },
+  s16: {
+    size: "16px",
+    height: "1.4em",
+  },
   s17: {
     size: "17px",
     height: "1.1em",

--- a/src/Components/ArtworkFilter/ForSaleCheckbox.tsx
+++ b/src/Components/ArtworkFilter/ForSaleCheckbox.tsx
@@ -1,16 +1,18 @@
-import React, { Component, HTMLProps } from "react"
+import React, { Component } from "react"
 
-import Checkbox from "../Checkbox"
+import Checkbox, { CheckboxProps } from "../Checkbox"
 
 import styled from "styled-components"
 import colors from "Assets/Colors"
 import { avantgarde } from "Assets/Fonts"
 
-export class ForSaleCheckbox extends Component<HTMLProps<Checkbox>, null> {
+export class ForSaleCheckbox extends Component<CheckboxProps, null> {
   render() {
+    const { ref, ...remainderProps } = this.props
+
     return (
       <CheckboxContainer>
-        <Checkbox {...this.props}>Only for Sale</Checkbox>
+        <Checkbox {...remainderProps}>Only for Sale</Checkbox>
       </CheckboxContainer>
     )
   }

--- a/src/Components/Checkbox.tsx
+++ b/src/Components/Checkbox.tsx
@@ -1,12 +1,14 @@
 import React, { Component, HTMLProps } from "react"
 import styled from "styled-components"
 import colors from "../Assets/Colors"
+import { Checkmark } from "Assets/Checkmark"
+import { garamond } from "Assets/Fonts"
 
 interface CheckboxState {
   checked: boolean
 }
 
-interface CheckboxProps extends HTMLProps<Checkbox> {
+export interface CheckboxProps extends HTMLProps<HTMLInputElement> {
   error?: boolean
 }
 
@@ -30,17 +32,34 @@ export class Checkbox extends Component<CheckboxProps, CheckboxState> {
   }
 
   render() {
-    const { children, className, error, ...propsForCheckbox } = this.props
+    const {
+      children,
+      className,
+      disabled,
+      error,
+      ref,
+      ...remainderProps
+    } = this.props
+    const { checked } = this.state
 
     return (
-      <Label className={className}>
-        <CheckboxInput
-          type="checkbox"
-          {...propsForCheckbox as any}
-          onChange={this.onChange}
-          checked={this.state.checked}
-          error={error}
-        />
+      <Label className={className} error={error}>
+        <CheckmarkContainer>
+          <CheckboxInput
+            {...remainderProps}
+            type="checkbox"
+            onChange={this.onChange}
+            checked={checked}
+            disabled={disabled}
+            error={error}
+          />
+
+          {(!disabled || checked) && (
+            <PositionedCheckmark
+              stroke={disabled && checked && colors.black30}
+            />
+          )}
+        </CheckmarkContainer>
 
         {children}
       </Label>
@@ -48,81 +67,65 @@ export class Checkbox extends Component<CheckboxProps, CheckboxState> {
   }
 }
 
-const CheckboxInput = styled.input.attrs<{ error: boolean }>({})`
+const CheckmarkContainer = styled.div`
   width: 20px;
   height: 20px;
-  position: relative;
   top: -1px;
-  margin: 0 0.5rem 0 0;
+  margin-right: 0.5rem;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
 
-  // The before represents the check mark
-  &:before {
-    transform: rotate(-45deg);
-    content: "";
-    position: absolute;
-    z-index: 1;
-    top: 5px;
-    left: 4px;
-    width: 0.6rem;
-    height: 0.3rem;
-    border: 2px solid ${colors.black};
-    border-top-style: none;
-    border-right-style: none;
-    transition: opacity 0.25s;
-    opacity: 0;
-  }
+const PositionedCheckmark = styled(Checkmark)`
+  z-index: 1;
+  margin-top: 1px;
+`
 
-  &:hover:before {
-    opacity: 0.1;
-  }
-
-  &:checked:before {
-    opacity: 1;
-  }
+const CheckboxInput = styled.input.attrs<CheckboxProps>({})`
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  margin: 0;
 
   // The after represents the square box
   &:after {
+    transition: all 0.25s;
     content: "";
     position: absolute;
-    left: 0;
-    width: 1rem;
-    height: 1rem;
-    background: ${colors.white};
-    border: 2px solid ${colors.grayRegular};
+    width: 20px;
+    height: 20px;
+    box-sizing: border-box;
+    background-color: ${colors.white};
+    border: 2px solid
+      ${({ error }) => (error ? colors.redMedium : colors.grayRegular)};
   }
 
-  &:disabled {
-    &:hover:before {
-      border-color: transparent;
-    }
-
-    &:checked {
-      &:before {
-        border-color: ${colors.grayDark};
-      }
-    }
-
-    &:after {
-      background-color: ${colors.grayRegular};
-    }
+  &:hover:after {
+    background-color: ${colors.grayRegular};
+    border-color: ${colors.grayRegular};
   }
 
-  ${p =>
-    p.error &&
-    `
-    color: ${colors.redMedium};
-    &:after {
-      border: 2px solid ${colors.redMedium};
-    }
-  `};
+  &:checked:after {
+    background-color: ${colors.black};
+    border-color: ${colors.black};
+  }
+
+  &:disabled:after {
+    background-color: ${colors.gray};
+    border-color: ${colors.grayRegular};
+  }
 `
 
-const Label = styled.label`
+const Label = styled.label.attrs<CheckboxProps>({})`
+  ${garamond("s16")};
   position: relative;
   line-height: 135%;
   cursor: pointer;
   display: flex;
   align-items: center;
+  ${({ error }) => error && `color: ${colors.redMedium}`};
 `
 
 export default Checkbox

--- a/src/Components/__stories__/Input.story.tsx
+++ b/src/Components/__stories__/Input.story.tsx
@@ -90,12 +90,25 @@ storiesOf("Components/Input", module)
       <div style={{ padding: 10 }}>
         <Checkbox>Remember me</Checkbox>
       </div>
+
       <div style={{ padding: 10 }}>
         <Checkbox checked>Remember me</Checkbox>
       </div>
+
+      <div style={{ padding: 10 }}>
+        <Checkbox error>Remember me</Checkbox>
+      </div>
+
+      <div style={{ padding: 10 }}>
+        <Checkbox error checked>
+          Remember me
+        </Checkbox>
+      </div>
+
       <div style={{ padding: 10 }}>
         <Checkbox disabled>Remember me</Checkbox>
       </div>
+
       <div style={{ padding: 10 }}>
         <Checkbox checked disabled>
           Remember me


### PR DESCRIPTION
There are some visual changes in the checkbox design system https://zpl.io/bAvnwlB, and this PR updates the `<Checkbox>` component in reaction to match the style.

<img width="168" alt="screen shot 2018-05-07 at 18 01 22" src="https://user-images.githubusercontent.com/386234/39727450-b10b83d6-5220-11e8-853b-c422e85c46a8.png">


The new one is compatible with the existing one but also adds a new `error: boolean` prop:

```html
<Checkbox error>
  Agree to Conditions of Sale.
</Checkbox>

<Checkbox error checked>
  Agree to Conditions of Sale.
</Checkbox>
```

