### PR TITLE
@mzikherman => [Artwork/Save] Support saves in non-relay artwork grids 

### DIFF
--- a/src/Components/Artwork/Save.tsx
+++ b/src/Components/Artwork/Save.tsx
@@ -1,4 +1,6 @@
+import { isNull } from "lodash"
 import React from "react"
+import * as RelayRuntimeTypes from "relay-runtime"
 import {
   commitMutation,
   createFragmentContainer,
@@ -7,86 +9,147 @@ import {
 } from "react-relay"
 
 import Icon from "../Icon"
-
 import styled from "styled-components"
 import colors from "../../Assets/Colors"
-
 import * as Artsy from "../../Components/Artsy"
 
 const SIZE = 40
 
 export interface Props
   extends RelayProps,
-    React.HTMLProps<SaveButtonContainer>,
-    Artsy.ContextProps {
+    Artsy.ContextProps,
+    React.HTMLProps<React.ComponentType> {
   style?: any
   relay?: RelayProp
+  relayEnvironment?: RelayRuntimeTypes.Environment
   useRelay?: boolean
 }
 
-export class SaveButtonContainer extends React.Component<Props, null> {
-  static defaultProps = {
-    useRelay: true,
-  }
-
-  handleSave() {
-    const { currentUser, artwork, relay, useRelay } = this.props
-    if (useRelay && currentUser && currentUser.id) {
-      commitMutation(relay.environment, {
-        mutation: graphql`
-          mutation SaveArtworkMutation($input: SaveArtworkInput!) {
-            saveArtwork(input: $input) {
-              artwork {
-                is_saved
-              }
-            }
-          }
-        `,
-        variables: {
-          input: {
-            artwork_id: artwork.id,
-            remove: this.props.artwork.is_saved,
-          },
-        },
-        // TODO: Relay Modern: This is not working yet
-        optimisticResponse: {
-          saveArtwork: {
-            artwork: {
-              __id: artwork.__id,
-              is_saved: !this.props.artwork.is_saved,
-            },
-          },
-        },
-      })
-
-      // FIXME: Add non-relay based favorite mechanism
-      // } else {
-    } else {
-      window.location.href = "/login"
-    }
-  }
-
-  render() {
-    const { style, artwork } = this.props
-    return (
-      <div
-        className={this.props.className}
-        style={style}
-        onClick={() => this.handleSave()}
-        data-saved={artwork.is_saved}
-      >
-        <Icon
-          name="heart"
-          height={SIZE}
-          color="white"
-          style={{ verticalAlign: "middle" }}
-        />
-      </div>
-    )
-  }
+// TODO: This will be refactored out once Artworks / Grids are full Relay in Force
+// and intermediate local state becomes unnecessary
+interface State {
+  is_saved: boolean
 }
 
+export const SaveButtonContainer = Artsy.ContextConsumer(
+  class extends React.Component<Props, State> {
+    static defaultProps = {
+      useRelay: true,
+    }
+
+    state = {
+      is_saved: null,
+    }
+
+    get isSaved() {
+      const isSaved = isNull(this.state.is_saved)
+        ? this.props.artwork.is_saved
+        : this.state.is_saved
+
+      return isSaved
+    }
+
+    handleSave() {
+      const {
+        currentUser,
+        artwork,
+        relay,
+        relayEnvironment,
+        useRelay,
+      } = this.props
+      const environment = (relay && relay.environment) || relayEnvironment
+
+      if (environment && currentUser && currentUser.id) {
+        // Optimistic update for environments that don't have typical access to
+        // Relay, e.g., where new ArtworkGrids are used in old code via Stitch. Note
+        // that the prop `useRelay` refers to outer HOC wrappers. In cases where
+        // Save UI components are used it is possible to piggyback on ContextProvider
+        // environment for mutations, but since the component exists outside of a
+        // Relay HOC props are not updated when successful mutations occur -- hence
+        // the need for setState.
+        //
+        // TODO:
+        // Refactor out `useRelay` prop when Force artwork Grids have been moved
+        // completely over to Relay
+
+        if (!useRelay) {
+          this.setState({
+            is_saved: !this.isSaved,
+          })
+        }
+
+        commitMutation(environment, {
+          mutation: graphql`
+            mutation SaveArtworkMutation($input: SaveArtworkInput!) {
+              saveArtwork(input: $input) {
+                artwork {
+                  id
+                  is_saved
+                }
+              }
+            }
+          `,
+          variables: {
+            input: {
+              artwork_id: artwork.id,
+              remove: this.isSaved,
+            },
+          },
+          optimisticResponse: {
+            saveArtwork: {
+              artwork: {
+                __id: artwork.__id,
+                is_saved: !this.isSaved,
+              },
+            },
+          },
+          onError: error => {
+            // Revert optimistic update
+            if (!useRelay) {
+              this.setState({
+                is_saved: this.isSaved,
+              })
+            }
+
+            console.error("Artwork/Save Error saving artwork: ", error)
+          },
+          onCompleted: ({ saveArtwork }) => {
+            if (!useRelay) {
+              this.setState({
+                is_saved: saveArtwork.artwork.is_saved,
+              })
+            }
+          },
+        })
+      } else {
+        window.location.href = "/login"
+      }
+    }
+
+    render() {
+      const { style } = this.props
+
+      return (
+        <div
+          className={this.props.className}
+          style={style}
+          onClick={() => this.handleSave()}
+          data-saved={this.isSaved}
+        >
+          <Icon
+            name="heart"
+            height={SIZE}
+            color="white"
+            style={{ verticalAlign: "middle" }}
+          />
+        </div>
+      )
+    }
+  }
+)
+
 export const SaveButton = styled(SaveButtonContainer)`
+  display: block;
   width: ${SIZE}px;
   height: ${SIZE}px;
   text-align: center;

--- a/src/__generated__/ArtistToolTip_artist.graphql.ts
+++ b/src/__generated__/ArtistToolTip_artist.graphql.ts
@@ -1,343 +1,365 @@
 /* tslint:disable */
 
-import { ConcreteFragment } from "relay-runtime";
+import { ConcreteFragment } from "relay-runtime"
 export type ArtistToolTip_artist = {
-    readonly name: string | null;
-    readonly id: string;
-    readonly formatted_nationality_and_birthday: string | null;
-    readonly href: string | null;
-    readonly blurb: string | null;
-    readonly carousel: ({
-        readonly images: ReadonlyArray<({
-                readonly resized: ({
-                    readonly url: string | null;
-                    readonly width: number | null;
-                    readonly height: number | null;
-                }) | null;
-            }) | null> | null;
-    }) | null;
-    readonly collections: ReadonlyArray<string | null> | null;
-    readonly highlights: ({
-        readonly partners: ({
-            readonly edges: ReadonlyArray<({
-                    readonly node: ({
-                        readonly categories: ReadonlyArray<({
-                                readonly id: string;
-                            }) | null> | null;
-                    }) | null;
-                }) | null> | null;
-        }) | null;
-    }) | null;
-    readonly auctionResults: ({
-        readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly price_realized: ({
-                        readonly display: string | null;
-                    }) | null;
-                }) | null;
-            }) | null> | null;
-    }) | null;
-    readonly genes: ReadonlyArray<({
-            readonly name: string | null;
-        }) | null> | null;
-};
+  readonly name: string | null
+  readonly id: string
+  readonly formatted_nationality_and_birthday: string | null
+  readonly href: string | null
+  readonly blurb: string | null
+  readonly carousel:
+    | ({
+        readonly images: ReadonlyArray<
+          | ({
+              readonly resized:
+                | ({
+                    readonly url: string | null
+                    readonly width: number | null
+                    readonly height: number | null
+                  })
+                | null
+            })
+          | null
+        > | null
+      })
+    | null
+  readonly collections: ReadonlyArray<string | null> | null
+  readonly highlights:
+    | ({
+        readonly partners:
+          | ({
+              readonly edges: ReadonlyArray<
+                | ({
+                    readonly node:
+                      | ({
+                          readonly categories: ReadonlyArray<
+                            | ({
+                                readonly id: string
+                              })
+                            | null
+                          > | null
+                        })
+                      | null
+                  })
+                | null
+              > | null
+            })
+          | null
+      })
+    | null
+  readonly auctionResults:
+    | ({
+        readonly edges: ReadonlyArray<
+          | ({
+              readonly node:
+                | ({
+                    readonly price_realized:
+                      | ({
+                          readonly display: string | null
+                        })
+                      | null
+                  })
+                | null
+            })
+          | null
+        > | null
+      })
+    | null
+  readonly genes: ReadonlyArray<
+    | ({
+        readonly name: string | null
+      })
+    | null
+  > | null
+}
 
-
-
-const node: ConcreteFragment = (function(){
-var v0 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v1 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v2 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-};
-return {
-  "kind": "Fragment",
-  "name": "ArtistToolTip_artist",
-  "type": "Artist",
-  "metadata": null,
-  "argumentDefinitions": [],
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "carousel",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "ArtistCarousel",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "images",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "Image",
-          "plural": true,
-          "selections": [
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "resized",
-              "storageKey": "resized(height:200)",
-              "args": [
-                {
-                  "kind": "Literal",
-                  "name": "height",
-                  "value": 200,
-                  "type": "Int"
-                }
-              ],
-              "concreteType": "ResizedImageUrl",
-              "plural": false,
-              "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "url",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "width",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "height",
-                  "args": null,
-                  "storageKey": null
-                }
-              ]
-            }
-          ]
-        }
-      ]
+const node: ConcreteFragment = (function() {
+  var v0 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "name",
+      args: null,
+      storageKey: null,
     },
-    v0,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "formatted_nationality_and_birthday",
-      "args": null,
-      "storageKey": null
+    v1 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "id",
+      args: null,
+      storageKey: null,
     },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "href",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "blurb",
-      "args": null,
-      "storageKey": null
-    },
-    v1,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "collections",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "highlights",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "ArtistHighlights",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "partners",
-          "storageKey": "partners(display_on_partner_profile:true,first:5,partner_category:[\"blue-chip\",\"top-established\",\"top-emerging\"],represented_by:true)",
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "display_on_partner_profile",
-              "value": true,
-              "type": "Boolean"
-            },
-            {
-              "kind": "Literal",
-              "name": "first",
-              "value": 5,
-              "type": "Int"
-            },
-            {
-              "kind": "Literal",
-              "name": "partner_category",
-              "value": [
-                "blue-chip",
-                "top-established",
-                "top-emerging"
-              ],
-              "type": "[String]"
-            },
-            {
-              "kind": "Literal",
-              "name": "represented_by",
-              "value": true,
-              "type": "Boolean"
-            }
-          ],
-          "concreteType": "PartnerArtistConnection",
-          "plural": false,
-          "selections": [
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "edges",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "PartnerArtistEdge",
-              "plural": true,
-              "selections": [
-                {
-                  "kind": "LinkedField",
-                  "alias": null,
-                  "name": "node",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "Partner",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "kind": "LinkedField",
-                      "alias": null,
-                      "name": "categories",
-                      "storageKey": null,
-                      "args": null,
-                      "concreteType": "Category",
-                      "plural": true,
-                      "selections": [
-                        v1
-                      ]
-                    },
-                    v2
-                  ]
-                },
-                v2
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "auctionResults",
-      "storageKey": "auctionResults(first:1,recordsTrusted:true,sort:\"PRICE_AND_DATE_DESC\")",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 1,
-          "type": "Int"
-        },
-        {
-          "kind": "Literal",
-          "name": "recordsTrusted",
-          "value": true,
-          "type": "Boolean"
-        },
-        {
-          "kind": "Literal",
-          "name": "sort",
-          "value": "PRICE_AND_DATE_DESC",
-          "type": "AuctionResultSorts"
-        }
-      ],
-      "concreteType": "AuctionResultConnection",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "edges",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "AuctionResultEdge",
-          "plural": true,
-          "selections": [
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "node",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "AuctionResult",
-              "plural": false,
-              "selections": [
-                {
-                  "kind": "LinkedField",
-                  "alias": null,
-                  "name": "price_realized",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "AuctionResultPriceRealized",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "kind": "ScalarField",
-                      "alias": null,
-                      "name": "display",
-                      "args": null,
-                      "storageKey": null
-                    }
-                  ]
-                },
-                v2
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "genes",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "Gene",
-      "plural": true,
-      "selections": [
-        v0,
-        v2
-      ]
-    },
-    v2
-  ]
-};
-})();
-(node as any).hash = '10b99c63399555511e9d9e3f84965e14';
-export default node;
+    v2 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "__id",
+      args: null,
+      storageKey: null,
+    }
+  return {
+    kind: "Fragment",
+    name: "ArtistToolTip_artist",
+    type: "Artist",
+    metadata: null,
+    argumentDefinitions: [],
+    selections: [
+      {
+        kind: "LinkedField",
+        alias: null,
+        name: "carousel",
+        storageKey: null,
+        args: null,
+        concreteType: "ArtistCarousel",
+        plural: false,
+        selections: [
+          {
+            kind: "LinkedField",
+            alias: null,
+            name: "images",
+            storageKey: null,
+            args: null,
+            concreteType: "Image",
+            plural: true,
+            selections: [
+              {
+                kind: "LinkedField",
+                alias: null,
+                name: "resized",
+                storageKey: "resized(height:200)",
+                args: [
+                  {
+                    kind: "Literal",
+                    name: "height",
+                    value: 200,
+                    type: "Int",
+                  },
+                ],
+                concreteType: "ResizedImageUrl",
+                plural: false,
+                selections: [
+                  {
+                    kind: "ScalarField",
+                    alias: null,
+                    name: "url",
+                    args: null,
+                    storageKey: null,
+                  },
+                  {
+                    kind: "ScalarField",
+                    alias: null,
+                    name: "width",
+                    args: null,
+                    storageKey: null,
+                  },
+                  {
+                    kind: "ScalarField",
+                    alias: null,
+                    name: "height",
+                    args: null,
+                    storageKey: null,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      v0,
+      {
+        kind: "ScalarField",
+        alias: null,
+        name: "formatted_nationality_and_birthday",
+        args: null,
+        storageKey: null,
+      },
+      {
+        kind: "ScalarField",
+        alias: null,
+        name: "href",
+        args: null,
+        storageKey: null,
+      },
+      {
+        kind: "ScalarField",
+        alias: null,
+        name: "blurb",
+        args: null,
+        storageKey: null,
+      },
+      v1,
+      {
+        kind: "ScalarField",
+        alias: null,
+        name: "collections",
+        args: null,
+        storageKey: null,
+      },
+      {
+        kind: "LinkedField",
+        alias: null,
+        name: "highlights",
+        storageKey: null,
+        args: null,
+        concreteType: "ArtistHighlights",
+        plural: false,
+        selections: [
+          {
+            kind: "LinkedField",
+            alias: null,
+            name: "partners",
+            storageKey:
+              'partners(display_on_partner_profile:true,first:5,partner_category:["blue-chip","top-established","top-emerging"],represented_by:true)',
+            args: [
+              {
+                kind: "Literal",
+                name: "display_on_partner_profile",
+                value: true,
+                type: "Boolean",
+              },
+              {
+                kind: "Literal",
+                name: "first",
+                value: 5,
+                type: "Int",
+              },
+              {
+                kind: "Literal",
+                name: "partner_category",
+                value: ["blue-chip", "top-established", "top-emerging"],
+                type: "[String]",
+              },
+              {
+                kind: "Literal",
+                name: "represented_by",
+                value: true,
+                type: "Boolean",
+              },
+            ],
+            concreteType: "PartnerArtistConnection",
+            plural: false,
+            selections: [
+              {
+                kind: "LinkedField",
+                alias: null,
+                name: "edges",
+                storageKey: null,
+                args: null,
+                concreteType: "PartnerArtistEdge",
+                plural: true,
+                selections: [
+                  {
+                    kind: "LinkedField",
+                    alias: null,
+                    name: "node",
+                    storageKey: null,
+                    args: null,
+                    concreteType: "Partner",
+                    plural: false,
+                    selections: [
+                      {
+                        kind: "LinkedField",
+                        alias: null,
+                        name: "categories",
+                        storageKey: null,
+                        args: null,
+                        concreteType: "Category",
+                        plural: true,
+                        selections: [v1],
+                      },
+                      v2,
+                    ],
+                  },
+                  v2,
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        kind: "LinkedField",
+        alias: null,
+        name: "auctionResults",
+        storageKey:
+          'auctionResults(first:1,recordsTrusted:true,sort:"PRICE_AND_DATE_DESC")',
+        args: [
+          {
+            kind: "Literal",
+            name: "first",
+            value: 1,
+            type: "Int",
+          },
+          {
+            kind: "Literal",
+            name: "recordsTrusted",
+            value: true,
+            type: "Boolean",
+          },
+          {
+            kind: "Literal",
+            name: "sort",
+            value: "PRICE_AND_DATE_DESC",
+            type: "AuctionResultSorts",
+          },
+        ],
+        concreteType: "AuctionResultConnection",
+        plural: false,
+        selections: [
+          {
+            kind: "LinkedField",
+            alias: null,
+            name: "edges",
+            storageKey: null,
+            args: null,
+            concreteType: "AuctionResultEdge",
+            plural: true,
+            selections: [
+              {
+                kind: "LinkedField",
+                alias: null,
+                name: "node",
+                storageKey: null,
+                args: null,
+                concreteType: "AuctionResult",
+                plural: false,
+                selections: [
+                  {
+                    kind: "LinkedField",
+                    alias: null,
+                    name: "price_realized",
+                    storageKey: null,
+                    args: null,
+                    concreteType: "AuctionResultPriceRealized",
+                    plural: false,
+                    selections: [
+                      {
+                        kind: "ScalarField",
+                        alias: null,
+                        name: "display",
+                        args: null,
+                        storageKey: null,
+                      },
+                    ],
+                  },
+                  v2,
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        kind: "LinkedField",
+        alias: null,
+        name: "genes",
+        storageKey: null,
+        args: null,
+        concreteType: "Gene",
+        plural: true,
+        selections: [v0, v2],
+      },
+      v2,
+    ],
+  }
+})()
+;(node as any).hash = "10b99c63399555511e9d9e3f84965e14"
+export default node

--- a/src/__generated__/SaveArtworkMutation.graphql.ts
+++ b/src/__generated__/SaveArtworkMutation.graphql.ts
@@ -11,6 +11,7 @@ export type SaveArtworkMutationVariables = {
 export type SaveArtworkMutationResponse = {
     readonly saveArtwork: ({
         readonly artwork: ({
+            readonly id: string;
             readonly is_saved: boolean | null;
         }) | null;
     }) | null;
@@ -24,6 +25,7 @@ mutation SaveArtworkMutation(
 ) {
   saveArtwork(input: $input) {
     artwork {
+      id
       is_saved
       __id
     }
@@ -69,6 +71,13 @@ v1 = [
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "is_saved",
             "args": null,
             "storageKey": null
@@ -90,7 +99,7 @@ return {
   "operationKind": "mutation",
   "name": "SaveArtworkMutation",
   "id": null,
-  "text": "mutation SaveArtworkMutation(\n  $input: SaveArtworkInput!\n) {\n  saveArtwork(input: $input) {\n    artwork {\n      is_saved\n      __id\n    }\n  }\n}\n",
+  "text": "mutation SaveArtworkMutation(\n  $input: SaveArtworkInput!\n) {\n  saveArtwork(input: $input) {\n    artwork {\n      id\n      is_saved\n      __id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -108,5 +117,5 @@ return {
   }
 };
 })();
-(node as any).hash = '691d5afb5f5bfd147f30029511d66cb0';
+(node as any).hash = 'b7e3f17c96d3173b62d2ece993864fe1';
 export default node;


### PR DESCRIPTION
Adds the ability to save artworks within contexts that don't directly support Relay. Depends on https://github.com/artsy/force/pull/2512.

How it works:
- Old force section wants to use new artwork bricks / grid
- Arbitrary data is fed into the grid from the outside as props
- Since there's no outer relay context managing data fetching and population, saves don't work since the typical Relay HOC environment is missing. Successful mutations don't re-inject props
- On the Force side of things we use `<ContextConsumer>` and pass in a user
- This boots up a new Relay environment at runtime that we can piggy back on for a `commitMutation` function call (saves), ignoring that the rest of the component display tree isn't using it directly
- During this update cycle we use `setState` to change the display state of the favorite, depending on the outcome of the mutation

![saves](https://user-images.githubusercontent.com/236943/39952046-0c9d2930-5545-11e8-9359-af20e3e8da03.gif)
