### PR TITLE
Pull mediaQueries from theme file

### DIFF
--- a/src/__stories__/storiesOf.js
+++ b/src/__stories__/storiesOf.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { storiesOf as _storiesOf } from "@storybook/react"
-import { Theme, injectGlobalCSS } from "@artsy/palette"
+import { Theme, themeProps, injectGlobalCSS } from "@artsy/palette"
 import { GlobalStyles } from "../Styleguide/Elements/GlobalStyles"
 import { ResponsiveProvider } from "../Styleguide/Utils/Responsive"
 
@@ -12,13 +12,7 @@ injectGlobalCSS(`
   }
 `)
 
-const breakpoints = {
-  xl: "(min-width: 1192px)",
-  lg: "(min-width: 1024px) and (max-width: 1191px)",
-  md: "(min-width: 900px) and (max-width: 1023px)",
-  sm: "(min-width: 768px) and (max-width: 899px)",
-  xs: "(max-width: 767px)",
-}
+const breakpoints = themeProps.mediaQueries
 
 export function storiesOf(desc, mod) {
   return _storiesOf(desc, mod).addDecorator(storyFn => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12127,13 +12127,13 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
+  version "1.0.3-2"
+  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
+
 styled-bootstrap-grid@damassi/styled-bootstrap-grid#e9d0160ea4ca97645fb88d812cbfab299f0919f8:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/e9d0160ea4ca97645fb88d812cbfab299f0919f8"
-
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
-  version "1.0.3-2"
-  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
 styled-components@^3.2.6, styled-components@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
There's a corresponding PR in palette that'll need to be merged for this to be complete. 

Moves the mediaQueries to the theme file so that they can be easily used in the styled-components css. 