### PR TITLE
Add responsive image component

### DIFF
--- a/src/Styleguide/Components/AuctionCard.tsx
+++ b/src/Styleguide/Components/AuctionCard.tsx
@@ -31,7 +31,7 @@ export const LargeAuctionCard = props => (
       {props.headline}
     </Serif>
     <Serif size="3t">{props.subHeadline}</Serif>
-    <ResponsiveImage src={props.src} />
+    <ResponsiveImage src={props.src} my={4} />
     <Sans size="1" weight="medium">
       {props.badge}
     </Sans>

--- a/src/Styleguide/Components/AuctionCard.tsx
+++ b/src/Styleguide/Components/AuctionCard.tsx
@@ -2,14 +2,8 @@ import React from "react"
 import { Responsive } from "../Utils/Responsive"
 import { BorderBox } from "../Elements/Box"
 import { Flex } from "../Elements/Flex"
-import { Image } from "../Elements/Image"
+import { Image, ResponsiveImage } from "../Elements/Image"
 import { Serif, Sans } from "@artsy/palette"
-
-const ScaledArtworkImage = props => (
-  <Flex height={props.height} justifyContent="center">
-    <Image {...props} />
-  </Flex>
-)
 
 export interface AuctionCardProps {
   src: string
@@ -37,7 +31,7 @@ export const LargeAuctionCard = props => (
       {props.headline}
     </Serif>
     <Serif size="3t">{props.subHeadline}</Serif>
-    <ScaledArtworkImage src={props.src} maxWidth="100%" height="auto" m={4} />
+    <ResponsiveImage src={props.src} />
     <Sans size="1" weight="medium">
       {props.badge}
     </Sans>
@@ -57,12 +51,6 @@ export const SmallAuctionCard = props => (
         {props.badge}
       </Sans>
     </Flex>
-    <ScaledArtworkImage
-      src={props.src}
-      width="auto"
-      height="82px"
-      mr={4}
-      ml={4}
-    />
+    <Image src={props.src} height="82px" mx={4} />
   </Flex>
 )

--- a/src/Styleguide/Elements/Box.tsx
+++ b/src/Styleguide/Elements/Box.tsx
@@ -8,6 +8,12 @@ import {
   DisplayProps,
   space,
   SpaceProps,
+  maxWidth,
+  MaxWidthProps,
+  width,
+  WidthProps,
+  height,
+  HeightProps,
 } from "styled-system"
 
 const hover = css`
@@ -16,22 +22,36 @@ const hover = css`
   }
 `
 
-export interface BorderBoxProps extends FlexProps {
+export interface BorderBoxProps
+  extends FlexProps,
+    SpaceProps,
+    MaxWidthProps,
+    WidthProps,
+    HeightProps {
   hover?: boolean
 }
 
 export const BorderBox = styled(Flex).attrs<BorderBoxProps>({})`
   border: 1px solid ${themeGet("colors.black10")};
   border-radius: 2px;
-  padding: 20px;
   ${props => props.hover && hover};
+  ${space};
+  ${maxWidth};
+  ${width};
+  ${height};
 `
 BorderBox.defaultProps = {
   p: 4,
 }
 
-export interface BoxProps extends DisplayProps, SpaceProps {}
+export interface BoxProps
+  extends DisplayProps,
+    SpaceProps,
+    WidthProps,
+    HeightProps {}
 export const Box = styled.div.attrs<BoxProps>({})`
   ${space};
   ${display};
+  ${width};
+  ${height};
 `

--- a/src/Styleguide/Elements/Image.tsx
+++ b/src/Styleguide/Elements/Image.tsx
@@ -11,12 +11,39 @@ import {
   HeightProps,
 } from "styled-system"
 
-export interface ImageProps extends SpaceProps, WidthProps, HeightProps {
+export interface BaseImageProps {
   src: string
+  alt?: string
+  ariaLabel?: string
   style?: object
 }
+
+export interface ImageProps
+  extends BaseImageProps,
+    SpaceProps,
+    WidthProps,
+    HeightProps {}
+
 export const Image = styled.img.attrs<ImageProps>({})`
   ${space};
   ${width};
   ${height};
 `
+
+export interface ResponsiveImageProps
+  extends BaseImageProps,
+    SpaceProps,
+    WidthProps {}
+export const ResponsiveImage = styled.div.attrs<ResponsiveImageProps>({})`
+  height: auto;
+  padding-top: 100%;
+  background: url(${props => props.src});
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  ${space};
+  ${width};
+`
+ResponsiveImage.defaultProps = {
+  width: "100%",
+}

--- a/src/Styleguide/Elements/__stories__/Image.story.tsx
+++ b/src/Styleguide/Elements/__stories__/Image.story.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import { Section } from "../../Utils/Section"
-import { Image } from "../Image"
+import { Image, ResponsiveImage } from "../Image"
 import { storiesOf } from "storybook/storiesOf"
+import { BorderBox } from "../Box"
 
 storiesOf("Styleguide/Elements", module).add("Image", () => {
   return (
@@ -15,6 +16,11 @@ storiesOf("Styleguide/Elements", module).add("Image", () => {
           height="200px"
           src="https://picsum.photos/300/300/?random"
         />
+      </Section>
+      <Section title="Responsive Image">
+        <BorderBox maxWidth="400px" width="100%" height="auto" p={0}>
+          <ResponsiveImage src="https://picsum.photos/400/250/?random" />
+        </BorderBox>
       </Section>
     </React.Fragment>
   )

--- a/src/Styleguide/Sections/__stories__/OtherAuctions.story.tsx
+++ b/src/Styleguide/Sections/__stories__/OtherAuctions.story.tsx
@@ -12,13 +12,13 @@ const auctions = [
     badge: "In progress",
   },
   {
-    src: "https://picsum.photos/200/180/?random",
+    src: "https://picsum.photos/400/180/?random",
     headline: "Sotheby’s",
     subHeadline: "Contemporary Day Sale",
     badge: "In progress",
   },
   {
-    src: "https://picsum.photos/200/180/?random",
+    src: "https://picsum.photos/200/600/?random",
     headline: "Sotheby’s",
     subHeadline: "Contemporary Day Sale",
     badge: "In progress",


### PR DESCRIPTION
So we had a need to create an image container that could stay square and scale but retain still show the full image inside of it. This is a first implementation of that pattern. It's implemented in the auction card component and in the image story. 

Note that I still need to work with Brian to figure out the details of the mobile version of the auction card so that looks a little.... weird at the moment. Will also need to work through the details of where else this component will need to be used. 

Here's the component rendering in the _Other Auction_ section.

![2018-06-13 19 08 25](https://user-images.githubusercontent.com/3087225/41383114-2e050a0e-6f3d-11e8-92fd-cf5b652b5f88.gif)

Notice that even though all the images have different sizes, they all fit in a square container. 





