### PR TITLE
Experimental responsive handler component

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,6 +7,7 @@
     "block-opening-brace-space-after": null,
     "block-closing-brace-space-before": null,
     "declaration-block-no-redundant-longhand-properties": null,
-    "color-hex-length": null
+    "color-hex-length": null,
+    "block-no-empty": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
   "dependencies": {
     "@artsy/palette": "^1.2.0",
     "cheerio": "^1.0.0-rc.2",
+    "create-react-context": "^0.2.2",
     "farce": "^0.2.6",
     "formik": "^0.11.11",
     "found": "^0.3.11",

--- a/src/Styleguide/Elements/Responsive.tsx
+++ b/src/Styleguide/Elements/Responsive.tsx
@@ -4,20 +4,20 @@ import createContext, { ConsumerProps } from "create-react-context"
 // FIXME: Replace with React.createContext after React 16.3+ upgrade
 const ResponsiveContext = createContext({})
 
-interface Breakpoints {
+export interface Breakpoints {
   [breakpoint: string]: string
 }
 
-interface ResponsiveProviderProps {
+export interface ResponsiveProviderProps {
   initialBreakpoint?: string
   breakpoints: Breakpoints
 }
 
-interface BreakpointState {
+export interface BreakpointState {
   [breakpoint: string]: boolean
 }
 
-interface ResponsiveProviderState {
+export interface ResponsiveProviderState {
   breakpoints: BreakpointState
   mediaMatchers: MediaQueryList[]
   mqHandler: MediaQueryListListener | null

--- a/src/Styleguide/Elements/Responsive.tsx
+++ b/src/Styleguide/Elements/Responsive.tsx
@@ -18,7 +18,7 @@ interface BreakpointState {
 interface ResponsiveProviderState {
   breakpoints: BreakpointState
   mediaMatchers: MediaQueryList[]
-  mqHandler: null | MediaQueryListListener
+  mqHandler: MediaQueryListListener | null
 }
 
 export class ResponsiveProvider extends React.Component<

--- a/src/Styleguide/Elements/Responsive.tsx
+++ b/src/Styleguide/Elements/Responsive.tsx
@@ -1,6 +1,8 @@
 import React from "react"
+import createContext, { ConsumerProps } from "create-react-context"
 
-const ResponsiveContext = React.createContext({})
+// FIXME: Replace with React.createContext after React 16.3+ upgrade
+const ResponsiveContext = createContext({})
 
 interface Breakpoints {
   [breakpoint: string]: string
@@ -80,7 +82,5 @@ export class ResponsiveProvider extends React.Component<
   }
 }
 
-export const Responsive: React.ComponentType<
-  React.ConsumerProps<BreakpointState>
-> =
+export const Responsive: React.ComponentClass<ConsumerProps<BreakpointState>> =
   ResponsiveContext.Consumer

--- a/src/Styleguide/Elements/Responsive.tsx
+++ b/src/Styleguide/Elements/Responsive.tsx
@@ -7,6 +7,7 @@ interface Breakpoints {
 }
 
 interface ResponsiveProviderProps {
+  initialBreakpoint?: string
   breakpoints: Breakpoints
 }
 
@@ -30,7 +31,7 @@ export class ResponsiveProvider extends React.Component<
       breakpoints: {
         ...Object.keys(props.breakpoints)
           .map(breakpoint => ({
-            [breakpoint]: false,
+            [breakpoint]: breakpoint === props.initialBreakpoint ? true : false,
           }))
           .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
       },

--- a/src/Styleguide/Elements/Responsive.tsx
+++ b/src/Styleguide/Elements/Responsive.tsx
@@ -1,0 +1,85 @@
+import React from "react"
+
+const ResponsiveContext = React.createContext({})
+
+interface Breakpoints {
+  [breakpoint: string]: string
+}
+
+interface ResponsiveProviderProps {
+  breakpoints: Breakpoints
+}
+
+interface BreakpointState {
+  [breakpoint: string]: boolean
+}
+
+interface ResponsiveProviderState {
+  breakpoints: BreakpointState
+  mediaMatchers: MediaQueryList[]
+  mqHandler: null | MediaQueryListListener
+}
+
+export class ResponsiveProvider extends React.Component<
+  ResponsiveProviderProps,
+  ResponsiveProviderState
+> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      breakpoints: {
+        ...Object.keys(props.breakpoints)
+          .map(breakpoint => ({
+            [breakpoint]: false,
+          }))
+          .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
+      },
+      mediaMatchers: [],
+      mqHandler: null,
+    }
+  }
+
+  componentDidMount() {
+    this.setupObservers(this.props.breakpoints)
+  }
+
+  componentWillUnmount() {
+    if (this.state.mqHandler) {
+      this.state.mediaMatchers.forEach(mediaQuery =>
+        mediaQuery.removeListener(this.state.mqHandler)
+      )
+    }
+  }
+
+  setupObservers = breakpoints => {
+    const breakpointKeys = Object.keys(breakpoints)
+    const mediaMatchers = breakpointKeys.map(breakpoint =>
+      window.matchMedia(breakpoints[breakpoint])
+    )
+    const mqHandler = () => {
+      for (let i = 0; i < mediaMatchers.length; ++i) {
+        this.setState({
+          breakpoints: { [breakpointKeys[i]]: mediaMatchers[i].matches },
+        })
+      }
+    }
+    this.setState({ mediaMatchers, mqHandler })
+    mediaMatchers.forEach(mediaQuery => {
+      mediaQuery.addListener(mqHandler)
+    })
+    mqHandler()
+  }
+
+  render() {
+    return (
+      <ResponsiveContext.Provider value={this.state.breakpoints}>
+        {this.props.children}
+      </ResponsiveContext.Provider>
+    )
+  }
+}
+
+export const Responsive: React.ComponentType<
+  React.ConsumerProps<BreakpointState>
+> =
+  ResponsiveContext.Consumer

--- a/src/Styleguide/Pages/Artwork/Banner.tsx
+++ b/src/Styleguide/Pages/Artwork/Banner.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Avatar } from "../../Elements/Avatar"
 import { Sans, Serif } from "@artsy/palette"
 import { Flex } from "../../Elements/Flex"
+import { Responsive } from "../../Elements/Responsive"
 
 export interface BannerProps {
   src: string
@@ -13,18 +14,42 @@ export interface BannerProps {
 export class Banner extends React.Component<BannerProps> {
   render() {
     return (
-      <Flex flexDirection="row">
-        <Avatar size="110px" src={this.props.src} />
-        <Flex flexDirection="column" justifyContent="center" ml={4}>
-          <Sans weight="medium" size="2">
-            {this.props.badge}
-          </Sans>
-          <Serif size="4t">{this.props.headline}</Serif>
-          <Serif size="4t" color="black60">
-            {this.props.subHeadline}
-          </Serif>
-        </Flex>
-      </Flex>
+      <Responsive>
+        {({ xs }) => {
+          if (xs) return <SmallBanner {...this.props} />
+          else return <LargeBanner {...this.props} />
+        }}
+      </Responsive>
     )
   }
 }
+
+export const LargeBanner = props => (
+  <Flex flexDirection="row">
+    <Avatar size="110px" src={props.src} />
+    <Flex flexDirection="column" justifyContent="center" ml={4}>
+      <Sans weight="medium" size="2">
+        {props.badge}
+      </Sans>
+      <Serif size="4t">{props.headline}</Serif>
+      <Serif size="4t" color="black60">
+        {props.subHeadline}
+      </Serif>
+    </Flex>
+  </Flex>
+)
+
+export const SmallBanner = props => (
+  <Flex flexDirection="row">
+    <Flex flexDirection="column" justifyContent="center" ml={4}>
+      <Sans weight="medium" size="2">
+        {props.badge}
+      </Sans>
+      <Serif size="4t">{props.headline}</Serif>
+      <Serif size="4t" color="black60">
+        {props.subHeadline}
+      </Serif>
+    </Flex>
+    <Avatar size="110px" src={props.src} />
+  </Flex>
+)

--- a/src/Styleguide/Pages/Artwork/Banner.tsx
+++ b/src/Styleguide/Pages/Artwork/Banner.tsx
@@ -26,8 +26,8 @@ export class Banner extends React.Component<BannerProps> {
 
 export const LargeBanner = props => (
   <Flex flexDirection="row">
-    <Avatar size="110px" src={props.src} />
-    <Flex flexDirection="column" justifyContent="center" ml={4}>
+    <Avatar size="110px" src={props.src} mr={4} />
+    <Flex flexDirection="column" justifyContent="center">
       <Sans weight="medium" size="2">
         {props.badge}
       </Sans>
@@ -41,7 +41,7 @@ export const LargeBanner = props => (
 
 export const SmallBanner = props => (
   <Flex flexDirection="row">
-    <Flex flexDirection="column" justifyContent="center" ml={4}>
+    <Flex flexDirection="column" justifyContent="center">
       <Sans weight="medium" size="2">
         {props.badge}
       </Sans>
@@ -50,6 +50,6 @@ export const SmallBanner = props => (
         {props.subHeadline}
       </Serif>
     </Flex>
-    <Avatar size="110px" src={props.src} />
+    <Avatar size="110px" src={props.src} ml={4} />
   </Flex>
 )

--- a/src/__stories__/storiesOf.js
+++ b/src/__stories__/storiesOf.js
@@ -1,11 +1,26 @@
 import React from "react"
 import { storiesOf as _storiesOf } from "@storybook/react"
 import { Theme, injectGlobalCSS } from "@artsy/palette"
+import { ResponsiveProvider } from "../Styleguide/Elements/Responsive"
 
 injectGlobalCSS()
 
+const breakpoints = {
+  xl: "(min-width: 1192px)",
+  lg: "(min-width: 1024px) and (max-width: 1191px)",
+  md: "(min-width: 900px) and (max-width: 1023px)",
+  sm: "(min-width: 768px) and (max-width: 889px)",
+  xs: "(max-width: 767px)",
+}
+
 export function storiesOf(desc, mod) {
   return _storiesOf(desc, mod).addDecorator(storyFn => {
-    return <Theme>{storyFn()}</Theme>
+    return (
+      <Theme>
+        <ResponsiveProvider breakpoints={breakpoints}>
+          {storyFn()}
+        </ResponsiveProvider>
+      </Theme>
+    )
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3967,6 +3967,13 @@ create-react-context@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.1.6.tgz#0f425931d907741127acc6e31acb4f9015dd9fdc"
 
+create-react-context@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -5145,7 +5152,7 @@ fb-watchman@2.0.0, fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -5930,6 +5937,10 @@ growl@1.10.3:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -12127,7 +12138,7 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 


### PR DESCRIPTION
This is an experimental responsive api built off of react's context api and the web's [matchMedia](https://caniuse.com/#search=matchmedia) api. 

It provides a framework for describing application level breakpoints, but doesn't enforce specific values. It uses dom events around `matchMedia` so it's not polling to figure out when to update a component. 

**Responsive Context Api**

`<ResponsiveProvider/>` is called near the root of the app. It can take two props. 

1. `initialBreakpoint` -- What breakpoint (if any) to initialize the app to. i.e. `"xs"`, `"sm"`, `"md"`
2. `breakpoints` -- An object with a key of the breakpoint's name and a value of the breakpoint expression. i.e. `{ xs: "(max-width: 767px)" }`

`<ResponsiveProvider/>` has the following state

1. `breakpoints` -- An object with key of the breakpoint's name and a boolean value of whether or not that breakpoint is currently active.
2. `mediaMatches` -- An array of [MediaQueryList](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList) objects that are responsible for managing the event listeners that fires when its corresponding media query is triggered
2. `mqHandler` -- This method is triggered whenever one of the `MediaQueryList` objects emits an event. The function which iterates through all the [MediaQueryList](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList) objects in `mediaMatches` and checks to see if they're triggered. Each breakpoint's state is updated when this method is called. 

`<ResponsiveProvider/>` has the following functionality flow

1. On instantiation, the breakpoint state object is initialized with all values to `false` except the `initialBreakpoint` (if one is provided). 
2. When (or if) `componentDidMount` is called, the provider creates the `MediaQueryList` for each media query provided, sets up the event listeners to react to those media queries, and runs `mqHandler` to set the correct initial state based on the browsers current viewport. 
3. When the provider renders, it passes the breakpoint state object to the _actual_ provider, which then passes the values down to the context component (`<Responsive/>`). 
4. on `componentWillUnmount` the media query event listeners are cleaned up. 
