### PR TITLE
[Styleguide] Move fixtures to /Fixtures directory 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -29,7 +29,8 @@
       "alias": {
         "storybook": "./src/__stories__",
         "Assets": "./src/Assets",
-        "Components": "./src/Components"
+        "Components": "./src/Components",
+        "Styleguide": "./src/Styleguide"
       }
     }],
     "lodash"

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -84,6 +84,7 @@ module.exports = (baseConfig, env) => {
       extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
       alias: {
         sharify: sharifyPath.replace(/\.js$/, ""),
+        "styled-components": path.resolve("./node_modules/styled-components"),
       },
     },
     module: {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "webpack-merge": "^4.1.0"
   },
   "dependencies": {
-    "@artsy/palette": "^2.0.0",
+    "@artsy/palette": "^2.0.2",
     "cheerio": "^1.0.0-rc.2",
     "farce": "^0.2.6",
     "formik": "^0.11.11",

--- a/src/Styleguide/Components/ArtworkGridExample.tsx
+++ b/src/Styleguide/Components/ArtworkGridExample.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { graphql } from "react-relay"
+
+import { RootQueryRenderer } from "../../Relay/RootQueryRenderer"
+import ArtworkGrid from "Components/ArtworkGrid"
+
+export function ArtworkGridExample(props: {
+  artistID: string
+  columnCount?: number
+}) {
+  return (
+    <RootQueryRenderer
+      query={graphql`
+        query ArtworkGridExampleQuery($artistID: String!) {
+          artist(id: $artistID) {
+            artworks: artworks_connection(first: 10) {
+              ...ArtworkGrid_artworks
+            }
+          }
+        }
+      `}
+      variables={{ artistID: props.artistID }}
+      render={readyState => {
+        return (
+          readyState.props && (
+            <ArtworkGrid {...readyState.props.artist as any} {...props} />
+          )
+        )
+      }}
+    />
+  )
+}

--- a/src/Styleguide/Components/__stories__/ArtistBio.story.tsx
+++ b/src/Styleguide/Components/__stories__/ArtistBio.story.tsx
@@ -2,28 +2,7 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { ArtistBio } from "../ArtistBio"
-
-export const bio = `Donald Judd, widely regarded as one of the most significant American artists of
-the post-war period, is perhaps best-known for the large-scale outdoor
-installations and long, spacious interiors he designed in Marfa, Texas. His
-oeuvre has come to define what has been referred to as Minimalist art—a label
-the artist strongly objected to. His sculptures and installations, constructed
-out of industrial materials such as Plexiglas, concrete, and steel and arranged
-in precise geometric shapes, were intended to emphasize the purity of the
-objects themselves rather than any symbolic meaning they might have—“the simple
-expression of complex thought,” said Judd. His particular interest in
-architecture led him to design both the sculptures and the spaces in which they
-would be contained. Donald Judd, widely regarded as one of the most significant
-American artists of the post-war period, is perhaps best-known for the
-large-scale outdoor installations and long, spacious interiors he designed in
-Marfa, Texas. His oeuvre has come to define what has been referred to as
-Minimalist art—a label the artist strongly objected to. His sculptures and
-installations, constructed out of industrial materials such as Plexiglas,
-concrete, and steel and arranged in precise geometric shapes, were intended to
-emphasize the purity of the objects themselves rather than any symbolic meaning
-they might have—“the simple expression of complex thought,” said Judd. His
-particular interest in architecture led him to design both the sculptures and
-the spaces in which they would be contained.`
+import { bio } from "Styleguide/Pages/Fixtures/ArtistBio"
 
 storiesOf("Styleguide/Components", module).add("ArtistBio", () => {
   return (

--- a/src/Styleguide/Components/__stories__/MarketInsight.story.tsx
+++ b/src/Styleguide/Components/__stories__/MarketInsight.story.tsx
@@ -2,21 +2,7 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { MarketInsights } from "../MarketInsights"
-
-export const insights = [
-  {
-    primaryLabel: "High auction record",
-    secondaryLabel: "$105m sale, Sotheby’s 2013",
-  },
-  {
-    primaryLabel: "Blue Chip",
-    secondaryLabel: "Represented by internationally recognized galleries.",
-  },
-  {
-    primaryLabel: "Collected by major museums",
-    secondaryLabel: "Tate, Museum of Modern Art (MoMA)",
-  },
-]
+import { insights } from "Styleguide/Pages/Fixtures/MarketInsights"
 
 storiesOf("Styleguide/Components", module).add("MarketInsights", () => {
   return (

--- a/src/Styleguide/Components/__stories__/SelectedExhibitions.story.tsx
+++ b/src/Styleguide/Components/__stories__/SelectedExhibitions.story.tsx
@@ -5,24 +5,7 @@ import {
   SelectedExhibitionsContainer,
 } from "../SelectedExhibitions"
 import { Section } from "Styleguide/Utils/Section"
-
-export const exhibitions = [
-  {
-    year: "2018",
-    show: "Adman: Warhol Before Pop",
-    gallery: "Andy Warhol Museum",
-  },
-  {
-    year: "2018",
-    show: "Brancusi: Pioneer of American Minimalism",
-    gallery: "Paul Kasmin Gallery",
-  },
-  {
-    year: "2017",
-    show: "Sculpture on the Move 1946–2016",
-    gallery: "Kunstmuseum Basel",
-  },
-]
+import { exhibitions } from "Styleguide/Pages/Fixtures/SelectedExhibitions"
 
 storiesOf("Styleguide/Components", module).add("SelectedExhibitions", () => {
   return (

--- a/src/Styleguide/Pages/Artist/Overview.js
+++ b/src/Styleguide/Pages/Artist/Overview.js
@@ -1,15 +1,15 @@
 import { Sans } from "@artsy/palette"
-import { ArtworkGridExample } from "Components/__stories__/ArtworkGrid.story"
 import React from "react"
 import styled from "styled-components"
 import { space, width } from "styled-system"
+import { ArtworkGridExample } from "Styleguide/Components/ArtworkGridExample"
 import { ArtistBio } from "Styleguide/Components/ArtistBio"
 import { MarketInsights } from "Styleguide/Components/MarketInsights"
 import { Pagination } from "Styleguide/Components/Pagination"
 import { SelectedExhibitions } from "Styleguide/Components/SelectedExhibitions"
 import { Toggle } from "Styleguide/Components/Toggle"
-import { insights } from "Styleguide/Components/__stories__/MarketInsight.story"
-import { exhibitions } from "Styleguide/Components/__stories__/SelectedExhibitions.story"
+import { insights } from "Styleguide/Pages/Fixtures/MarketInsights"
+import { exhibitions } from "Styleguide/Pages/Fixtures/SelectedExhibitions"
 import { Checkbox } from "Styleguide/Elements/Checkbox"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
@@ -70,7 +70,7 @@ export const Overview = () => {
                   {gene}
                   {geneDivider}
                 </GeneFamilyItem>
-              );
+              )
             })}
           </GeneFamily>
 
@@ -135,13 +135,13 @@ export const Overview = () => {
                     <Pagination />
                   </ArtworkGrid>
                 </ArtworkBrowser>
-              );
+              )
             }}
           </Responsive>
         </Col>
       </Row>
     </React.Fragment>
-  );
+  )
 }
 
 const GeneFamily = styled.div``

