### PR TITLE
@kanaabe => Mobile auth server errors

### DIFF
--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -9,6 +9,7 @@ import Colors from "Assets/Colors"
 import { MobileLoginValidator } from "../Validators"
 import {
   BackButton,
+  Error,
   Footer,
   ForgotPassword,
   MobileContainer,
@@ -96,7 +97,10 @@ export const MobileLoginForm: FormComponentType = props => {
   return (
     <Wizard steps={steps}>
       {context => {
-        const { wizard, form } = context
+        const {
+          wizard,
+          form: { handleSubmit, status },
+        } = context
         const { currentStep } = wizard
 
         return (
@@ -112,9 +116,10 @@ export const MobileLoginForm: FormComponentType = props => {
               </BackButton>
               <MobileHeader>Log in</MobileHeader>
               {currentStep}
+              {status && !status.success && <Error show>{status.error}</Error>}
               <MobileSubmitButton
                 disabled={!wizard.shouldAllowNext}
-                onClick={form.handleSubmit as any}
+                onClick={handleSubmit as any}
               >
                 Next
               </MobileSubmitButton>

--- a/src/Components/Authentication/Mobile/ResetPasswordForm.tsx
+++ b/src/Components/Authentication/Mobile/ResetPasswordForm.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Formik, FormikProps } from "formik"
 import {
+  Error,
   FormContainer as Form,
   Footer,
   MobileContainer,
@@ -28,6 +29,7 @@ export const MobileResetPasswordForm: FormComponentType = props => {
         handleSubmit,
         isSubmitting,
         isValid,
+        status,
       }: FormikProps<InputValues>) => {
         return (
           <MobileContainer>
@@ -46,6 +48,8 @@ export const MobileResetPasswordForm: FormComponentType = props => {
                   onChange={handleChange}
                   onBlur={handleBlur}
                 />
+                {status &&
+                  !status.success && <Error show>{status.error}</Error>}
                 <MobileSubmitButton disabled={isSubmitting}>
                   Next
                 </MobileSubmitButton>

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -6,6 +6,7 @@ import { metaphysics } from "Utils/metaphysics"
 import { Step, Wizard } from "Components/Wizard"
 import { ProgressIndicator } from "Components/ProgressIndicator"
 import {
+  Error,
   Footer,
   MobileHeader,
   TermsOfServiceCheckbox,
@@ -130,8 +131,12 @@ export const MobileSignUpForm: FormComponentType = props => {
   return (
     <Wizard steps={steps}>
       {context => {
-        const { form, wizard } = context
+        const {
+          form: { handleSubmit, status },
+          wizard,
+        } = context
         const { currentStep } = wizard
+
         return (
           <Container>
             <ProgressIndicator percentComplete={wizard.progressPercentage} />
@@ -145,8 +150,9 @@ export const MobileSignUpForm: FormComponentType = props => {
               </BackButton>
               <MobileHeader>Sign up</MobileHeader>
               {currentStep}
+              {status && !status.success && <Error show>{status.error}</Error>}
               <Button
-                onClick={form.handleSubmit as any}
+                onClick={handleSubmit as any}
                 block
                 disabled={!wizard.shouldAllowNext}
               >

--- a/yarn.lock
+++ b/yarn.lock
@@ -12139,13 +12139,13 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
+  version "1.0.3-2"
+  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
+
 styled-bootstrap-grid@damassi/styled-bootstrap-grid#e9d0160ea4ca97645fb88d812cbfab299f0919f8:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/e9d0160ea4ca97645fb88d812cbfab299f0919f8"
-
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
-  version "1.0.3-2"
-  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
 styled-components@^3.2.6, styled-components@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
Addresses [GROW-690](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-690)

This uses the same `context.form.status` as the desktop component, assuming the data will be structured in the same way.

Q - there are no tests at the moment for the existing form components, are we planning to add those separately as a work item? 