### PR TITLE
@kanaabe => Tooltip arrows are centered to link text

### DIFF
--- a/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
+++ b/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
@@ -138,17 +138,24 @@ export class LinkWithTooltip extends Component<Props, State> {
 
   getToolTipPosition = type => {
     if (this.link) {
-      const { width, x } = this.state.position
-      const anchorPosition = width / 2
+      const { left, width, x } = this.state.position
+      const linkCenter = width / 2
       const toolTipWidth = type === "artist" ? 360 : 280
 
-      const toolTipLeft = anchorPosition - toolTipWidth / 2
+      let toolTipLeft = linkCenter - toolTipWidth / 2
       const isAtWindowBoundary = x + toolTipLeft < 10
+      let arrowLeft = null
 
       if (isAtWindowBoundary) {
-        return 10 - x
-      } else {
-        return toolTipLeft
+        const padding = 20
+        const arrowSize = 30
+
+        arrowLeft = `${left + linkCenter - padding - arrowSize}px`
+        toolTipLeft = 10 - x
+      }
+      return {
+        arrowLeft,
+        toolTipLeft,
       }
     }
   }
@@ -178,9 +185,10 @@ export class LinkWithTooltip extends Component<Props, State> {
     const toolTipData = this.entityTypeToEntity()
     const { entity, entityType } = toolTipData
     const id = entity ? entity.id : null
-    const toolTipLeft = this.getToolTipPosition(entityType)
-    const show = id ? id === activeToolTip : false
-    const showWithFade = show || waitForFade === id
+    const toolTipPosition = this.getToolTipPosition(entityType)
+
+    const show = id && activeToolTip ? id === activeToolTip : false
+    const showWithFade = show || (waitForFade && waitForFade === id)
 
     return (
       <Link
@@ -214,7 +222,8 @@ export class LinkWithTooltip extends Component<Props, State> {
               onMouseEnter={() => {
                 this.setState({ inToolTip: true })
               }}
-              positionLeft={toolTipLeft}
+              positionLeft={toolTipPosition && toolTipPosition.toolTipLeft}
+              arrowLeft={toolTipPosition && toolTipPosition.arrowLeft}
               orientation={orientation}
             />
           </FadeTransition>

--- a/src/Components/Publishing/ToolTip/ToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/ToolTip.tsx
@@ -5,6 +5,7 @@ import { ArtistTooltipContainer } from "./ArtistToolTip"
 import { GeneToolTipContainer } from "./GeneToolTip"
 
 interface Props extends React.HTMLProps<HTMLDivElement> {
+  arrowLeft?: string
   entity: object
   orientation?: string
   model: string
@@ -38,6 +39,7 @@ export class ToolTip extends React.Component<Props> {
 
   render() {
     const {
+      arrowLeft,
       entity,
       orientation,
       onMouseEnter,
@@ -54,7 +56,7 @@ export class ToolTip extends React.Component<Props> {
         onMouseLeave={onMouseLeave}
         positionLeft={positionLeft}
       >
-        <Content orientation={orientation}>
+        <Content orientation={orientation} arrowLeft={arrowLeft}>
           {orientation === "down" && (
             // point up from below content
             <Arrow orientation="up" />
@@ -85,7 +87,9 @@ export const ToolTipContainer = styled.div.attrs<DivProps>({})`
     props.orientation === "up" ? `bottom: 95%;` : `top: calc(100% + 10px);`};
 `
 
-const Content = styled.div.attrs<{ orientation: string }>({})`
+const Content = styled.div.attrs<{ orientation: string; arrowLeft?: string }>(
+  {}
+)`
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.15);
   padding: 20px;
   background: white;
@@ -95,7 +99,7 @@ const Content = styled.div.attrs<{ orientation: string }>({})`
     background-image: none;
   }
   ${ArrowContainer} {
-    left: calc(50% - 30px);
+    left: ${props => (props.arrowLeft ? props.arrowLeft : `calc(50% - 30px)`)};
     ${props =>
       props.orientation === "down" ? `top: -35px;` : `bottom: -15px;`};
   }

--- a/src/Components/Publishing/ToolTip/__tests__/LinkWithTooltip.test.js
+++ b/src/Components/Publishing/ToolTip/__tests__/LinkWithTooltip.test.js
@@ -225,42 +225,52 @@ describe("LinkWithTooltip", () => {
   })
 
   describe("#getToolTipPosition", () => {
-    it("Returns a position for artist links", () => {
+    it("Returns tooltip position for artist links", () => {
       const wrapper = getWrapper(context, props)
         .childAt(0)
         .childAt(0)
         .instance()
       wrapper.setState({ position })
-      expect(wrapper.getToolTipPosition("artist")).toBe(-116.3203125)
+      expect(wrapper.getToolTipPosition("artist").toolTipLeft).toBe(-116.3203125)
     })
 
-    it("Returns a position for gene links", () => {
+    it("Returns tooltip position for gene links", () => {
       const wrapper = getWrapper(context, props)
         .childAt(0)
         .childAt(0)
         .instance()
       wrapper.setState({ position })
-      expect(wrapper.getToolTipPosition("gene")).toBe(-76.3203125)
+      expect(wrapper.getToolTipPosition("gene").toolTipLeft).toBe(-76.3203125)
     })
 
-    it("Returns a position for artist links at left window boundary", () => {
+    it("Returns tooltip and arrow position for artist links at left window boundary", () => {
       position.x = 80
+      position.width = 100
+      position.left = 60
       const wrapper = getWrapper(context, props)
         .childAt(0)
         .childAt(0)
         .instance()
       wrapper.setState({ position })
-      expect(wrapper.getToolTipPosition("artist")).toBe(-70)
+      const { arrowLeft, toolTipLeft } = wrapper.getToolTipPosition("artist")
+
+      expect(toolTipLeft).toBe(-70)
+      expect(arrowLeft).toBe("60px")
     })
 
     it("Returns a position for gene links at left window boundary", () => {
       position.x = 80
+      position.width = 100
+      position.left = 60
       const wrapper = getWrapper(context, props)
         .childAt(0)
         .childAt(0)
         .instance()
       wrapper.setState({ position })
-      expect(wrapper.getToolTipPosition("gene")).toBe(-70)
+      const { arrowLeft, toolTipLeft } = wrapper.getToolTipPosition("gene")
+
+      expect(toolTipLeft).toBe(-70)
+      expect(arrowLeft).toBe("60px")
     })
   })
 })


### PR DESCRIPTION
Addresses [GROW-669](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-669)

![screen shot 2018-05-30 at 4 50 16 pm](https://user-images.githubusercontent.com/1497424/40747795-6358f7e0-642c-11e8-9e98-54cd722b8841.png)
