### PR TITLE
Update React Types

### DIFF
--- a/src/Components/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid.tsx
@@ -54,7 +54,7 @@ export class ArtworkGridContainer extends React.Component<
 
   maybeLoadMore() {
     const threshold = window.innerHeight + window.scrollY
-    const el = ReactDOM.findDOMNode(this)
+    const el = ReactDOM.findDOMNode(this) as Element
     if (threshold >= el.clientHeight + el.scrollTop) {
       this.props.onLoadMore()
     }

--- a/src/Components/Publishing/ReadMore/ReadMoreWrapper.tsx
+++ b/src/Components/Publishing/ReadMore/ReadMoreWrapper.tsx
@@ -40,7 +40,7 @@ export class ReadMoreWrapper extends React.Component<
     if (isTruncated) {
       let height = 0
       let charCount = 0
-      const thisNode = ReactDOM.findDOMNode(this)
+      const thisNode = ReactDOM.findDOMNode(this) as Element
 
       // Iterate over text sections
       find(

--- a/src/Components/Publishing/Sections/ImageWrapper.tsx
+++ b/src/Components/Publishing/Sections/ImageWrapper.tsx
@@ -32,7 +32,7 @@ export class ImageWrapper extends React.PureComponent<Props, any> {
      * Guard against snapshot tests See: https://reactjs.org/blog/2016/11/16/react-v15.4.0.html#mocking-refs-for-snapshot-testing
      */
     try {
-      const imgTag = ReactDOM.findDOMNode(this.image)
+      const imgTag = ReactDOM.findDOMNode(this.image) as Element
       const imgSrc = imgTag.getAttribute("src")
       img.src = imgSrc
     } catch (error) {

--- a/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
+++ b/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
@@ -170,7 +170,9 @@ export class LinkWithTooltip extends Component<Props, State> {
 
   setupToolTipPosition = () => {
     if (this.link) {
-      const position = findDOMNode(this.link).getBoundingClientRect()
+      const position = (findDOMNode(
+        this.link
+      ) as Element).getBoundingClientRect()
       const orientation = this.getOrientation(position)
 
       this.setState({ position, orientation })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,16 +1071,16 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.91.tgz#794611b28056d16b5436059c6d800b39d573cd3a"
 
 "@types/node@*":
-  version "6.0.88"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
+  version "10.3.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.2.tgz#3840ec6c12556fdda6e0e6d036df853101d732a4"
 
 "@types/prop-types@^15.5.1":
   version "15.5.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.1.tgz#1ecf52621299e65b855374337fb11fd2d1066fc1"
 
 "@types/react-dom@^16.0.3":
-  version "16.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.3.tgz#8accad7eabdab4cca3e1a56f5ccb57de2da0ff64"
+  version "16.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.6.tgz#f1a65a4e7be8ed5d123f8b3b9eacc913e35a1a3c"
   dependencies:
     "@types/node" "*"
     "@types/react" "*"
@@ -1118,8 +1118,8 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.0.31":
-  version "16.3.16"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.16.tgz#78fc44a90b45701f50c8a7008f733680ba51fc86"
+  version "16.3.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.17.tgz#d59d1a632570b0713946ed9c2949d994773633c5"
   dependencies:
     csstype "^2.2.0"
 
@@ -12127,7 +12127,7 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 


### PR DESCRIPTION
Reaction is on React 16.4. This is just a bump to types. I'm going to open a similar PR on force, but that'll be actually updating react too. 