### PR TITLE
[ArtistFilter] Working unstyled component w/ inf scroll

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -131,6 +131,39 @@ type Artist implements Node {
     size: Int = 5
   ): [Show]
 
+  # Artworks Elastic Search results
+  filtered_artworks(
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+  ): FilterArtworks
+
   # A string showing the total number of works and those for sale
   formatted_artworks_count: String
 
@@ -334,6 +367,39 @@ type ArtistItem implements Node {
     # The number of Shows to return
     size: Int = 5
   ): [Show]
+
+  # Artworks Elastic Search results
+  filtered_artworks(
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+  ): FilterArtworks
 
   # A string showing the total number of works and those for sale
   formatted_artworks_count: String

--- a/data/schema.json
+++ b/data/schema.json
@@ -2926,11 +2926,6 @@
             },
             {
               "kind": "OBJECT",
-              "name": "Gene",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
               "name": "FilterArtworks",
               "ofType": null
             },
@@ -2942,6 +2937,11 @@
             {
               "kind": "OBJECT",
               "name": "ArtworkFilterGene",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Gene",
               "ofType": null
             },
             {
@@ -5815,6 +5815,322 @@
                   "name": "Show",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filtered_artworks",
+              "description": "Artworks Elastic Search results",
+              "args": [
+                {
+                  "name": "aggregation_partner_cities",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "aggregations",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ArtworkAggregation",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "artist_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "artist_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "color",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "dimension_range",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "extra_aggregation_gene_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "for_sale",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "gene_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "gene_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "height",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "width",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "medium",
+                  "description":
+                    "A string from the list of allocations, or * to denote all mediums",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "period",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "periods",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "major_periods",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "partner_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "partner_cities",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "price_range",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sale_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "size",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "tag_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "keyword",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilterArtworks",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -11708,6 +12024,1408 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "ArtworkAggregation",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "COLOR",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DIMENSION_RANGE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FOLLOWED_ARTISTS",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MAJOR_PERIOD",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MEDIUM",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MERCHANDISABLE_ARTISTS",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GALLERY",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INSTITUTION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PARTNER_CITY",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PERIOD",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PRICE_RANGE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TOTAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilterArtworks",
+          "description": null,
+          "fields": [
+            {
+              "name": "__id",
+              "description": "The ID of the object.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "aggregations",
+              "description":
+                "Returns aggregation counts for the given filter query.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ArtworksAggregationResults",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "artworks_connection",
+              "description": null,
+              "args": [
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ArtworkConnection",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason":
+                "Favour artwork connections that take filter arguments."
+            },
+            {
+              "name": "counts",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilterArtworksCounts",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "followed_artists_total",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Favor `favor counts.followed_artists`"
+            },
+            {
+              "name": "hits",
+              "description": "Artwork results.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Artwork",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "merchandisable_artists",
+              "description":
+                "Returns a list of merchandisable artists sorted by merch score.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Artist",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Favor `counts.total`"
+            },
+            {
+              "name": "facet",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "UNION",
+                "name": "ArtworkFilterFacet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ArtworksAggregationResults",
+          "description": "The results for one of the requested aggregations",
+          "fields": [
+            {
+              "name": "counts",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AggregationCount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "slice",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "ArtworkAggregation",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AggregationCount",
+          "description": "One item in an aggregation",
+          "fields": [
+            {
+              "name": "__id",
+              "description": "A globally unique ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "A type-specific ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "count",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sortable_id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilterArtworksCounts",
+          "description": null,
+          "fields": [
+            {
+              "name": "total",
+              "description": null,
+              "args": [
+                {
+                  "name": "format",
+                  "description":
+                    "Returns a `String` when format is specified. e.g.`'0,0.0000''`",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "label",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FormattedNumber",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "followed_artists",
+              "description": null,
+              "args": [
+                {
+                  "name": "format",
+                  "description":
+                    "Returns a `String` when format is specified. e.g.`'0,0.0000''`",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "label",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FormattedNumber",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "ArtworkFilterFacet",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "ArtworkFilterTag",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ArtworkFilterGene",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ArtworkFilterTag",
+          "description": null,
+          "fields": [
+            {
+              "name": "__id",
+              "description": "A globally unique ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "A type-specific ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "_id",
+              "description": "A type-specific Gravity Mongo Document ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cached",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "href",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "image",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "count",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filtered_artworks",
+              "description": "Artworks Elastic Search results",
+              "args": [
+                {
+                  "name": "aggregation_partner_cities",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "aggregations",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ArtworkAggregation",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "artist_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "artist_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "color",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "dimension_range",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "extra_aggregation_gene_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "for_sale",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "gene_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "gene_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "height",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "width",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "medium",
+                  "description":
+                    "A string from the list of allocations, or * to denote all mediums",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "period",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "periods",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "major_periods",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "partner_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "partner_cities",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "price_range",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sale_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "size",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "tag_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "keyword",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilterArtworks",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ArtworkFilterGene",
+          "description": null,
+          "fields": [
+            {
+              "name": "__id",
+              "description": "A globally unique ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "A type-specific ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "_id",
+              "description": "A type-specific Gravity Mongo Document ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cached",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "href",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "image",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "count",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filtered_artworks",
+              "description": "Artworks Elastic Search results",
+              "args": [
+                {
+                  "name": "aggregation_partner_cities",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "aggregations",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ArtworkAggregation",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "artist_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "artist_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "color",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "dimension_range",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "extra_aggregation_gene_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "for_sale",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "gene_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "gene_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "height",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "width",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "medium",
+                  "description":
+                    "A string from the list of allocations, or * to denote all mediums",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "period",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "periods",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "major_periods",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "partner_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "partner_cities",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "price_range",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sale_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "size",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "tag_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "keyword",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilterArtworks",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "Gene",
           "description": null,
@@ -12799,89 +14517,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "ArtworkAggregation",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "COLOR",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DIMENSION_RANGE",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FOLLOWED_ARTISTS",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MAJOR_PERIOD",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MEDIUM",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MERCHANDISABLE_ARTISTS",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GALLERY",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INSTITUTION",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PARTNER_CITY",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PERIOD",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PRICE_RANGE",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TOTAL",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "GeneArtworksConnection",
           "description": "A connection to a list of items.",
@@ -12989,1325 +14624,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ArtworksAggregationResults",
-          "description": "The results for one of the requested aggregations",
-          "fields": [
-            {
-              "name": "counts",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AggregationCount",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "slice",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "ENUM",
-                "name": "ArtworkAggregation",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "AggregationCount",
-          "description": "One item in an aggregation",
-          "fields": [
-            {
-              "name": "__id",
-              "description": "A globally unique ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "A type-specific ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "count",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "sortable_id",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "FilterArtworksCounts",
-          "description": null,
-          "fields": [
-            {
-              "name": "total",
-              "description": null,
-              "args": [
-                {
-                  "name": "format",
-                  "description":
-                    "Returns a `String` when format is specified. e.g.`'0,0.0000''`",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "label",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "FormattedNumber",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "followed_artists",
-              "description": null,
-              "args": [
-                {
-                  "name": "format",
-                  "description":
-                    "Returns a `String` when format is specified. e.g.`'0,0.0000''`",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "label",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "FormattedNumber",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "FilterArtworks",
-          "description": null,
-          "fields": [
-            {
-              "name": "__id",
-              "description": "The ID of the object.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "aggregations",
-              "description":
-                "Returns aggregation counts for the given filter query.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ArtworksAggregationResults",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "artworks_connection",
-              "description": null,
-              "args": [
-                {
-                  "name": "sort",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "ArtworkConnection",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason":
-                "Favour artwork connections that take filter arguments."
-            },
-            {
-              "name": "counts",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "FilterArtworksCounts",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "followed_artists_total",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Favor `favor counts.followed_artists`"
-            },
-            {
-              "name": "hits",
-              "description": "Artwork results.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Artwork",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "merchandisable_artists",
-              "description":
-                "Returns a list of merchandisable artists sorted by merch score.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Artist",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "total",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Favor `counts.total`"
-            },
-            {
-              "name": "facet",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "UNION",
-                "name": "ArtworkFilterFacet",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "UNION",
-          "name": "ArtworkFilterFacet",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": [
-            {
-              "kind": "OBJECT",
-              "name": "ArtworkFilterTag",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "ArtworkFilterGene",
-              "ofType": null
-            }
-          ]
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ArtworkFilterTag",
-          "description": null,
-          "fields": [
-            {
-              "name": "__id",
-              "description": "A globally unique ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "A type-specific ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "_id",
-              "description": "A type-specific Gravity Mongo Document ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "cached",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "href",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "image",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Image",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "count",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "filtered_artworks",
-              "description": "Artworks Elastic Search results",
-              "args": [
-                {
-                  "name": "aggregation_partner_cities",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "aggregations",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "ArtworkAggregation",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "artist_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "artist_ids",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "color",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "dimension_range",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "extra_aggregation_gene_ids",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "include_artworks_by_followed_artists",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "include_medium_filter_in_aggregation",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "for_sale",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "gene_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "gene_ids",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "height",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "width",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "medium",
-                  "description":
-                    "A string from the list of allocations, or * to denote all mediums",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "period",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "periods",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "major_periods",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "partner_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "partner_cities",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "price_range",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "page",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "sale_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "size",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "sort",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "tag_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "keyword",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "FilterArtworks",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ArtworkFilterGene",
-          "description": null,
-          "fields": [
-            {
-              "name": "__id",
-              "description": "A globally unique ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "A type-specific ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "_id",
-              "description": "A type-specific Gravity Mongo Document ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "cached",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "href",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "image",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Image",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "count",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "filtered_artworks",
-              "description": "Artworks Elastic Search results",
-              "args": [
-                {
-                  "name": "aggregation_partner_cities",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "aggregations",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "ArtworkAggregation",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "artist_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "artist_ids",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "color",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "dimension_range",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "extra_aggregation_gene_ids",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "include_artworks_by_followed_artists",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "include_medium_filter_in_aggregation",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "for_sale",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "gene_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "gene_ids",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "height",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "width",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "medium",
-                  "description":
-                    "A string from the list of allocations, or * to denote all mediums",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "period",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "periods",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "major_periods",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "partner_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "partner_cities",
-                  "description": null,
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "price_range",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "page",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "sale_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "size",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "sort",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "tag_id",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "keyword",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "FilterArtworks",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -32709,6 +33025,322 @@
                   "name": "Show",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filtered_artworks",
+              "description": "Artworks Elastic Search results",
+              "args": [
+                {
+                  "name": "aggregation_partner_cities",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "aggregations",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ArtworkAggregation",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "artist_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "artist_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "color",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "dimension_range",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "extra_aggregation_gene_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "for_sale",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "gene_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "gene_ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "height",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "width",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "medium",
+                  "description":
+                    "A string from the list of allocations, or * to denote all mediums",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "period",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "periods",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "major_periods",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "partner_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "partner_cities",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "price_range",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sale_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "size",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "tag_id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "keyword",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilterArtworks",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "serialize-javascript": "^1.5.0",
     "sharify": "^0.1.6",
     "superagent": "^3.6.3",
+    "unstated": "^2.1.1",
     "url": "^0.11.0",
     "yup": "^0.24.1"
   },

--- a/src/Components/ArtistFilter/Artworks.tsx
+++ b/src/Components/ArtistFilter/Artworks.tsx
@@ -1,0 +1,136 @@
+import * as React from "react"
+import {
+  ConnectionData,
+  createPaginationContainer,
+  graphql,
+  RelayPaginationProp,
+} from "react-relay"
+import { Subscribe } from "unstated"
+
+import { FilterState } from "./state"
+import ArtworkGrid from "../ArtworkGrid"
+
+import { Artworks_filtered_artworks } from "../../__generated__/Artworks_filtered_artworks.graphql"
+
+interface Props {
+  filtered_artworks: Artworks_filtered_artworks
+  relay: RelayPaginationProp
+  artistID: string
+}
+
+const PAGE_SIZE = 10
+
+class Artworks extends React.Component<Props> {
+  loadMoreArtworks(filters) {
+    const hasMore = this.props.filtered_artworks.artworks.pageInfo.hasNextPage
+    const endCursor = this.props.filtered_artworks.artworks.pageInfo.endCursor
+    if (hasMore) {
+      // TODO: Should refetchConnection keep appending records?
+      this.props.relay.refetchConnection(
+        PAGE_SIZE,
+        error => {
+          if (error) {
+            console.error(error)
+          }
+          filters.incrementPage()
+        },
+        { cursor: endCursor }
+      )
+    }
+  }
+  renderPagination(filters) {
+    return (
+      <div>
+        <div>Current Page: {filters.state.page}</div>
+        <div
+          onClick={() => {
+            this.loadMoreArtworks(filters)
+          }}
+        >
+          Next
+        </div>
+      </div>
+    )
+  }
+
+  render() {
+    return (
+      <Subscribe to={[FilterState]}>
+        {filters => {
+          return (
+            <div>
+              {this.renderPagination(filters)}
+              <ArtworkGrid
+                artworks={this.props.filtered_artworks.artworks as any}
+                columnCount={4}
+                itemMargin={40}
+              />
+            </div>
+          )
+        }}
+      </Subscribe>
+    )
+  }
+}
+
+export default createPaginationContainer(
+  Artworks,
+  {
+    filtered_artworks: graphql`
+      fragment Artworks_filtered_artworks on FilterArtworks
+        @argumentDefinitions(
+          count: { type: "Int", defaultValue: 10 }
+          cursor: { type: "String", defaultValue: "" }
+        ) {
+        __id
+        artworks: artworks_connection(first: $count, after: $cursor)
+          @connection(key: "Artworks_filtered_artworks") {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          ...ArtworkGrid_artworks
+          edges {
+            node {
+              __id
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    direction: "forward",
+    getConnectionFromProps(props) {
+      return props.filtered_artworks.artworks as ConnectionData
+    },
+    getFragmentVariables(prevVars, totalCount) {
+      return {
+        ...prevVars,
+        count: totalCount,
+      }
+    },
+    getVariables(props, { count, cursor }, fragmentVariables) {
+      return {
+        // in most cases, for variables other than connection filters like
+        // `first`, `after`, etc. you may want to use the previous values.
+        ...fragmentVariables,
+        count,
+        cursor,
+        filteredArtworksNodeID: props.filtered_artworks.__id,
+      }
+    },
+    query: graphql`
+      query ArtworksQuery(
+        $filteredArtworksNodeID: ID!
+        $count: Int!
+        $cursor: String
+      ) {
+        node(__id: $filteredArtworksNodeID) {
+          ...Artworks_filtered_artworks
+            @arguments(count: $count, cursor: $cursor)
+        }
+      }
+    `,
+  }
+)

--- a/src/Components/ArtistFilter/Filter.tsx
+++ b/src/Components/ArtistFilter/Filter.tsx
@@ -1,0 +1,154 @@
+import * as React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Subscribe } from "unstated"
+
+import { FilterState } from "./state"
+import ArtworksContent from "./Artworks"
+
+import { Filter_artist } from "../../__generated__/Filter_artist.graphql"
+
+interface Props {
+  artist: Filter_artist
+}
+
+class Filter extends React.Component<Props> {
+  renderCurrentlySelected(filter, state) {
+    if (
+      (filter === "institution" || filter === "gallery") &&
+      state.partner_id
+    ) {
+      return state.partner_id
+    }
+    if (filter === "major_period" && state.major_periods) {
+      return state.major_periods[0]
+    }
+    return state[filter]
+  }
+
+  renderFilters(filters) {
+    return this.props.artist.filtered_artworks.aggregations.map(aggregation => {
+      return (
+        <div>
+          <div>
+            {aggregation.slice} -{" "}
+            {this.renderCurrentlySelected(
+              aggregation.slice.toLowerCase(),
+              filters.state
+            )}
+            {this.renderSection(aggregation, filters)}
+          </div>
+          <br />
+        </div>
+      )
+    })
+  }
+
+  renderForSale(filters) {
+    return (
+      <div>
+        <div>
+          Currently selected: {filters.state.for_sale ? "Only for sale" : "All"}
+        </div>
+        <div
+          onClick={() => {
+            filters.setFilter("for_sale", true)
+          }}
+        >
+          For sale
+        </div>
+        <div
+          onClick={() => {
+            filters.setFilter("for_sale", null)
+          }}
+        >
+          All
+        </div>
+        <br />
+      </div>
+    )
+  }
+
+  renderSidebar(filters) {
+    return (
+      <div>
+        {this.renderForSale(filters)}
+        {this.renderFilters(filters)}
+      </div>
+    )
+  }
+
+  renderSection(aggregation, filters) {
+    return aggregation.counts.slice(0, 10).map(count => {
+      return (
+        <div
+          onClick={() => {
+            filters.setFilter(aggregation.slice.toLowerCase(), count.id)
+          }}
+        >
+          <span>{count.name}</span>
+          <span>({count.count})</span>
+        </div>
+      )
+    })
+  }
+
+  renderArtworks() {
+    return (
+      <ArtworksContent
+        artistID={this.props.artist.id}
+        filtered_artworks={this.props.artist.filtered_artworks as any}
+      />
+    )
+  }
+
+  render() {
+    return (
+      <Subscribe to={[FilterState]}>
+        {filters => {
+          return (
+            <div>
+              <div style={{ float: "left" }}>{this.renderSidebar(filters)}</div>
+              {this.renderArtworks()}
+            </div>
+          )
+        }}
+      </Subscribe>
+    )
+  }
+}
+
+export default createFragmentContainer(Filter, {
+  artist: graphql`
+    fragment Filter_artist on Artist
+      @argumentDefinitions(
+        medium: { type: "String", defaultValue: "*" }
+        major_periods: { type: "[String]" }
+        partner_id: { type: "ID" }
+        for_sale: { type: "Boolean" }
+        aggregations: {
+          type: "[ArtworkAggregation]"
+          defaultValue: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]
+        }
+      ) {
+      id
+      filtered_artworks(
+        aggregations: $aggregations
+        medium: $medium
+        major_periods: $major_periods
+        partner_id: $partner_id
+        for_sale: $for_sale
+        size: 0
+      ) {
+        aggregations {
+          slice
+          counts {
+            name
+            count
+            id
+          }
+        }
+        ...Artworks_filtered_artworks
+      }
+    }
+  `,
+})

--- a/src/Components/ArtistFilter/index.tsx
+++ b/src/Components/ArtistFilter/index.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { ContextProps, ContextConsumer } from "../Artsy"
+import { Subscribe } from "unstated"
+
+import { FilterState } from "./state"
+import FilterContainer from "./Filter"
+
+interface Props extends ContextProps {
+  artistID: string
+}
+
+class ArtistFilter extends React.Component<Props, null> {
+  render() {
+    const { artistID, relayEnvironment } = this.props
+
+    return (
+      <Subscribe to={[FilterState]}>
+        {filters => {
+          const { page, ...filtersWithoutPage } = filters.state
+          return (
+            <QueryRenderer
+              environment={relayEnvironment}
+              query={graphql`
+                query ArtistFilterArtworksQuery(
+                  $artistID: String!
+                  $medium: String
+                  $major_periods: [String]
+                  $partner_id: ID
+                  $for_sale: Boolean
+                ) {
+                  artist(id: $artistID) {
+                    ...Filter_artist
+                      @arguments(
+                        medium: $medium
+                        major_periods: $major_periods
+                        partner_id: $partner_id
+                        for_sale: $for_sale
+                      )
+                  }
+                }
+              `}
+              variables={{ artistID, ...filtersWithoutPage }}
+              render={({ props }) => {
+                if (props) {
+                  return <FilterContainer artist={props.artist} />
+                } else {
+                  return null
+                }
+              }}
+            />
+          )
+        }}
+      </Subscribe>
+    )
+  }
+}
+
+export const Browser = ContextConsumer(ArtistFilter)

--- a/src/Components/ArtistFilter/state.ts
+++ b/src/Components/ArtistFilter/state.ts
@@ -1,0 +1,42 @@
+import { Container } from "unstated"
+
+type State = {
+  medium: string
+  major_periods?: string[]
+  partner_id?: string
+  for_sale?: boolean
+  page?: number
+}
+
+export class FilterState extends Container<State> {
+  state = {
+    medium: "*",
+    for_sale: true,
+    page: 1,
+  }
+
+  setMajorPeriods(value) {
+    this.setState({ major_periods: [value], page: 1 })
+  }
+
+  setPartner(value) {
+    this.setState({ partner_id: value, page: 1 })
+  }
+
+  incrementPage() {
+    this.setState({ page: this.state.page + 1 })
+  }
+
+  setFilter(filter, value) {
+    if (filter === "major_period") {
+      return this.setMajorPeriods(value)
+    }
+    if (filter === "gallery" || filter === "institution") {
+      return this.setPartner(value)
+    }
+    this.setState({
+      [filter.toLowerCase()]: value,
+      page: 1,
+    })
+  }
+}

--- a/src/Components/__stories__/ArtistFilter.story.tsx
+++ b/src/Components/__stories__/ArtistFilter.story.tsx
@@ -1,0 +1,21 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Browser } from "../ArtistFilter"
+
+import { ContextProvider } from "../Artsy"
+import { Provider as StateProvider } from "unstated"
+
+storiesOf("Components/ArtistFilter/Browser", module).add(
+  "Pablo Picasso",
+  () => {
+    return (
+      <div>
+        <ContextProvider>
+          <StateProvider>
+            <Browser artistID="pablo-picasso" />
+          </StateProvider>
+        </ContextProvider>
+      </div>
+    )
+  }
+)

--- a/src/__generated__/ArtistFilterArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistFilterArtworksQuery.graphql.ts
@@ -1,0 +1,755 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime"
+export type ArtistFilterArtworksQueryVariables = {
+  readonly artistID: string
+  readonly medium?: string | null
+  readonly major_periods?: ReadonlyArray<string | null> | null
+  readonly partner_id?: string | null
+  readonly for_sale?: boolean | null
+}
+export type ArtistFilterArtworksQueryResponse = {
+  readonly artist: ({}) | null
+}
+
+/*
+query ArtistFilterArtworksQuery(
+  $artistID: String!
+  $medium: String
+  $major_periods: [String]
+  $partner_id: ID
+  $for_sale: Boolean
+) {
+  artist(id: $artistID) {
+    ...Filter_artist_81Ela
+    __id
+  }
+}
+
+fragment Filter_artist_81Ela on Artist {
+  id
+  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0) {
+    aggregations {
+      slice
+      counts {
+        name
+        count
+        id
+        __id
+      }
+    }
+    ...Artworks_filtered_artworks
+    __id
+  }
+  __id
+}
+
+fragment Artworks_filtered_artworks on FilterArtworks {
+  __id
+  artworks: artworks_connection(first: 10, after: "") {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    ...ArtworkGrid_artworks
+    edges {
+      node {
+        __id
+        __typename
+      }
+      cursor
+    }
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnection {
+  edges {
+    node {
+      __id
+      image {
+        aspect_ratio
+      }
+      ...GridItem_artwork
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  __id
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  __id
+}
+
+fragment Save_artwork on Artwork {
+  __id
+  id
+  is_saved
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message
+  cultural_maker
+  artists(shallow: true) {
+    __id
+    href
+    name
+  }
+  collecting_institution
+  partner(shallow: true) {
+    name
+    href
+    __id
+  }
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  __id
+}
+
+fragment Contact_artwork on Artwork {
+  _id
+  href
+  is_inquireable
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  partner(shallow: true) {
+    type
+    __id
+  }
+  sale_artwork {
+    highest_bid {
+      display
+      __id: id
+    }
+    opening_bid {
+      display
+    }
+    counts {
+      bidder_positions
+    }
+    __id
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function() {
+  var v0 = [
+      {
+        kind: "LocalArgument",
+        name: "artistID",
+        type: "String!",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "medium",
+        type: "String",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "major_periods",
+        type: "[String]",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "partner_id",
+        type: "ID",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "for_sale",
+        type: "Boolean",
+        defaultValue: null,
+      },
+    ],
+    v1 = [
+      {
+        kind: "Variable",
+        name: "id",
+        variableName: "artistID",
+        type: "String!",
+      },
+    ],
+    v2 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "__id",
+      args: null,
+      storageKey: null,
+    },
+    v3 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "id",
+      args: null,
+      storageKey: null,
+    },
+    v4 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "name",
+      args: null,
+      storageKey: null,
+    },
+    v5 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "href",
+      args: null,
+      storageKey: null,
+    },
+    v6 = [
+      {
+        kind: "Literal",
+        name: "shallow",
+        value: true,
+        type: "Boolean",
+      },
+    ],
+    v7 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "display",
+      args: null,
+      storageKey: null,
+    }
+  return {
+    kind: "Request",
+    operationKind: "query",
+    name: "ArtistFilterArtworksQuery",
+    id: null,
+    text:
+      'query ArtistFilterArtworksQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n) {\n  artist(id: $artistID) {\n    ...Filter_artist_81Ela\n    __id\n  }\n}\n\nfragment Filter_artist_81Ela on Artist {\n  id\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        count\n        id\n        __id\n      }\n    }\n    ...Artworks_filtered_artworks\n    __id\n  }\n  __id\n}\n\nfragment Artworks_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: "") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: "large")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n',
+    metadata: {},
+    fragment: {
+      kind: "Fragment",
+      name: "ArtistFilterArtworksQuery",
+      type: "Query",
+      metadata: null,
+      argumentDefinitions: v0,
+      selections: [
+        {
+          kind: "LinkedField",
+          alias: null,
+          name: "artist",
+          storageKey: null,
+          args: v1,
+          concreteType: "Artist",
+          plural: false,
+          selections: [
+            {
+              kind: "FragmentSpread",
+              name: "Filter_artist",
+              args: [
+                {
+                  kind: "Variable",
+                  name: "for_sale",
+                  variableName: "for_sale",
+                  type: null,
+                },
+                {
+                  kind: "Variable",
+                  name: "major_periods",
+                  variableName: "major_periods",
+                  type: null,
+                },
+                {
+                  kind: "Variable",
+                  name: "medium",
+                  variableName: "medium",
+                  type: null,
+                },
+                {
+                  kind: "Variable",
+                  name: "partner_id",
+                  variableName: "partner_id",
+                  type: null,
+                },
+              ],
+            },
+            v2,
+          ],
+        },
+      ],
+    },
+    operation: {
+      kind: "Operation",
+      name: "ArtistFilterArtworksQuery",
+      argumentDefinitions: v0,
+      selections: [
+        {
+          kind: "LinkedField",
+          alias: null,
+          name: "artist",
+          storageKey: null,
+          args: v1,
+          concreteType: "Artist",
+          plural: false,
+          selections: [
+            v3,
+            {
+              kind: "LinkedField",
+              alias: null,
+              name: "filtered_artworks",
+              storageKey: null,
+              args: [
+                {
+                  kind: "Literal",
+                  name: "aggregations",
+                  value: [
+                    "MEDIUM",
+                    "TOTAL",
+                    "GALLERY",
+                    "INSTITUTION",
+                    "MAJOR_PERIOD",
+                  ],
+                  type: "[ArtworkAggregation]",
+                },
+                {
+                  kind: "Variable",
+                  name: "for_sale",
+                  variableName: "for_sale",
+                  type: "Boolean",
+                },
+                {
+                  kind: "Variable",
+                  name: "major_periods",
+                  variableName: "major_periods",
+                  type: "[String]",
+                },
+                {
+                  kind: "Variable",
+                  name: "medium",
+                  variableName: "medium",
+                  type: "String",
+                },
+                {
+                  kind: "Variable",
+                  name: "partner_id",
+                  variableName: "partner_id",
+                  type: "ID",
+                },
+                {
+                  kind: "Literal",
+                  name: "size",
+                  value: 0,
+                  type: "Int",
+                },
+              ],
+              concreteType: "FilterArtworks",
+              plural: false,
+              selections: [
+                {
+                  kind: "LinkedField",
+                  alias: null,
+                  name: "aggregations",
+                  storageKey: null,
+                  args: null,
+                  concreteType: "ArtworksAggregationResults",
+                  plural: true,
+                  selections: [
+                    {
+                      kind: "ScalarField",
+                      alias: null,
+                      name: "slice",
+                      args: null,
+                      storageKey: null,
+                    },
+                    {
+                      kind: "LinkedField",
+                      alias: null,
+                      name: "counts",
+                      storageKey: null,
+                      args: null,
+                      concreteType: "AggregationCount",
+                      plural: true,
+                      selections: [
+                        v4,
+                        {
+                          kind: "ScalarField",
+                          alias: null,
+                          name: "count",
+                          args: null,
+                          storageKey: null,
+                        },
+                        v3,
+                        v2,
+                      ],
+                    },
+                  ],
+                },
+                v2,
+                {
+                  kind: "LinkedField",
+                  alias: "artworks",
+                  name: "artworks_connection",
+                  storageKey: 'artworks_connection(after:"",first:10)',
+                  args: [
+                    {
+                      kind: "Literal",
+                      name: "after",
+                      value: "",
+                      type: "String",
+                    },
+                    {
+                      kind: "Literal",
+                      name: "first",
+                      value: 10,
+                      type: "Int",
+                    },
+                  ],
+                  concreteType: "ArtworkConnection",
+                  plural: false,
+                  selections: [
+                    {
+                      kind: "LinkedField",
+                      alias: null,
+                      name: "pageInfo",
+                      storageKey: null,
+                      args: null,
+                      concreteType: "PageInfo",
+                      plural: false,
+                      selections: [
+                        {
+                          kind: "ScalarField",
+                          alias: null,
+                          name: "hasNextPage",
+                          args: null,
+                          storageKey: null,
+                        },
+                        {
+                          kind: "ScalarField",
+                          alias: null,
+                          name: "endCursor",
+                          args: null,
+                          storageKey: null,
+                        },
+                      ],
+                    },
+                    {
+                      kind: "LinkedField",
+                      alias: null,
+                      name: "edges",
+                      storageKey: null,
+                      args: null,
+                      concreteType: "ArtworkEdge",
+                      plural: true,
+                      selections: [
+                        {
+                          kind: "LinkedField",
+                          alias: null,
+                          name: "node",
+                          storageKey: null,
+                          args: null,
+                          concreteType: "Artwork",
+                          plural: false,
+                          selections: [
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "collecting_institution",
+                              args: null,
+                              storageKey: null,
+                            },
+                            v2,
+                            v5,
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "title",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "date",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "sale_message",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "cultural_maker",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "artists",
+                              storageKey: "artists(shallow:true)",
+                              args: v6,
+                              concreteType: "Artist",
+                              plural: true,
+                              selections: [v2, v5, v4],
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "image",
+                              storageKey: null,
+                              args: null,
+                              concreteType: "Image",
+                              plural: false,
+                              selections: [
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "aspect_ratio",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "placeholder",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "url",
+                                  args: [
+                                    {
+                                      kind: "Literal",
+                                      name: "version",
+                                      value: "large",
+                                      type: "[String]",
+                                    },
+                                  ],
+                                  storageKey: 'url(version:"large")',
+                                },
+                              ],
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "partner",
+                              storageKey: "partner(shallow:true)",
+                              args: v6,
+                              concreteType: "Partner",
+                              plural: false,
+                              selections: [
+                                v4,
+                                v5,
+                                v2,
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "type",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                              ],
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "sale",
+                              storageKey: null,
+                              args: null,
+                              concreteType: "Sale",
+                              plural: false,
+                              selections: [
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "is_auction",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "is_live_open",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "is_open",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "is_closed",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                v2,
+                              ],
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "_id",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "is_inquireable",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "sale_artwork",
+                              storageKey: null,
+                              args: null,
+                              concreteType: "SaleArtwork",
+                              plural: false,
+                              selections: [
+                                {
+                                  kind: "LinkedField",
+                                  alias: null,
+                                  name: "highest_bid",
+                                  storageKey: null,
+                                  args: null,
+                                  concreteType: "SaleArtworkHighestBid",
+                                  plural: false,
+                                  selections: [
+                                    v7,
+                                    {
+                                      kind: "ScalarField",
+                                      alias: "__id",
+                                      name: "id",
+                                      args: null,
+                                      storageKey: null,
+                                    },
+                                  ],
+                                },
+                                {
+                                  kind: "LinkedField",
+                                  alias: null,
+                                  name: "opening_bid",
+                                  storageKey: null,
+                                  args: null,
+                                  concreteType: "SaleArtworkOpeningBid",
+                                  plural: false,
+                                  selections: [v7],
+                                },
+                                {
+                                  kind: "LinkedField",
+                                  alias: null,
+                                  name: "counts",
+                                  storageKey: null,
+                                  args: null,
+                                  concreteType: "SaleArtworkCounts",
+                                  plural: false,
+                                  selections: [
+                                    {
+                                      kind: "ScalarField",
+                                      alias: null,
+                                      name: "bidder_positions",
+                                      args: null,
+                                      storageKey: null,
+                                    },
+                                  ],
+                                },
+                                v2,
+                              ],
+                            },
+                            v3,
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "is_saved",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "__typename",
+                              args: null,
+                              storageKey: null,
+                            },
+                          ],
+                        },
+                        {
+                          kind: "ScalarField",
+                          alias: null,
+                          name: "cursor",
+                          args: null,
+                          storageKey: null,
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  kind: "LinkedHandle",
+                  alias: "artworks",
+                  name: "artworks_connection",
+                  args: [
+                    {
+                      kind: "Literal",
+                      name: "after",
+                      value: "",
+                      type: "String",
+                    },
+                    {
+                      kind: "Literal",
+                      name: "first",
+                      value: 10,
+                      type: "Int",
+                    },
+                  ],
+                  handle: "connection",
+                  key: "Artworks_filtered_artworks",
+                  filters: null,
+                },
+              ],
+            },
+            v2,
+          ],
+        },
+      ],
+    },
+  }
+})()
+;(node as any).hash = "5d3fe134bb816bbf96cfff8b219cde23"
+export default node

--- a/src/__generated__/ArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtworksQuery.graphql.ts
@@ -1,0 +1,622 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime"
+export type ArtworksQueryVariables = {
+  readonly filteredArtworksNodeID: string
+  readonly count: number
+  readonly cursor?: string | null
+}
+export type ArtworksQueryResponse = {
+  readonly node: ({}) | null
+}
+
+/*
+query ArtworksQuery(
+  $filteredArtworksNodeID: ID!
+  $count: Int!
+  $cursor: String
+) {
+  node(__id: $filteredArtworksNodeID) {
+    __typename
+    ...Artworks_filtered_artworks_1G22uz
+    __id
+  }
+}
+
+fragment Artworks_filtered_artworks_1G22uz on FilterArtworks {
+  __id
+  artworks: artworks_connection(first: $count, after: $cursor) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    ...ArtworkGrid_artworks
+    edges {
+      node {
+        __id
+        __typename
+      }
+      cursor
+    }
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnection {
+  edges {
+    node {
+      __id
+      image {
+        aspect_ratio
+      }
+      ...GridItem_artwork
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  __id
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  __id
+}
+
+fragment Save_artwork on Artwork {
+  __id
+  id
+  is_saved
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message
+  cultural_maker
+  artists(shallow: true) {
+    __id
+    href
+    name
+  }
+  collecting_institution
+  partner(shallow: true) {
+    name
+    href
+    __id
+  }
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  __id
+}
+
+fragment Contact_artwork on Artwork {
+  _id
+  href
+  is_inquireable
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  partner(shallow: true) {
+    type
+    __id
+  }
+  sale_artwork {
+    highest_bid {
+      display
+      __id: id
+    }
+    opening_bid {
+      display
+    }
+    counts {
+      bidder_positions
+    }
+    __id
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function() {
+  var v0 = [
+      {
+        kind: "LocalArgument",
+        name: "filteredArtworksNodeID",
+        type: "ID!",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "count",
+        type: "Int!",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "cursor",
+        type: "String",
+        defaultValue: null,
+      },
+    ],
+    v1 = [
+      {
+        kind: "Variable",
+        name: "__id",
+        variableName: "filteredArtworksNodeID",
+        type: "ID!",
+      },
+    ],
+    v2 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "__id",
+      args: null,
+      storageKey: null,
+    },
+    v3 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "__typename",
+      args: null,
+      storageKey: null,
+    },
+    v4 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "href",
+      args: null,
+      storageKey: null,
+    },
+    v5 = [
+      {
+        kind: "Literal",
+        name: "shallow",
+        value: true,
+        type: "Boolean",
+      },
+    ],
+    v6 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "name",
+      args: null,
+      storageKey: null,
+    },
+    v7 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "display",
+      args: null,
+      storageKey: null,
+    }
+  return {
+    kind: "Request",
+    operationKind: "query",
+    name: "ArtworksQuery",
+    id: null,
+    text:
+      'query ArtworksQuery(\n  $filteredArtworksNodeID: ID!\n  $count: Int!\n  $cursor: String\n) {\n  node(__id: $filteredArtworksNodeID) {\n    __typename\n    ...Artworks_filtered_artworks_1G22uz\n    __id\n  }\n}\n\nfragment Artworks_filtered_artworks_1G22uz on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: $count, after: $cursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: "large")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n',
+    metadata: {},
+    fragment: {
+      kind: "Fragment",
+      name: "ArtworksQuery",
+      type: "Query",
+      metadata: null,
+      argumentDefinitions: v0,
+      selections: [
+        {
+          kind: "LinkedField",
+          alias: null,
+          name: "node",
+          storageKey: null,
+          args: v1,
+          concreteType: null,
+          plural: false,
+          selections: [
+            {
+              kind: "FragmentSpread",
+              name: "Artworks_filtered_artworks",
+              args: [
+                {
+                  kind: "Variable",
+                  name: "count",
+                  variableName: "count",
+                  type: null,
+                },
+                {
+                  kind: "Variable",
+                  name: "cursor",
+                  variableName: "cursor",
+                  type: null,
+                },
+              ],
+            },
+            v2,
+          ],
+        },
+      ],
+    },
+    operation: {
+      kind: "Operation",
+      name: "ArtworksQuery",
+      argumentDefinitions: v0,
+      selections: [
+        {
+          kind: "LinkedField",
+          alias: null,
+          name: "node",
+          storageKey: null,
+          args: v1,
+          concreteType: null,
+          plural: false,
+          selections: [
+            v3,
+            v2,
+            {
+              kind: "InlineFragment",
+              type: "FilterArtworks",
+              selections: [
+                {
+                  kind: "LinkedField",
+                  alias: "artworks",
+                  name: "artworks_connection",
+                  storageKey: null,
+                  args: [
+                    {
+                      kind: "Variable",
+                      name: "after",
+                      variableName: "cursor",
+                      type: "String",
+                    },
+                    {
+                      kind: "Variable",
+                      name: "first",
+                      variableName: "count",
+                      type: "Int",
+                    },
+                  ],
+                  concreteType: "ArtworkConnection",
+                  plural: false,
+                  selections: [
+                    {
+                      kind: "LinkedField",
+                      alias: null,
+                      name: "pageInfo",
+                      storageKey: null,
+                      args: null,
+                      concreteType: "PageInfo",
+                      plural: false,
+                      selections: [
+                        {
+                          kind: "ScalarField",
+                          alias: null,
+                          name: "hasNextPage",
+                          args: null,
+                          storageKey: null,
+                        },
+                        {
+                          kind: "ScalarField",
+                          alias: null,
+                          name: "endCursor",
+                          args: null,
+                          storageKey: null,
+                        },
+                      ],
+                    },
+                    {
+                      kind: "LinkedField",
+                      alias: null,
+                      name: "edges",
+                      storageKey: null,
+                      args: null,
+                      concreteType: "ArtworkEdge",
+                      plural: true,
+                      selections: [
+                        {
+                          kind: "LinkedField",
+                          alias: null,
+                          name: "node",
+                          storageKey: null,
+                          args: null,
+                          concreteType: "Artwork",
+                          plural: false,
+                          selections: [
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "collecting_institution",
+                              args: null,
+                              storageKey: null,
+                            },
+                            v2,
+                            v4,
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "title",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "date",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "sale_message",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "cultural_maker",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "artists",
+                              storageKey: "artists(shallow:true)",
+                              args: v5,
+                              concreteType: "Artist",
+                              plural: true,
+                              selections: [v2, v4, v6],
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "image",
+                              storageKey: null,
+                              args: null,
+                              concreteType: "Image",
+                              plural: false,
+                              selections: [
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "aspect_ratio",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "placeholder",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "url",
+                                  args: [
+                                    {
+                                      kind: "Literal",
+                                      name: "version",
+                                      value: "large",
+                                      type: "[String]",
+                                    },
+                                  ],
+                                  storageKey: 'url(version:"large")',
+                                },
+                              ],
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "partner",
+                              storageKey: "partner(shallow:true)",
+                              args: v5,
+                              concreteType: "Partner",
+                              plural: false,
+                              selections: [
+                                v6,
+                                v4,
+                                v2,
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "type",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                              ],
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "sale",
+                              storageKey: null,
+                              args: null,
+                              concreteType: "Sale",
+                              plural: false,
+                              selections: [
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "is_auction",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "is_live_open",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "is_open",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: "ScalarField",
+                                  alias: null,
+                                  name: "is_closed",
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                v2,
+                              ],
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "_id",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "is_inquireable",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "LinkedField",
+                              alias: null,
+                              name: "sale_artwork",
+                              storageKey: null,
+                              args: null,
+                              concreteType: "SaleArtwork",
+                              plural: false,
+                              selections: [
+                                {
+                                  kind: "LinkedField",
+                                  alias: null,
+                                  name: "highest_bid",
+                                  storageKey: null,
+                                  args: null,
+                                  concreteType: "SaleArtworkHighestBid",
+                                  plural: false,
+                                  selections: [
+                                    v7,
+                                    {
+                                      kind: "ScalarField",
+                                      alias: "__id",
+                                      name: "id",
+                                      args: null,
+                                      storageKey: null,
+                                    },
+                                  ],
+                                },
+                                {
+                                  kind: "LinkedField",
+                                  alias: null,
+                                  name: "opening_bid",
+                                  storageKey: null,
+                                  args: null,
+                                  concreteType: "SaleArtworkOpeningBid",
+                                  plural: false,
+                                  selections: [v7],
+                                },
+                                {
+                                  kind: "LinkedField",
+                                  alias: null,
+                                  name: "counts",
+                                  storageKey: null,
+                                  args: null,
+                                  concreteType: "SaleArtworkCounts",
+                                  plural: false,
+                                  selections: [
+                                    {
+                                      kind: "ScalarField",
+                                      alias: null,
+                                      name: "bidder_positions",
+                                      args: null,
+                                      storageKey: null,
+                                    },
+                                  ],
+                                },
+                                v2,
+                              ],
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "id",
+                              args: null,
+                              storageKey: null,
+                            },
+                            {
+                              kind: "ScalarField",
+                              alias: null,
+                              name: "is_saved",
+                              args: null,
+                              storageKey: null,
+                            },
+                            v3,
+                          ],
+                        },
+                        {
+                          kind: "ScalarField",
+                          alias: null,
+                          name: "cursor",
+                          args: null,
+                          storageKey: null,
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  kind: "LinkedHandle",
+                  alias: "artworks",
+                  name: "artworks_connection",
+                  args: [
+                    {
+                      kind: "Variable",
+                      name: "after",
+                      variableName: "cursor",
+                      type: "String",
+                    },
+                    {
+                      kind: "Variable",
+                      name: "first",
+                      variableName: "count",
+                      type: "Int",
+                    },
+                  ],
+                  handle: "connection",
+                  key: "Artworks_filtered_artworks",
+                  filters: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  }
+})()
+;(node as any).hash = "71e7a55140bff978328959a298166bb3"
+export default node

--- a/src/__generated__/Artworks_filtered_artworks.graphql.ts
+++ b/src/__generated__/Artworks_filtered_artworks.graphql.ts
@@ -1,0 +1,146 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime"
+export type Artworks_filtered_artworks = {
+  readonly __id: string
+  readonly artworks:
+    | ({
+        readonly pageInfo: {
+          readonly hasNextPage: boolean
+          readonly endCursor: string | null
+        }
+        readonly edges: ReadonlyArray<
+          | ({
+              readonly node:
+                | ({
+                    readonly __id: string
+                  })
+                | null
+            })
+          | null
+        > | null
+      })
+    | null
+}
+
+const node: ConcreteFragment = (function() {
+  var v0 = {
+    kind: "ScalarField",
+    alias: null,
+    name: "__id",
+    args: null,
+    storageKey: null,
+  }
+  return {
+    kind: "Fragment",
+    name: "Artworks_filtered_artworks",
+    type: "FilterArtworks",
+    metadata: {
+      connection: [
+        {
+          count: "count",
+          cursor: "cursor",
+          direction: "forward",
+          path: ["artworks"],
+        },
+      ],
+    },
+    argumentDefinitions: [
+      {
+        kind: "LocalArgument",
+        name: "count",
+        type: "Int",
+        defaultValue: 10,
+      },
+      {
+        kind: "LocalArgument",
+        name: "cursor",
+        type: "String",
+        defaultValue: "",
+      },
+    ],
+    selections: [
+      v0,
+      {
+        kind: "LinkedField",
+        alias: "artworks",
+        name: "__Artworks_filtered_artworks_connection",
+        storageKey: null,
+        args: null,
+        concreteType: "ArtworkConnection",
+        plural: false,
+        selections: [
+          {
+            kind: "LinkedField",
+            alias: null,
+            name: "pageInfo",
+            storageKey: null,
+            args: null,
+            concreteType: "PageInfo",
+            plural: false,
+            selections: [
+              {
+                kind: "ScalarField",
+                alias: null,
+                name: "hasNextPage",
+                args: null,
+                storageKey: null,
+              },
+              {
+                kind: "ScalarField",
+                alias: null,
+                name: "endCursor",
+                args: null,
+                storageKey: null,
+              },
+            ],
+          },
+          {
+            kind: "FragmentSpread",
+            name: "ArtworkGrid_artworks",
+            args: null,
+          },
+          {
+            kind: "LinkedField",
+            alias: null,
+            name: "edges",
+            storageKey: null,
+            args: null,
+            concreteType: "ArtworkEdge",
+            plural: true,
+            selections: [
+              {
+                kind: "LinkedField",
+                alias: null,
+                name: "node",
+                storageKey: null,
+                args: null,
+                concreteType: "Artwork",
+                plural: false,
+                selections: [
+                  v0,
+                  {
+                    kind: "ScalarField",
+                    alias: null,
+                    name: "__typename",
+                    args: null,
+                    storageKey: null,
+                  },
+                ],
+              },
+              {
+                kind: "ScalarField",
+                alias: null,
+                name: "cursor",
+                args: null,
+                storageKey: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+})()
+;(node as any).hash = "250ba34f28ae36138f84452694a88f27"
+export default node

--- a/src/__generated__/Filter_artist.graphql.ts
+++ b/src/__generated__/Filter_artist.graphql.ts
@@ -1,0 +1,204 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime"
+export type ArtworkAggregation =
+  | "COLOR"
+  | "DIMENSION_RANGE"
+  | "FOLLOWED_ARTISTS"
+  | "GALLERY"
+  | "INSTITUTION"
+  | "MAJOR_PERIOD"
+  | "MEDIUM"
+  | "MERCHANDISABLE_ARTISTS"
+  | "PARTNER_CITY"
+  | "PERIOD"
+  | "PRICE_RANGE"
+  | "TOTAL"
+  | "%future added value"
+export type Filter_artist = {
+  readonly id: string
+  readonly filtered_artworks:
+    | ({
+        readonly aggregations: ReadonlyArray<
+          | ({
+              readonly slice: ArtworkAggregation | null
+              readonly counts: ReadonlyArray<
+                | ({
+                    readonly name: string | null
+                    readonly count: number | null
+                    readonly id: string
+                  })
+                | null
+              > | null
+            })
+          | null
+        > | null
+      })
+    | null
+}
+
+const node: ConcreteFragment = (function() {
+  var v0 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "id",
+      args: null,
+      storageKey: null,
+    },
+    v1 = {
+      kind: "ScalarField",
+      alias: null,
+      name: "__id",
+      args: null,
+      storageKey: null,
+    }
+  return {
+    kind: "Fragment",
+    name: "Filter_artist",
+    type: "Artist",
+    metadata: null,
+    argumentDefinitions: [
+      {
+        kind: "LocalArgument",
+        name: "medium",
+        type: "String",
+        defaultValue: "*",
+      },
+      {
+        kind: "LocalArgument",
+        name: "major_periods",
+        type: "[String]",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "partner_id",
+        type: "ID",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "for_sale",
+        type: "Boolean",
+        defaultValue: null,
+      },
+      {
+        kind: "LocalArgument",
+        name: "aggregations",
+        type: "[ArtworkAggregation]",
+        defaultValue: [
+          "MEDIUM",
+          "TOTAL",
+          "GALLERY",
+          "INSTITUTION",
+          "MAJOR_PERIOD",
+        ],
+      },
+    ],
+    selections: [
+      v0,
+      {
+        kind: "LinkedField",
+        alias: null,
+        name: "filtered_artworks",
+        storageKey: null,
+        args: [
+          {
+            kind: "Variable",
+            name: "aggregations",
+            variableName: "aggregations",
+            type: "[ArtworkAggregation]",
+          },
+          {
+            kind: "Variable",
+            name: "for_sale",
+            variableName: "for_sale",
+            type: "Boolean",
+          },
+          {
+            kind: "Variable",
+            name: "major_periods",
+            variableName: "major_periods",
+            type: "[String]",
+          },
+          {
+            kind: "Variable",
+            name: "medium",
+            variableName: "medium",
+            type: "String",
+          },
+          {
+            kind: "Variable",
+            name: "partner_id",
+            variableName: "partner_id",
+            type: "ID",
+          },
+          {
+            kind: "Literal",
+            name: "size",
+            value: 0,
+            type: "Int",
+          },
+        ],
+        concreteType: "FilterArtworks",
+        plural: false,
+        selections: [
+          {
+            kind: "LinkedField",
+            alias: null,
+            name: "aggregations",
+            storageKey: null,
+            args: null,
+            concreteType: "ArtworksAggregationResults",
+            plural: true,
+            selections: [
+              {
+                kind: "ScalarField",
+                alias: null,
+                name: "slice",
+                args: null,
+                storageKey: null,
+              },
+              {
+                kind: "LinkedField",
+                alias: null,
+                name: "counts",
+                storageKey: null,
+                args: null,
+                concreteType: "AggregationCount",
+                plural: true,
+                selections: [
+                  {
+                    kind: "ScalarField",
+                    alias: null,
+                    name: "name",
+                    args: null,
+                    storageKey: null,
+                  },
+                  {
+                    kind: "ScalarField",
+                    alias: null,
+                    name: "count",
+                    args: null,
+                    storageKey: null,
+                  },
+                  v0,
+                  v1,
+                ],
+              },
+            ],
+          },
+          {
+            kind: "FragmentSpread",
+            name: "Artworks_filtered_artworks",
+            args: null,
+          },
+          v1,
+        ],
+      },
+      v1,
+    ],
+  }
+})()
+;(node as any).hash = "f105a92bf1f646d95599cb818d849b23"
+export default node

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,6 +3765,10 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.1.5:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.1.6.tgz#0f425931d907741127acc6e31acb4f9015dd9fdc"
+
 cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -11957,6 +11961,12 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unstated@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/unstated/-/unstated-2.1.1.tgz#36b124dfb2e7a12d39d0bb9c46dfb6e51276e3a2"
+  dependencies:
+    create-react-context "^0.1.5"
 
 unzip-response@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
![bp](https://user-images.githubusercontent.com/1457859/41001261-752d458c-68de-11e8-84f7-8b2f9f384968.gif)

This has a quick pass at a somewhat functional filter component for the artist page. It uses `unstated` for state management (so no `setState` appears in our components).

There's a fragment container for the filter sidebar and artworks, and the artworks 'browser' is a pagination container. The prev/next windowed pagination appears to be quite tricky...I haven't found any good libs for that yet, so didn't really make too much of a stab at that yet (besides a hacky 'next' button). I'll make some comments inline.

Depends on some local Metaphysics changes as well, will open a PR there.