### PR TITLE
@xtina-starr => Rename redirectUrl to redirectTo

### DIFF
--- a/src/Components/Authentication/Desktop/FormSwitcher.tsx
+++ b/src/Components/Authentication/Desktop/FormSwitcher.tsx
@@ -13,8 +13,10 @@ interface Props {
   type: ModalType
   values?: InputValues
   handleSubmit: SubmitHandler
-  signupIntent?: string
-  redirectTo?: string
+  options?: {
+    signupIntent?: string
+    redirectTo?: string
+  }
 }
 
 interface State {

--- a/src/Components/Authentication/Desktop/FormSwitcher.tsx
+++ b/src/Components/Authentication/Desktop/FormSwitcher.tsx
@@ -14,7 +14,7 @@ interface Props {
   values?: InputValues
   handleSubmit: SubmitHandler
   signupIntent?: string
-  redirectUrl?: string
+  redirectTo?: string
 }
 
 interface State {

--- a/src/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/Components/Authentication/Desktop/ModalManager.tsx
@@ -13,7 +13,7 @@ import {
 export interface ModalManagerProps {
   submitUrls?: { [P in ModalType]: string }
   csrf?: string
-  redirectUrl?: string
+  redirectTo?: string
   handleSubmit?: (
     type: ModalType,
     values: InputValues,
@@ -49,7 +49,7 @@ export class ModalManager extends Component<
   }
 
   render() {
-    const { csrf, submitUrls, redirectUrl } = this.props
+    const { csrf, submitUrls, redirectTo } = this.props
     const { currentType, copy } = this.state
 
     if (!currentType) {
@@ -58,7 +58,7 @@ export class ModalManager extends Component<
 
     const handleSubmit: SubmitHandler = !!this.props.handleSubmit
       ? this.props.handleSubmit.bind(this, currentType)
-      : defaultHandleSubmit(submitUrls[currentType], csrf, redirectUrl)
+      : defaultHandleSubmit(submitUrls[currentType], csrf, redirectTo)
 
     return (
       <DesktopModal

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -35,9 +35,14 @@ export interface ModalOptions {
   mode?: ModalType
   /**
    * the page path the user is redirected to after successfully
+   * login or account creation after onboarding.
+   */
+  destination?: string
+  /**
+   * the page path the user is redirected to after successfully
    * login or account creation (skips onboarding).
    */
-  redirectUrl?: string
+  redirectTo?: string
   /**
    * the action taken that prompted user to signup or login.
    */

--- a/src/Components/Authentication/helpers.ts
+++ b/src/Components/Authentication/helpers.ts
@@ -4,13 +4,13 @@ import { metaphysics } from "Utils/metaphysics"
 export const handleSubmit = (
   url: string,
   csrf: string,
-  redirectUrl?: string
+  redirectTo?: string
 ) => async (values, formikBag) => {
   try {
     const data = await sendAuthData(url, { _csrf: csrf, ...values })
     if (data.success) {
-      if (redirectUrl) {
-        document.location.pathname = redirectUrl
+      if (redirectTo) {
+        document.location.pathname = redirectTo
       }
     } else {
       formikBag.setStatus(data)


### PR DESCRIPTION
Follows up on https://github.com/artsy/force/pull/2620

- Uses `options` object in props for FormSwitcher
- Renames `redirectUrl` to `redirectTo`
- Adds `destination` to  ModalOptions type