### PR TITLE
Banner, Gallery fully responsive

### DIFF
--- a/src/Styleguide/Elements/Flex.tsx
+++ b/src/Styleguide/Elements/Flex.tsx
@@ -10,7 +10,9 @@ import {
   space,
   SpaceProps,
   HeightProps,
+  WidthProps,
   height,
+  width,
   style,
 } from "styled-system"
 
@@ -27,7 +29,8 @@ interface FlexProps
     FlexDirectionProps,
     JustifyContentProps,
     SpaceProps,
-    HeightProps {
+    HeightProps,
+    WidthProps {
   flexGrow?: number | string
 }
 
@@ -39,5 +42,6 @@ export const Flex = styled.div.attrs<FlexProps>({})`
   ${justifyContent};
   ${space};
   ${height};
+  ${width};
   ${flexGrow};
 `

--- a/src/Styleguide/Pages/Artwork/Banner.tsx
+++ b/src/Styleguide/Pages/Artwork/Banner.tsx
@@ -26,7 +26,7 @@ export class Banner extends React.Component<BannerProps> {
 
 export const LargeBanner = props => (
   <Flex flexDirection="row">
-    <Avatar size="110px" src={props.src} mr={4} />
+    <Avatar size="100px" src={props.src} mr={4} />
     <Flex flexDirection="column" justifyContent="center">
       <Sans weight="medium" size="2">
         {props.badge}
@@ -50,6 +50,6 @@ export const SmallBanner = props => (
         {props.subHeadline}
       </Serif>
     </Flex>
-    <Avatar size="110px" src={props.src} ml={4} />
+    <Avatar size="70px" src={props.src} ml={4} />
   </Flex>
 )

--- a/src/Styleguide/Pages/Artwork/Gallery.tsx
+++ b/src/Styleguide/Pages/Artwork/Gallery.tsx
@@ -2,8 +2,9 @@ import React from "react"
 import { Flex } from "../../Elements/Flex"
 import { Avatar, Button } from "../../Elements"
 import { Serif, Sans } from "@artsy/palette"
+import { Responsive } from "../../Elements/Responsive"
 
-interface GalleryProps {
+export interface GalleryProps {
   src: string
   headline: string
   subHeadline: string
@@ -12,16 +13,38 @@ interface GalleryProps {
 export class Gallery extends React.Component<GalleryProps> {
   render() {
     return (
-      <Flex>
-        <Avatar src={this.props.src} size="100px" />
-        <Flex flexDirection="column" justifyContent="center" ml={4}>
-          <Serif size="5t">{this.props.headline}</Serif>
-          <Sans size="2">{this.props.subHeadline}</Sans>
-          <Button variant="secondaryOutline" size="small" mt={3} width="80px">
-            Follow
-          </Button>
-        </Flex>
-      </Flex>
+      <Responsive>
+        {({ xs }) => {
+          if (xs) return <SmallGallery {...this.props} />
+          else return <LargeGallery {...this.props} />
+        }}
+      </Responsive>
     )
   }
 }
+
+export const LargeGallery = props => (
+  <Flex>
+    <Avatar src={props.src} size="100px" mr={4} />
+    <Flex flexDirection="column" justifyContent="center">
+      <Serif size="5t">{props.headline}</Serif>
+      <Sans size="2">{props.subHeadline}</Sans>
+      <Button variant="secondaryOutline" size="small" mt={3} width="90px">
+        Follow
+      </Button>
+    </Flex>
+  </Flex>
+)
+
+export const SmallGallery = props => (
+  <Flex>
+    <Flex flexDirection="column" justifyContent="center">
+      <Serif size="4">{props.headline}</Serif>
+      <Sans size="1">{props.subHeadline}</Sans>
+      <Button variant="secondaryOutline" size="small" mt={2} width="90px">
+        Follow
+      </Button>
+    </Flex>
+    <Avatar src={props.src} size="100px" ml={4} />
+  </Flex>
+)

--- a/src/Styleguide/Pages/Artwork/__stories__/Banner.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Banner.story.tsx
@@ -1,14 +1,35 @@
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
-import { Banner } from "../Banner"
+import { Banner, SmallBanner, LargeBanner } from "../Banner"
+import { Section } from "../../../Utils/Section"
 
 storiesOf("Styleguide/Artwork", module).add("Banner", () => {
   return (
-    <Banner
-      src="https://picsum.photos/110/110/?random"
-      badge="In show"
-      headline="Francesca DiMattio: Boucherouite"
-      subHeadline="Salon 94"
-    />
+    <React.Fragment>
+      <Section title="Responsive">
+        <Banner
+          src="https://picsum.photos/110/110/?random"
+          badge="In show"
+          headline="Francesca DiMattio: Boucherouite"
+          subHeadline="Salon 94"
+        />
+      </Section>
+      <Section title="Large Banner">
+        <LargeBanner
+          src="https://picsum.photos/110/110/?random"
+          badge="In show"
+          headline="Francesca DiMattio: Boucherouite"
+          subHeadline="Salon 94"
+        />
+      </Section>
+      <Section title="Small Banner">
+        <SmallBanner
+          src="https://picsum.photos/110/110/?random"
+          badge="In show"
+          headline="Francesca DiMattio: Boucherouite"
+          subHeadline="Salon 94"
+        />
+      </Section>
+    </React.Fragment>
   )
 })

--- a/src/Styleguide/Pages/Artwork/__stories__/Gallery.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Gallery.story.tsx
@@ -1,13 +1,32 @@
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
-import { Gallery } from "../Gallery"
+import { Gallery, SmallGallery, LargeGallery } from "../Gallery"
+import { Section } from "../../../Utils/Section"
 
 storiesOf("Styleguide/Artwork", module).add("Gallery", () => {
   return (
-    <Gallery
-      src="https://picsum.photos/110/110/?random"
-      headline="Salon 94"
-      subHeadline="New York, London, Beijing, Hong Kong"
-    />
+    <React.Fragment>
+      <Section title="Responsive">
+        <Gallery
+          src="https://picsum.photos/110/110/?random"
+          headline="Salon 94"
+          subHeadline="New York, London, Beijing, Hong Kong"
+        />
+      </Section>
+      <Section title="Large Gallery">
+        <LargeGallery
+          src="https://picsum.photos/110/110/?random"
+          headline="Salon 94"
+          subHeadline="New York, London, Beijing, Hong Kong"
+        />
+      </Section>
+      <Section title="Small Gallery">
+        <SmallGallery
+          src="https://picsum.photos/110/110/?random"
+          headline="Salon 94"
+          subHeadline="New York, London, Beijing, Hong Kong"
+        />
+      </Section>
+    </React.Fragment>
   )
 })

--- a/src/Styleguide/Utils/Section.tsx
+++ b/src/Styleguide/Utils/Section.tsx
@@ -43,7 +43,6 @@ export class Section extends React.Component<SectionProps> {
         </Header>
         {this.state.expanded && (
           <Flex
-            // @ts-ignore
             flexDirection="column"
             alignItems="center"
             mt={4}

--- a/src/Styleguide/Utils/Section.tsx
+++ b/src/Styleguide/Utils/Section.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import { Flex } from "../Elements/Flex"
+import { Sans } from "@artsy/palette"
+import styled from "styled-components"
+import { themeGet } from "styled-system"
+
+const Header = styled.div`
+  padding: 5px 10px 3px;
+  border-bottom: 1px solid ${themeGet("colors.black10")};
+  user-select: none;
+  transition: 0.4s;
+
+  &:hover {
+    background-color: ${themeGet("colors.black5")};
+  }
+`
+
+export interface SectionProps {
+  title: string
+}
+
+export class Section extends React.Component<SectionProps> {
+  state = {
+    expanded: true,
+  }
+  toggleExpand = () => {
+    this.setState({ expanded: !this.state.expanded })
+  }
+  render() {
+    return (
+      <React.Fragment>
+        <Header onClick={this.toggleExpand}>
+          <Flex justifyContent="space-between">
+            <Sans size="4" color="black60">
+              {this.props.title}
+            </Sans>
+            <Flex width="20px" justifyContent="center">
+              <Sans size="6" color="black60">
+                {this.state.expanded ? "-" : "+"}
+              </Sans>
+            </Flex>
+          </Flex>
+        </Header>
+        {this.state.expanded && (
+          <Flex
+            // @ts-ignore
+            flexDirection="column"
+            alignItems="center"
+            mt={4}
+            mb={4}
+            ml={2}
+            mr={2}
+          >
+            {this.props.children}
+          </Flex>
+        )}
+      </React.Fragment>
+    )
+  }
+}


### PR DESCRIPTION
Both the artwork banner and the artwork gallery are now fully responsive. I went through and corrected minor things like font and avatar sizes between the different breakpoints. 

Also, because I got tired of dragging the browser, I created a Section component to wrap the component in. It's an accordion type thing that makes it easier for one story to show multiple variations on a component. 

![image](https://user-images.githubusercontent.com/3087225/41198722-75210f20-6c52-11e8-922e-ae8eb2d7cf0c.png)
