### PR TITLE
[Toolchain] Add --raw to concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
     "prettier-write": "yarn run prettier --write",
     "relay": "relay-compiler --src ./src --schema data/schema.graphql --language typescript --artifactDirectory ./src/__generated__",
     "start": "yarn storybook",
-    "storybook": "node verify-node-version.js && concurrently --kill-others 'yarn relay --watch' 'start-storybook -p 9001'",
+    "storybook": "node verify-node-version.js && concurrently --raw --kill-others 'yarn relay --watch' 'start-storybook -p 9001'",
     "sync-colors": "cd externals/elan && git fetch && git checkout origin/master && cp components/lib/variables/colors.json ../../data",
     "sync-schema": "cd externals/metaphysics && git fetch && git checkout origin/master && cp .env.example .env && yarn install && yarn dump-schema -- ../../data",
     "sync-schema:localhost": "cd ../metaphysics && yarn dump-schema -- ../reaction/data",
     "test": "node verify-node-version.js && jest",
     "test:watch": "jest --watch --runInBand",
     "type-check": "tsc --noEmit --pretty",
-    "watch": "concurrently --kill-others 'yarn relay --watch' 'yarn compile -w'",
+    "watch": "concurrently --raw --kill-others 'yarn relay --watch' 'yarn compile -w'",
     "semantic-release": "semantic-release"
   },
   "resolutions": {


### PR DESCRIPTION
Don't clobber stdout when starting app with `concurrently` 