### PR TITLE
@eessex => [Warning] Fix react key issue in Details

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -31,10 +31,10 @@ export class Details extends React.Component<Props, null> {
       )
     } else if (artists && artists.length) {
       const artistLine = artists
-        .reduce((acc, artist) => {
+        .reduce((acc, artist, index) => {
           return acc.concat([
             ", ",
-            <TextLink href={artist.href} key={artist.__id}>
+            <TextLink href={artist.href} key={artist.__id + "-" + index}>
               {artist.name}
             </TextLink>,
           ])


### PR DESCRIPTION
Adds the array index to the key for an extra level of specificity. Problem can be seen when the same grid content is rendered in more than one place; since the key is currently pointing to the artwork ID in two places the react reconciler warns. 

<img width="551" alt="screen shot 2018-05-14 at 1 37 59 pm" src="https://user-images.githubusercontent.com/236943/40022392-b6d916d2-577c-11e8-82b0-c8fbd260cb2a.png">
