### PR TITLE
@l2succes => Match Desktop Modals to latest design

### DIFF
--- a/src/Components/Authentication/Desktop/Components/DesktopHeader.tsx
+++ b/src/Components/Authentication/Desktop/Components/DesktopHeader.tsx
@@ -1,7 +1,7 @@
 import React, { SFC } from "react"
 import styled from "styled-components"
 import Icon from "Components/Icon"
-import { garamond } from "../../../../Assets/Fonts"
+import { garamond } from "Assets/Fonts"
 
 export const DesktopHeader: SFC<{ subtitle?: string }> = props => {
   const subtitle = props.subtitle || "The art world online"

--- a/src/Components/Authentication/Desktop/Components/DesktopHeader.tsx
+++ b/src/Components/Authentication/Desktop/Components/DesktopHeader.tsx
@@ -1,10 +1,10 @@
 import React, { SFC } from "react"
 import styled from "styled-components"
-import Text from "Components/Text"
 import Icon from "Components/Icon"
+import { garamond } from "../../../../Assets/Fonts"
 
 export const DesktopHeader: SFC<{ subtitle?: string }> = props => {
-  const subtitle = props.subtitle || "The Art World Online"
+  const subtitle = props.subtitle || "The art world online"
   return (
     <Header>
       <Logo name="logotype" />
@@ -21,10 +21,9 @@ const Logo = styled(Icon).attrs({
   line-height: 1em;
 `
 
-const Subtitle = styled(Text).attrs({
-  textSize: "medium",
-  align: "center",
-})`
+const Subtitle = styled.div`
+  ${garamond("s23")};
+  font-weight: bold;
   margin: 10px 0 15px 0;
 `
 
@@ -33,6 +32,4 @@ const Header = styled.div`
   text-align: center;
   justify-content: center;
   flex-direction: column;
-  padding: 10px;
-  margin: 20px 0 0;
 `

--- a/src/Components/Authentication/Desktop/Components/DesktopModal.tsx
+++ b/src/Components/Authentication/Desktop/Components/DesktopModal.tsx
@@ -31,9 +31,9 @@ const CloseButton = styled(Icon).attrs({
   top: 20px;
   right: 15px;
   cursor: pointer;
+  color: ${Colors.black30};
 `
 
 const Content = styled.div`
   box-sizing: border-box;
-  margin: 0px 60px;
 `

--- a/src/Components/Authentication/Desktop/Components/DesktopModal.tsx
+++ b/src/Components/Authentication/Desktop/Components/DesktopModal.tsx
@@ -24,14 +24,13 @@ export class DesktopModal extends Component<DesktopModalProps> {
 }
 
 const CloseButton = styled(Icon).attrs({
-  color: Colors.grayRegular,
+  color: Colors.graySemibold,
   fontSize: "16px",
 })`
   position: absolute;
   top: 20px;
   right: 15px;
   cursor: pointer;
-  color: ${Colors.black30};
 `
 
 const Content = styled.div`

--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -13,6 +13,7 @@ import Button from "Components/Buttons/Inverted"
 
 const ForgotPasswordLink = styled(SmallTextLink)`
   margin-left: auto;
+  color: ${Colors.graySemibold};
 `
 
 const Row = styled.div`
@@ -49,7 +50,7 @@ export const LoginForm: FormComponentType = props => {
         const hasErrors = Object.keys(errors).length > 0 || !!status
 
         return (
-          <Form onSubmit={handleSubmit}>
+          <Form onSubmit={handleSubmit} height={320}>
             <Input
               block
               quick
@@ -81,7 +82,7 @@ export const LoginForm: FormComponentType = props => {
                 onChange={handleChange}
                 onBlur={handleBlur}
               >
-                <Text color={Colors.grayDark}>Remember me</Text>
+                <Text color={Colors.graySemibold}>Remember me</Text>
               </Checkbox>
               <ForgotPasswordLink
                 onClick={() => props.handleTypeChange(ModalType.resetPassword)}
@@ -95,6 +96,7 @@ export const LoginForm: FormComponentType = props => {
             <Footer
               handleTypeChange={() => props.handleTypeChange(ModalType.signup)}
               mode="login"
+              inline
             />
           </Form>
         )

--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -2,12 +2,20 @@ import React from "react"
 import styled from "styled-components"
 import { Formik, FormikProps } from "formik"
 
-import { SmallTextLink, Footer, FormContainer as Form } from "../commonElements"
+import {
+  SmallTextLink,
+  Footer,
+  FormContainer as Form,
+} from "Components/Authentication/commonElements"
 import { LoginValidator } from "Components/Authentication/Validators"
 import Input from "Components/Input"
 import Text from "Components/Text"
 import Colors from "Assets/Colors"
-import { FormComponentType, InputValues, ModalType } from "../Types"
+import {
+  FormComponentType,
+  InputValues,
+  ModalType,
+} from "Components/Authentication/Types"
 import Checkbox from "Components/Checkbox"
 import Button from "Components/Buttons/Inverted"
 

--- a/src/Components/Authentication/Desktop/ResetPasswordForm.tsx
+++ b/src/Components/Authentication/Desktop/ResetPasswordForm.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Formik, FormikProps } from "formik"
+import styled from "styled-components"
 
 import {
   Footer,
@@ -9,6 +10,13 @@ import Input from "Components/Input"
 import { FormComponentType, InputValues, ModalType } from "../Types"
 import { ResetPasswordValidator } from "../Validators"
 import Button from "Components/Buttons/Inverted"
+
+const ResetButton = styled(Button).attrs({
+  type: "submit",
+  block: true,
+})`
+  margin: auto 0 10px 0;
+`
 
 export const ResetPasswordForm: FormComponentType = props => {
   return (
@@ -28,7 +36,7 @@ export const ResetPasswordForm: FormComponentType = props => {
         isValid,
       }: FormikProps<InputValues>) => {
         return (
-          <Form onSubmit={handleSubmit}>
+          <Form onSubmit={handleSubmit} height={180}>
             <Input
               block
               quick
@@ -42,11 +50,12 @@ export const ResetPasswordForm: FormComponentType = props => {
               onBlur={handleBlur}
             />
             {/* touched.email && errors.email && <div>{errors.email}</div */}
-            <Button block type="submit" disabled={isSubmitting}>
+            <ResetButton block type="submit" disabled={isSubmitting}>
               Send Reset Instructions
-            </Button>
+            </ResetButton>
             <Footer
               handleTypeChange={() => props.handleTypeChange(ModalType.login)}
+              mode="reset_password"
             />
           </Form>
         )

--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -2,12 +2,20 @@ import React from "react"
 import styled from "styled-components"
 import { Formik, FormikProps } from "formik"
 
-import { Error, Footer, FormContainer as Form } from "../commonElements"
-import { TermsOfServiceCheckbox } from "../TermsOfServiceCheckbox"
+import {
+  Error,
+  Footer,
+  FormContainer as Form,
+  TermsOfServiceCheckbox,
+} from "Components/Authentication/commonElements"
 import Input from "Components/Input"
-import { FormComponentType, InputValues, ModalType } from "../Types"
+import {
+  FormComponentType,
+  InputValues,
+  ModalType,
+} from "Components/Authentication/Types"
 import Button from "Components/Buttons/Inverted"
-import { SignUpValidator } from "../Validators"
+import { SignUpValidator } from "Components/Authentication/Validators"
 
 const SignUpButton = styled(Button).attrs({
   type: "submit",

--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -2,14 +2,12 @@ import React from "react"
 import styled from "styled-components"
 import { Formik, FormikProps } from "formik"
 
-import { Error, Footer, FormContainer, TOSCheckbox } from "../commonElements"
-import Text from "Components/Text"
-import TextLink from "Components/TextLink"
+import { Error, Footer, FormContainer as Form } from "../commonElements"
+import { TermsOfServiceCheckbox } from "../TermsOfServiceCheckbox"
 import Input from "Components/Input"
 import { FormComponentType, InputValues, ModalType } from "../Types"
 import Button from "Components/Buttons/Inverted"
 import { SignUpValidator } from "../Validators"
-import Colors from "Assets/Colors"
 
 const SignUpButton = styled(Button).attrs({
   type: "submit",
@@ -36,10 +34,8 @@ export const SignUpForm: FormComponentType = props => {
         isValid,
         status,
       }: FormikProps<InputValues>) => {
-        const checkboxError =
-          touched.acceptedTermsOfService && errors.acceptedTermsOfService
         return (
-          <FormContainer onSubmit={handleSubmit}>
+          <Form onSubmit={handleSubmit} height={430}>
             <Input
               block
               quick
@@ -77,42 +73,24 @@ export const SignUpForm: FormComponentType = props => {
               onChange={handleChange}
               onBlur={handleBlur}
             />
-            <TOSCheckbox
-              error={checkboxError}
+            <TermsOfServiceCheckbox
+              error={
+                touched.acceptedTermsOfService && errors.acceptedTermsOfService
+              }
               checked={values.acceptedTermsOfService}
               value={values.acceptedTermsOfService}
               type="checkbox"
               name="acceptedTermsOfService"
               onChange={handleChange}
               onBlur={handleBlur}
-            >
-              <Text color={checkboxError ? Colors.redMedium : Colors.grayDark}>
-                {"I agree to the "}
-                <TextLink
-                  href="https://www.artsy.net/terms"
-                  target="_blank"
-                  color={checkboxError ? Colors.redMedium : Colors.grayDark}
-                  underline
-                >
-                  Terms Of Service
-                </TextLink>
-                {" and "}
-                <TextLink
-                  href="https://www.artsy.net/privacy"
-                  target="_blank"
-                  color={checkboxError ? Colors.redMedium : Colors.grayDark}
-                  underline
-                >
-                  Privacy Policy
-                </TextLink>
-              </Text>
-            </TOSCheckbox>
+            />
             {status && !status.success && <Error show>{status.error}</Error>}
             <SignUpButton disabled={isSubmitting}>Sign Up</SignUpButton>
             <Footer
               handleTypeChange={() => props.handleTypeChange(ModalType.login)}
+              inline
             />
-          </FormContainer>
+          </Form>
         )
       }}
     </Formik>

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -1,18 +1,24 @@
 import React from "react"
 import styled from "styled-components"
 import * as sharify from "sharify"
-import { metaphysics } from "../../../Utils/metaphysics"
+import { metaphysics } from "Utils/metaphysics"
 
-import { Step, Wizard } from "../../Wizard"
-import { ProgressIndicator } from "../../ProgressIndicator"
-import { Footer, MobileHeader } from "../commonElements"
-import Input from "../../Input"
-import Button from "../../Buttons/Inverted"
-import Icon from "../../Icon"
-import { FormComponentType, ModalType } from "../Types"
+import { Step, Wizard } from "Components/Wizard"
+import { ProgressIndicator } from "Components/ProgressIndicator"
+import {
+  Footer,
+  MobileHeader,
+  TermsOfServiceCheckbox,
+} from "Components/Authentication/commonElements"
+import Input from "Components/Input"
+import Button from "Components/Buttons/Inverted"
+import Icon from "Components/Icon"
+import { FormComponentType, ModalType } from "Components/Authentication/Types"
 import Colors from "Assets/Colors"
-import { CustomMobileValidator, MobileSignUpValidator } from "../Validators"
-import { TermsOfServiceCheckbox } from "../TermsOfServiceCheckbox"
+import {
+  CustomMobileValidator,
+  MobileSignUpValidator,
+} from "Components/Authentication/Validators"
 
 const checkEmail = (values, actions) => {
   const query = `

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -1,20 +1,18 @@
 import React from "react"
+import styled from "styled-components"
+import * as sharify from "sharify"
+import { metaphysics } from "../../../Utils/metaphysics"
+
 import { Step, Wizard } from "../../Wizard"
 import { ProgressIndicator } from "../../ProgressIndicator"
-
-import { Footer, MobileHeader, TOSCheckbox } from "../commonElements"
-import styled from "styled-components"
+import { Footer, MobileHeader } from "../commonElements"
 import Input from "../../Input"
 import Button from "../../Buttons/Inverted"
 import Icon from "../../Icon"
 import { FormComponentType, ModalType } from "../Types"
-
-import Text from "../../Text"
-import TextLink from "../../TextLink"
 import Colors from "Assets/Colors"
 import { CustomMobileValidator, MobileSignUpValidator } from "../Validators"
-import { metaphysics } from "../../../Utils/metaphysics"
-import * as sharify from "sharify"
+import { TermsOfServiceCheckbox } from "../TermsOfServiceCheckbox"
 
 const checkEmail = (values, actions) => {
   const query = `
@@ -92,8 +90,6 @@ export const MobileSignUpForm: FormComponentType = props => {
         wizard,
         form: { errors, touched, values, handleChange, handleBlur, setTouched },
       }) => {
-        const checkboxError =
-          touched.acceptedTermsOfService && errors.acceptedTermsOfService
         return (
           <div style={{ marginBottom: "80px" }}>
             <Input
@@ -109,36 +105,17 @@ export const MobileSignUpForm: FormComponentType = props => {
               setTouched={setTouched}
               quick
             />
-            <TOSCheckbox
-              error={checkboxError}
-              value={values.acceptedTermsOfService}
+            <TermsOfServiceCheckbox
+              error={
+                touched.acceptedTermsOfService && errors.acceptedTermsOfService
+              }
               checked={values.acceptedTermsOfService}
+              value={values.acceptedTermsOfService}
               type="checkbox"
               name="acceptedTermsOfService"
               onChange={handleChange}
               onBlur={handleBlur}
-            >
-              <Text color={checkboxError ? Colors.redMedium : Colors.grayDark}>
-                {"I agree to the "}
-                <TextLink
-                  href="https://www.artsy.net/terms"
-                  target="_blank"
-                  color={checkboxError ? Colors.redMedium : Colors.grayDark}
-                  underline
-                >
-                  Terms Of Service
-                </TextLink>
-                {" and "}
-                <TextLink
-                  href="https://www.artsy.net/privacy"
-                  target="_blank"
-                  color={checkboxError ? Colors.redMedium : Colors.grayDark}
-                  underline
-                >
-                  Privacy Policy
-                </TextLink>
-              </Text>
-            </TOSCheckbox>
+            />
           </div>
         )
       }}

--- a/src/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import styled from "styled-components"
+import Checkbox from "../Checkbox"
+import Text from "../Text"
+import Colors from "../../Assets/Colors"
+import TextLink from "../TextLink"
+
+export const TermsOfServiceCheckbox = ({
+  error,
+  name,
+  onChange,
+  onBlur,
+  value,
+  ...props
+}) => (
+  <StyledCheckbox {...{ checked: value, error, onChange, onBlur, name }}>
+    <TOSText color={error ? Colors.redMedium : Colors.graySemibold}>
+      {"I agree to Artsy’s "}
+      <TextLink
+        href="https://www.artsy.net/terms"
+        target="_blank"
+        color={error ? Colors.redMedium : Colors.graySemibold}
+      >
+        Terms Of Service
+      </TextLink>
+      {" and "}
+      <TextLink
+        href="https://www.artsy.net/privacy"
+        target="_blank"
+        color={error ? Colors.redMedium : Colors.graySemibold}
+      >
+        Privacy Policy
+      </TextLink>
+      {" and to receive emails from Artsy."}
+    </TOSText>
+  </StyledCheckbox>
+)
+
+const StyledCheckbox = styled(Checkbox)`
+  margin: 5px 0;
+  align-items: flex-start;
+`
+
+export const TOSText = styled(Text)`
+  margin: 0 0 0 5px;
+  line-height: 22px;
+`

--- a/src/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -1,9 +1,9 @@
 import React from "react"
 import styled from "styled-components"
-import Checkbox from "../Checkbox"
-import Text from "../Text"
-import Colors from "../../Assets/Colors"
-import TextLink from "../TextLink"
+import Checkbox from "Components/Checkbox"
+import Text from "Components/Text"
+import Colors from "Assets/Colors"
+import TextLink from "Components/TextLink"
 
 export const TermsOfServiceCheckbox = ({
   error,

--- a/src/Components/Authentication/commonElements.tsx
+++ b/src/Components/Authentication/commonElements.tsx
@@ -1,13 +1,9 @@
-import React from "react"
 import styled from "styled-components"
-
 import Colors from "Assets/Colors"
 import { growAndFadeIn } from "Assets/Animations"
 import { garamond, unica } from "Assets/Fonts"
-import Checkbox from "../Checkbox"
-import Text from "../Text"
-
 export { Footer } from "./Footer"
+export { TermsOfServiceCheckbox } from "./TermsOfServiceCheckbox"
 
 interface FormProps {
   height?: number
@@ -18,21 +14,6 @@ export const FormContainer = styled.form`
   flex-direction: column;
   height: ${(props: FormProps) =>
     props.height ? props.height + "px" : "auto"};
-`
-
-export const TOSCheckbox = ({ error, name, onChange, value, ...props }) => (
-  <StyledCheckbox {...{ checked: value, error, onChange, name }}>
-    {props.children}
-  </StyledCheckbox>
-)
-
-const StyledCheckbox = styled(Checkbox)`
-  margin-bottom: 5px;
-  align-items: flex-start;
-`
-
-export const TOSText = styled(Text)`
-  margin: 0 0 0 5px;
 `
 
 export const SmallTextLink = styled.a`

--- a/src/Components/Authentication/commonElements.tsx
+++ b/src/Components/Authentication/commonElements.tsx
@@ -5,14 +5,19 @@ import Colors from "Assets/Colors"
 import { growAndFadeIn } from "Assets/Animations"
 import { garamond, unica } from "Assets/Fonts"
 import Checkbox from "../Checkbox"
+import Text from "../Text"
 
 export { Footer } from "./Footer"
+
+interface FormProps {
+  height?: number
+}
 
 export const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
-  padding: 0 20px 30px;
-  height: 425px;
+  height: ${(props: FormProps) =>
+    props.height ? props.height + "px" : "auto"};
 `
 
 export const TOSCheckbox = ({ error, name, onChange, value, ...props }) => (
@@ -22,7 +27,12 @@ export const TOSCheckbox = ({ error, name, onChange, value, ...props }) => (
 )
 
 const StyledCheckbox = styled(Checkbox)`
-  margin: 20px 0;
+  margin-bottom: 5px;
+  align-items: flex-start;
+`
+
+export const TOSText = styled(Text)`
+  margin: 0 0 0 5px;
 `
 
 export const SmallTextLink = styled.a`

--- a/src/Components/Buttons/Default.tsx
+++ b/src/Components/Buttons/Default.tsx
@@ -69,6 +69,7 @@ export const StyledButton = styled(Button)`
   border: none;
   box-sizing: border-box;
   text-decoration: none;
+  border-radius: 2px;
 
   &:hover:not(:disabled) {
     cursor: pointer;

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -267,7 +267,7 @@ const Error = styled.div.attrs<{ show: boolean }>({})`
 const PasswordMessage = styled.div`
   ${unica("s12")};
   margin-top: 10px;
-  color: ${Colors.grayDark};
+  color: ${Colors.graySemibold};
   height: 16px;
 `
 

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -13,8 +13,9 @@ const ModalContainer = styled.div`
   transform: translate(-50%, -50%);
   z-index: 9999;
   background: #fff;
-  width: 500px;
+  width: 440px;
   border-radius: 4px;
+  padding: 20px 40px;
 `
 
 const Overlay = styled.div`

--- a/src/Components/Publishing/Email/__tests__/__snapshots__/EmailPanel.test.tsx.snap
+++ b/src/Components/Publishing/Email/__tests__/__snapshots__/EmailPanel.test.tsx.snap
@@ -117,6 +117,7 @@ exports[`EmailSignup renders an email signup 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   border-radius: 2px;
+  border-radius: 2px;
   height: 30px;
   width: 80px;
   margin-left: -100px;

--- a/src/Components/Publishing/Email/__tests__/__snapshots__/InstantArticleEmailSignup.test.tsx.snap
+++ b/src/Components/Publishing/Email/__tests__/__snapshots__/InstantArticleEmailSignup.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`EmailSignup renders an email signup 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   border-radius: 2px;
+  border-radius: 2px;
   height: 30px;
   width: 80px;
   margin-left: -100px;

--- a/src/Components/Publishing/Nav/__tests__/__snapshots__/SubNav.test.tsx.snap
+++ b/src/Components/Publishing/Nav/__tests__/__snapshots__/SubNav.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`SubNav renders SubNav 1`] = `
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
+  border-radius: 2px;
   font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
   -webkit-font-smoothing: antialiased;
   text-transform: uppercase;
@@ -107,6 +108,7 @@ exports[`SubNav renders SubNav 1`] = `
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
+  border-radius: 2px;
   font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
   -webkit-font-smoothing: antialiased;
   text-transform: uppercase;

--- a/src/Components/__stories__/Authentication.story.tsx
+++ b/src/Components/__stories__/Authentication.story.tsx
@@ -7,7 +7,10 @@ import { FormSwitcher } from "../Authentication/Desktop/FormSwitcher"
 import { DesktopModal } from "../Authentication/Desktop/Components/DesktopModal"
 import { ModalType } from "../Authentication/Types"
 import { MobileSignUpForm } from "../../Components/Authentication/Mobile/SignUpForm"
-import { Footer } from "../../Components/Authentication/Footer"
+import {
+  TermsOfServiceCheckbox,
+  Footer,
+} from "../../Components/Authentication/commonElements"
 
 const submit = (values, actions) => {
   setTimeout(() => {
@@ -63,6 +66,15 @@ storiesOf("Components/Authentication/Common Elements", module)
     </div>
   ))
   .add("Footer - Reset Password", () => <Footer mode="reset_password" />)
+  .add("TermsOfServiceCheckbox", () => (
+    <TermsOfServiceCheckbox
+      error={null}
+      name="accepted_terms_of_service"
+      onChange={() => null}
+      onBlur={() => null}
+      value={false}
+    />
+  ))
 
 const MobileContainer = styled.div`
   border: 1px solid ${Colors.grayRegular};


### PR DESCRIPTION
This should cover all the latest changes for Desktop Modals in Zeplin. Here are some screenshots...

I think the only visual difference is the button heights (which would mean changing the line height of the `Default` button -- something I'd like to address more carefully later on).

One more thing that needs to be handled further is the `subtitle` -- it seems like we want to use the "Log in to your account" copy for Login screens always, but I need to check with @owendodd if that is indeed the case. If it is, we can include a default for Login screens to avoid having to overwrite in many places. 

Also went ahead and extracted TOS stuff to it's own component so it can be reused for mobile.. `src/Components/Authentication/TermsOfServiceCheckbox.tsx`

Login:
![image](https://user-images.githubusercontent.com/2236794/41256360-56045d68-6d97-11e8-9486-ec3247ba6467.png)

Signup:
![image](https://user-images.githubusercontent.com/2236794/41256772-932ee37e-6d98-11e8-80be-52938ce9608c.png)

Reset Password:
![image](https://user-images.githubusercontent.com/2236794/41256778-9d04c08a-6d98-11e8-8a16-e9ed73074744.png)
