### PR TITLE
@zephraph => <ReadMore /> expandable component

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "qs": "^6.5.0",
     "react-css-transition-replace": "^3.0.2",
     "react-html-parser": "^2.0.2",
-    "react-lines-ellipsis": "^0.8.0",
+    "react-lines-ellipsis": "damassi/react-lines-ellipsis#77616c11401f3f468e33bf2b91e69a50f86732c9",
     "react-markdown": "^2.5.0",
     "react-oembed-container": "^0.3.0",
     "react-overlays": "^0.8.3",

--- a/src/Components/Publishing/News/NewsSections.tsx
+++ b/src/Components/Publishing/News/NewsSections.tsx
@@ -5,7 +5,7 @@ import { NewsByline } from "../Byline/NewsByline"
 import { ImageCollection } from "../Sections/ImageCollection"
 import { SocialEmbed } from "../Sections/SocialEmbed"
 import { Text } from "../Sections/Text"
-import { Truncator } from "../Sections/Truncator"
+import { Truncator } from "Components/Truncator"
 import { ArticleData, SectionData } from "../Typings"
 
 interface Props {
@@ -49,7 +49,10 @@ export class NewsSections extends Component<Props> {
   }
 
   renderSections() {
-    const { article: { sections }, isTruncated } = this.props
+    const {
+      article: { sections },
+      isTruncated,
+    } = this.props
     const hasMainImage = sections[0].type === "image_collection"
 
     let limit
@@ -75,7 +78,9 @@ export class NewsSections extends Component<Props> {
   }
 
   renderByline() {
-    const { article: { authors, published_at } } = this.props
+    const {
+      article: { authors, published_at },
+    } = this.props
 
     if (authors || published_at) {
       return (

--- a/src/Components/Publishing/Sections/ArtworkCaption.tsx
+++ b/src/Components/Publishing/Sections/ArtworkCaption.tsx
@@ -6,7 +6,7 @@ import { pMedia } from "../../Helpers"
 import TextLink from "../../TextLink"
 import { garamond, unica } from "Assets/Fonts"
 import { ArticleLayout, SectionLayout } from "../Typings"
-import { Truncator } from "./Truncator"
+import { Truncator } from "Components/Truncator"
 import { ErrorBoundary } from "../../ErrorBoundary"
 
 interface ArtworkCaptionProps extends React.HTMLProps<HTMLDivElement> {

--- a/src/Components/Publishing/ToolTip/Components/Description.tsx
+++ b/src/Components/Publishing/ToolTip/Components/Description.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components"
 import React from "react"
 import { garamond } from "Assets/Fonts"
 import Markdown from "react-markdown"
-import { Truncator } from "../../Sections/Truncator"
+import { Truncator } from "Components/Truncator"
 
 interface Props {
   text: string

--- a/src/Components/Truncator.tsx
+++ b/src/Components/Truncator.tsx
@@ -4,16 +4,29 @@ import { ErrorBoundary } from "Components/ErrorBoundary"
 
 interface Props {
   maxLineCount?: number
+  ellipsis?: string
+  ReadMoreLink?: () => any
 }
 
-export const Truncator: React.SFC<Props> = ({ children, maxLineCount }) => {
+export const Truncator: React.SFC<Props> = ({
+  ReadMoreLink,
+  children,
+  ellipsis,
+  maxLineCount,
+}) => {
   const html = ReactDOM.renderToStaticMarkup(<span>{children}</span>)
+  let readMoreHTML = null
+
+  if (ReadMoreLink) {
+    readMoreHTML = ReactDOM.renderToStaticMarkup(ReadMoreLink())
+  }
 
   // FIXME: Make safe for tests
   let HTMLEllipsis
 
   if (process.env.NODE_ENV !== "test") {
-    HTMLEllipsis = require("react-lines-ellipsis/lib/html")
+    const responsiveHOC = require("react-lines-ellipsis/lib/responsiveHOC")
+    HTMLEllipsis = responsiveHOC()(require("react-lines-ellipsis/lib/html"))
   } else {
     HTMLEllipsis = ({ unsafeHTML }) => (
       <div
@@ -30,7 +43,8 @@ export const Truncator: React.SFC<Props> = ({ children, maxLineCount }) => {
         unsafeHTML={html}
         trimRight={false}
         maxLine={maxLineCount || 2}
-        ellipsis="..."
+        ellipsis={ellipsis}
+        ellipsisHTML={readMoreHTML}
       />
     </ErrorBoundary>
   )

--- a/src/Components/Truncator.tsx
+++ b/src/Components/Truncator.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import ReactDOM from "react-dom/server"
-import { ErrorBoundary } from "../../ErrorBoundary"
+import { ErrorBoundary } from "Components/ErrorBoundary"
 
 interface Props {
   maxLineCount?: number

--- a/src/Styleguide/Components/ReadMore.tsx
+++ b/src/Styleguide/Components/ReadMore.tsx
@@ -1,0 +1,82 @@
+import React, { Component } from "react"
+import styled from "styled-components"
+import { Truncator } from "../../Components/Truncator"
+import { Theme, Sans } from "@artsy/palette"
+
+interface ReadMoreProps {
+  isExpanded?: boolean
+  maxLineCount?: number
+}
+
+interface ReadMoreState {
+  isExpanded: boolean
+}
+
+export class ReadMore extends Component<ReadMoreProps, ReadMoreState> {
+  state = {
+    isExpanded: false,
+  }
+
+  static defaultProps = {
+    isExpanded: false,
+    maxLineCount: 3,
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      isExpanded: props.isExpanded,
+    }
+  }
+
+  expandText = () => {
+    this.setState({
+      isExpanded: true,
+    })
+  }
+
+  render() {
+    const { isExpanded } = this.state
+    const { maxLineCount } = this.props
+
+    return (
+      <Container onClick={this.expandText} isExpanded>
+        {isExpanded ? (
+          this.props.children
+        ) : (
+          <Truncator
+            maxLineCount={maxLineCount}
+            ReadMoreLink={() => <ReadMoreLink>Read More</ReadMoreLink>}
+          >
+            {this.props.children}
+          </Truncator>
+        )}
+      </Container>
+    )
+  }
+}
+
+const ReadMoreLink = ({ children }) => {
+  return (
+    // TODO: Investigate why <Truncator />, when calling `renderToStaticMarkup`,
+    // breaks the context chain requiring us to wrap ReadMore in a <Theme />
+
+    <Theme>
+      <ReadMoreLinkContiner>
+        ... <Sans size="2">{children}</Sans>
+      </ReadMoreLinkContiner>
+    </Theme>
+  )
+}
+
+const ReadMoreLinkContiner = styled.span`
+  ${Sans} {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+`
+
+const Container = styled.div.attrs<ReadMoreState>({})`
+  cursor: ${p => (p.isExpanded ? "auto" : "pointer")};
+`

--- a/src/Styleguide/Components/__stories__/ReadMore.story.tsx
+++ b/src/Styleguide/Components/__stories__/ReadMore.story.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import styled from "styled-components"
+import { InfoContainer } from "../../Utils/InfoContainer"
+import { storiesOf } from "storybook/storiesOf"
+import { withInfo } from "@storybook/addon-info"
+import { ReadMore } from "../ReadMore"
+
+storiesOf("Styleguide/Components", module).add(
+  "ReadMore",
+  withInfo(`
+
+    Expandable Read More
+
+  `)(() => {
+    return (
+      <InfoContainer>
+        <Item>
+          <ReadMore maxLineCount={2}>
+            Donald Judd, widely regarded as one of the most significant American
+            artists of the post-war period, is perhaps best-known for the
+            large-scale outdoor installations and long, spacious interiors he
+            designed in Marfa. Donald Judd, widely regarded as one of the most
+            significant American artists of the post-war period, is perhaps
+            best-known for the large-scale outdoor installations and long,
+            spacious interiors he designed in Marfa
+          </ReadMore>
+        </Item>
+        <Item>
+          <ReadMore>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor <a href="#">incididunt ut labore et dolore</a> magna
+            aliqua. Ut enim ad minim veniam, <a href="#">quis nostrud</a>{" "}
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. <a href="#">Duis aute</a> irure dolor in reprehenderit in
+            voluptate velit esse cillum dolore eu fugiat nulla pariatur. Lorem
+            ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            tempor <a href="#">incididunt ut labore et dolore</a> magna aliqua.
+            Ut enim ad minim veniam, <a href="#">quis nostrud</a> exercitation
+            ullamco laboris nisi ut aliquip ex ea commodo consequat.{" "}
+            <a href="#">Duis aute</a> irure dolor in reprehenderit in voluptate
+            velit esse cillum dolore eu fugiat nulla pariatur. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit, sed do eiusmod tempor{" "}
+            <a href="#">incididunt ut labore et dolore</a> magna aliqua. Ut enim
+            ad minim veniam, <a href="#">quis nostrud</a> exercitation ullamco
+            laboris nisi ut aliquip ex ea commodo consequat.{" "}
+            <a href="#">Duis aute</a> irure dolor in reprehenderit in voluptate
+            velit esse cillum dolore eu fugiat nulla pariatur. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit, sed do eiusmod tempor{" "}
+            <a href="#">incididunt ut labore et dolore</a> magna aliqua. Ut enim
+            ad minim veniam, <a href="#">quis nostrud</a> exercitation ullamco
+            laboris nisi ut aliquip ex ea commodo consequat.{" "}
+            <a href="#">Duis aute</a> irure dolor in reprehenderit in voluptate
+            velit esse cillum dolore eu fugiat nulla pariatur.
+          </ReadMore>
+        </Item>
+      </InfoContainer>
+    )
+  })
+)
+
+const Item = styled.div`
+  padding-bottom: 30px;
+`

--- a/yarn.lock
+++ b/yarn.lock
@@ -10338,9 +10338,9 @@ react-lifecycles-compat@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-lines-ellipsis@^0.8.0:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/react-lines-ellipsis/-/react-lines-ellipsis-0.8.1.tgz#f287fa1ac22cca06df8705dccdd0f27cce3d5e6c"
+react-lines-ellipsis@damassi/react-lines-ellipsis#77616c11401f3f468e33bf2b91e69a50f86732c9:
+  version "0.10.5"
+  resolved "https://codeload.github.com/damassi/react-lines-ellipsis/tar.gz/77616c11401f3f468e33bf2b91e69a50f86732c9"
 
 react-markdown@^2.5.0:
   version "2.5.1"
@@ -12076,7 +12076,7 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 


### PR DESCRIPTION
This adds a new `<ReadMore>` component to our set. Note that "read more" is an old, tricky, edge-case filled problem that hasn't yet (to my knowledge) been solved in an performant way that a) addresses browser dimensions; and b) includes SSR, since we need to measure the viewport. @zephraph - have you had to deal with this before? Any thoughts? For now however I think this will be sufficient, but all in all its pretty whatevs as you can see by dragging the viewport width around... 

I'm using the same component that we use elsewhere in publishing (https://www.artsy.net/news), but I had to make a PR to the underlying lib to support custom "read more" links: https://github.com/xiaody/react-lines-ellipsis/pull/19. We're currently pointing at this PR commit in `package.json`, so I'll make sure to track this. 

**NOTE:** In the [Artist zeplin spec](zpl.io/bPdMXLm) it requests that we cap at a particular character count, which is different than the [Artwork spec](zpl.io/25y0NGQ) in that it requests a full line count. Character count is definitely solvable as its context/display independent. I think that this feature can take place in a follow up PR though. 

<img width="261" alt="screen shot 2018-06-09 at 12 32 39 am" src="https://user-images.githubusercontent.com/236943/41189036-cc1dcbe6-6b7c-11e8-97c4-20723e30c2d1.png">

So we're supposed to cap after a character count, as opposed to a line count. 

![readmore](https://user-images.githubusercontent.com/236943/41188963-c45b375a-6b7b-11e8-95ba-f4446a1dfcf9.gif)
