### PR TITLE
First pass at artwork gallery component

### DIFF
--- a/src/Styleguide/Artwork/Gallery.tsx
+++ b/src/Styleguide/Artwork/Gallery.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { Flex } from "../Elements/Flex"
+import { Avatar, Button } from "../Elements"
+import { Serif, Sans } from "@artsy/palette"
+
+interface GalleryProps {
+  src: string
+  headline: string
+  subHeadline: string
+}
+
+export class Gallery extends React.Component<GalleryProps> {
+  render() {
+    return (
+      <Flex>
+        <Avatar src={this.props.src} size="100px" />
+        <Flex flexDirection="column" justifyContent="center" ml={4}>
+          <Serif size="5t">{this.props.headline}</Serif>
+          <Sans size="2">{this.props.subHeadline}</Sans>
+          <Button variant="outline" size="small" mt={3} width="80px">
+            Follow
+          </Button>
+        </Flex>
+      </Flex>
+    )
+  }
+}

--- a/src/Styleguide/Artwork/__stories__/Gallery.story.tsx
+++ b/src/Styleguide/Artwork/__stories__/Gallery.story.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Gallery } from "../Gallery"
+
+storiesOf("Styleguide/Artwork", module).add("Gallery", () => {
+  return (
+    <Gallery
+      src="https://picsum.photos/110/110/?random"
+      headline="Salon 94"
+      subHeadline="New York, London, Beijing, Hong Kong"
+    />
+  )
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -12076,7 +12076,7 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 


### PR DESCRIPTION
Takes a first pass at fleshing out the desktop version of the artwork gallery component. Would note that there is some similarities between this and the banner. 