### PR TITLE
@zephraph => Update font weights, Mobile pagination, Render props in <Tabs /> component

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "webpack-merge": "^4.1.0"
   },
   "dependencies": {
-    "@artsy/palette": "^1.4.1",
+    "@artsy/palette": "^1.4.2",
     "cheerio": "^1.0.0-rc.2",
     "farce": "^0.2.6",
     "formik": "^0.11.11",

--- a/src/Styleguide/Components/Pagination.tsx
+++ b/src/Styleguide/Components/Pagination.tsx
@@ -1,9 +1,9 @@
 import React from "react"
-import Icon from "Components/Icon"
 import styled, { css } from "styled-components"
 import { themeGet } from "styled-system"
 import { Sans } from "@artsy/palette"
 import { Responsive } from "../Utils/Responsive"
+import { Arrow } from "../Elements/Arrow"
 import { Flex } from "../Elements/Flex"
 
 export class Pagination extends React.Component {
@@ -40,9 +40,21 @@ export const LargePagination = () => {
 
 export const SmallPagination = () => {
   return (
-    <Flex flexDirection="row">
-      <PrevButton />
-      <NextButton />
+    <Flex flexDirection="row" width="100%">
+      <Flex width="50%" pl={5} pr={2}>
+        <ButtonWithBorder
+          alignItems="center"
+          justifyContent="flex-start"
+          pl={3}
+        >
+          <Arrow direction="left" />
+        </ButtonWithBorder>
+      </Flex>
+      <Flex width="50%" pr={5} pl={2}>
+        <ButtonWithBorder alignItems="center" justifyContent="flex-end" pr={3}>
+          <Arrow direction="right" />
+        </ButtonWithBorder>
+      </Flex>
     </Flex>
   )
 }
@@ -50,7 +62,7 @@ export const SmallPagination = () => {
 const Page = ({ num, ...props }) => {
   return (
     <Button {...props}>
-      <Sans display="inline" size={3}>
+      <Sans size="3" weight="medium" display="inline">
         {num}
       </Sans>
     </Button>
@@ -59,7 +71,7 @@ const Page = ({ num, ...props }) => {
 
 const PageSpan = ({ mx }) => {
   return (
-    <Sans display="inline" size={3} mx={mx} color="black30">
+    <Sans size="3" display="inline" mx={mx} color="black30">
       ...
     </Sans>
   )
@@ -67,7 +79,7 @@ const PageSpan = ({ mx }) => {
 
 const PrevButton = props => {
   return (
-    <Sans display="inline" size={3} mx={2}>
+    <Sans size="3" weight="medium" display="inline" mx={2}>
       <a href="#" className="noUnderline">
         <Arrow direction="left" /> Prev
       </a>
@@ -77,22 +89,11 @@ const PrevButton = props => {
 
 const NextButton = props => {
   return (
-    <Sans display="inline" size={3} mx={2}>
+    <Sans size="3" weight="medium" display="inline" mx={2}>
       <a href="#" className="noUnderline">
         Next <Arrow direction="right" />
       </a>
     </Sans>
-  )
-}
-
-const Arrow = ({ direction }) => {
-  return (
-    <Icon
-      name={`chevron-${direction}` as any}
-      color="black"
-      fontSize="9px"
-      top={-1}
-    />
   )
 }
 
@@ -116,4 +117,12 @@ const Button = styled.button.attrs<{ active?: boolean }>({})`
   &:hover {
     ${activeButton};
   }
+`
+
+const ButtonWithBorder = styled(Flex)`
+  border: ${props => props.theme.borders[1]};
+  border-color: ${themeGet("colors.black10")};
+  border-radius: 3px;
+  width: 100%;
+  height: ${props => props.theme.space[6]}px;
 `

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -51,13 +51,17 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
 
 const Tab = ({ children, ...props }) => (
   <TabContainer {...props}>
-    <Sans size="3t">{children}</Sans>
+    <Sans size="3t" weight="medium" color="black30">
+      {children}
+    </Sans>
   </TabContainer>
 )
 
 const ActiveTab = ({ children }) => (
   <ActiveTabContainer>
-    <Sans size="3t">{children}</Sans>
+    <Sans size="3t" weight="medium">
+      {children}
+    </Sans>
   </ActiveTabContainer>
 )
 

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -1,50 +1,91 @@
-import React from "react"
+import React, { ReactNode } from "react"
 import styled from "styled-components"
-import { borders, themeGet } from "styled-system"
+import { borders, themeGet, WidthProps } from "styled-system"
 import { Sans } from "@artsy/palette"
+import { Flex } from "../Elements/Flex"
 
-export interface TabsProps {
-  labels: string[]
+export interface ActiveTabProps {
+  activeTab: {
+    index: number
+    label: string
+  }
+}
+
+export interface TabsProps extends WidthProps {
+  children?: (activeTab: ActiveTabProps) => ReactNode
+  onChange?: (activeTab?: ActiveTabProps) => void
   activeTabIndex?: number
+  labels: string[]
 }
 
 export interface TabsState {
-  activeTab: number
+  activeTabIndex: number
 }
 
 export class Tabs extends React.Component<TabsProps, TabsState> {
   state = {
-    activeTab: 0,
+    activeTabIndex: 0,
   }
 
   constructor(props) {
     super(props)
 
     this.state = {
-      activeTab: props.activeTabIndex || 0,
+      activeTabIndex: props.activeTabIndex || this.state.activeTabIndex,
     }
   }
 
-  setActiveTab = activeTab => {
-    this.setState({ activeTab })
+  setActiveTab = (activeTabIndex, label) => {
+    this.setState({
+      activeTabIndex,
+    })
+
+    if (this.props.onChange) {
+      this.props.onChange(this.getActiveTab())
+    }
+  }
+
+  getActiveTab() {
+    const { activeTabIndex } = this.state
+    const activeTabLabel = this.props.labels[activeTabIndex]
+
+    return {
+      activeTab: {
+        index: activeTabIndex,
+        label: activeTabLabel,
+      },
+    }
   }
 
   render() {
-    const { labels } = this.props
-    const { activeTab } = this.state
+    const { children, labels } = this.props
+    const { activeTab } = this.getActiveTab()
 
     return (
-      <TabsContainer>
-        {labels.map((label, index) => {
-          return activeTab === index ? (
-            <ActiveTab key={index}>{label}</ActiveTab>
-          ) : (
-            <Tab key={index} onClick={() => this.setActiveTab(index)}>
-              {label}
-            </Tab>
-          )
-        })}
-      </TabsContainer>
+      <React.Fragment>
+        <TabsContainer mb={2} width="100%">
+          {labels.map((label, index) => {
+            return activeTab.index === index ? (
+              <ActiveTab key={index}>{label}</ActiveTab>
+            ) : (
+              <Tab key={index} onClick={() => this.setActiveTab(index, label)}>
+                {label}
+              </Tab>
+            )
+          })}
+        </TabsContainer>
+
+        {children && (
+          <Flex flexDirection="column" width="100%">
+            {children({
+              activeTab: {
+                index: activeTab.index,
+                label: activeTab.label,
+              },
+            })}
+          </Flex>
+        )}
+      </React.Fragment>
     )
   }
 }
@@ -65,10 +106,8 @@ const ActiveTab = ({ children }) => (
   </ActiveTabContainer>
 )
 
-const TabsContainer = styled.div`
+const TabsContainer = styled(Flex)`
   border-bottom: 1px solid ${themeGet("colors.black10")};
-  display: flex;
-  margin-bottom: 5px;
 `
 
 const TabContainer = styled.div`

--- a/src/Styleguide/Components/Toggle.tsx
+++ b/src/Styleguide/Components/Toggle.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import Icon from "Components/Icon"
 import styled from "styled-components"
+import { Arrow } from "../Elements/Arrow"
 import { Flex } from "../Elements/Flex"
 import { Sans } from "@artsy/palette"
 import { themeGet } from "styled-system"
@@ -41,7 +41,7 @@ export class Toggle extends React.Component<ToggleProps> {
       <Flex width="100%" flexDirection="column">
         <Header onClick={this.toggleExpand} disabled={disabled}>
           <Flex justifyContent="space-between">
-            <Sans size="2" color="black100" mt={1}>
+            <Sans size="2" weight="medium" color="black100" mt={1}>
               {this.props.label}
             </Sans>
             {!disabled && (
@@ -69,9 +69,3 @@ const Header = styled.div.attrs<ToggleProps>({})`
   pointer-events: ${props => (props.disabled ? "none" : "auto")};
   user-select: none;
 `
-
-const Arrow = ({ direction }) => {
-  return (
-    <Icon name={`chevron-${direction}` as any} color="black" fontSize="9px" />
-  )
-}

--- a/src/Styleguide/Components/__stories__/Tabs.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.story.tsx
@@ -1,4 +1,6 @@
 import React from "react"
+import { Sans } from "@artsy/palette"
+import { Flex } from "../../Elements/Flex"
 import { Section } from "../../Utils/Section"
 import { Tabs } from "../Tabs"
 import { storiesOf } from "storybook/storiesOf"
@@ -23,6 +25,27 @@ storiesOf("Styleguide/Components", module).add("Tabs", () => {
           activeTabIndex={1}
           labels={["About the work", "Exhibition history", "Bibliography"]}
         />
+      </Section>
+      <Section title="With renderProps and onChange handler">
+        <Tabs
+          activeTabIndex={1}
+          labels={["Hello", "How", "Are", "You?"]}
+          onChange={activeTab => {
+            // tslint:disable-next-line
+            console.log(activeTab)
+          }}
+        >
+          {({ activeTab }) => {
+            return (
+              <Flex flexDirection="column" py={3}>
+                <Sans size="4" weight="medium">
+                  ActiveTab:
+                </Sans>
+                <Sans size="3">{activeTab.label}</Sans>
+              </Flex>
+            )
+          }}
+        </Tabs>
       </Section>
     </React.Fragment>
   )

--- a/src/Styleguide/Elements/Button.tsx
+++ b/src/Styleguide/Elements/Button.tsx
@@ -10,6 +10,8 @@ import {
   BorderRadiusProps,
   space,
   SpaceProps,
+  textAlign,
+  TextAlignProps,
   width,
   WidthProps,
 } from "styled-system"
@@ -136,6 +138,7 @@ export interface ButtonBaseProps
   extends BorderProps,
     BorderRadiusProps,
     SpaceProps,
+    TextAlignProps,
     TypographyProps,
     WidthProps {
   variantStyles?: any // FIXME: Type to styled.css
@@ -153,7 +156,9 @@ export class ButtonBase extends Component<ButtonBaseProps> {
 
     return (
       <Container {...rest}>
-        <Sans {...textProps}>{children}</Sans>
+        <Sans {...textProps} pt="1px">
+          {children}
+        </Sans>
       </Container>
     )
   }
@@ -163,6 +168,7 @@ const Container = styled.button.attrs<ButtonBaseProps>({})`
   ${border};
   ${borderRadius};
   ${space};
+  ${textAlign};
   ${width};
 
   cursor: pointer;

--- a/src/Styleguide/Pages/Artist/Components/CurrentEvent.tsx
+++ b/src/Styleguide/Pages/Artist/Components/CurrentEvent.tsx
@@ -6,6 +6,7 @@ import { Serif, Sans } from "@artsy/palette"
 
 export interface CurrentEventProps {
   src: string
+  label: string
   title: string
   gallery: string
   location: string
@@ -29,8 +30,8 @@ export const LargeCurrentEvent = props => {
   return (
     <Flex flexDirection="column">
       <Image src={props.src} mb={3} />
-      <Sans size="2" my={2}>
-        Currently on view
+      <Sans size="2" weight="medium" my={2}>
+        {props.label}
       </Sans>
       <Serif size="3t">{props.title}</Serif>
       <Serif size="2" color="black60">

--- a/src/Styleguide/Pages/Artist/__stories__/CurrentEvent.story.tsx
+++ b/src/Styleguide/Pages/Artist/__stories__/CurrentEvent.story.tsx
@@ -9,6 +9,7 @@ storiesOf("Styleguide/Artist", module).add("Current Event", () => {
       <Section title="Responsive Current Event">
         <CurrentEvent
           src="https://picsum.photos/300/200/?random"
+          label="Currently on view"
           title="Brancusi: Pioneer of American Minimalism"
           gallery="Paul Kasmin Gallery"
           location="Miami"
@@ -18,6 +19,7 @@ storiesOf("Styleguide/Artist", module).add("Current Event", () => {
       <Section title="Large Current Event">
         <LargeCurrentEvent
           src="https://picsum.photos/300/200/?random"
+          label="Currently on view"
           title="Brancusi: Pioneer of American Minimalism"
           gallery="Paul Kasmin Gallery"
           location="Miami"

--- a/src/Styleguide/Utils/Section.tsx
+++ b/src/Styleguide/Utils/Section.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 import { Flex } from "../Elements/Flex"
-import { Sans } from "@artsy/palette"
+import { Sans, themeProps } from "@artsy/palette"
 import { themeGet } from "styled-system"
 
 const Header = styled.div`
@@ -27,6 +27,8 @@ export class Section extends React.Component<SectionProps> {
     this.setState({ expanded: !this.state.expanded })
   }
   render() {
+    const maxWidth = themeProps.grid.breakpoints.xl + "px"
+
     return (
       <React.Fragment>
         <Header onClick={this.toggleExpand}>
@@ -46,8 +48,8 @@ export class Section extends React.Component<SectionProps> {
             flexDirection="column"
             alignItems="center"
             my={4}
-            mx="auto"
-            maxWidth="1192px"
+            mx={3}
+            maxWidth={maxWidth}
           >
             {this.props.children}
           </Flex>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@artsy/palette@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-1.4.1.tgz#80a25e9d0af9d67c7a7c1bab7605a358001faa0a"
+"@artsy/palette@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-1.4.2.tgz#1d1ac01fe97ef30a80ae0e48126a0680f56eb067"
   dependencies:
     react "^16.3.2"
     react-primitives "^0.5.0"


### PR DESCRIPTION
Update sans medium fonts where necessary and replace `<Icon>` with `<Arrow>`. Finishes up mobile pagination: 

![screen shot 2018-06-13 at 12 00 06 pm](https://user-images.githubusercontent.com/236943/41372199-68e0dfc2-6f01-11e8-9988-14dd13a76bec.png)

Also adds new API around `<Tabs />`:

```jsx
<Tabs labels=['hello', 'how', 'are', 'you']>
  {({ activeTab }) => {
    return <div>{activeTab.label}</div>
  }}
</Tabs>
```

![tabs](https://user-images.githubusercontent.com/236943/41376204-614f0e3a-6f0d-11e8-9d67-b8278a321b5a.gif)
