### PR TITLE
Remove create-react-context dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
   "dependencies": {
     "@artsy/palette": "^1.2.2",
     "cheerio": "^1.0.0-rc.2",
-    "create-react-context": "^0.2.2",
     "farce": "^0.2.6",
     "formik": "^0.11.11",
     "found": "^0.3.11",

--- a/src/Styleguide/Utils/Responsive.tsx
+++ b/src/Styleguide/Utils/Responsive.tsx
@@ -80,5 +80,7 @@ export class ResponsiveProvider extends React.Component<
   }
 }
 
-export const Responsive: React.ComponentClass<ConsumerProps<BreakpointState>> =
+export const Responsive: React.ComponentType<
+  React.ConsumerProps<BreakpointState>
+> =
   ResponsiveContext.Consumer

--- a/src/Styleguide/Utils/Responsive.tsx
+++ b/src/Styleguide/Utils/Responsive.tsx
@@ -1,8 +1,6 @@
 import React from "react"
-import createContext, { ConsumerProps } from "create-react-context"
 
-// FIXME: Replace with React.createContext after React 16.3+ upgrade
-const ResponsiveContext = createContext({})
+const ResponsiveContext = React.createContext({})
 
 export interface Breakpoints {
   [breakpoint: string]: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -3967,13 +3967,6 @@ create-react-context@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.1.6.tgz#0f425931d907741127acc6e31acb4f9015dd9fdc"
 
-create-react-context@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
-
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -5152,7 +5145,7 @@ fb-watchman@2.0.0, fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -5937,10 +5930,6 @@ growl@1.10.3:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
We temporarily added a polyfill of sorts for React's context api while we were on 16.2.0. Now that we're on 16.4.0 it's no longer needed. 