### PR TITLE
@kanabe: ensure forgot password link works

### DIFF
--- a/src/Components/Authentication/commonElements.tsx
+++ b/src/Components/Authentication/commonElements.tsx
@@ -88,7 +88,7 @@ const ForgotPasswordLink = styled(SmallTextLink)`
 `
 
 export const ForgotPassword = props => (
-  <ForgotPasswordLink onClick={props.handleForgotPassword}>
+  <ForgotPasswordLink onClick={props.handleForgotPasswordChange}>
     Forgot Password?
   </ForgotPasswordLink>
 )

--- a/src/Components/Authentication/commonElements.tsx
+++ b/src/Components/Authentication/commonElements.tsx
@@ -87,7 +87,11 @@ const ForgotPasswordLink = styled(SmallTextLink)`
   color: ${Colors.graySemibold};
 `
 
-export const ForgotPassword = props => (
+export interface ForgotPasswordProps {
+  handleForgotPasswordChange: () => void
+}
+
+export const ForgotPassword = (props: ForgotPasswordProps) => (
   <ForgotPasswordLink onClick={props.handleForgotPasswordChange}>
     Forgot Password?
   </ForgotPasswordLink>


### PR DESCRIPTION
This address one of the [QA items](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=AR&modal=detail&selectedIssue=GROW-702). Where the forgot password link isn't working on the login static page.