### PR TITLE
@damassi => Make CV tab dynamic

### DIFF
--- a/src/Styleguide/Pages/Artist/Routes/CV/CVContents.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/CV/CVContents.tsx
@@ -1,4 +1,5 @@
 import { Sans, Serif } from "@artsy/palette"
+import { groupBy } from "lodash"
 import React from "react"
 import {
   createPaginationContainer,
@@ -57,8 +58,27 @@ export const Container = createPaginationContainer(
         </div>
       )
     }
-
+    renderShow(node) {
+      return (
+        <Show size="3">
+          <Serif size="3" display="inline" italic>
+            <a href="#" className="noUnderline">
+              {node.name}
+            </a>
+          </Serif>,{" "}
+          <a href="#" className="noUnderline">
+            {node.partner.name}
+          </a>, {node.city}
+        </Show>
+      )
+    }
     render() {
+      const groupedByYear = groupBy(
+        this.props.artist.showsConnection.edges,
+        ({ node: show }) => {
+          return show.start_at
+        }
+      )
       return (
         <Responsive>
           {({ xs }) => {
@@ -77,28 +97,23 @@ export const Container = createPaginationContainer(
                             </Box>
                           </Col>
                           <Col sm={10}>
-                            {this.props.artist.showsConnection.edges.map(
-                              ({ node }) => {
+                            {Object.keys(groupedByYear)
+                              .sort()
+                              .reverse()
+                              .map(year => {
                                 return (
                                   <YearGroup mb={1}>
-                                    <Year size="3">{node.start_at}</Year>
+                                    <Year size="3">{year}</Year>
                                     <Spacer mr={xs ? 1 : 4} />
                                     <ShowGroup>
-                                      <Show size="3">
-                                        <Serif size="3" display="inline" italic>
-                                          <a href="#" className="noUnderline">
-                                            {node.name}
-                                          </a>
-                                        </Serif>,{" "}
-                                        <a href="#" className="noUnderline">
-                                          {node.partner.name}
-                                        </a>, {node.city}
-                                      </Show>
+                                      {groupedByYear[year].map(({ node }) => {
+                                        return this.renderShow(node)
+                                      })}
                                     </ShowGroup>
                                   </YearGroup>
                                 )
-                              }
-                            )}
+                              })}
+
                             <Spacer my={1} />
                             {this.renderPagination()}
                           </Col>

--- a/src/Styleguide/Pages/Artist/Routes/CV/CVContents.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/CV/CVContents.tsx
@@ -1,0 +1,206 @@
+import { Sans, Serif } from "@artsy/palette"
+import React from "react"
+import {
+  createPaginationContainer,
+  graphql,
+  RelayPaginationProp,
+} from "react-relay"
+import styled from "styled-components"
+
+import { Box } from "Styleguide/Elements/Box"
+import { Flex } from "Styleguide/Elements/Flex"
+import { Col, Row } from "Styleguide/Elements/Grid"
+import { Spacer } from "Styleguide/Elements/Spacer"
+
+import { Responsive } from "Styleguide/Utils/Responsive"
+
+import { CVContents_artist } from "__generated__/CVContents_artist.graphql"
+
+interface CVProps {
+  relay: RelayPaginationProp
+  artist: CVContents_artist
+  category: string
+}
+
+export const PAGE_SIZE = 10
+
+const CVItems = styled.div``
+const CVItem = Box
+const YearGroup = styled(Flex)``
+const Year = Serif
+const ShowGroup = styled.div``
+const Show = Serif
+const Category = Sans
+
+export const Container = createPaginationContainer(
+  class extends React.Component<CVProps> {
+    loadMore() {
+      const hasMore = this.props.artist.showsConnection.pageInfo.hasNextPage
+      if (hasMore) {
+        this.props.relay.loadMore(PAGE_SIZE, error => {
+          if (error) {
+            // tslint:disable-next-line:no-console
+            console.log(error)
+          }
+        })
+      }
+    }
+
+    renderPagination() {
+      return (
+        <div
+          onClick={() => {
+            this.loadMore()
+          }}
+        >
+          Load More
+        </div>
+      )
+    }
+
+    render() {
+      return (
+        <Responsive>
+          {({ xs }) => {
+            return (
+              <React.Fragment>
+                <Row>
+                  <Col>
+                    <CVItems>
+                      <CVItem>
+                        <Row>
+                          <Col sm={2}>
+                            <Box mb={xs ? 1 : 1}>
+                              <Category size="3" weight="medium">
+                                {this.props.category}
+                              </Category>
+                            </Box>
+                          </Col>
+                          <Col sm={10}>
+                            {this.props.artist.showsConnection.edges.map(
+                              ({ node }) => {
+                                return (
+                                  <YearGroup mb={1}>
+                                    <Year size="3">{node.start_at}</Year>
+                                    <Spacer mr={xs ? 1 : 4} />
+                                    <ShowGroup>
+                                      <Show size="3">
+                                        <Serif size="3" display="inline" italic>
+                                          <a href="#" className="noUnderline">
+                                            {node.name}
+                                          </a>
+                                        </Serif>,{" "}
+                                        <a href="#" className="noUnderline">
+                                          {node.partner.name}
+                                        </a>, {node.city}
+                                      </Show>
+                                    </ShowGroup>
+                                  </YearGroup>
+                                )
+                              }
+                            )}
+                            <Spacer my={1} />
+                            {this.renderPagination()}
+                          </Col>
+                        </Row>
+                      </CVItem>
+                    </CVItems>
+                  </Col>
+                </Row>
+              </React.Fragment>
+            )
+          }}
+        </Responsive>
+      )
+    }
+  },
+  {
+    artist: graphql`
+      fragment CVContents_artist on Artist
+        @argumentDefinitions(
+          count: { type: "Int", defaultValue: 10 }
+          cursor: { type: "String", defaultValue: "" }
+          sort: { type: "PartnerShowSorts" }
+          at_a_fair: { type: "Boolean" }
+          solo_show: { type: "Boolean" }
+          is_reference: { type: "Boolean" }
+          visible_to_public: { type: "Boolean" }
+        ) {
+        id
+        showsConnection(
+          first: $count
+          after: $cursor
+          sort: $sort
+          at_a_fair: $at_a_fair
+          solo_show: $solo_show
+          is_reference: $is_reference
+          visible_to_public: $visible_to_public
+        ) @connection(key: "Artist_showsConnection") {
+          pageInfo {
+            hasNextPage
+          }
+          edges {
+            node {
+              __id
+              partner {
+                ... on ExternalPartner {
+                  name
+                }
+                ... on Partner {
+                  name
+                }
+              }
+              name
+              start_at(format: "YYYY")
+              city
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    direction: "forward",
+    getConnectionFromProps(props) {
+      return props.artist.showsConnection as any
+    },
+    getFragmentVariables(prevVars, totalCount) {
+      return { ...prevVars, count: totalCount }
+    },
+    getVariables(props, { count, cursor }, fragmentVariables) {
+      return {
+        // in most cases, for variables other than connection filters like
+        // `first`, `after`, etc. you may want to use the previous values.
+        ...fragmentVariables,
+        count,
+        cursor,
+        artistID: props.artist.id,
+      }
+    },
+    query: graphql`
+      query CVContentsQuery(
+        $count: Int
+        $cursor: String
+        $artistID: String!
+        $sort: PartnerShowSorts
+        $at_a_fair: Boolean
+        $solo_show: Boolean
+        $is_reference: Boolean
+        $visible_to_public: Boolean
+      ) {
+        artist(id: $artistID) {
+          ...CVContents_artist
+            @arguments(
+              sort: $sort
+              count: $count
+              cursor: $cursor
+              at_a_fair: $at_a_fair
+              solo_show: $solo_show
+              is_reference: $is_reference
+              visible_to_public: $visible_to_public
+            )
+        }
+      }
+    `,
+  }
+)

--- a/src/Styleguide/Pages/Artist/Routes/CV/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/CV/index.tsx
@@ -1,4 +1,7 @@
 import { Sans, Serif } from "@artsy/palette"
+import { ContextConsumer, ContextProps } from "Components/Artsy"
+import { graphql, QueryRenderer } from "react-relay"
+
 import React from "react"
 import styled from "styled-components"
 import { Box } from "Styleguide/Elements/Box"
@@ -7,6 +10,66 @@ import { Col, Row } from "Styleguide/Elements/Grid"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Responsive } from "Styleguide/Utils/Responsive"
 
+import { Container, PAGE_SIZE } from "./CVContents"
+
+interface ShowFilter {
+  at_a_fair: boolean
+  solo_show?: boolean
+  sort: string
+  is_reference?: boolean
+  visible_to_public?: boolean
+}
+
+interface Props extends ContextProps {
+  artistID: string
+  filters: ShowFilter
+  category: string
+}
+
+export const RelayCVContent = ContextConsumer(
+  class extends React.Component<Props> {
+    render() {
+      const { artistID, relayEnvironment, filters, category } = this.props
+      return (
+        <QueryRenderer
+          environment={relayEnvironment}
+          query={graphql`
+            query CVArtistQuery(
+              $artistID: String!
+              $first: Int!
+              $sort: PartnerShowSorts
+              $at_a_fair: Boolean
+              $solo_show: Boolean
+              $is_reference: Boolean
+              $visible_to_public: Boolean
+            ) {
+              artist(id: $artistID) {
+                ...CVContents_artist
+                  @arguments(
+                    sort: $sort
+
+                    first: $first
+                    at_a_fair: $at_a_fair
+                    solo_show: $solo_show
+                    is_reference: $is_reference
+                    visible_to_public: $visible_to_public
+                  )
+              }
+            }
+          `}
+          variables={{ artistID, first: PAGE_SIZE, ...filters }}
+          render={({ props }) => {
+            if (props) {
+              return <Container category={category} artist={props.artist} />
+            } else {
+              return null
+            }
+          }}
+        />
+      )
+    }
+  }
+)
 export const CV = () => {
   return (
     <Responsive>

--- a/src/Styleguide/Pages/Artist/index.tsx
+++ b/src/Styleguide/Pages/Artist/index.tsx
@@ -1,4 +1,4 @@
-import { Sans } from "@artsy/palette"
+import { Sans, Serif } from "@artsy/palette"
 import { injectGlobalCSS, Theme, themeProps } from "@artsy/palette"
 import { ContextProvider } from "Components/Artsy"
 import React from "react"
@@ -14,7 +14,7 @@ import { Provider as StateProvider } from "unstated"
 import { ArtistHeader } from "./ArtistHeader"
 import { ArticlesContent } from "./Routes/Articles"
 import { RelayAuctionResults } from "./Routes/AuctionResults"
-import { CV } from "./Routes/CV"
+import { RelayCVContent } from "./Routes/CV"
 import { Overview } from "./Routes/Overview"
 import { RelatedArtists } from "./Routes/RelatedArtists"
 import { RelayShowsContent } from "./Routes/Shows"
@@ -45,7 +45,44 @@ export class Artist extends React.Component {
                           <Overview />
                         </Tab>
                         <Tab name="CV">
-                          <CV />
+                          <RelayCVContent
+                            artistID="pablo-picasso"
+                            filters={{
+                              at_a_fair: false,
+                              solo_show: true,
+                              sort: "start_at_desc",
+                              is_reference: true,
+                              visible_to_public: false,
+                            }}
+                            category="Solo Shows"
+                          />
+                          <Spacer my={1} />
+                          <RelayCVContent
+                            artistID="pablo-picasso"
+                            filters={{
+                              at_a_fair: false,
+                              solo_show: false,
+                              sort: "start_at_desc",
+                              is_reference: true,
+                              visible_to_public: false,
+                            }}
+                            category="Group Shows"
+                          />
+                          <Spacer my={1} />
+                          <RelayCVContent
+                            artistID="pablo-picasso"
+                            filters={{ at_a_fair: true, sort: "start_at_desc" }}
+                            category="Fair Booths"
+                          />
+                          <Spacer my={1} />
+                          <Row>
+                            <Col smOffset={2}>
+                              <Serif size="2" color="black60">
+                                Artist CVs are assembled using only exhibition
+                                data available on Artsy.
+                              </Serif>
+                            </Col>
+                          </Row>
                         </Tab>
                         <Tab name="Articles">
                           <ContextProvider>

--- a/src/__generated__/CVArtistQuery.graphql.ts
+++ b/src/__generated__/CVArtistQuery.graphql.ts
@@ -1,0 +1,459 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type PartnerShowSorts = "CREATED_AT_ASC" | "CREATED_AT_DESC" | "END_AT_ASC" | "END_AT_DESC" | "NAME_ASC" | "NAME_DESC" | "PUBLISH_AT_ASC" | "PUBLISH_AT_DESC" | "START_AT_ASC" | "START_AT_DESC" | "created_at_asc" | "created_at_desc" | "end_at_asc" | "end_at_desc" | "name_asc" | "name_desc" | "publish_at_asc" | "publish_at_desc" | "start_at_asc" | "start_at_desc" | "%future added value";
+export type CVArtistQueryVariables = {
+    readonly artistID: string;
+    readonly first: number;
+    readonly sort?: PartnerShowSorts | null;
+    readonly at_a_fair?: boolean | null;
+    readonly solo_show?: boolean | null;
+    readonly is_reference?: boolean | null;
+    readonly visible_to_public?: boolean | null;
+};
+export type CVArtistQueryResponse = {
+    readonly artist: ({}) | null;
+};
+
+
+
+/*
+query CVArtistQuery(
+  $artistID: String!
+  $sort: PartnerShowSorts
+  $at_a_fair: Boolean
+  $solo_show: Boolean
+  $is_reference: Boolean
+  $visible_to_public: Boolean
+) {
+  artist(id: $artistID) {
+    ...CVContents_artist_39hiyk
+    __id
+  }
+}
+
+fragment CVContents_artist_39hiyk on Artist {
+  id
+  showsConnection(first: 10, after: "", sort: $sort, at_a_fair: $at_a_fair, solo_show: $solo_show, is_reference: $is_reference, visible_to_public: $visible_to_public) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        __id
+        partner {
+          __typename
+          ... on ExternalPartner {
+            name
+            __id
+          }
+          ... on Partner {
+            name
+          }
+          ... on Node {
+            __id
+          }
+        }
+        name
+        start_at(format: "YYYY")
+        city
+        __typename
+      }
+      cursor
+    }
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "first",
+    "type": "Int!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "sort",
+    "type": "PartnerShowSorts",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "at_a_fair",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "solo_show",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "is_reference",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "visible_to_public",
+    "type": "Boolean",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  v4
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "CVArtistQuery",
+  "id": null,
+  "text": "query CVArtistQuery(\n  $artistID: String!\n  $sort: PartnerShowSorts\n  $at_a_fair: Boolean\n  $solo_show: Boolean\n  $is_reference: Boolean\n  $visible_to_public: Boolean\n) {\n  artist(id: $artistID) {\n    ...CVContents_artist_39hiyk\n    __id\n  }\n}\n\nfragment CVContents_artist_39hiyk on Artist {\n  id\n  showsConnection(first: 10, after: \"\", sort: $sort, at_a_fair: $at_a_fair, solo_show: $solo_show, is_reference: $is_reference, visible_to_public: $visible_to_public) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        __id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            __id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            __id\n          }\n        }\n        name\n        start_at(format: \"YYYY\")\n        city\n        __typename\n      }\n      cursor\n    }\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "CVArtistQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "CVContents_artist",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "at_a_fair",
+                "variableName": "at_a_fair",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "first",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "is_reference",
+                "variableName": "is_reference",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "solo_show",
+                "variableName": "solo_show",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "visible_to_public",
+                "variableName": "visible_to_public",
+                "type": null
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "CVArtistQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "showsConnection",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "after",
+                "value": "",
+                "type": "String"
+              },
+              {
+                "kind": "Variable",
+                "name": "at_a_fair",
+                "variableName": "at_a_fair",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10,
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "is_reference",
+                "variableName": "is_reference",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "solo_show",
+                "variableName": "solo_show",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": "PartnerShowSorts"
+              },
+              {
+                "kind": "Variable",
+                "name": "visible_to_public",
+                "variableName": "visible_to_public",
+                "type": "Boolean"
+              }
+            ],
+            "concreteType": "ShowConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ShowEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Show",
+                    "plural": false,
+                    "selections": [
+                      v2,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          v3,
+                          v2,
+                          {
+                            "kind": "InlineFragment",
+                            "type": "Partner",
+                            "selections": v5
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "type": "ExternalPartner",
+                            "selections": v5
+                          }
+                        ]
+                      },
+                      v4,
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "start_at",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "YYYY",
+                            "type": "String"
+                          }
+                        ],
+                        "storageKey": "start_at(format:\"YYYY\")"
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "city",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v3
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": null,
+            "name": "showsConnection",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "after",
+                "value": "",
+                "type": "String"
+              },
+              {
+                "kind": "Variable",
+                "name": "at_a_fair",
+                "variableName": "at_a_fair",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10,
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "is_reference",
+                "variableName": "is_reference",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "solo_show",
+                "variableName": "solo_show",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": "PartnerShowSorts"
+              },
+              {
+                "kind": "Variable",
+                "name": "visible_to_public",
+                "variableName": "visible_to_public",
+                "type": "Boolean"
+              }
+            ],
+            "handle": "connection",
+            "key": "Artist_showsConnection",
+            "filters": [
+              "sort",
+              "at_a_fair",
+              "solo_show",
+              "is_reference",
+              "visible_to_public"
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'f3abb1a914b73a28a0d938638ffc1dd4';
+export default node;

--- a/src/__generated__/CVContentsQuery.graphql.ts
+++ b/src/__generated__/CVContentsQuery.graphql.ts
@@ -1,0 +1,474 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type PartnerShowSorts = "CREATED_AT_ASC" | "CREATED_AT_DESC" | "END_AT_ASC" | "END_AT_DESC" | "NAME_ASC" | "NAME_DESC" | "PUBLISH_AT_ASC" | "PUBLISH_AT_DESC" | "START_AT_ASC" | "START_AT_DESC" | "created_at_asc" | "created_at_desc" | "end_at_asc" | "end_at_desc" | "name_asc" | "name_desc" | "publish_at_asc" | "publish_at_desc" | "start_at_asc" | "start_at_desc" | "%future added value";
+export type CVContentsQueryVariables = {
+    readonly count?: number | null;
+    readonly cursor?: string | null;
+    readonly artistID: string;
+    readonly sort?: PartnerShowSorts | null;
+    readonly at_a_fair?: boolean | null;
+    readonly solo_show?: boolean | null;
+    readonly is_reference?: boolean | null;
+    readonly visible_to_public?: boolean | null;
+};
+export type CVContentsQueryResponse = {
+    readonly artist: ({}) | null;
+};
+
+
+
+/*
+query CVContentsQuery(
+  $count: Int
+  $cursor: String
+  $artistID: String!
+  $sort: PartnerShowSorts
+  $at_a_fair: Boolean
+  $solo_show: Boolean
+  $is_reference: Boolean
+  $visible_to_public: Boolean
+) {
+  artist(id: $artistID) {
+    ...CVContents_artist_2utmRv
+    __id
+  }
+}
+
+fragment CVContents_artist_2utmRv on Artist {
+  id
+  showsConnection(first: $count, after: $cursor, sort: $sort, at_a_fair: $at_a_fair, solo_show: $solo_show, is_reference: $is_reference, visible_to_public: $visible_to_public) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        __id
+        partner {
+          __typename
+          ... on ExternalPartner {
+            name
+            __id
+          }
+          ... on Partner {
+            name
+          }
+          ... on Node {
+            __id
+          }
+        }
+        name
+        start_at(format: "YYYY")
+        city
+        __typename
+      }
+      cursor
+    }
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "count",
+    "type": "Int",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "cursor",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "sort",
+    "type": "PartnerShowSorts",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "at_a_fair",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "solo_show",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "is_reference",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "visible_to_public",
+    "type": "Boolean",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  v4
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "CVContentsQuery",
+  "id": null,
+  "text": "query CVContentsQuery(\n  $count: Int\n  $cursor: String\n  $artistID: String!\n  $sort: PartnerShowSorts\n  $at_a_fair: Boolean\n  $solo_show: Boolean\n  $is_reference: Boolean\n  $visible_to_public: Boolean\n) {\n  artist(id: $artistID) {\n    ...CVContents_artist_2utmRv\n    __id\n  }\n}\n\nfragment CVContents_artist_2utmRv on Artist {\n  id\n  showsConnection(first: $count, after: $cursor, sort: $sort, at_a_fair: $at_a_fair, solo_show: $solo_show, is_reference: $is_reference, visible_to_public: $visible_to_public) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        __id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            __id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            __id\n          }\n        }\n        name\n        start_at(format: \"YYYY\")\n        city\n        __typename\n      }\n      cursor\n    }\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "CVContentsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "CVContents_artist",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "at_a_fair",
+                "variableName": "at_a_fair",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "count",
+                "variableName": "count",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "cursor",
+                "variableName": "cursor",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "is_reference",
+                "variableName": "is_reference",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "solo_show",
+                "variableName": "solo_show",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "visible_to_public",
+                "variableName": "visible_to_public",
+                "type": null
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "CVContentsQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "showsConnection",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "after",
+                "variableName": "cursor",
+                "type": "String"
+              },
+              {
+                "kind": "Variable",
+                "name": "at_a_fair",
+                "variableName": "at_a_fair",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "count",
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "is_reference",
+                "variableName": "is_reference",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "solo_show",
+                "variableName": "solo_show",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": "PartnerShowSorts"
+              },
+              {
+                "kind": "Variable",
+                "name": "visible_to_public",
+                "variableName": "visible_to_public",
+                "type": "Boolean"
+              }
+            ],
+            "concreteType": "ShowConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ShowEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Show",
+                    "plural": false,
+                    "selections": [
+                      v2,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          v3,
+                          v2,
+                          {
+                            "kind": "InlineFragment",
+                            "type": "Partner",
+                            "selections": v5
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "type": "ExternalPartner",
+                            "selections": v5
+                          }
+                        ]
+                      },
+                      v4,
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "start_at",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "YYYY",
+                            "type": "String"
+                          }
+                        ],
+                        "storageKey": "start_at(format:\"YYYY\")"
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "city",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v3
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": null,
+            "name": "showsConnection",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "after",
+                "variableName": "cursor",
+                "type": "String"
+              },
+              {
+                "kind": "Variable",
+                "name": "at_a_fair",
+                "variableName": "at_a_fair",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "count",
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "is_reference",
+                "variableName": "is_reference",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "solo_show",
+                "variableName": "solo_show",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": "PartnerShowSorts"
+              },
+              {
+                "kind": "Variable",
+                "name": "visible_to_public",
+                "variableName": "visible_to_public",
+                "type": "Boolean"
+              }
+            ],
+            "handle": "connection",
+            "key": "Artist_showsConnection",
+            "filters": [
+              "sort",
+              "at_a_fair",
+              "solo_show",
+              "is_reference",
+              "visible_to_public"
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '308add12337bea5aaa141882f6586899';
+export default node;

--- a/src/__generated__/CVContents_artist.graphql.ts
+++ b/src/__generated__/CVContents_artist.graphql.ts
@@ -1,0 +1,265 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type CVContents_artist = {
+    readonly id: string;
+    readonly showsConnection: ({
+        readonly pageInfo: {
+            readonly hasNextPage: boolean;
+        };
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly __id: string;
+                readonly partner: ({
+                    readonly name?: string | null;
+                }) | null;
+                readonly name: string | null;
+                readonly start_at: string | null;
+                readonly city: string | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+};
+
+
+
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v2 = [
+  v1
+];
+return {
+  "kind": "Fragment",
+  "name": "CVContents_artist",
+  "type": "Artist",
+  "metadata": {
+    "connection": [
+      {
+        "count": "count",
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": [
+          "showsConnection"
+        ]
+      }
+    ]
+  },
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "count",
+      "type": "Int",
+      "defaultValue": 10
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "cursor",
+      "type": "String",
+      "defaultValue": ""
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "sort",
+      "type": "PartnerShowSorts",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "at_a_fair",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "solo_show",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "is_reference",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "visible_to_public",
+      "type": "Boolean",
+      "defaultValue": null
+    }
+  ],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "showsConnection",
+      "name": "__Artist_showsConnection_connection",
+      "storageKey": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "at_a_fair",
+          "variableName": "at_a_fair",
+          "type": "Boolean"
+        },
+        {
+          "kind": "Variable",
+          "name": "is_reference",
+          "variableName": "is_reference",
+          "type": "Boolean"
+        },
+        {
+          "kind": "Variable",
+          "name": "solo_show",
+          "variableName": "solo_show",
+          "type": "Boolean"
+        },
+        {
+          "kind": "Variable",
+          "name": "sort",
+          "variableName": "sort",
+          "type": "PartnerShowSorts"
+        },
+        {
+          "kind": "Variable",
+          "name": "visible_to_public",
+          "variableName": "visible_to_public",
+          "type": "Boolean"
+        }
+      ],
+      "concreteType": "ShowConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageInfo",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "hasNextPage",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "endCursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ShowEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Show",
+              "plural": false,
+              "selections": [
+                v0,
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "partner",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": null,
+                  "plural": false,
+                  "selections": [
+                    v0,
+                    {
+                      "kind": "InlineFragment",
+                      "type": "Partner",
+                      "selections": v2
+                    },
+                    {
+                      "kind": "InlineFragment",
+                      "type": "ExternalPartner",
+                      "selections": v2
+                    }
+                  ]
+                },
+                v1,
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "start_at",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "format",
+                      "value": "YYYY",
+                      "type": "String"
+                    }
+                  ],
+                  "storageKey": "start_at(format:\"YYYY\")"
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "city",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__typename",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "cursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    },
+    v0
+  ]
+};
+})();
+(node as any).hash = 'a255ba54058b9770f701abb37e2c301b';
+export default node;


### PR DESCRIPTION
This is v similar to the Shows tab, except here since it's just a textual list our pagination is actually done using `createPaginationContainer` (and no fancy cursor/pagination stuff). As you click 'Load More' (not styled!), you append the next page of that section.

![bp](https://user-images.githubusercontent.com/1457859/41749967-6ef3c28a-7587-11e8-95c7-5974125a8bc1.gif)
