### PR TITLE
Artwork share sheet

### DIFF
--- a/src/Styleguide/Elements/Flex.tsx
+++ b/src/Styleguide/Elements/Flex.tsx
@@ -54,6 +54,7 @@ export const Flex = styled.div.attrs<FlexProps>({})`
   ${alignItems};
   ${flexBasis};
   ${flexDirection};
+  ${flexGrow};
   ${flexWrap};
   ${justifyContent};
   ${space};
@@ -61,5 +62,4 @@ export const Flex = styled.div.attrs<FlexProps>({})`
   ${maxHeight};
   ${width};
   ${maxWidth};
-  ${flexGrow};
 `

--- a/src/Styleguide/Pages/Artwork/Share.tsx
+++ b/src/Styleguide/Pages/Artwork/Share.tsx
@@ -38,7 +38,9 @@ const Platform: React.SFC<{ iconName: IconName; title: string }> = ({
 }) => (
   <Flex flexDirection="row" flexBasis="50%">
     <Icon name={iconName} color="black" />
-    <Sans color="black60">{title}</Sans>
+    <Sans size="3" color="black60">
+      {title}
+    </Sans>
   </Flex>
 )
 
@@ -54,11 +56,11 @@ export class Share extends React.Component<ShareProps> {
   render() {
     return (
       <Container flexDirection="column" p={2}>
-        <Sans typeSize="sans3" weight="medium" color="black100" mb={2}>
+        <Sans size="3" weight="medium" color="black100" mb={2}>
           Share
         </Sans>
         <Flex flexDirection="row">
-          <SansGrow typeSize="sans2" color="black60">
+          <SansGrow size="2" color="black60">
             <URLInput
               type="text"
               readOnly
@@ -67,14 +69,11 @@ export class Share extends React.Component<ShareProps> {
               onClick={this.selectURL}
             />
           </SansGrow>
-          <Sans
-            typeSize="sans2"
-            weight="medium"
-            color="black60"
-            onClick={this.selectURL}
-          >
-            Copy
-          </Sans>
+          <a onClick={this.selectURL}>
+            <Sans size="2" weight="medium" color="black60">
+              Copy
+            </Sans>
+          </a>
         </Flex>
         <Separator />
         <Flex flexDirection="row" wrap>

--- a/src/Styleguide/Pages/Artwork/Share.tsx
+++ b/src/Styleguide/Pages/Artwork/Share.tsx
@@ -1,0 +1,90 @@
+import React from "react"
+import { Flex } from "../../Elements/Flex"
+import Icon from "Components/Icon"
+import { IconName } from "Assets/Icons"
+import { Separator } from "../../Elements/Separator"
+import { Sans } from "@artsy/palette"
+import styled from "styled-components"
+
+interface ShareProps {
+  url: string
+}
+
+// TODO: We need to figure out if this is going to be a new re-usable panel type
+//       in which I wouldn’t want to add this into Share
+const Container = styled(Flex)`
+  width: 300px;
+  height: 216px;
+  border-radius: 2px;
+  background-color: #ffffff;
+  box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.2);
+`
+
+const SansGrow = styled(Sans)`
+  display: flex;
+  flex-grow: 1;
+`
+
+const URLInput = styled.input`
+  border: 0;
+  text-overflow: ellipsis;
+  display: flex;
+  flex-grow: 1;
+`
+
+const Platform: React.SFC<{ iconName: IconName; title: string }> = ({
+  iconName,
+  title,
+}) => (
+  <Flex flexDirection="row" flexBasis="50%">
+    <Icon name={iconName} color="black" />
+    <Sans color="black60">{title}</Sans>
+  </Flex>
+)
+
+export class Share extends React.Component<ShareProps> {
+  private input: HTMLInputElement
+
+  selectURL = () => {
+    this.input.focus()
+    this.input.setSelectionRange(0, this.input.value.length)
+    document.execCommand("copy")
+  }
+
+  render() {
+    return (
+      <Container flexDirection="column" p={2}>
+        <Sans typeSize="sans3" weight="medium" color="black100" mb={2}>
+          Share
+        </Sans>
+        <Flex flexDirection="row">
+          <SansGrow typeSize="sans2" color="black60">
+            <URLInput
+              type="text"
+              readOnly
+              value={this.props.url}
+              innerRef={input => (this.input = input)}
+              onClick={this.selectURL}
+            />
+          </SansGrow>
+          <Sans
+            typeSize="sans2"
+            weight="medium"
+            color="black60"
+            onClick={this.selectURL}
+          >
+            Copy
+          </Sans>
+        </Flex>
+        <Separator />
+        <Flex flexDirection="row" wrap>
+          <Platform iconName="facebook" title="Facebook" />
+          <Platform iconName="twitter" title="Twitter" />
+          <Platform iconName="mail" title="Email" />
+          <Platform iconName="pinterest" title="Pinterest" />
+          <Platform iconName="tumblr" title="Tumblr" />
+        </Flex>
+      </Container>
+    )
+  }
+}

--- a/src/Styleguide/Pages/Artwork/Share.tsx
+++ b/src/Styleguide/Pages/Artwork/Share.tsx
@@ -1,10 +1,10 @@
-import React from "react"
-import { Flex } from "../../Elements/Flex"
-import Icon from "Components/Icon"
-import { IconName } from "Assets/Icons"
-import { Separator } from "../../Elements/Separator"
 import { Sans } from "@artsy/palette"
+import { IconName } from "Assets/Icons"
+import Icon from "Components/Icon"
+import React from "react"
 import styled from "styled-components"
+import { Flex } from "../../Elements/Flex"
+import { Separator } from "../../Elements/Separator"
 
 interface ShareProps {
   url: string
@@ -30,6 +30,7 @@ const URLInput = styled.input`
   text-overflow: ellipsis;
   display: flex;
   flex-grow: 1;
