### PR TITLE
@kanaabe => [PATCH auth] adds global errors to login/reset password view

### DIFF
--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { Formik, FormikProps } from "formik"
 
 import {
+  Error,
   SmallTextLink,
   Footer,
   FormContainer as Form,
@@ -98,6 +99,7 @@ export const LoginForm: FormComponentType = props => {
                 Forgot Password?
               </ForgotPasswordLink>
             </Row>
+            {status && !status.success && <Error show>{status.error}</Error>}
             <LoginButton disabled={isSubmitting || hasErrors}>
               Log In
             </LoginButton>

--- a/src/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/Components/Authentication/Desktop/ModalManager.tsx
@@ -11,8 +11,8 @@ import {
 } from "Components/Authentication/Types"
 
 export interface ModalManagerProps {
-  submitUrls: { [P in ModalType]: string }
-  csrf: string
+  submitUrls?: { [P in ModalType]: string }
+  csrf?: string
   redirectUrl?: string
   handleSubmit?: (
     type: ModalType,

--- a/src/Components/Authentication/Desktop/ResetPasswordForm.tsx
+++ b/src/Components/Authentication/Desktop/ResetPasswordForm.tsx
@@ -3,6 +3,7 @@ import { Formik, FormikProps } from "formik"
 import styled from "styled-components"
 
 import {
+  Error,
   Footer,
   FormContainer as Form,
 } from "Components/Authentication/commonElements"
@@ -34,6 +35,7 @@ export const ResetPasswordForm: FormComponentType = props => {
         handleSubmit,
         isSubmitting,
         isValid,
+        status,
       }: FormikProps<InputValues>) => {
         return (
           <Form onSubmit={handleSubmit} height={180}>
@@ -49,7 +51,7 @@ export const ResetPasswordForm: FormComponentType = props => {
               onChange={handleChange}
               onBlur={handleBlur}
             />
-            {/* touched.email && errors.email && <div>{errors.email}</div */}
+            {status && !status.success && <Error show>{status.error}</Error>}
             <ResetButton block type="submit" disabled={isSubmitting}>
               Send Reset Instructions
             </ResetButton>

--- a/src/Components/Authentication/__tests__/Desktop/ModalManager.test.tsx
+++ b/src/Components/Authentication/__tests__/Desktop/ModalManager.test.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { mount } from "enzyme"
 import { ModalManager } from "../../Desktop/ModalManager"
-import { ModalType } from "../../Types"
 import { LoginForm } from "../../Desktop/LoginForm"
 
 describe("ModalManager", () => {
@@ -29,7 +28,6 @@ describe("ModalManager", () => {
           reset_password: "/reset_password",
         }}
         csrf="CSRF_TOKEN"
-        type={ModalType.login}
       />
     )
 

--- a/src/Components/Authentication/commonElements.tsx
+++ b/src/Components/Authentication/commonElements.tsx
@@ -43,7 +43,7 @@ export const MobileHeader = styled.div`
 
 export const Error = styled.div.attrs<{ show: boolean }>({})`
   ${unica("s12")};
-  margin-top: ${p => (p.show ? "10px" : "0")};
+  margin-top: ${p => (p.show ? "auto" : "0")};
   margin-bottom: 10px;
   color: ${Colors.redMedium};
   visibility: ${p => (p.show ? "visible" : "hidden")};


### PR DESCRIPTION
Forgot to display server errors in the Login & reset password forms