### PR TITLE
@essex => [Display Ad] adds support for pixel tracking in ads

### DIFF
--- a/src/Components/Publishing/Display/Canvas/index.tsx
+++ b/src/Components/Publishing/Display/Canvas/index.tsx
@@ -14,6 +14,7 @@ interface DisplayCanvasProps {
   unit: any
   campaign: any
   article?: any
+  renderPixelTracker?: (unit: any) => React.ReactElement<any>
 }
 
 interface DivProps extends React.HTMLProps<HTMLDivElement> {
@@ -39,7 +40,7 @@ export class DisplayCanvas extends React.Component<DisplayCanvasProps, null> {
   }
 
   render() {
-    const { unit, campaign, article } = this.props
+    const { unit, campaign, article, renderPixelTracker } = this.props
     const url = get(unit, "link.url", "")
 
     const disclaimer = (
@@ -64,6 +65,7 @@ export class DisplayCanvas extends React.Component<DisplayCanvasProps, null> {
           />
 
           {unit.layout === "overlay" && disclaimer}
+          {renderPixelTracker && renderPixelTracker(unit)}
         </DisplayContainer>
       </ErrorBoundary>
     )

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -88,7 +88,7 @@ export class DisplayPanel extends Component<Props, State> {
 
   @trackImpression(() => "panel")
   trackImpression() {
-    // Add 3rd party impression support
+    // noop
   }
 
   // TODO: This could be shared with <CanvasVideo />

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -18,6 +18,7 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
   isMobile?: boolean
   unit: any
   tracking?: any
+  renderPixelTracker?: (unit: any) => React.ReactElement<any>
 }
 
 interface State {
@@ -87,7 +88,7 @@ export class DisplayPanel extends Component<Props, State> {
 
   @trackImpression(() => "panel")
   trackImpression() {
-    // noop
+    // Add 3rd party impression support
   }
 
   // TODO: This could be shared with <CanvasVideo />
@@ -353,7 +354,7 @@ export class DisplayPanel extends Component<Props, State> {
 
   render() {
     const { showCoverImage } = this.state
-    const { unit, campaign, isMobile } = this.props
+    const { unit, campaign, isMobile, renderPixelTracker } = this.props
     const url = get(unit.assets, "0.url", "")
     const isVideo = this.isVideo()
     const cover = unit.cover_image_url || ""
@@ -395,6 +396,7 @@ export class DisplayPanel extends Component<Props, State> {
               <SponsoredBy>{`Sponsored by ${campaign.name}`}</SponsoredBy>
             </div>
           </DisplayPanelContainer>
+          {renderPixelTracker && renderPixelTracker(unit)}
         </Wrapper>
       </ErrorBoundary>
     )

--- a/src/Components/Publishing/Display/__tests__/DisplayCanvas.test.js
+++ b/src/Components/Publishing/Display/__tests__/DisplayCanvas.test.js
@@ -24,35 +24,35 @@ jest.mock("react-slick", () => {
 jest.mock("react-sizeme", () => jest.fn(c => d => d))
 
 jest.mock("../../../../Utils/track.ts", () => ({
-  track: jest.fn()
+  track: jest.fn(),
 }))
 
 describe("snapshot", () => {
   it("renders the canvas in standard layout with image", () => {
-    const displayPanel = renderer.create(
-      <DisplayCanvas unit={UnitCanvasImage} campaign={Campaign} />
-    ).toJSON()
+    const displayPanel = renderer
+      .create(<DisplayCanvas unit={UnitCanvasImage} campaign={Campaign} />)
+      .toJSON()
     expect(displayPanel).toMatchSnapshot()
   })
 
   it("renders the canvas in standard layout with video", () => {
-    const displayPanel = renderer.create(
-      <DisplayCanvas unit={UnitCanvasVideo} campaign={Campaign} />
-    ).toJSON()
+    const displayPanel = renderer
+      .create(<DisplayCanvas unit={UnitCanvasVideo} campaign={Campaign} />)
+      .toJSON()
     expect(displayPanel).toMatchSnapshot()
   })
 
   it("renders the canvas in overlay layout", () => {
-    const displayPanel = renderer.create(
-      <DisplayCanvas unit={UnitCanvasOverlay} campaign={Campaign} />
-    ).toJSON()
+    const displayPanel = renderer
+      .create(<DisplayCanvas unit={UnitCanvasOverlay} campaign={Campaign} />)
+      .toJSON()
     expect(displayPanel).toMatchSnapshot()
   })
 
   it("renders the canvas in slideshow layout", () => {
-    const displayPanel = renderer.create(
-      <DisplayCanvas unit={UnitCanvasSlideshow} campaign={Campaign} />
-    ).toJSON()
+    const displayPanel = renderer
+      .create(<DisplayCanvas unit={UnitCanvasSlideshow} campaign={Campaign} />)
+      .toJSON()
     expect(displayPanel).toMatchSnapshot()
   })
 })
@@ -72,7 +72,9 @@ describe("unit", () => {
   }
 
   it("renders the unit data", () => {
-    const canvas = mount(<DisplayCanvas unit={UnitCanvasImage} campaign={Campaign} />)
+    const canvas = mount(
+      <DisplayCanvas unit={UnitCanvasImage} campaign={Campaign} />
+    )
     expect(canvas.html()).toMatch(UnitCanvasImage.disclaimer)
     expect(canvas.html()).toMatch(UnitCanvasImage.headline)
     expect(canvas.html()).toMatch(UnitCanvasImage.link.text)
@@ -84,13 +86,29 @@ describe("unit", () => {
   })
 
   it("renders the video component if standard layout with video", () => {
-    const canvas = mount(<DisplayCanvas unit={UnitCanvasVideo} campaign={Campaign} />)
+    const canvas = mount(
+      <DisplayCanvas unit={UnitCanvasVideo} campaign={Campaign} />
+    )
     expect(canvas.find(CanvasVideo).length).toBe(1)
   })
 
   it("renders the slideshow component if slideshow layout", () => {
-    const canvas = mount(<DisplayCanvas unit={UnitCanvasSlideshow} campaign={Campaign} />)
+    const canvas = mount(
+      <DisplayCanvas unit={UnitCanvasSlideshow} campaign={Campaign} />
+    )
     expect(canvas.find(CanvasSlideshow).length).toBe(1)
+  })
+
+  it("calls renderPixelTracker with a unit object", () => {
+    const spy = jest.fn()
+    const displayPanel = renderer.create(
+      <DisplayCanvas
+        unit={UnitCanvasVideo}
+        campaign={Campaign}
+        renderPixelTracker={spy}
+      />
+    )
+    expect(spy).toBeCalledWith(UnitCanvasVideo)
   })
 
   describe("analytics", () => {
@@ -103,7 +121,7 @@ describe("unit", () => {
           action: "Impression",
           entity_type: "display_ad",
           campaign_name: "Artsy",
-          unit_layout: "canvas_standard"
+          unit_layout: "canvas_standard",
         })
       )
     })
@@ -117,7 +135,7 @@ describe("unit", () => {
           action: "Viewability",
           entity_type: "display_ad",
           campaign_name: "Artsy",
-          unit_layout: "canvas_standard"
+          unit_layout: "canvas_standard",
         })
       )
     })

--- a/src/Components/Publishing/Display/__tests__/DisplayPanel.test.js
+++ b/src/Components/Publishing/Display/__tests__/DisplayPanel.test.js
@@ -15,13 +15,13 @@ describe("snapshots", () => {
   it("renders the display panel with an image", () => {
     const displayPanel = renderer
       .create(
-      <DisplayPanel
-        unit={UnitPanel}
-        campaign={Campaign}
-        tracking={{
-          trackEvent: jest.fn(),
-        }}
-      />
+        <DisplayPanel
+          unit={UnitPanel}
+          campaign={Campaign}
+          tracking={{
+            trackEvent: jest.fn(),
+          }}
+        />
       )
       .toJSON()
     expect(displayPanel).toMatchSnapshot()
@@ -30,13 +30,13 @@ describe("snapshots", () => {
   it("renders the display panel with video", () => {
     const displayPanel = renderer
       .create(
-      <DisplayPanel
-        unit={UnitPanelVideo}
-        campaign={Campaign}
-        tracking={{
-          trackEvent: jest.fn(),
-        }}
-      />
+        <DisplayPanel
+          unit={UnitPanelVideo}
+          campaign={Campaign}
+          tracking={{
+            trackEvent: jest.fn(),
+          }}
+        />
       )
       .toJSON()
     expect(displayPanel).toMatchSnapshot()
@@ -171,6 +171,21 @@ describe("units", () => {
           label: "Display ad play video",
         })
       )
+    })
+
+    it("calls renderPixelTracker with a unit object", () => {
+      const spy = jest.fn()
+      const displayPanel = renderer.create(
+        <DisplayPanel
+          unit={UnitPanelVideo}
+          campaign={Campaign}
+          tracking={{
+            trackEvent: jest.fn(),
+          }}
+          renderPixelTracker={spy}
+        />
+      )
+      expect(spy).toBeCalledWith(UnitPanelVideo)
     })
   })
 

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -40,8 +40,8 @@ export class StandardLayout extends React.Component<
     this.setState({ isTruncated: false })
   }
 
-  renderPixelTracker(unit) {
-    let url = unit.pixel_tracking_code
+  renderPixelTracker({ pixel_tracking_code }) {
+    let url = pixel_tracking_code
     if (!url) {
       return null
     }
@@ -53,7 +53,7 @@ export class StandardLayout extends React.Component<
       )
     }
 
-    // handle doubleclick
+    // TODO: handle doubleclick
     return <TrackerImage width={1} height={1} src={url} />
   }
 

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -40,6 +40,23 @@ export class StandardLayout extends React.Component<
     this.setState({ isTruncated: false })
   }
 
+  renderPixelTracker(unit) {
+    let url = unit.pixel_tracking_code
+    if (!url) {
+      return null
+    }
+    const isSizmek = url.indexOf("serving-sys") !== -1
+    if (isSizmek) {
+      url = url.replace(
+        "[timestamp]",
+        String(new Date().getMilliseconds() / 1000)
+      )
+    }
+
+    // handle doubleclick
+    return <TrackerImage width={1} height={1} src={url} />
+  }
+
   render() {
     const {
       article,
@@ -69,6 +86,7 @@ export class StandardLayout extends React.Component<
                   unit={display.panel}
                   campaign={campaign}
                   article={article}
+                  renderPixelTracker={this.renderPixelTracker}
                 />
               )
             )
@@ -131,6 +149,7 @@ export class StandardLayout extends React.Component<
                         unit={display.canvas}
                         campaign={campaign}
                         article={article}
+                        renderPixelTracker={this.renderPixelTracker}
                       />
                     </div>
                   ) : (
@@ -139,6 +158,7 @@ export class StandardLayout extends React.Component<
                         unit={display.canvas}
                         campaign={campaign}
                         article={article}
+                        renderPixelTracker={this.renderPixelTracker}
                       />
                     </FooterContainer>
                   )}
@@ -176,4 +196,8 @@ const FooterContainer = styled.div`
   ${pMedia.sm`
     margin: 0 20px;
   `};
+`
+
+const TrackerImage = styled.img`
+  display: none;
 `


### PR DESCRIPTION
https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-596

One thing to note, for sizmek we assume the `pixel_tracking_code` is a URL here, so we'll have to make sure to let the team know to only include the url and not the script tags.