### PR TITLE
[PATCH lib] Bump palette@1.2.0; Disable type declarations temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "compile": "babel src --out-dir dist --copy-files -s --source-map --extensions '.js,.jsx,.ts,.tsx' --ignore src/**/__tests__,src/**/__stories__ && yarn emit-types",
+    "compile": "babel src --out-dir dist --copy-files -s --source-map --extensions '.js,.jsx,.ts,.tsx' --ignore src/**/__tests__,src/**/__stories__",
     "deploy-storybook": "yarn relay && NODE_ENV=production storybook-to-ghpages",
     "emit-types": "tsc --declaration --emitDeclarationOnly --listEmittedFiles --jsx react --outDir dist",
     "lint": "tslint -c tslint.json --project tsconfig.json",
@@ -45,7 +45,7 @@
     "test": "node verify-node-version.js && jest",
     "test:watch": "jest --watch --runInBand",
     "type-check": "tsc --noEmit --pretty",
-    "watch": "concurrently --kill-others 'yarn relay --watch' 'yarn compile -w' 'yarn emit-types -w'",
+    "watch": "concurrently --kill-others 'yarn relay --watch' 'yarn compile -w'",
     "semantic-release": "semantic-release"
   },
   "resolutions": {
@@ -140,7 +140,7 @@
     "webpack-merge": "^4.1.0"
   },
   "dependencies": {
-    "@artsy/palette": "^1.1.3",
+    "@artsy/palette": "^1.2.0",
     "cheerio": "^1.0.0-rc.2",
     "farce": "^0.2.6",
     "formik": "^0.11.11",
@@ -227,7 +227,6 @@
   "lint-staged": {
     "*.@(ts|tsx)": [
       "tslint -c tslint.json --fix",
-      "yarn emit-types",
       "yarn prettier-write --",
       "git add"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@artsy/palette@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-1.1.3.tgz#a1a60d3b8c20c4af0e084e3096e0c04c206a69c5"
+"@artsy/palette@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-1.2.0.tgz#2de49f85d64e6d740721b4429bdfd6a6e3e8e4b4"
   dependencies:
     react "^16.3.2"
     react-primitives "^0.5.0"
@@ -12127,7 +12127,7 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 


### PR DESCRIPTION
Bumps palette to the latest and temporarily disables `--declaration` emission due to its increased strictness. Since we're having to move fast right now we can refactor and re-introduce after our sprint. 