### PR TITLE
[Dev] fix `yarn type-check` #trivial

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "sync-schema:localhost": "cd ../metaphysics && yarn dump-schema -- ../reaction/data",
     "test": "node verify-node-version.js && jest",
     "test:watch": "jest --watch --runInBand",
-    "type-check": "tsc --noEmit --pretty",
+    "type-check": "tsc --pretty",
     "watch": "concurrently --raw --kill-others 'yarn relay --watch' 'yarn compile -w' 'yarn emit-types --watch'",
     "semantic-release": "semantic-release"
   },

--- a/src/Assets/Animations.tsx
+++ b/src/Assets/Animations.tsx
@@ -40,6 +40,6 @@ export const shrinkAndFadeOut = height => keyframes`
 
   to {
     opacity: 1;
-    height: ${height}
+    height: ${height};
   }
 `

--- a/src/Styleguide/Elements/Image.tsx
+++ b/src/Styleguide/Elements/Image.tsx
@@ -1,3 +1,5 @@
+// @ts-ignore
+import React from "react"
 import styled from "styled-components"
 
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "experimentalDecorators": true,
     "jsx": "react",
     "lib": ["dom", "es2015", "es2016", "es2017"],
-    "listEmittedFiles": true,
     "module": "es2015",
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION
Type emission errors weren't getting exposed in `yarn type-check` so errors don't get outputted in PR builds.

merge on green