+  color: inherit;
 `
 
 const Platform: React.SFC<{ iconName: IconName; title: string }> = ({
@@ -59,8 +60,8 @@ export class Share extends React.Component<ShareProps> {
         <Sans size="3" weight="medium" color="black100" mb={2}>
           Share
         </Sans>
-        <Flex flexDirection="row">
-          <SansGrow size="2" color="black60">
+        <Flex flexDirection="row" mb={1}>
+          <SansGrow size="2" color="black60" mr={4}>
             <URLInput
               type="text"
               readOnly
@@ -76,7 +77,7 @@ export class Share extends React.Component<ShareProps> {
           </a>
         </Flex>
         <Separator />
-        <Flex flexDirection="row" wrap>
+        <Flex flexDirection="row" flexWrap>
           <Platform iconName="facebook" title="Facebook" />
           <Platform iconName="twitter" title="Twitter" />
           <Platform iconName="mail" title="Email" />

--- a/src/Styleguide/Pages/Artwork/__stories__/Share.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Share.story.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Share } from "../Share"
+import { Flex } from "Styleguide/Elements/Flex"
+
+storiesOf("Styleguide/Artwork", module).add("Share", () => {
+  return (
+    <Flex justifyContent="center">
+      <Share url="http://example.com/of/a/super/duper/long/url/who/even/comes/up/with/these/slugs/because/are/they/even/readable/and/do/people/really/care/i/dont/know/dude/that/is/an/excellent/question" />
+    </Flex>
+  )
+})

--- a/src/Styleguide/Pages/Artwork/__stories__/Share.story.tsx
+++ b/src/Styleguide/Pages/Artwork/__stories__/Share.story.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
-import { Share } from "../Share"
 import { Flex } from "Styleguide/Elements/Flex"
+import { Share } from "../Share"
 
 storiesOf("Styleguide/Artwork", module).add("Share", () => {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -12178,13 +12178,13 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
+  version "1.0.3-2"
+  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
+
 styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
-
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
-  version "1.0.3-2"
-  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
 styled-components@^3.2.6:
   version "3.3.3"


### PR DESCRIPTION
#closes https://artsyproduct.atlassian.net/browse/RA-2

This doesn’t actually pull the sheet into the static page yet, because I wasn’t quite sure how to do that right now or if this is going to be using another modal implementation. But this is what it currently looks like:

<img width="319" alt="screen shot 2018-06-24 at 15 49 01" src="https://user-images.githubusercontent.com/2320/41819759-4d562320-77c6-11e8-9153-b6b86d8a5c28.png">
