### PR TITLE
[PATCH checkDeclarations] Ensure declaration in precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf dist",
     "compile": "babel src --out-dir dist --copy-files -s --source-map --extensions '.js,.jsx,.ts,.tsx' --ignore src/**/__tests__,src/**/__stories__ && yarn emit-types",
     "deploy-storybook": "yarn relay && NODE_ENV=production storybook-to-ghpages",
-    "emit-types": "tsc --declaration --emitDeclarationOnly --listEmittedFiles --outDir dist",
+    "emit-types": "tsc --declaration --emitDeclarationOnly --listEmittedFiles --jsx react --outDir dist",
     "lint": "tslint -c tslint.json --project tsconfig.json",
     "prepare": "patch-package",
     "precommit": "lint-staged",
@@ -227,6 +227,7 @@
   "lint-staged": {
     "*.@(ts|tsx)": [
       "tslint -c tslint.json --fix",
+      "yarn emit-types",
       "yarn prettier-write --",
       "git add"
     ],

--- a/src/Styleguide/Elements/Flex.tsx
+++ b/src/Styleguide/Elements/Flex.tsx
@@ -14,6 +14,9 @@ import {
   style,
 } from "styled-system"
 
+// @ts-ignore
+import { ClassAttributes, HTMLAttributes } from "react"
+
 const flexGrow = style({
   prop: "flexGrow",
   numberToPx: false,

--- a/src/Styleguide/GlobalStyles/index.tsx
+++ b/src/Styleguide/GlobalStyles/index.tsx
@@ -2,6 +2,9 @@ import styled from "styled-components"
 import { Body } from "./Body"
 import { Links } from "./Links"
 
+// @ts-ignore
+import { ClassAttributes, HTMLAttributes } from "react"
+
 export const GlobalStyles = styled.div`
   ${Body()};
   ${Links()};


### PR DESCRIPTION
Runs `tsc emit-types` in the `precommit` hook so that we can see if there are any issues with `--declaration` files. 