### PR TITLE
Add <Radio> and <Checkbox> + Artwork Filter 

### DIFF
--- a/src/Components/Icon.tsx
+++ b/src/Components/Icon.tsx
@@ -1,9 +1,9 @@
 // @ts-ignore
 import React, { StatelessComponent } from "react"
 import styled from "styled-components"
-import { space, PositionProps } from "styled-system"
 import "../Assets/Fonts"
 import icons, { IconName } from "../Assets/Icons"
+import { top, right, bottom, left, space, PositionProps } from "styled-system"
 
 export type FontName = string
 
@@ -34,4 +34,8 @@ export default styled(Icon)`
   position: relative;
 
   ${space};
+  ${top};
+  ${right};
+  ${bottom};
+  ${left};
 `

--- a/src/Styleguide/Components/__stories__/Toggle.story.tsx
+++ b/src/Styleguide/Components/__stories__/Toggle.story.tsx
@@ -2,7 +2,10 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "../../Utils/Section"
 import { Toggle } from "../Toggle"
+import { Checkbox } from "../../Elements/Checkbox"
+import { Radio } from "../../Elements/Radio"
 import { Sans, Serif } from "@artsy/palette"
+import { Flex } from "../../Elements/Flex"
 import styled from "styled-components"
 
 storiesOf("Styleguide/Components", module).add("Toggle", () => {
@@ -46,7 +49,16 @@ storiesOf("Styleguide/Components", module).add("Toggle", () => {
       </Section>
       <Section title="Artwork Filter">
         <Item>
-          <Toggle label="Medium" />
+          <Toggle label="Purchase type" expanded disabled>
+            <Flex justifyContent="space-between">
+              <Checkbox>For sale</Checkbox>
+              <Serif color="black60">1000</Serif>
+            </Flex>
+          </Toggle>
+          <Toggle label="Medium" expanded>
+            <Radio>Painting</Radio>
+            <Radio>Sculpture</Radio>
+          </Toggle>
           <Toggle label="Gallery" />
           <Toggle label="Institution" />
           <Toggle label="Time period" />

--- a/src/Styleguide/Elements/Checkbox.tsx
+++ b/src/Styleguide/Elements/Checkbox.tsx
@@ -1,0 +1,100 @@
+// TODO: This and <Radio /> can be shared
+
+import React from "react"
+import Icon from "Components/Icon"
+import styled from "styled-components"
+import { Flex } from "./Flex"
+
+import {
+  border,
+  BorderProps,
+  SizeProps,
+  space,
+  SpaceProps,
+} from "styled-system"
+
+interface CheckboxProps {
+  selected?: boolean
+}
+
+interface CheckboxState {
+  selected: boolean
+}
+
+interface CheckboxToggleProps
+  extends CheckboxProps,
+    BorderProps,
+    SizeProps,
+    SpaceProps {}
+
+export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
+  state = {
+    selected: false,
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      selected: props.selected || this.state.selected,
+    }
+  }
+
+  toggleSelected = () => {
+    this.setState({ selected: !this.state.selected })
+  }
+
+  render() {
+    const { selected } = this.state
+    const { children } = this.props
+
+    return (
+      <Flex my={2} onClick={this.toggleSelected}>
+        <CheckboxButton border={1} mr={3} selected={selected}>
+          {selected && (
+            <Icon
+              name="check"
+              color="white"
+              fontSize="11px"
+              top={-3}
+              left={-3}
+            />
+          )}
+        </CheckboxButton>
+        <Label>{children}</Label>
+      </Flex>
+    )
+  }
+}
+
+const CheckboxButton = styled.div.attrs<CheckboxToggleProps>({})`
+  ${border};
+  ${space};
+
+  ${props => {
+    const {
+      selected,
+      theme: {
+        colors: { black100, black10, white100 },
+        space,
+      },
+    } = props
+
+    const backgroundColor = selected ? black100 : white100
+    const borderColor = selected ? black100 : black10
+    const buttonSize = space[4]
+
+    return `
+      background-color: ${backgroundColor};
+      border-color: ${borderColor};
+      width: ${buttonSize}px;
+      height: ${buttonSize}px;
+      cursor: pointer;
+    `
+  }};
+`
+
+const Label = styled.div`
+  cursor: pointer;
+  user-select: none;
+`

--- a/src/Styleguide/Elements/Radio.tsx
+++ b/src/Styleguide/Elements/Radio.tsx
@@ -1,0 +1,103 @@
+// TODO: This and <Checkbox /> can be shared
+
+import React from "react"
+import styled from "styled-components"
+import { Flex } from "./Flex"
+
+import {
+  border,
+  BorderProps,
+  SizeProps,
+  space,
+  SpaceProps,
+} from "styled-system"
+
+interface RadioProps {
+  selected?: boolean
+}
+
+interface RadioState {
+  selected: boolean
+}
+
+interface RadioToggleProps
+  extends RadioProps,
+    BorderProps,
+    SizeProps,
+    SpaceProps {}
+
+export class Radio extends React.Component<RadioProps, RadioState> {
+  state = {
+    selected: false,
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      selected: props.selected || this.state.selected,
+    }
+  }
+
+  toggleSelected = () => {
+    this.setState({ selected: !this.state.selected })
+  }
+
+  render() {
+    const { selected } = this.state
+    const { children } = this.props
+
+    return (
+      <Flex my={1} onClick={this.toggleSelected}>
+        <RadioButton border={1} mr={3} selected={selected}>
+          {selected && <InnerCircle />}
+        </RadioButton>
+        <Label>{children}</Label>
+      </Flex>
+    )
+  }
+}
+
+const RadioButton = styled.div.attrs<RadioToggleProps>({})`
+  ${border};
+  ${space};
+
+  ${props => {
+    const {
+      selected,
+      theme: {
+        colors: { black100, black10, white100 },
+        space,
+      },
+    } = props
+
+    const backgroundColor = selected ? black100 : white100
+    const borderColor = selected ? black100 : black10
+    const buttonSize = space[4]
+
+    return `
+      background-color: ${backgroundColor};
+      border-color: ${borderColor};
+      width: ${buttonSize}px;
+      height: ${buttonSize}px;
+
+      border-radius: 50%;
+      cursor: pointer;
+    `
+  }};
+`
+
+const InnerCircle = styled.div`
+  width: ${props => props.theme.space[3]}px;
+  height: ${props => props.theme.space[3]}px;
+  border-radius: 50%;
+  background-color: white;
+  position: relative;
+  left: 3px;
+  top: 3px;
+`
+
+const Label = styled.div`
+  cursor: pointer;
+  user-select: none;
+`

--- a/src/Styleguide/Elements/__stories__/Input.story.tsx
+++ b/src/Styleguide/Elements/__stories__/Input.story.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { Section } from "../../Utils/Section"
+import { Checkbox } from "../Checkbox"
+import { Radio } from "../Radio"
+import { storiesOf } from "storybook/storiesOf"
+
+storiesOf("Styleguide/Elements", module).add("Inputs", () => {
+  return (
+    <React.Fragment>
+      <Section title="Checkbox">
+        <Checkbox>Check me</Checkbox>
+        <Checkbox selected>Check me</Checkbox>
+      </Section>
+      <Section title="Radio">
+        <Radio>Click me</Radio>
+        <Radio selected>Selected</Radio>
+      </Section>
+    </React.Fragment>
+  )
+})

--- a/typings/styled-system.d.ts
+++ b/typings/styled-system.d.ts
@@ -54,9 +54,15 @@ declare module "styled-system" {
     height?: ResponsiveHeightValue
   }
 
+  export function width(...args: any[]): any
+
   export function height(...args: any[]): any
 
-  export function width(...args: any[]): any
+  export interface SizeProps {
+    size?: ResponsiveWidthValue | ResponsiveHeightValue
+  }
+
+  export function size(...args: any[]): any
 
   export type FontSizeValue = number | string
   export type ResponsiveFontSizeValue = ResponsiveValue<FontSizeValue>
@@ -367,13 +373,18 @@ declare module "styled-system" {
     display?: DisplayValue
   }
 
-  export function position(...args: any[]): any
-  export function top(...args: any[]): any
-
   export type PositionValue = string | number
 
   export interface PositionProps {
     top?: PositionValue
+    right?: PositionValue
     bottom?: PositionValue
+    left?: PositionValue
   }
+
+  export function position(...args: any[]): any
+  export function top(...args: any[]): any
+  export function right(...args: any[]): any
+  export function bottom(...args: any[]): any
+  export function left(...args: any[]): any
 }


### PR DESCRIPTION
Adds new `<Radio />` and `<Checkbox />` + Stub out `ArtworkFilter` layout.

**Note**: We'll be able to share most stuff between checkbox / radio; for the time being I just duplicated contents. Will sweep back over and consolidate. 

![artwork filter](https://user-images.githubusercontent.com/236943/41210502-05b986a4-6ce7-11e8-8e57-c8ef4cb28761.gif)


