### PR TITLE
adding Artwork metadata component

### DIFF
--- a/src/Styleguide/Pages/Artwork/Sidebar/Artists.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/Artists.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Serif } from "@artsy/palette"
 import styled from "styled-components"
+import { space, SpaceProps } from "styled-system"
 import { FollowIcon } from "../../../Elements/FollowIcon"
 
 interface ArtistsProps {
@@ -13,8 +14,9 @@ interface ArtistsProps {
   }>
 }
 
-const Artist = styled.div``
-const ArtistsContainer = styled.div``
+const ArtistsContainer = styled.div.attrs<SpaceProps>({})`
+  ${space};
+`
 
 export class Artists extends React.Component<ArtistsProps> {
   renderArtistName(artist) {
@@ -29,7 +31,16 @@ export class Artists extends React.Component<ArtistsProps> {
     )
   }
 
-  renderArtists(artists) {
+  renderSingleArtist(artist) {
+    return (
+      <React.Fragment>
+        {this.renderArtistName(artist)}
+        <FollowIcon is_followed={artist.is_followed} />
+      </React.Fragment>
+    )
+  }
+
+  renderMultipleArtists(artists) {
     return artists.map((artist, index) => {
       return (
         <React.Fragment>
@@ -42,16 +53,12 @@ export class Artists extends React.Component<ArtistsProps> {
 
   render() {
     const { artists } = this.props
-    if (artists.length === 1) {
-      const artist = artists[0]
-      return (
-        <Artist>
-          {this.renderArtistName(artist)}
-          <FollowIcon is_followed={artist.is_followed} />
-        </Artist>
-      )
-    } else {
-      return <ArtistsContainer>{this.renderArtists(artists)}</ArtistsContainer>
-    }
+    return (
+      <ArtistsContainer pb={4}>
+        {artists.length === 1
+          ? this.renderSingleArtist(artists[0])
+          : this.renderMultipleArtists(artists)}
+      </ArtistsContainer>
+    )
   }
 }

--- a/src/Styleguide/Pages/Artwork/Sidebar/Artists.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/Artists.tsx
@@ -45,7 +45,7 @@ export class Artists extends React.Component<ArtistsProps> {
       return (
         <React.Fragment>
           {this.renderArtistName(artist)}
-          {index !== artists.length - 1 ? ", " : ""}
+          {index !== artists.length - 1 && ", "}
         </React.Fragment>
       )
     })

--- a/src/Styleguide/Pages/Artwork/Sidebar/ArtworkMetadata.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/ArtworkMetadata.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+import styled from "styled-components"
+import { space, SpaceProps } from "styled-system"
+import { TitleInfo } from "./TitleInfo"
+import { SizeInfo } from "./SizeInfo"
+import { Classification } from "./Classification"
+
+interface ArtworkMetadataProps {
+  artwork: {
+    readonly title: string
+    readonly date: string
+    readonly medium: string
+    readonly dimensions: {
+      in: string
+      cm: string
+    }
+    readonly edition_of: string
+    readonly attribution_class: {
+      short_description: string
+    }
+    readonly edition_sets: Array<{
+      id: string
+    }>
+  }
+}
+
+const ArtworkMetadataContainer = styled.div.attrs<SpaceProps>({})`
+  ${space};
+`
+
+export class ArtworkMetadata extends React.Component<ArtworkMetadataProps> {
+  render() {
+    const { artwork } = this.props
+    return (
+      <ArtworkMetadataContainer pb={4}>
+        <TitleInfo artwork={artwork} />
+        {artwork.edition_sets.length > 1 ? "" : <SizeInfo artwork={artwork} />}
+        <Classification artwork={artwork} />
+      </ArtworkMetadataContainer>
+    )
+  }
+}

--- a/src/Styleguide/Pages/Artwork/Sidebar/ArtworkMetadata.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/ArtworkMetadata.tsx
@@ -34,7 +34,7 @@ export class ArtworkMetadata extends React.Component<ArtworkMetadataProps> {
     return (
       <ArtworkMetadataContainer pb={4}>
         <TitleInfo artwork={artwork} />
-        {artwork.edition_sets.length > 1 ? "" : <SizeInfo artwork={artwork} />}
+        {artwork.edition_sets.length < 2 && <SizeInfo artwork={artwork} />}
         <Classification artwork={artwork} />
       </ArtworkMetadataContainer>
     )

--- a/src/Styleguide/Pages/Artwork/Sidebar/Classification.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/Classification.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import styled from "styled-components"
+import { Serif } from "@artsy/palette"
+import { themeGet, space, SpaceProps } from "styled-system"
+
+interface ClassificationProps {
+  artwork: {
+    readonly attribution_class?: {
+      readonly short_description: string
+    }
+  }
+}
+
+const ClassificationContainer = styled.div.attrs<SpaceProps>({})`
+  color: ${themeGet("colors.black60")};
+  text-align: left;
+  ${space};
+`
+
+export class Classification extends React.Component<ClassificationProps> {
+  render() {
+    const { artwork } = this.props
+    if (!artwork.attribution_class) {
+      return null
+    }
+    return (
+      <ClassificationContainer pt={4}>
+        <Serif size="2">
+          <a href="#">{artwork.attribution_class.short_description}</a>.
+        </Serif>
+      </ClassificationContainer>
+    )
+  }
+}

--- a/src/Styleguide/Pages/Artwork/Sidebar/SizeInfo.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/SizeInfo.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import styled from "styled-components"
+import { Serif } from "@artsy/palette"
+import { themeGet } from "styled-system"
+
+interface SizeInfoProps {
+  artwork: {
+    readonly dimensions?: {
+      readonly in: string
+      readonly cm: string
+    }
+    readonly edition_of?: string
+  }
+}
+
+const SizeInfoContainer = styled.div`
+  color: ${themeGet("colors.black60")};
+  text-align: left;
+`
+
+export class SizeInfo extends React.Component<SizeInfoProps> {
+  render() {
+    const { artwork } = this.props
+    return (
+      <SizeInfoContainer>
+        <Serif size="2">
+          {artwork.dimensions
+            ? [artwork.dimensions.in, artwork.dimensions.cm].join("; ")
+            : ""}
+        </Serif>
+        {artwork.edition_of ? <Serif size="2">{artwork.edition_of}</Serif> : ""}
+      </SizeInfoContainer>
+    )
+  }
+}

--- a/src/Styleguide/Pages/Artwork/Sidebar/SizeInfo.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/SizeInfo.tsx
@@ -24,11 +24,11 @@ export class SizeInfo extends React.Component<SizeInfoProps> {
     return (
       <SizeInfoContainer>
         <Serif size="2">
-          {artwork.dimensions
-            ? [artwork.dimensions.in, artwork.dimensions.cm].join("; ")
-            : ""}
+          {artwork.dimensions &&
+            (artwork.dimensions.in || artwork.dimensions.cm) &&
+            [artwork.dimensions.in, artwork.dimensions.cm].join("; ")}
         </Serif>
-        {artwork.edition_of ? <Serif size="2">{artwork.edition_of}</Serif> : ""}
+        {artwork.edition_of && <Serif size="2">{artwork.edition_of}</Serif>}
       </SizeInfoContainer>
     )
   }

--- a/src/Styleguide/Pages/Artwork/Sidebar/TitleInfo.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/TitleInfo.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import styled from "styled-components"
+import { Serif } from "@artsy/palette"
+import { themeGet } from "styled-system"
+
+interface TitleInfoProps {
+  artwork: {
+    readonly title: string
+    readonly date?: string
+    readonly medium?: string
+  }
+}
+
+const TitleInfoContainer = styled.div`
+  color: ${themeGet("colors.black60")};
+  text-align: left;
+`
+
+export class TitleInfo extends React.Component<TitleInfoProps> {
+  render() {
+    const { artwork } = this.props
+    return (
+      <TitleInfoContainer>
+        <Serif size="2">
+          <Serif size="2" display="inline-block" italic>
+            {artwork.title}
+          </Serif>
+          {artwork.date && artwork.date.replace(/\s+/g, "").length > 0
+            ? ", " + artwork.date
+            : ""}
+        </Serif>
+        {artwork.medium ? <Serif size="2">{artwork.medium}</Serif> : ""}
+      </TitleInfoContainer>
+    )
+  }
+}

--- a/src/Styleguide/Pages/Artwork/Sidebar/TitleInfo.tsx
+++ b/src/Styleguide/Pages/Artwork/Sidebar/TitleInfo.tsx
@@ -25,11 +25,11 @@ export class TitleInfo extends React.Component<TitleInfoProps> {
           <Serif size="2" display="inline-block" italic>
             {artwork.title}
           </Serif>
-          {artwork.date && artwork.date.replace(/\s+/g, "").length > 0
-            ? ", " + artwork.date
-            : ""}
+          {artwork.date &&
+            artwork.date.replace(/\s+/g, "").length > 0 &&
+            ", " + artwork.date}
         </Serif>
-        {artwork.medium ? <Serif size="2">{artwork.medium}</Serif> : ""}
+        {artwork.medium && <Serif size="2">{artwork.medium}</Serif>}
       </TitleInfoContainer>
     )
   }

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/ArtworkMetadata.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/ArtworkMetadata.story.tsx
@@ -1,0 +1,118 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Section } from "../../../../Utils/Section"
+import { ArtworkMetadata } from "../../Sidebar/ArtworkMetadata"
+
+export const FilledOutMetadataNoEditions = {
+  title: "Full metadata / No editions",
+  date: "2016-2017",
+  medium:
+    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
+  dimensions: {
+    in: "48 2/5 in diameter",
+    cm: "123 cm diameter",
+  },
+  edition_of: null,
+  attribution_class: {
+    short_description: "This is a made-to-order piece",
+  },
+  edition_sets: [],
+}
+
+export const FilledOutMetadataOneEditionSet = {
+  title: "Full metadata / One Edition Set",
+  date: "2016-2017",
+  medium:
+    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
+  dimensions: { in: "4 3/10 × 8 7/10 × 13 in", cm: "11 × 22 × 33 cm" },
+  edition_of: "Edition of 21",
+  attribution_class: { short_description: "This is a made-to-order piece" },
+  edition_sets: [{ id: "5b1ffd455405ff0020d933bb" }],
+}
+
+export const FilledOutMetadataMultipleEditionSets = {
+  title: "Full metadata / Multiple edition sets",
+  date: "2016-2017",
+  medium:
+    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
+  dimensions: {
+    in: "22 × 33 × 11 in",
+    cm: "55.9 × 83.8 × 27.9 cm",
+  },
+  edition_of: null,
+  attribution_class: {
+    short_description: "This is a made-to-order piece",
+  },
+  edition_sets: [
+    { id: "5b1ffd455405ff0020d933bb" },
+    { id: "5b1ffdb20923cc00205152d3" },
+  ],
+}
+
+export const EmptyMetadataNoEditions = {
+  title: "Empty metadata / No editions",
+  date: " ",
+  medium: "",
+  dimensions: {
+    in: null,
+    cm: null,
+  },
+  edition_of: null,
+  attribution_class: null,
+  edition_sets: [],
+}
+
+export const EmptyMetadataOneEditionSet = {
+  title: "Empty metadata / One edition set",
+  date: " ",
+  medium: "",
+  dimensions: {
+    in: null,
+    cm: null,
+  },
+  edition_of: "",
+  attribution_class: null,
+  edition_sets: [
+    {
+      id: "5b1fff790923cc00205152fe",
+    },
+  ],
+}
+
+export const EmptyMetadataMultipleEditionSets = {
+  title: "Empty metadata / Multiple edition Sets",
+  date: " ",
+  medium: "",
+  dimensions: { in: null, cm: null },
+  edition_of: "",
+  attribution_class: null,
+  edition_sets: [
+    { id: "5b1ffd455405ff0020d933bb" },
+    { id: "5b1ffdb20923cc00205152d3" },
+  ],
+}
+
+storiesOf("Styleguide/Artwork/Sidebar", module).add("ArtworkMetadata", () => {
+  return (
+    <React.Fragment>
+      <Section title="Filled out metadata no editions">
+        <ArtworkMetadata artwork={FilledOutMetadataNoEditions} />
+      </Section>
+      <Section title="Filled out metadata one edition set">
+        <ArtworkMetadata artwork={FilledOutMetadataOneEditionSet} />
+      </Section>
+      <Section title="Filled out metadata multiple edition sets">
+        <ArtworkMetadata artwork={FilledOutMetadataMultipleEditionSets} />
+      </Section>
+      <Section title="Empty metadata no editions">
+        <ArtworkMetadata artwork={EmptyMetadataNoEditions} />
+      </Section>
+      <Section title="Empty metadata one edition set">
+        <ArtworkMetadata artwork={EmptyMetadataOneEditionSet} />
+      </Section>
+      <Section title="Empty metadata multiple edition sets">
+        <ArtworkMetadata artwork={EmptyMetadataMultipleEditionSets} />
+      </Section>
+    </React.Fragment>
+  )
+})

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/Classification.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/Classification.story.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Section } from "../../../../Utils/Section"
+import { Classification } from "../../Sidebar/Classification"
+
+export const ArtworkWithClassification = {
+  attribution_class: { short_description: "This is a unique work" },
+}
+
+export const ArtworkWithoutClassification = { attribution_class: null }
+
+storiesOf("Styleguide/Artwork/Sidebar", module).add("Classification", () => {
+  return (
+    <React.Fragment>
+      <Section title="Artwork with Classification">
+        <Classification artwork={ArtworkWithClassification} />
+      </Section>
+      <Section title="Artwork without Classification">
+        <Classification artwork={ArtworkWithoutClassification} />
+      </Section>
+    </React.Fragment>
+  )
+})

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/SizeInfo.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/SizeInfo.story.tsx
@@ -13,6 +13,7 @@ export const ArtworkWithSizeOnly = {
 }
 
 export const ArtworkWithEditionOfOnly = {
+  dimensions: { in: null, cm: null },
   edition_of: "Edition of 20",
 }
 

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/SizeInfo.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/SizeInfo.story.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Section } from "../../../../Utils/Section"
+import { SizeInfo } from "../../Sidebar/SizeInfo"
+
+export const ArtworkWithSizeAndEditionOf = {
+  dimensions: { in: "10 1/4 × 8 7/8 in", cm: "26 × 22.5 cm" },
+  edition_of: "Edition of 20",
+}
+
+export const ArtworkWithSizeOnly = {
+  dimensions: { in: "10 1/4 × 8 7/8 in", cm: "26 × 22.5 cm" },
+}
+
+export const ArtworkWithEditionOfOnly = {
+  edition_of: "Edition of 20",
+}
+
+storiesOf("Styleguide/Artwork/Sidebar", module).add("SizeInfo", () => {
+  return (
+    <React.Fragment>
+      <Section title="Artwork with Size and Edition of presentt">
+        <SizeInfo artwork={ArtworkWithSizeAndEditionOf} />
+      </Section>
+      <Section title="Artwork with Size only">
+        <SizeInfo artwork={ArtworkWithSizeOnly} />
+      </Section>
+      <Section title="Artwork with Edition of only">
+        <SizeInfo artwork={ArtworkWithEditionOfOnly} />
+      </Section>
+    </React.Fragment>
+  )
+})

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/TitleInfo.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/TitleInfo.story.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Section } from "../../../../Utils/Section"
+import { TitleInfo } from "../../Sidebar/TitleInfo"
+
+export const ArtworkWithTitleDateAndMedium = {
+  title: "The Fox and the Hound",
+  date: "2018",
+  medium: "Oil on canvas",
+}
+
+export const ArtworkWithTitleOnly = {
+  title: "The Fox and the Hound",
+}
+
+export const ArtworkWithTitlAndDate = {
+  title: "The Fox and the Hound",
+  date: " 2013 - 2012 ",
+}
+export const ArtworkWithTitleAndMedium = {
+  title: "The Fox and the Hound",
+  date: null,
+  medium:
+    "Hand selected materials to paint this piece were sourced from the old villages on magic lands.",
+}
+
+storiesOf("Styleguide/Artwork/Sidebar", module).add("TitleInfo", () => {
+  return (
+    <React.Fragment>
+      <Section title="Artwork with Title Date and Medium present">
+        <TitleInfo artwork={ArtworkWithTitleDateAndMedium} />
+      </Section>
+      <Section title="Artwork with Title onlyt">
+        <TitleInfo artwork={ArtworkWithTitleOnly} />
+      </Section>
+      <Section title="Artwork with Title and Date">
+        <TitleInfo artwork={ArtworkWithTitlAndDate} />
+      </Section>
+      <Section title="Artwork with Title and Medium">
+        <TitleInfo artwork={ArtworkWithTitleAndMedium} />
+      </Section>
+    </React.Fragment>
+  )
+})

--- a/src/Styleguide/Pages/Artwork/index.js
+++ b/src/Styleguide/Pages/Artwork/index.js
@@ -7,6 +7,8 @@ import { ExhibitionHistory } from "./ExhibitionHistory"
 import { Banner } from "./Banner"
 import { Artists } from "./Sidebar/Artists"
 import { SingleFollowedArtist } from "./__stories__/Sidebar/Artists.story"
+import { ArtworkMetadata } from "./Sidebar/ArtworkMetadata"
+import { FilledOutMetadataNoEditions } from "./__stories__/Sidebar/ArtworkMetadata.story"
 
 export class Artwork extends Component {
   state = {
@@ -44,17 +46,8 @@ export class Artwork extends Component {
             </ArtworkSlider>
           </Col>
           <Col sm={4}>
-            <ArtworkInfo>
-              <Artists artists={SingleFollowedArtist} />
-              <ArtworkMetadata>
-                The Fox and the Hound, 2018 <br />
-                Oil on canvas <br />
-                96 × 79 in; 243.8 × 200.7 cm <br />
-                <br />
-                <br />
-                This is a unique work.
-              </ArtworkMetadata>
-            </ArtworkInfo>
+            <Artists artists={SingleFollowedArtist} />
+            <ArtworkMetadata artwork={FilledOutMetadataNoEditions} />
 
             <hr />
 
@@ -63,12 +56,12 @@ export class Artwork extends Component {
             <Gallery>
               <ContactButton>Contact Gallery</ContactButton>
 
-              <Metadata>
+              <PartnerInfo>
                 <Name>Salon 94</Name>
                 <PinIcon>TODO: Pin Icon</PinIcon>
                 <Location>New York, London, Beijing, Hong Kong</Location>
                 <FollowButton>Follow Button</FollowButton>
-              </Metadata>
+              </PartnerInfo>
             </Gallery>
 
             <hr />
@@ -238,14 +231,12 @@ const SlideIndicatorDots = styled.div``
 const UtilityButtons = styled.div``
 const FavoriteButton = styled.div``
 const ShareButton = styled.div``
-const ArtworkInfo = styled.div``
 const ArtistName = styled.div``
 const FollowButton = styled.div``
-const ArtworkMetadata = styled.div``
 const Price = styled.div``
 const Gallery = styled.div``
 const ContactButton = styled.div``
-const Metadata = styled.div``
+const PartnerInfo = styled.div``
 const Name = styled.div``
 const PinIcon = styled.div``
 const Location = styled.div``
@@ -253,6 +244,7 @@ const HelpText = styled.div``
 const Tabber = styled.div``
 const TabNav = styled.div``
 const Tab = styled.div``
+const Metadata = styled.div``
 const TabContent = styled.div``
 const OtherWorksByArtist = styled.div``
 const GridBlock = styled.div``


### PR DESCRIPTION
Another baby step in the sidebar.

Produced this:
![screen shot 2018-06-12 at 2 15 56 pm](https://user-images.githubusercontent.com/437156/41309085-b3454776-6e4b-11e8-992b-cdc4defc2d9e.png)

Thanks @zephraph for walking me through `styled-system` conventions.

Also not exactly sure level of stories is good there. Quite a lot of data setup but I think it's good to see all the variations. And also I think once we start testing with real data - would be very helpful to produce the extreme case data scenarios and have those displayed in stories
