### PR TITLE
[Dep] Bump / patch graphql@0.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "resolutions": {
     "babel-loader": "8.0.0-beta.0",
-    "graphql": "^0.12.3",
+    "graphql": "^0.13.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-plugin-relay": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/babel-plugin-relay-1.5.0-artsy.3.tgz",
     "relay-compiler": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-compiler-1.5.0-artsy.3.tgz",

--- a/patches/graphql+0.13.2.patch
+++ b/patches/graphql+0.13.2.patch
@@ -1,24 +1,18 @@
 patch-package
 --- a/node_modules/graphql/utilities/assertValidName.js
 +++ b/node_modules/graphql/utilities/assertValidName.js
-@@ -41,13 +41,13 @@ function assertValidName(name) {
+@@ -41,10 +41,11 @@ function assertValidName(name) {
   */
  function isValidNameError(name, node) {
    !(typeof name === 'string') ? (0, _invariant2.default)(0, 'Expected string') : void 0;
--  if (name.length > 1 && name[0] === '_' && name[1] === '_' &&
--  // Note: this special case is not part of the spec and exists only to
--  // support legacy server configurations. Do not rely on this special case
--  // as it may be removed at any time.
--  name !== '__configs__') {
+-  if (name.length > 1 && name[0] === '_' && name[1] === '_') {
 -    return new _GraphQLError.GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
 -  }
-+  // if (name.length > 1 && name[0] === '_' && name[1] === '_' &&
-+  // // Note: this special case is not part of the spec and exists only to
-+  // // support legacy server configurations. Do not rely on this special case
-+  // // as it may be removed at any time.
-+  // name !== '__configs__') {
++  // if (name.length > 1 && name[0] === '_' && name[1] === '_') {
 +  //   return new _GraphQLError.GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
 +  // }
    if (!NAME_RX.test(name)) {
      return new _GraphQLError.GraphQLError('Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "' + name + '" does not.', node);
    }
++
+ }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5549,11 +5549,11 @@ graphql-language-service-utils@0.0.10:
     graphql "^0.9.6"
     graphql-language-service-types "0.0.16"
 
-"graphql@0.7.1 - 1.0.0", graphql@0.9.6, graphql@^0.12.3, graphql@^0.13.0, graphql@^0.13.1, graphql@^0.9.5, graphql@^0.9.6:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
+"graphql@0.7.1 - 1.0.0", graphql@0.9.6, graphql@^0.13.0, graphql@^0.13.1, graphql@^0.13.2, graphql@^0.9.5, graphql@^0.9.6:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
-    iterall "1.1.3"
+    iterall "^1.2.1"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -6517,9 +6517,9 @@ istanbul-reports@^1.1.3:
   dependencies:
     handlebars "^4.0.3"
 
-iterall@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+iterall@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
 java-properties@^0.2.9:
   version "0.2.10"


### PR DESCRIPTION
Bump `graphql@0.12.3` -> `graphql@0.13.2`. 

Fixes:

<img width="543" alt="screen shot 2018-06-02 at 3 30 44 pm" src="https://user-images.githubusercontent.com/236943/40881378-fd0e0eb2-6679-11e8-8e90-324b67d8df42.png">

Related: https://github.com/graphql/graphql-js/pull/1174

