### PR TITLE
@kanaabe => [FIX tooltips] track clicks on tooltip hover background

### DIFF
--- a/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
+++ b/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
@@ -225,6 +225,7 @@ export class LinkWithTooltip extends Component<Props, State> {
             onMouseLeave={this.onLeaveLink}
             href={url}
             target="_blank"
+            onClick={() => this.trackClick(toolTipData)}
           />
         )}
       </Link>

--- a/src/Components/Publishing/ToolTip/__tests__/LinkWithTooltip.test.js
+++ b/src/Components/Publishing/ToolTip/__tests__/LinkWithTooltip.test.js
@@ -150,6 +150,19 @@ describe("LinkWithTooltip", () => {
     expect(tracking.destination_path).toBe("/artist/nick-mauss")
   })
 
+  it("Tracks click events from hover background", () => {
+    context.activeToolTip = "nick-mauss"
+    const wrapper = getWrapper(context, props)
+    wrapper.find(Background).simulate("click")
+    const tracking = props.tracking.trackEvent.mock.calls[0][0]
+
+    expect(tracking.action).toBe("Click")
+    expect(tracking.flow).toBe("tooltip")
+    expect(tracking.type).toBe("artist stub")
+    expect(tracking.context_module).toBe("intext tooltip")
+    expect(tracking.destination_path).toBe("/artist/nick-mauss")
+  })
+
   it("Sets tooltip position on mount", () => {
     const wrapper = getWrapper(context, props)
       .childAt(0)


### PR DESCRIPTION
Addresses missing click event for tooltips.  (Hover background covers in-text link while tooltip is open.)