### PR TITLE
Implement Auction Card

### DIFF
--- a/src/Styleguide/Components/ArtistCard.tsx
+++ b/src/Styleguide/Components/ArtistCard.tsx
@@ -1,19 +1,9 @@
 import React from "react"
-import styled from "styled-components"
 import { Flex } from "../Elements/Flex"
+import { Card } from "../Elements/Card"
 import { Avatar, Button } from "../Elements"
 import { Serif, Sans } from "@artsy/palette"
-import { themeGet } from "styled-system"
 import { Responsive } from "../Utils/Responsive"
-
-const Container = styled(Flex)`
-  border: 1px solid ${themeGet("colors.black10")};
-  border-radius: 2px;
-
-  &:hover {
-    border-color: ${themeGet("colors.black60")};
-  }
-`
 
 interface ArtistCardProps {
   src: string
@@ -35,7 +25,7 @@ export class ArtistCard extends React.Component<ArtistCardProps> {
 }
 
 export const LargeArtistCard = props => (
-  <Container flexDirection="column" height="254px" p={4}>
+  <Card flexDirection="column" height="254px" p={4}>
     <Flex flexDirection="column" flexGrow="1" alignItems="center">
       <Avatar src={props.src} mb={3} />
       <Serif size="3t">{props.headline}</Serif>
@@ -46,11 +36,11 @@ export const LargeArtistCard = props => (
         Follow
       </Button>
     </Flex>
-  </Container>
+  </Card>
 )
 
 export const SmallArtistCard = props => (
-  <Container p={4}>
+  <Card p={4}>
     <Flex flexDirection="column" justifyContent="center">
       <Sans weight="medium" size="2">
         {props.badge}
@@ -62,5 +52,5 @@ export const SmallArtistCard = props => (
       </Button>
     </Flex>
     <Avatar size="small" src={props.src} ml={4} />
-  </Container>
+  </Card>
 )

--- a/src/Styleguide/Components/AuctionCard.tsx
+++ b/src/Styleguide/Components/AuctionCard.tsx
@@ -1,0 +1,90 @@
+import React from "react"
+import { Responsive } from "../Utils/Responsive"
+import { Card } from "../Elements/Card"
+import { Flex } from "../Elements/Flex"
+import { Serif, Sans } from "@artsy/palette"
+import styled from "styled-components"
+import {
+  space,
+  width,
+  SpaceProps,
+  WidthProps,
+  height,
+  HeightProps,
+} from "styled-system"
+
+interface ImageWrapperProps extends HeightProps {}
+const ImageWrapper = styled.div.attrs<ImageWrapperProps>({})`
+  ${height};
+`
+
+interface ArtworkImageProps extends SpaceProps, WidthProps, HeightProps {
+  src: string
+}
+const ArtworkImage = styled.img.attrs<ArtworkImageProps>({})`
+  ${space};
+  ${width};
+  ${height};
+`
+
+const ScaledArtworkImage = props => (
+  <ImageWrapper height={props.height}>
+    <ArtworkImage {...props} />
+  </ImageWrapper>
+)
+
+export interface AuctionCardProps {
+  src: string
+  headline: string
+  subHeadline: string
+  badge: string
+}
+
+export class AuctionCard extends React.Component<AuctionCardProps> {
+  render() {
+    return (
+      <Responsive>
+        {({ xs }) => {
+          if (xs) return <SmallAuctionCard {...this.props} />
+          else return <LargeAuctionCard {...this.props} />
+        }}
+      </Responsive>
+    )
+  }
+}
+
+export const LargeAuctionCard = props => (
+  <Card flexDirection="column" p={4}>
+    <Serif size="3t" weight="semibold">
+      {props.headline}
+    </Serif>
+    <Serif size="3t">{props.subHeadline}</Serif>
+    <ArtworkImage src={props.src} m={4} />
+    <Sans size="1" weight="medium">
+      {props.badge}
+    </Sans>
+  </Card>
+)
+
+export const SmallAuctionCard = props => (
+  <Flex p={4}>
+    <Flex flexDirection="column" justifyContent="space-between">
+      <div>
+        <Serif size="3t" weight="semibold">
+          {props.headline}
+        </Serif>
+        <Serif size="3t">{props.subHeadline}</Serif>
+      </div>
+      <Sans size="1" weight="medium">
+        {props.badge}
+      </Sans>
+    </Flex>
+    <ScaledArtworkImage
+      src={props.src}
+      width="auto"
+      height="82px"
+      mr={4}
+      ml={4}
+    />
+  </Flex>
+)

--- a/src/Styleguide/Components/__stories__/AuctionCard.story.tsx
+++ b/src/Styleguide/Components/__stories__/AuctionCard.story.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { AuctionCard, SmallAuctionCard, LargeAuctionCard } from "../AuctionCard"
+import { Section } from "../../Utils/Section"
+
+storiesOf("Styleguide/Components", module).add("AuctionCard", () => {
+  return (
+    <React.Fragment>
+      <Section title="Responsive Auction Card">
+        <AuctionCard
+          src="https://picsum.photos/200/180/?random"
+          headline="Sotheby’s"
+          subHeadline="Contemporary Day Sale"
+          badge="In progress"
+        />
+      </Section>
+      <Section title="Large Auction Card">
+        <LargeAuctionCard
+          src="https://picsum.photos/200/180/?random"
+          headline="Sotheby’s"
+          subHeadline="Contemporary Day Sale"
+          badge="In progress"
+        />
+      </Section>
+      <Section title="Small Auction Card">
+        <SmallAuctionCard
+          src="https://picsum.photos/200/180/?random"
+          headline="Sotheby’s"
+          subHeadline="Contemporary Day Sale"
+          badge="In progress"
+        />
+      </Section>
+    </React.Fragment>
+  )
+})

--- a/src/Styleguide/Elements/Card.tsx
+++ b/src/Styleguide/Elements/Card.tsx
@@ -1,0 +1,12 @@
+import styled from "styled-components"
+import { Flex } from "./Flex"
+import { themeGet } from "styled-system"
+
+export const Card = styled(Flex)`
+  border: 1px solid ${themeGet("colors.black10")};
+  border-radius: 2px;
+
+  &:hover {
+    border-color: ${themeGet("colors.black60")};
+  }
+`


### PR DESCRIPTION
Adds an implementation of a responsive auction card. 

Refactored the "card" functionality and hoisted it up into elements. It's likely something that we'll see more of and it has some pretty specific shared behavior. 

I'm not necessarily happy with the image implementation of this component. Getting the xs implementation correct was a bit difficult, and I'm not sure approached it in the best way. Would love some feedback.