### PR TITLE
@l2succes => Use renderTime from server

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -13,6 +13,7 @@ export interface ArticleProps {
   relatedArticles?: any
   relatedArticlesForPanel?: any
   relatedArticlesForCanvas?: any
+  renderTime?: string
   seriesArticle?: ArticleData
   isHovered?: boolean
   isMobile?: boolean

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -13,7 +13,6 @@ import { RelatedArticlesCanvas } from "../RelatedArticles/RelatedArticlesCanvas"
 import { Sections } from "../Sections/Sections"
 import { Sidebar } from "./Components/Sidebar"
 import { ArticleProps } from "../Article"
-import { getCurrentUnixTimestamp } from "../Constants"
 
 interface ArticleState {
   isTruncated: boolean
@@ -48,6 +47,7 @@ export class StandardLayout extends React.Component<
       emailSignupUrl,
       relatedArticlesForCanvas,
       relatedArticlesForPanel,
+      renderTime,
       showTooltips,
       showToolTipMarketData,
     } = this.props
@@ -55,7 +55,6 @@ export class StandardLayout extends React.Component<
 
     const campaign = omit(display, "panel", "canvas")
     const displayOverflows = display && display.canvas.layout === "slideshow"
-    const renderTime = getCurrentUnixTimestamp()
 
     return (
       <Responsive initialState={{ isMobile: this.props.isMobile }}>


### PR DESCRIPTION
The dupe impression issue happens in Force on window resizes (i guess re-renders are happening on the parent level there) -- instead lets just use a fixed `renderTime` from the server so the timestamp is guaranteed to only be set once. Then for infinite scroll we can store an array of `renderTimes` that will also be unique and unaffected by any re-renders.