### PR TITLE
Make artist card responsive

### DIFF
--- a/src/Styleguide/Components/ArtistCard.tsx
+++ b/src/Styleguide/Components/ArtistCard.tsx
@@ -4,10 +4,15 @@ import { Flex } from "../Elements/Flex"
 import { Avatar, Button } from "../Elements"
 import { Serif, Sans } from "@artsy/palette"
 import { themeGet } from "styled-system"
+import { Responsive } from "../Utils/Responsive"
 
 const Container = styled(Flex)`
   border: 1px solid ${themeGet("colors.black10")};
   border-radius: 2px;
+
+  &:hover {
+    border-color: ${themeGet("colors.black60")};
+  }
 `
 
 interface ArtistCardProps {
@@ -19,18 +24,43 @@ interface ArtistCardProps {
 export class ArtistCard extends React.Component<ArtistCardProps> {
   render() {
     return (
-      <Container flexDirection="column" height="254px" p={4}>
-        <Flex flexDirection="column" flexGrow="1" alignItems="center">
-          <Avatar src={this.props.src} size="100px" mb={3} />
-          <Serif size="3t">{this.props.headline}</Serif>
-          <Sans size="1">{this.props.subHeadline}</Sans>
-        </Flex>
-        <Flex flexDirection="column" alignItems="center">
-          <Button size="small" variant="outline">
-            Follow
-          </Button>
-        </Flex>
-      </Container>
+      <Responsive>
+        {({ xs }) => {
+          if (xs) return <SmallArtistCard {...this.props} />
+          else return <LargeArtistCard {...this.props} />
+        }}
+      </Responsive>
     )
   }
 }
+
+export const LargeArtistCard = props => (
+  <Container flexDirection="column" height="254px" p={4}>
+    <Flex flexDirection="column" flexGrow="1" alignItems="center">
+      <Avatar src={props.src} mb={3} />
+      <Serif size="3t">{props.headline}</Serif>
+      <Sans size="1">{props.subHeadline}</Sans>
+    </Flex>
+    <Flex flexDirection="column" alignItems="center">
+      <Button size="small" variant="secondaryOutline" width="90px">
+        Follow
+      </Button>
+    </Flex>
+  </Container>
+)
+
+export const SmallArtistCard = props => (
+  <Container p={4}>
+    <Flex flexDirection="column" justifyContent="center">
+      <Sans weight="medium" size="2">
+        {props.badge}
+      </Sans>
+      <Serif size="3t">{props.headline}</Serif>
+      <Sans size="1">{props.subHeadline}</Sans>
+      <Button size="small" variant="secondaryOutline" width="70px" mt={3}>
+        Follow
+      </Button>
+    </Flex>
+    <Avatar size="small" src={props.src} ml={4} />
+  </Container>
+)

--- a/src/Styleguide/Components/__stories__/ArtistCard.story.tsx
+++ b/src/Styleguide/Components/__stories__/ArtistCard.story.tsx
@@ -1,13 +1,27 @@
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
-import { ArtistCard } from "../ArtistCard"
+import { ArtistCard, SmallArtistCard, LargeArtistCard } from "../ArtistCard"
 import { Section } from "../../Utils/Section"
 
 storiesOf("Styleguide/Components", module).add("ArtistCard", () => {
   return (
     <React.Fragment>
-      <Section title="Responsive">
+      <Section title="Responsive Artist Card">
         <ArtistCard
+          src="https://picsum.photos/110/110/?random"
+          headline="Francesca DiMattio"
+          subHeadline="American, b. 1979"
+        />
+      </Section>
+      <Section title="Large Artist Card">
+        <LargeArtistCard
+          src="https://picsum.photos/110/110/?random"
+          headline="Francesca DiMattio"
+          subHeadline="American, b. 1979"
+        />
+      </Section>
+      <Section title="Small Artist Card">
+        <SmallArtistCard
           src="https://picsum.photos/110/110/?random"
           headline="Francesca DiMattio"
           subHeadline="American, b. 1979"

--- a/src/Styleguide/Elements/Avatar.tsx
+++ b/src/Styleguide/Elements/Avatar.tsx
@@ -3,13 +3,22 @@ import React from "react"
 import styled from "styled-components"
 import { space, SpaceProps } from "styled-system"
 
+const sizeValue = ({ size = "" }) => {
+  switch (size) {
+    case "small":
+      return "70px"
+    default:
+      return "100px"
+  }
+}
+
 export interface AvatarProps extends SpaceProps {
-  size: string
+  size?: "small" | "default"
 }
 
 export const Avatar = styled.img.attrs<AvatarProps>({})`
-  width: ${props => props.size};
-  height: ${props => props.size};
-  border-radius: ${props => props.size};
+  width: ${props => sizeValue(props)};
+  height: ${props => sizeValue(props)};
+  border-radius: ${props => sizeValue(props)};
   ${space};
 `

--- a/src/Styleguide/Elements/__stories__/Avatar.story.tsx
+++ b/src/Styleguide/Elements/__stories__/Avatar.story.tsx
@@ -5,8 +5,13 @@ import { storiesOf } from "storybook/storiesOf"
 
 storiesOf("Styleguide/Elements", module).add("Avatar", () => {
   return (
-    <Section title="Default">
-      <Avatar size="110px" src="https://picsum.photos/110/110/?random" />
-    </Section>
+    <React.Fragment>
+      <Section title="Default Avatar">
+        <Avatar src="https://picsum.photos/110/110/?random" />
+      </Section>
+      <Section title="Small Avatar">
+        <Avatar size="small" src="https://picsum.photos/110/110/?random" />
+      </Section>
+    </React.Fragment>
   )
 })

--- a/src/Styleguide/Pages/Artwork/Banner.tsx
+++ b/src/Styleguide/Pages/Artwork/Banner.tsx
@@ -26,7 +26,7 @@ export class Banner extends React.Component<BannerProps> {
 
 export const LargeBanner = props => (
   <Flex flexDirection="row">
-    <Avatar size="100px" src={props.src} mr={4} />
+    <Avatar src={props.src} mr={4} />
     <Flex flexDirection="column" justifyContent="center">
       <Sans weight="medium" size="2">
         {props.badge}
@@ -50,6 +50,6 @@ export const SmallBanner = props => (
         {props.subHeadline}
       </Serif>
     </Flex>
-    <Avatar size="70px" src={props.src} ml={4} />
+    <Avatar size="small" src={props.src} ml={4} />
   </Flex>
 )

--- a/src/Styleguide/Pages/Artwork/Gallery.tsx
+++ b/src/Styleguide/Pages/Artwork/Gallery.tsx
@@ -25,7 +25,7 @@ export class Gallery extends React.Component<GalleryProps> {
 
 export const LargeGallery = props => (
   <Flex>
-    <Avatar src={props.src} size="100px" mr={4} />
+    <Avatar src={props.src} mr={4} />
     <Flex flexDirection="column" justifyContent="center">
       <Serif size="5t">{props.headline}</Serif>
       <Sans size="2">{props.subHeadline}</Sans>
@@ -45,6 +45,6 @@ export const SmallGallery = props => (
         Follow
       </Button>
     </Flex>
-    <Avatar src={props.src} size="100px" ml={4} />
+    <Avatar src={props.src} size="small" ml={4} />
   </Flex>
 )


### PR DESCRIPTION
Implements the small artist card view as well as wiring it up w/ the responsive component. 

Does a little clean-up/consistence around the avatar. There are only two sizes in the designs currently (100px, 70px) so I added a size prop to that. @damassi it might be worth having a discussion about hoisting that into palette. 