--- a/src/Styleguide/Pages/Artist/index.js
+++ b/src/Styleguide/Pages/Artist/index.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { Tabs, Tab } from "Styleguide/Components/Tabs"
-import { Box } from "Styleguide/Elements/Box"
 import { Col, Grid, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Spacer } from "Styleguide/Elements/Spacer"

--- a/src/Styleguide/Pages/Artist/index.js
+++ b/src/Styleguide/Pages/Artist/index.js
@@ -50,9 +50,7 @@ export class Artist extends React.Component {
           </Col>
         </Row>
 
-        <Box my={6}>
-          <Separator />
-        </Box>
+        <Separator my={6} />
 
         <Row>
           <Col>
@@ -60,6 +58,6 @@ export class Artist extends React.Component {
           </Col>
         </Row>
       </Grid>
-    );
+    )
   }
 }

--- a/src/Styleguide/Pages/Artwork/__stories__/ArtistInfo.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/ArtistInfo.story.tsx
@@ -3,9 +3,9 @@ import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { ArtistInfo } from "../ArtistInfo"
 import { Grid, Row, Col } from "Styleguide/Elements/Grid"
-import { bio } from "Styleguide/Components/__stories__/ArtistBio.story"
-import { insights } from "Styleguide/Components/__stories__/MarketInsight.story"
-import { exhibitions } from "Styleguide/Components/__stories__/SelectedExhibitions.story"
+import { bio } from "Styleguide/Pages/Fixtures/ArtistBio"
+import { insights } from "Styleguide/Pages/Fixtures/MarketInsights"
+import { exhibitions } from "Styleguide/Pages/Fixtures/SelectedExhibitions"
 
 storiesOf("Styleguide/Artwork", module).add("ArtistInfo", () => {
   return (

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/Artists.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/Artists.story.tsx
@@ -2,41 +2,11 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { Artists } from "../../Sidebar/Artists"
-
-const SingleFollowedArtist = [
-  {
-    __id: "francesca-dimattio",
-    id: "francesca-dimattio",
-    name: "Francesca DiMattio",
-    is_followed: true,
-    href: "https://www.artsy.net/artist/francesca-dimattio",
-  },
-]
-
-const SingleNonFollowedArtist = [
-  {
-    __id: "francesca-dimattio",
-    id: "francesca-dimattio",
-    name: "Francesca DiMattio",
-    is_followed: false,
-  },
-]
-
-const MultipleArtists = [
-  {
-    __id: "francesca-dimattio",
-    id: "francesca-dimattio",
-    name: "Francesca DiMattio",
-    is_followed: false,
-  },
-  {
-    __id: "sol-lewitt-piramidi-c",
-    id: "sol-lewitt-piramidi-c",
-    name: "Sol LeWitt",
-    href: "https://www.artsy.net/artwork/sol-lewitt-piramidi-c",
-    is_followed: false,
-  },
-]
+import {
+  SingleFollowedArtist,
+  SingleNonFollowedArtist,
+  MultipleArtists,
+} from "Styleguide/Pages/Fixtures/Artwork/Sidebar/Artists"
 
 storiesOf("Styleguide/Artwork/Sidebar", module).add("Artists", () => {
   return (

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/ArtworkMetadata.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/ArtworkMetadata.story.tsx
@@ -2,95 +2,14 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { ArtworkMetadata } from "../../Sidebar/ArtworkMetadata"
-
-const FilledOutMetadataNoEditions = {
-  title: "Full metadata / No editions",
-  date: "2016-2017",
-  medium:
-    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
-  dimensions: {
-    in: "48 2/5 in diameter",
-    cm: "123 cm diameter",
-  },
-  edition_of: null,
-  attribution_class: {
-    short_description: "This is a made-to-order piece",
-  },
-  edition_sets: [],
-}
-
-const FilledOutMetadataOneEditionSet = {
-  title: "Full metadata / One Edition Set",
-  date: "2016-2017",
-  medium:
-    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
-  dimensions: { in: "4 3/10 × 8 7/10 × 13 in", cm: "11 × 22 × 33 cm" },
-  edition_of: "Edition of 21",
-  attribution_class: { short_description: "This is a made-to-order piece" },
-  edition_sets: [{ id: "5b1ffd455405ff0020d933bb" }],
-}
-
-const FilledOutMetadataMultipleEditionSets = {
-  title: "Full metadata / Multiple edition sets",
-  date: "2016-2017",
-  medium:
-    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
-  dimensions: {
-    in: "22 × 33 × 11 in",
-    cm: "55.9 × 83.8 × 27.9 cm",
-  },
-  edition_of: null,
-  attribution_class: {
-    short_description: "This is a made-to-order piece",
-  },
-  edition_sets: [
-    { id: "5b1ffd455405ff0020d933bb" },
-    { id: "5b1ffdb20923cc00205152d3" },
-  ],
-}
-
-const EmptyMetadataNoEditions = {
-  title: "Empty metadata / No editions",
-  date: " ",
-  medium: "",
-  dimensions: {
-    in: null,
-    cm: null,
-  },
-  edition_of: null,
-  attribution_class: null,
-  edition_sets: [],
-}
-
-const EmptyMetadataOneEditionSet = {
-  title: "Empty metadata / One edition set",
-  date: " ",
-  medium: "",
-  dimensions: {
-    in: null,
-    cm: null,
-  },
-  edition_of: "",
-  attribution_class: null,
-  edition_sets: [
-    {
-      id: "5b1fff790923cc00205152fe",
-    },
-  ],
-}
-
-const EmptyMetadataMultipleEditionSets = {
-  title: "Empty metadata / Multiple edition Sets",
-  date: " ",
-  medium: "",
-  dimensions: { in: null, cm: null },
-  edition_of: "",
-  attribution_class: null,
-  edition_sets: [
-    { id: "5b1ffd455405ff0020d933bb" },
-    { id: "5b1ffdb20923cc00205152d3" },
-  ],
-}
+import {
+  FilledOutMetadataNoEditions,
+  FilledOutMetadataOneEditionSet,
+  FilledOutMetadataMultipleEditionSets,
+  EmptyMetadataNoEditions,
+  EmptyMetadataOneEditionSet,
+  EmptyMetadataMultipleEditionSets,
+} from "Styleguide/Pages/Fixtures/Artwork/Sidebar/ArtworkMetadata"
 
 storiesOf("Styleguide/Artwork/Sidebar", module).add("ArtworkMetadata", () => {
   return (

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/Classification.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/Classification.story.tsx
@@ -2,12 +2,10 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { Classification } from "../../Sidebar/Classification"
-
-const ArtworkWithClassification = {
-  attribution_class: { short_description: "This is a unique work" },
-}
-
-const ArtworkWithoutClassification = { attribution_class: null }
+import {
+  ArtworkWithClassification,
+  ArtworkWithoutClassification,
+} from "Styleguide/Pages/Fixtures/Artwork/Sidebar/Classification"
 
 storiesOf("Styleguide/Artwork/Sidebar", module).add("Classification", () => {
   return (

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/Commercial.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/Commercial.story.tsx
@@ -2,88 +2,12 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { Commercial } from "../../Sidebar/Commercial"
-
-const FoSaleArtworkNoEditions = {
-  availability: "for sale",
-  sale_message: "$40,000 - 50,000",
-  is_inquireable: true,
-  is_price_range: true,
-  edition_sets: [],
-}
-
-const FoSaleArtworkWithOneEdition = {
-  availability: "for sale",
-  sale_message: "$2,222",
-  is_inquireable: true,
-  is_price_range: false,
-  edition_sets: [
-    {
-      sale_message: "$2,222",
-      dimensions: {
-        in: "22 × 33 in",
-        cm: "55.9 × 83.8 cm",
-      },
-      edition_of: "",
-    },
-  ],
-}
-
-const FoSaleArtworkWithMultipleEditions = {
-  availability: "for sale",
-  sale_message: "$2,500 - 5,000",
-  is_inquireable: true,
-  is_price_range: false,
-  edition_sets: [
-    {
-      sale_message: "$2,500 - 5,000",
-      dimensions: {
-        in: "13 × 9 1/10 × 12 3/5 in",
-        cm: "33 × 23 × 32 cm",
-      },
-      edition_of: "Editions 3, 5, 8-10 of 123 + 0AP",
-    },
-    {
-      sale_message: "On hold",
-      dimensions: {
-        in: "1 × 2 × 3 in",
-        cm: "2.5 × 5.1 × 7.6 cm",
-      },
-      edition_of: "",
-    },
-    {
-      sale_message: "On loan",
-      dimensions: {
-        in: "222 in diameter",
-        cm: "563.9 cm diameter",
-      },
-      edition_of: "Edition 1/234",
-    },
-    {
-      sale_message: "Sold",
-      dimensions: {
-        in: "1 × 2 × 3 in",
-        cm: "2.5 × 5.1 × 7.6 cm",
-      },
-      edition_of: "",
-    },
-  ],
-}
-
-const ContactForPriceWork = {
-  availability: "for sale",
-  sale_message: "Contact For Price",
-  is_inquireable: true,
-  is_price_range: false,
-  edition_sets: [
-    {
-      dimensions: {
-        in: "26 4/5 × 8 7/10 in",
-        cm: "68 × 22 cm",
-      },
-      edition_of: "Edition 250/400/400",
-    },
-  ],
-}
+import {
+  FoSaleArtworkNoEditions,
+  FoSaleArtworkWithOneEdition,
+  FoSaleArtworkWithMultipleEditions,
+  ContactForPriceWork,
+} from "Styleguide/Pages/Fixtures/Artwork/Sidebar/Commercial"
 
 storiesOf("Styleguide/Artwork/Sidebar", module).add("Commercial", () => {
   return (

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/SizeInfo.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/SizeInfo.story.tsx
@@ -2,20 +2,11 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { SizeInfo } from "../../Sidebar/SizeInfo"
-
-const ArtworkWithSizeAndEditionOf = {
-  dimensions: { in: "10 1/4 × 8 7/8 in", cm: "26 × 22.5 cm" },
-  edition_of: "Edition of 20",
-}
-
-const ArtworkWithSizeOnly = {
-  dimensions: { in: "10 1/4 × 8 7/8 in", cm: "26 × 22.5 cm" },
-}
-
-const ArtworkWithEditionOfOnly = {
-  dimensions: { in: null, cm: null },
-  edition_of: "Edition of 20",
-}
+import {
+  ArtworkWithSizeAndEditionOf,
+  ArtworkWithSizeOnly,
+  ArtworkWithEditionOfOnly,
+} from "Styleguide/Pages/Fixtures/Artwork/Sidebar/SizeInfo"
 
 storiesOf("Styleguide/Artwork/Sidebar", module).add("SizeInfo", () => {
   return (

--- a/src/Styleguide/Pages/Artwork/__stories__/Sidebar/TitleInfo.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Sidebar/TitleInfo.story.tsx
@@ -2,27 +2,12 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
 import { TitleInfo } from "../../Sidebar/TitleInfo"
-
-const ArtworkWithTitleDateAndMedium = {
-  title: "The Fox and the Hound",
-  date: "2018",
-  medium: "Oil on canvas",
-}
-
-const ArtworkWithTitleOnly = {
-  title: "The Fox and the Hound",
-}
-
-const ArtworkWithTitlAndDate = {
-  title: "The Fox and the Hound",
-  date: " 2013 - 2012 ",
-}
-const ArtworkWithTitleAndMedium = {
-  title: "The Fox and the Hound",
-  date: null,
-  medium:
-    "Hand selected materials to paint this piece were sourced from the old villages on magic lands.",
-}
+import {
+  ArtworkWithTitleDateAndMedium,
+  ArtworkWithTitleOnly,
+  ArtworkWithTitlAndDate,
+  ArtworkWithTitleAndMedium,
+} from "Styleguide/Pages/Fixtures/Artwork/Sidebar/TitleInfo"
 
 storiesOf("Styleguide/Artwork/Sidebar", module).add("TitleInfo", () => {
   return (

--- a/src/Styleguide/Pages/Fixtures/ArtistBio.ts
+++ b/src/Styleguide/Pages/Fixtures/ArtistBio.ts
@@ -1,0 +1,21 @@
+export const bio = `Donald Judd, widely regarded as one of the most significant American artists of
+the post-war period, is perhaps best-known for the large-scale outdoor
+installations and long, spacious interiors he designed in Marfa, Texas. His
+oeuvre has come to define what has been referred to as Minimalist art—a label
+the artist strongly objected to. His sculptures and installations, constructed
+out of industrial materials such as Plexiglas, concrete, and steel and arranged
+in precise geometric shapes, were intended to emphasize the purity of the
+objects themselves rather than any symbolic meaning they might have—“the simple
+expression of complex thought,” said Judd. His particular interest in
+architecture led him to design both the sculptures and the spaces in which they
+would be contained. Donald Judd, widely regarded as one of the most significant
+American artists of the post-war period, is perhaps best-known for the
+large-scale outdoor installations and long, spacious interiors he designed in
+Marfa, Texas. His oeuvre has come to define what has been referred to as
+Minimalist art—a label the artist strongly objected to. His sculptures and
+installations, constructed out of industrial materials such as Plexiglas,
+concrete, and steel and arranged in precise geometric shapes, were intended to
+emphasize the purity of the objects themselves rather than any symbolic meaning
+they might have—“the simple expression of complex thought,” said Judd. His
+particular interest in architecture led him to design both the sculptures and
+the spaces in which they would be contained.`

--- a/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/Artists.ts
+++ b/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/Artists.ts
@@ -1,0 +1,34 @@
+export const SingleFollowedArtist = [
+  {
+    __id: "francesca-dimattio",
+    id: "francesca-dimattio",
+    name: "Francesca DiMattio",
+    is_followed: true,
+    href: "https://www.artsy.net/artist/francesca-dimattio",
+  },
+]
+
+export const SingleNonFollowedArtist = [
+  {
+    __id: "francesca-dimattio",
+    id: "francesca-dimattio",
+    name: "Francesca DiMattio",
+    is_followed: false,
+  },
+]
+
+export const MultipleArtists = [
+  {
+    __id: "francesca-dimattio",
+    id: "francesca-dimattio",
+    name: "Francesca DiMattio",
+    is_followed: false,
+  },
+  {
+    __id: "sol-lewitt-piramidi-c",
+    id: "sol-lewitt-piramidi-c",
+    name: "Sol LeWitt",
+    href: "https://www.artsy.net/artwork/sol-lewitt-piramidi-c",
+    is_followed: false,
+  },
+]

--- a/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/ArtworkMetadata.ts
+++ b/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/ArtworkMetadata.ts
@@ -1,0 +1,88 @@
+export const FilledOutMetadataNoEditions = {
+  title: "Full metadata / No editions",
+  date: "2016-2017",
+  medium:
+    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
+  dimensions: {
+    in: "48 2/5 in diameter",
+    cm: "123 cm diameter",
+  },
+  edition_of: null,
+  attribution_class: {
+    short_description: "This is a made-to-order piece",
+  },
+  edition_sets: [],
+}
+
+export const FilledOutMetadataOneEditionSet = {
+  title: "Full metadata / One Edition Set",
+  date: "2016-2017",
+  medium:
+    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
+  dimensions: { in: "4 3/10 × 8 7/10 × 13 in", cm: "11 × 22 × 33 cm" },
+  edition_of: "Edition of 21",
+  attribution_class: { short_description: "This is a made-to-order piece" },
+  edition_sets: [{ id: "5b1ffd455405ff0020d933bb" }],
+}
+
+export const FilledOutMetadataMultipleEditionSets = {
+  title: "Full metadata / Multiple edition sets",
+  date: "2016-2017",
+  medium:
+    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
+  dimensions: {
+    in: "22 × 33 × 11 in",
+    cm: "55.9 × 83.8 × 27.9 cm",
+  },
+  edition_of: null,
+  attribution_class: {
+    short_description: "This is a made-to-order piece",
+  },
+  edition_sets: [
+    { id: "5b1ffd455405ff0020d933bb" },
+    { id: "5b1ffdb20923cc00205152d3" },
+  ],
+}
+
+export const EmptyMetadataNoEditions = {
+  title: "Empty metadata / No editions",
+  date: " ",
+  medium: "",
+  dimensions: {
+    in: null,
+    cm: null,
+  },
+  edition_of: null,
+  attribution_class: null,
+  edition_sets: [],
+}
+
+export const EmptyMetadataOneEditionSet = {
+  title: "Empty metadata / One edition set",
+  date: " ",
+  medium: "",
+  dimensions: {
+    in: null,
+    cm: null,
+  },
+  edition_of: "",
+  attribution_class: null,
+  edition_sets: [
+    {
+      id: "5b1fff790923cc00205152fe",
+    },
+  ],
+}
+
+export const EmptyMetadataMultipleEditionSets = {
+  title: "Empty metadata / Multiple edition Sets",
+  date: " ",
+  medium: "",
+  dimensions: { in: null, cm: null },
+  edition_of: "",
+  attribution_class: null,
+  edition_sets: [
+    { id: "5b1ffd455405ff0020d933bb" },
+    { id: "5b1ffdb20923cc00205152d3" },
+  ],
+}

--- a/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/Classification.ts
+++ b/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/Classification.ts
@@ -1,0 +1,5 @@
+export const ArtworkWithClassification = {
+  attribution_class: { short_description: "This is a unique work" },
+}
+
+export const ArtworkWithoutClassification = { attribution_class: null }

--- a/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/Commercial.ts
+++ b/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/Commercial.ts
@@ -1,0 +1,81 @@
+export const FoSaleArtworkNoEditions = {
+  availability: "for sale",
+  sale_message: "$40,000 - 50,000",
+  is_inquireable: true,
+  is_price_range: true,
+  edition_sets: [],
+}
+
+export const FoSaleArtworkWithOneEdition = {
+  availability: "for sale",
+  sale_message: "$2,222",
+  is_inquireable: true,
+  is_price_range: false,
+  edition_sets: [
+    {
+      sale_message: "$2,222",
+      dimensions: {
+        in: "22 × 33 in",
+        cm: "55.9 × 83.8 cm",
+      },
+      edition_of: "",
+    },
+  ],
+}
+
+export const FoSaleArtworkWithMultipleEditions = {
+  availability: "for sale",
+  sale_message: "$2,500 - 5,000",
+  is_inquireable: true,
+  is_price_range: false,
+  edition_sets: [
+    {
+      sale_message: "$2,500 - 5,000",
+      dimensions: {
+        in: "13 × 9 1/10 × 12 3/5 in",
+        cm: "33 × 23 × 32 cm",
+      },
+      edition_of: "Editions 3, 5, 8-10 of 123 + 0AP",
+    },
+    {
+      sale_message: "On hold",
+      dimensions: {
+        in: "1 × 2 × 3 in",
+        cm: "2.5 × 5.1 × 7.6 cm",
+      },
+      edition_of: "",
+    },
+    {
+      sale_message: "On loan",
+      dimensions: {
+        in: "222 in diameter",
+        cm: "563.9 cm diameter",
+      },
+      edition_of: "Edition 1/234",
+    },
+    {
+      sale_message: "Sold",
+      dimensions: {
+        in: "1 × 2 × 3 in",
+        cm: "2.5 × 5.1 × 7.6 cm",
+      },
+      edition_of: "",
+    },
+  ],
+}
+
+export const ContactForPriceWork = {
+  availability: "for sale",
+  sale_message: "Contact For Price",
+  is_inquireable: true,
+  is_price_range: false,
+  edition_sets: [
+    {
+      dimensions: {
+        in: "26 4/5 × 8 7/10 in",
+        cm: "68 × 22 cm",
+      },
+      edition_of: "Edition 250/400/400",
+    },
+  ],
+}

--- a/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/SizeInfo.ts
+++ b/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/SizeInfo.ts
@@ -1,0 +1,13 @@
+export const ArtworkWithSizeAndEditionOf = {
+  dimensions: { in: "10 1/4 × 8 7/8 in", cm: "26 × 22.5 cm" },
+  edition_of: "Edition of 20",
+}
+
+export const ArtworkWithSizeOnly = {
+  dimensions: { in: "10 1/4 × 8 7/8 in", cm: "26 × 22.5 cm" },
+}
+
+export const ArtworkWithEditionOfOnly = {
+  dimensions: { in: null, cm: null },
+  edition_of: "Edition of 20",
+}

--- a/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/TitleInfo.ts
+++ b/src/Styleguide/Pages/Fixtures/Artwork/Sidebar/TitleInfo.ts
@@ -1,0 +1,21 @@
+export const ArtworkWithTitleDateAndMedium = {
+  title: "The Fox and the Hound",
+  date: "2018",
+  medium: "Oil on canvas",
+}
+
+export const ArtworkWithTitleOnly = {
+  title: "The Fox and the Hound",
+}
+
+export const ArtworkWithTitlAndDate = {
+  title: "The Fox and the Hound",
+  date: " 2013 - 2012 ",
+}
+
+export const ArtworkWithTitleAndMedium = {
+  title: "The Fox and the Hound",
+  date: null,
+  medium:
+    "Hand selected materials to paint this piece were sourced from the old villages on magic lands.",
+}

--- a/src/Styleguide/Pages/Fixtures/MarketInsights.ts
+++ b/src/Styleguide/Pages/Fixtures/MarketInsights.ts
@@ -1,0 +1,14 @@
+export const insights = [
+  {
+    primaryLabel: "High auction record",
+    secondaryLabel: "$105m sale, Sotheby’s 2013",
+  },
+  {
+    primaryLabel: "Blue Chip",
+    secondaryLabel: "Represented by internationally recognized galleries.",
+  },
+  {
+    primaryLabel: "Collected by major museums",
+    secondaryLabel: "Tate, Museum of Modern Art (MoMA)",
+  },
+]

--- a/src/Styleguide/Pages/Fixtures/SelectedExhibitions.ts
+++ b/src/Styleguide/Pages/Fixtures/SelectedExhibitions.ts
@@ -1,0 +1,17 @@
+export const exhibitions = [
+  {
+    year: "2018",
+    show: "Adman: Warhol Before Pop",
+    gallery: "Andy Warhol Museum",
+  },
+  {
+    year: "2018",
+    show: "Brancusi: Pioneer of American Minimalism",
+    gallery: "Paul Kasmin Gallery",
+  },
+  {
+    year: "2017",
+    show: "Sculpture on the Move 1946–2016",
+    gallery: "Kunstmuseum Basel",
+  },
+]

--- a/src/__generated__/ArtworkGridExampleQuery.graphql.ts
+++ b/src/__generated__/ArtworkGridExampleQuery.graphql.ts
@@ -1,0 +1,522 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type ArtworkGridExampleQueryVariables = {
+    readonly artistID: string;
+};
+export type ArtworkGridExampleQueryResponse = {
+    readonly artist: ({
+        readonly artworks: ({}) | null;
+    }) | null;
+};
+
+
+
+/*
+query ArtworkGridExampleQuery(
+  $artistID: String!
+) {
+  artist(id: $artistID) {
+    artworks: artworks_connection(first: 10) {
+      ...ArtworkGrid_artworks
+    }
+    __id
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnection {
+  edges {
+    node {
+      __id
+      image {
+        aspect_ratio
+      }
+      ...GridItem_artwork
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  __id
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  __id
+}
+
+fragment Save_artwork on Artwork {
+  __id
+  id
+  is_saved
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message
+  cultural_maker
+  artists(shallow: true) {
+    __id
+    href
+    name
+  }
+  collecting_institution
+  partner(shallow: true) {
+    name
+    href
+    __id
+  }
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  __id
+}
+
+fragment Contact_artwork on Artwork {
+  _id
+  href
+  is_inquireable
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  partner(shallow: true) {
+    type
+    __id
+  }
+  sale_artwork {
+    highest_bid {
+      display
+      __id: id
+    }
+    opening_bid {
+      display
+    }
+    counts {
+      bidder_positions
+    }
+    __id
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID",
+    "type": "String!"
+  }
+],
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10,
+    "type": "Int"
+  }
+],
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "display",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "ArtworkGridExampleQuery",
+  "id": null,
+  "text": "query ArtworkGridExampleQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    artworks: artworks_connection(first: 10) {\n      ...ArtworkGrid_artworks\n    }\n    __id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtworkGridExampleQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": "artworks",
+            "name": "artworks_connection",
+            "storageKey": "artworks_connection(first:10)",
+            "args": v2,
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "FragmentSpread",
+                "name": "ArtworkGrid_artworks",
+                "args": null
+              }
+            ]
+          },
+          v3
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtworkGridExampleQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": "artworks",
+            "name": "artworks_connection",
+            "storageKey": "artworks_connection(first:10)",
+            "args": v2,
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "collecting_institution",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v3,
+                      v4,
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "sale_message",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "cultural_maker",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artists",
+                        "storageKey": "artists(shallow:true)",
+                        "args": v5,
+                        "concreteType": "Artist",
+                        "plural": true,
+                        "selections": [
+                          v3,
+                          v4,
+                          v6
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspect_ratio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "placeholder",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large",
+                                "type": "[String]"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": "partner(shallow:true)",
+                        "args": v5,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          v6,
+                          v4,
+                          v3,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "type",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_auction",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_live_open",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_open",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_closed",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          v3
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "_id",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "is_inquireable",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale_artwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "highest_bid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "plural": false,
+                            "selections": [
+                              v7,
+                              {
+                                "kind": "ScalarField",
+                                "alias": "__id",
+                                "name": "id",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "opening_bid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "plural": false,
+                            "selections": [
+                              v7
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "counts",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "bidder_positions",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          v3
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "id",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "is_saved",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          v3
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '734641ed095467662983692c58509959';
+export default node;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
     "paths": {
       "storybook/*": ["./__stories__/*"],
       "Assets/*": ["./Assets/*"],
-      "^Components/*": ["./Components/*"]
+      "^Components/*": ["./Components/*"],
+      "^Styleguide/*": ["./Styleguide/*"]
     }
   },
   "include": ["typings/*.d.ts", "src/**/*.ts", "src/**/*.tsx"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12152,13 +12152,13 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
+  version "1.0.3-2"
+  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
+
 styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
-
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
-  version "1.0.3-2"
-  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
 styled-components@^3.2.6, styled-components@^3.3.2:
   version "3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@artsy/palette@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.0.0.tgz#66a2d6718aa7c853c926a1b649c121cd2c8788d1"
+"@artsy/palette@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.0.2.tgz#329323e1d451ce94ca98d2089b2959710ab7241c"
   dependencies:
     react "^16.3.2"
     react-primitives "^0.5.0"
@@ -12152,13 +12152,13 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
-  version "1.0.3-2"
-  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
-
 styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
+
+"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
+  version "1.0.3-2"
+  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
 styled-components@^3.2.6, styled-components@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
Was noticing when trying to bring pages into force that it doesn't like anything to come from `__storybooks__` folders. Moved fixtures out (which were referenced in a few places in our code) so that we can start presenting stuff in force. 

cc @oxaudo, @alloy, @zephraph, @mzikherman  