### PR TITLE
@alloy => First pass at moving query to route + PreloadLink

### DIFF
--- a/src/Router/PreloadLink.tsx
+++ b/src/Router/PreloadLink.tsx
@@ -163,8 +163,8 @@ export const PreloadLink = Found.withRouter<PreloadLinkProps>(props => {
         return (
           <Found.Link
             onClick={this.handleClick}
-            {..._props}
             activeClassName="active"
+            {..._props}
           >
             {renderChildren()}
           </Found.Link>

--- a/src/Styleguide/Components/RouteTabs.tsx
+++ b/src/Styleguide/Components/RouteTabs.tsx
@@ -6,17 +6,7 @@ import { themeGet } from "styled-system"
 import { Flex } from "Styleguide/Elements/Flex"
 import { styles } from "./Tabs"
 
-export const RouterTab = ({ children, ...props }) => {
-  return (
-    <PreloadLink {...props}>
-      <Sans size="3t" weight="medium">
-        {children}
-      </Sans>
-    </PreloadLink>
-  )
-}
-
-export const RouterTabs = styled(Flex)`
+export const RouteTabs = styled(Flex)`
   ${styles.tabsContainer};
 
   a {
@@ -30,3 +20,13 @@ export const RouterTabs = styled(Flex)`
     }
   }
 `
+
+export const RouteTab = ({ children, ...props }) => {
+  return (
+    <PreloadLink {...props}>
+      <Sans size="3t" weight="medium">
+        {children}
+      </Sans>
+    </PreloadLink>
+  )
+}

--- a/src/Styleguide/Pages/Artist/ArtistApp.tsx
+++ b/src/Styleguide/Pages/Artist/ArtistApp.tsx
@@ -1,51 +1,62 @@
+import ArtistHeader_artist from "__generated__/ArtistHeader_artist.graphql"
 import React from "react"
 import { Footer } from "Styleguide/Components/Footer"
-import { RouterTab, RouterTabs } from "Styleguide/Components/RouterTabs"
+import { RouteTab, RouteTabs } from "Styleguide/Components/RouteTabs"
 import { Box } from "Styleguide/Elements/Box"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { ArtistHeaderQueryRenderer as ArtistHeader } from "./Components/ArtistHeaderQueryRenderer"
 
-export const ArtistApp = ({ children }) => {
-  return (
-    <React.Fragment>
-      <Row>
-        <Col>
-          <ArtistHeader artistID="pablo-picasso" />
-        </Col>
-      </Row>
+// TODO:
+// Max width 1192
+// Inner content max width 1112
 
-      <Spacer mb={3} />
+interface Props {
+  artist: ArtistHeader_artist
+}
 
-      <Row>
-        <Col>
-          <RouterTabs>
-            <RouterTab to="/" exact>
-              Overview
-            </RouterTab>
-            <RouterTab to="/cv">CV</RouterTab>
-            <RouterTab to="/articles">Articles</RouterTab>
-            <RouterTab to="/shows">Shows</RouterTab>
-            <RouterTab to="/auction-results">Auction results</RouterTab>
-            <RouterTab to="/related-artists">Related artists</RouterTab>
-          </RouterTabs>
+export class ArtistApp extends React.Component<Props> {
+  render() {
+    return (
+      <React.Fragment>
+        <Row>
+          <Col>
+            <ArtistHeader artistID="pablo-picasso" />
+          </Col>
+        </Row>
 
-          <Spacer mb={3} />
+        <Spacer mb={3} />
 
-          {children}
-        </Col>
-      </Row>
+        <Row>
+          <Col>
+            <RouteTabs>
+              <RouteTab to="/" exact>
+                Overview
+              </RouteTab>
+              <RouteTab to="/cv">CV</RouteTab>
+              <RouteTab to="/articles">Articles</RouteTab>
+              <RouteTab to="/shows">Shows</RouteTab>
+              <RouteTab to="/auction-results">Auction results</RouteTab>
+              <RouteTab to="/related-artists">Related artists</RouteTab>
+            </RouteTabs>
 
-      <Box my={3}>
-        <Separator />
-      </Box>
+            <Spacer mb={3} />
 
-      <Row>
-        <Col>
-          <Footer />
-        </Col>
-      </Row>
-    </React.Fragment>
-  )
+            {this.props.children}
+          </Col>
+        </Row>
+
+        <Box my={3}>
+          <Separator />
+        </Box>
+
+        <Row>
+          <Col>
+            <Footer />
+          </Col>
+        </Row>
+      </React.Fragment>
+    )
+  }
 }

--- a/src/Styleguide/Pages/Artist/ArtistApp.tsx
+++ b/src/Styleguide/Pages/Artist/ArtistApp.tsx
@@ -1,4 +1,4 @@
-import ArtistHeader_artist from "__generated__/ArtistHeader_artist.graphql"
+import { ArtistHeader_artist } from "__generated__/ArtistHeader_artist.graphql"
 import React from "react"
 import { Footer } from "Styleguide/Components/Footer"
 import { RouteTab, RouteTabs } from "Styleguide/Components/RouteTabs"

--- a/src/Styleguide/Pages/Artist/ArtistApp.tsx
+++ b/src/Styleguide/Pages/Artist/ArtistApp.tsx
@@ -5,14 +5,14 @@ import { Box } from "Styleguide/Elements/Box"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Spacer } from "Styleguide/Elements/Spacer"
-import { ArtistHeaderQueryRenderer } from "./Components/ArtistHeaderQueryRenderer"
+import { ArtistHeaderQueryRenderer as ArtistHeader } from "./Components/ArtistHeaderQueryRenderer"
 
 export const ArtistApp = ({ children }) => {
   return (
     <React.Fragment>
       <Row>
         <Col>
-          <ArtistHeaderQueryRenderer artistID="pablo-picasso" />
+          <ArtistHeader artistID="pablo-picasso" />
         </Col>
       </Row>
 

--- a/src/Styleguide/Pages/Artist/Components/ArtistHeader.tsx
+++ b/src/Styleguide/Pages/Artist/Components/ArtistHeader.tsx
@@ -30,6 +30,7 @@ export class ArtistHeader extends React.Component<Props> {
 
 export const LargeArtistHeader = (props: Props) => {
   const { carousel } = props.artist
+
   return (
     <Box width="100%">
       <SliderContainer my={3}>
@@ -41,7 +42,7 @@ export const LargeArtistHeader = (props: Props) => {
       </SliderContainer>
       <Flex justifyContent="space-between">
         <Box>
-          <Serif size="10">Donald Judd</Serif>
+          <Serif size="10">{props.artist.name}</Serif>
           <Flex>
             <Serif size="3">Brazilian, 1886-1973</Serif>
             <Spacer mr={2} />
@@ -66,7 +67,7 @@ export const SmallArtistHeader = (props: Props) => {
         })}
       </SmallSlider>
       <Flex flexDirection="column" alignItems="center">
-        <Serif size="5">Donald Judd</Serif>
+        <Serif size="5">{props.artist.name}</Serif>
         <Flex>
           <Box mx={1}>
             <Serif size="2">Brazilian, 1886-1973</Serif>
@@ -93,6 +94,8 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
   ArtistHeader,
   graphql`
     fragment ArtistHeader_artist on Artist {
+      name
+      bio
       carousel {
         images {
           resized(height: 300) {

--- a/src/Styleguide/Pages/Artist/Routes/Articles/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Articles/index.tsx
@@ -1,8 +1,12 @@
 import React from "react"
-import { ArticlesQueryRenderer } from "./ArticlesQueryRenderer"
+import { ArticlesRefetchContainer } from "./ArticlesRefetchContainer"
 
-export class ArticlesRoute extends React.Component {
+interface Props {
+  artist: any
+}
+
+export class ArticlesRoute extends React.Component<Props> {
   render() {
-    return <ArticlesQueryRenderer artistID="pablo-picasso" />
+    return <ArticlesRefetchContainer artist={this.props.artist} />
   }
 }

--- a/src/Styleguide/Pages/Artist/Routes/Articles/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Articles/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ArticlesRefetchContainer } from "./ArticlesRefetchContainer"
+import { ArticlesRefetchContainer as Articles } from "./ArticlesRefetchContainer"
 
 interface Props {
   artist: any
@@ -7,6 +7,6 @@ interface Props {
 
 export class ArticlesRoute extends React.Component<Props> {
   render() {
-    return <ArticlesRefetchContainer artist={this.props.artist} />
+    return <Articles artist={this.props.artist} />
   }
 }

--- a/src/Styleguide/Pages/Artist/Routes/AuctionResults/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/AuctionResults/index.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { AuctionResultsRefetchContainer } from "./AuctionResultsRefetchContainer"
+import { AuctionResultsRefetchContainer as AuctionResults } from "./AuctionResultsRefetchContainer"
 
 export const AuctionResultsRoute = props => {
-  return <AuctionResultsRefetchContainer artist={props.artist} />
+  return <AuctionResults artist={props.artist} />
 }

--- a/src/Styleguide/Pages/Artist/Routes/AuctionResults/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/AuctionResults/index.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { AuctionResultsQueryRenderer } from "./AuctionResultsQueryRenderer"
+import { AuctionResultsRefetchContainer } from "./AuctionResultsRefetchContainer"
 
-export const AuctionResultsRoute = () => {
-  return <AuctionResultsQueryRenderer artistID="pablo-picasso" />
+export const AuctionResultsRoute = props => {
+  return <AuctionResultsRefetchContainer artist={props.artist} />
 }

--- a/src/Styleguide/Pages/Artist/Routes/CV/CVQuery.ts
+++ b/src/Styleguide/Pages/Artist/Routes/CV/CVQuery.ts
@@ -1,0 +1,26 @@
+import { graphql } from "react-relay"
+
+export const CVQuery = graphql`
+  query CVQuery(
+    $artistID: String!
+    $first: Int!
+    $sort: PartnerShowSorts
+    $at_a_fair: Boolean
+    $solo_show: Boolean
+    $is_reference: Boolean
+    $visible_to_public: Boolean
+  ) {
+    artist(id: $artistID) {
+      ...CVPaginationContainer_artist
+        @arguments(
+          sort: $sort
+
+          first: $first
+          at_a_fair: $at_a_fair
+          solo_show: $solo_show
+          is_reference: $is_reference
+          visible_to_public: $visible_to_public
+        )
+    }
+  }
+`

--- a/src/Styleguide/Pages/Artist/Routes/CV/CVQueryRenderer.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/CV/CVQueryRenderer.tsx
@@ -1,7 +1,8 @@
 import { ContextConsumer, ContextProps } from "Components/Artsy"
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { QueryRenderer } from "react-relay"
 import { CVPaginationContainer, PAGE_SIZE } from "./CVPaginationContainer"
+import { CVQuery } from "./CVQuery"
 
 interface ShowFilter {
   at_a_fair: boolean
@@ -24,30 +25,7 @@ export const CVQueryRenderer = ContextConsumer(
       return (
         <QueryRenderer
           environment={relayEnvironment}
-          query={graphql`
-            query CVQueryRendererQuery(
-              $artistID: String!
-              $first: Int!
-              $sort: PartnerShowSorts
-              $at_a_fair: Boolean
-              $solo_show: Boolean
-              $is_reference: Boolean
-              $visible_to_public: Boolean
-            ) {
-              artist(id: $artistID) {
-                ...CVPaginationContainer_artist
-                  @arguments(
-                    sort: $sort
-
-                    first: $first
-                    at_a_fair: $at_a_fair
-                    solo_show: $solo_show
-                    is_reference: $is_reference
-                    visible_to_public: $visible_to_public
-                  )
-              }
-            }
-          `}
+          query={CVQuery}
           variables={{ artistID, first: PAGE_SIZE, ...filters }}
           render={({ props }) => {
             if (props) {

--- a/src/Styleguide/Pages/Artist/Routes/CV/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/CV/index.tsx
@@ -1,24 +1,23 @@
 import { Serif } from "@artsy/palette"
+import { ArtistHeader_artist } from "__generated__/ArtistHeader_artist.graphql"
 import React from "react"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Spacer } from "Styleguide/Elements/Spacer"
+import { CVPaginationContainer } from "./CVPaginationContainer"
 import { CVQueryRenderer } from "./CVQueryRenderer"
 
-export class CVRoute extends React.Component {
+interface Props {
+  artist: ArtistHeader_artist
+  category: string
+}
+
+export class CVRoute extends React.Component<Props> {
   render() {
+    const { artist, category } = this.props
+
     return (
       <React.Fragment>
-        <CVQueryRenderer
-          artistID="pablo-picasso"
-          filters={{
-            at_a_fair: false,
-            solo_show: true,
-            sort: "start_at_desc",
-            is_reference: true,
-            visible_to_public: false,
-          }}
-          category="Solo Shows"
-        />
+        <CVPaginationContainer category={category} artist={artist as any} />
 
         <Spacer my={1} />
 

--- a/src/Styleguide/Pages/Artist/Routes/CV/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/CV/index.tsx
@@ -3,7 +3,7 @@ import { ArtistHeader_artist } from "__generated__/ArtistHeader_artist.graphql"
 import React from "react"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Spacer } from "Styleguide/Elements/Spacer"
-import { CVPaginationContainer } from "./CVPaginationContainer"
+import { CVPaginationContainer as CV } from "./CVPaginationContainer"
 import { CVQueryRenderer } from "./CVQueryRenderer"
 
 interface Props {
@@ -17,7 +17,7 @@ export class CVRoute extends React.Component<Props> {
 
     return (
       <React.Fragment>
-        <CVPaginationContainer category={category} artist={artist as any} />
+        <CV category={category} artist={artist as any} />
 
         <Spacer my={1} />
 

--- a/src/Styleguide/Pages/Artist/Routes/RelatedArtists/RelatedArtistsQuery.ts
+++ b/src/Styleguide/Pages/Artist/Routes/RelatedArtists/RelatedArtistsQuery.ts
@@ -1,0 +1,14 @@
+import { graphql } from "react-relay"
+
+export const RelatedArtistsQuery = graphql`
+  query RelatedArtistsQueryRendererQuery(
+    $artistID: String!
+    $first: Int!
+    $kind: RelatedArtistsKind!
+  ) {
+    artist(id: $artistID) {
+      ...RelatedArtistsRefetchContainer_artist
+        @arguments(kind: $kind, first: $first)
+    }
+  }
+`

--- a/src/Styleguide/Pages/Artist/Routes/RelatedArtists/RelatedArtistsQueryRenderer.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/RelatedArtists/RelatedArtistsQueryRenderer.tsx
@@ -1,6 +1,7 @@
 import { ContextConsumer, ContextProps } from "Components/Artsy"
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { QueryRenderer } from "react-relay"
+import { RelatedArtistsQuery } from "./RelatedArtistsQuery"
 
 import {
   PAGE_SIZE,
@@ -19,18 +20,7 @@ export const RelatedArtistsQueryRenderer = ContextConsumer(
       return (
         <QueryRenderer
           environment={relayEnvironment}
-          query={graphql`
-            query RelatedArtistsQueryRendererQuery(
-              $artistID: String!
-              $first: Int!
-              $kind: RelatedArtistsKind!
-            ) {
-              artist(id: $artistID) {
-                ...RelatedArtistsRefetchContainer_artist
-                  @arguments(kind: $kind, first: $first)
-              }
-            }
-          `}
+          query={RelatedArtistsQuery}
           variables={{ artistID, first: PAGE_SIZE, kind }}
           render={({ props }) => {
             if (props) {

--- a/src/Styleguide/Pages/Artist/Routes/RelatedArtists/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/RelatedArtists/index.tsx
@@ -1,15 +1,16 @@
 import { Sans } from "@artsy/palette"
 import React from "react"
 import { RelatedArtistsQueryRenderer } from "./RelatedArtistsQueryRenderer"
+import { RelatedArtistsRefetchContainer } from "./RelatedArtistsRefetchContainer"
 
-export const RelatedArtistsRoute = () => {
+export const RelatedArtistsRoute = props => {
   return (
     <React.Fragment>
       <Sans size="3" weight="medium">
         Related
       </Sans>
 
-      <RelatedArtistsQueryRenderer artistID="pablo-picasso" kind="MAIN" />
+      <RelatedArtistsRefetchContainer kind={props.kind} artist={props.artist} />
 
       <Sans size="3" weight="medium">
         Suggested contemporary

--- a/src/Styleguide/Pages/Artist/Routes/RelatedArtists/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/RelatedArtists/index.tsx
@@ -1,7 +1,7 @@
 import { Sans } from "@artsy/palette"
 import React from "react"
 import { RelatedArtistsQueryRenderer } from "./RelatedArtistsQueryRenderer"
-import { RelatedArtistsRefetchContainer } from "./RelatedArtistsRefetchContainer"
+import { RelatedArtistsRefetchContainer as RelatedArtists } from "./RelatedArtistsRefetchContainer"
 
 export const RelatedArtistsRoute = props => {
   return (
@@ -10,7 +10,7 @@ export const RelatedArtistsRoute = props => {
         Related
       </Sans>
 
-      <RelatedArtistsRefetchContainer kind={props.kind} artist={props.artist} />
+      <RelatedArtists kind={props.kind} artist={props.artist} />
 
       <Sans size="3" weight="medium">
         Suggested contemporary

--- a/src/Styleguide/Pages/Artist/Routes/Shows/ShowsQuery.ts
+++ b/src/Styleguide/Pages/Artist/Routes/Shows/ShowsQuery.ts
@@ -1,0 +1,15 @@
+import { graphql } from "react-relay"
+
+export const ShowsQuery = graphql`
+  query ShowsQueryRendererQuery(
+    $artistID: String!
+    $first: Int!
+    $sort: PartnerShowSorts
+    $status: String!
+  ) {
+    artist(id: $artistID) {
+      ...ShowsRefetchContainer_artist
+        @arguments(sort: $sort, status: $status, first: $first)
+    }
+  }
+`

--- a/src/Styleguide/Pages/Artist/Routes/Shows/ShowsQueryRenderer.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Shows/ShowsQueryRenderer.tsx
@@ -1,6 +1,7 @@
 import { ContextConsumer, ContextProps } from "Components/Artsy"
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { QueryRenderer } from "react-relay"
+import { ShowsQuery } from "./ShowsQuery"
 import { PAGE_SIZE, ShowsRefetchContainer } from "./ShowsRefetchContainer"
 
 interface Props extends ContextProps {
@@ -16,19 +17,7 @@ export const ShowsQueryRenderer = ContextConsumer(
       return (
         <QueryRenderer
           environment={relayEnvironment}
-          query={graphql`
-            query ShowsQueryRendererQuery(
-              $artistID: String!
-              $first: Int!
-              $sort: PartnerShowSorts
-              $status: String!
-            ) {
-              artist(id: $artistID) {
-                ...ShowsRefetchContainer_artist
-                  @arguments(sort: $sort, status: $status, first: $first)
-              }
-            }
-          `}
+          query={ShowsQuery}
           variables={{ artistID, first: PAGE_SIZE, status, sort }}
           render={({ props }) => {
             if (props) {

--- a/src/Styleguide/Pages/Artist/Routes/Shows/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Shows/index.tsx
@@ -1,18 +1,15 @@
 import { Sans } from "@artsy/palette"
 import React from "react"
 import { ShowsQueryRenderer } from "./ShowsQueryRenderer"
+import { ShowsRefetchContainer } from "./ShowsRefetchContainer"
 
-export const ShowsRoute = () => {
+export const ShowsRoute = props => {
   return (
     <React.Fragment>
       <Sans size="3" weight="medium">
         Currently on view
       </Sans>
-      <ShowsQueryRenderer
-        status="running"
-        artistID="pablo-picasso"
-        sort="end_at_asc"
-      />
+      <ShowsRefetchContainer status={status} artist={props.artist} />
       <Sans size="3" weight="medium">
         Upcoming
       </Sans>

--- a/src/Styleguide/Pages/Artist/Routes/Shows/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Shows/index.tsx
@@ -1,7 +1,7 @@
 import { Sans } from "@artsy/palette"
 import React from "react"
 import { ShowsQueryRenderer } from "./ShowsQueryRenderer"
-import { ShowsRefetchContainer } from "./ShowsRefetchContainer"
+import { ShowsRefetchContainer as Shows } from "./ShowsRefetchContainer"
 
 export const ShowsRoute = props => {
   return (
@@ -9,7 +9,7 @@ export const ShowsRoute = props => {
       <Sans size="3" weight="medium">
         Currently on view
       </Sans>
-      <ShowsRefetchContainer status={status} artist={props.artist} />
+      <Shows status={status} artist={props.artist} />
       <Sans size="3" weight="medium">
         Upcoming
       </Sans>

--- a/src/Styleguide/Pages/Artist/__stories__/ArtistHeader.story.tsx
+++ b/src/Styleguide/Pages/Artist/__stories__/ArtistHeader.story.tsx
@@ -23,17 +23,17 @@ storiesOf("Styleguide/Artist", module).add("ArtistHeader", () => {
     <React.Fragment>
       <Section title="Responsive Artist Header">
         <Box width="98%">
-          <ArtistHeader artist={artist} />
+          <ArtistHeader artist={artist as any} />
         </Box>
       </Section>
       <Section title="Large Artist Header">
         <Box width="98%">
-          <LargeArtistHeader artist={artist} />
+          <LargeArtistHeader artist={artist as any} />
         </Box>
       </Section>
       <Section title="Small Artist Header">
         <Box width="100%">
-          <SmallArtistHeader artist={artist} />
+          <SmallArtistHeader artist={artist as any} />
         </Box>
       </Section>
     </React.Fragment>

--- a/src/Styleguide/Pages/Artist/routes.tsx
+++ b/src/Styleguide/Pages/Artist/routes.tsx
@@ -1,7 +1,9 @@
+import { graphql } from "react-relay"
 import { ArtistApp } from "./ArtistApp"
 import { ArticlesRoute } from "./Routes/Articles"
 import { AuctionResultsRoute } from "./Routes/AuctionResults"
 import { CVRoute } from "./Routes/CV"
+import { CVQuery } from "./Routes/CV/CVQuery"
 import { Overview } from "./Routes/Overview"
 import { RelatedArtistsRoute } from "./Routes/RelatedArtists"
 import { ShowsRoute } from "./Routes/Shows"
@@ -10,6 +12,16 @@ export const routes = [
   {
     path: "/",
     Component: ArtistApp,
+    prepareVariables: params => ({
+      artistID: "pablo-picasso",
+    }),
+    query: graphql`
+      query routesQuery($artistID: String!) {
+        artist(id: $artistID) {
+          ...ArtistHeader_artist
+        }
+      }
+    `,
     children: [
       {
         path: "/",
@@ -18,6 +30,16 @@ export const routes = [
       {
         path: "cv",
         Component: CVRoute,
+        query: CVQuery,
+        prepareVariables: params => ({
+          artistID: "pablo-picasso",
+          first: 10,
+          at_a_fair: false,
+          solo_show: true,
+          sort: "start_at_desc",
+          is_reference: true,
+          visible_to_public: false,
+        }),
       },
       {
         path: "articles",

--- a/src/Styleguide/Pages/Artist/routes.tsx
+++ b/src/Styleguide/Pages/Artist/routes.tsx
@@ -6,22 +6,25 @@ import { CVRoute } from "./Routes/CV"
 import { CVQuery } from "./Routes/CV/CVQuery"
 import { Overview } from "./Routes/Overview"
 import { RelatedArtistsRoute } from "./Routes/RelatedArtists"
+import { RelatedArtistsQuery } from "./Routes/RelatedArtists/RelatedArtistsQuery"
 import { ShowsRoute } from "./Routes/Shows"
+import { ShowsQuery } from "./Routes/Shows/ShowsQuery"
 
 export const routes = [
   {
     path: "/",
     Component: ArtistApp,
-    prepareVariables: params => ({
-      artistID: "pablo-picasso",
-    }),
     query: graphql`
-      query routesQuery($artistID: String!) {
+      query routes_OverviewQueryRendererQuery($artistID: String!) {
         artist(id: $artistID) {
           ...ArtistHeader_artist
         }
       }
     `,
+    prepareVariables: params => ({
+      artistID: "pablo-picasso",
+    }),
+
     children: [
       {
         path: "/",
@@ -44,18 +47,64 @@ export const routes = [
       {
         path: "articles",
         Component: ArticlesRoute,
+        query: graphql`
+          query routes_ArticlesQueryRendererQuery(
+            $artistID: String!
+            $first: Int!
+          ) {
+            artist(id: $artistID) {
+              ...ArticlesRefetchContainer_artist @arguments(first: $first)
+            }
+          }
+        `,
+        prepareVariables: params => ({
+          artistID: "pablo-picasso",
+          first: 10,
+        }),
       },
       {
         path: "shows",
         Component: ShowsRoute,
+        query: ShowsQuery,
+        prepareVariables: params => ({
+          artistID: "pablo-picasso",
+          status: "running",
+          sort: "end_at_asc",
+          first: 10,
+        }),
       },
       {
         path: "auction-results",
         Component: AuctionResultsRoute,
+        query: graphql`
+          query routes_ResultsQueryRendererQuery(
+            $artistID: String!
+            $first: Int!
+            $sort: AuctionResultSorts
+          ) {
+            artist(id: $artistID) {
+              ...AuctionResultsRefetchContainer_artist
+                @arguments(first: $first, sort: $sort)
+            }
+          }
+        `,
+        prepareVariables: params => ({
+          artistID: "pablo-picasso",
+          status: "running",
+          first: 10,
+          // FIXME: Pull from state
+          sort: "PRICE_AND_DATE_DESC",
+        }),
       },
       {
         path: "related-artists",
         Component: RelatedArtistsRoute,
+        query: RelatedArtistsQuery,
+        prepareVariables: params => ({
+          artistID: "pablo-picasso",
+          first: 10,
+          kind: "MAIN",
+        }),
       },
     ],
   },

--- a/src/__generated__/ArtistHeader_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader_artist.graphql.ts
@@ -2,6 +2,8 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type ArtistHeader_artist = {
+    readonly name: string | null;
+    readonly bio: string | null;
     readonly carousel: ({
         readonly images: ReadonlyArray<({
             readonly resized: ({
@@ -20,6 +22,20 @@ const node: ConcreteFragment = {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "name",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "bio",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "LinkedField",
       "alias": null,
@@ -76,5 +92,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'e984b0711b6aab50d62ddb33321545f5';
+(node as any).hash = 'fed4de77e2861c8a8910d2baafe80255';
 export default node;

--- a/src/__generated__/CVQuery.graphql.ts
+++ b/src/__generated__/CVQuery.graphql.ts
@@ -2,7 +2,7 @@
 
 import { ConcreteRequest } from "relay-runtime";
 export type PartnerShowSorts = "CREATED_AT_ASC" | "CREATED_AT_DESC" | "END_AT_ASC" | "END_AT_DESC" | "NAME_ASC" | "NAME_DESC" | "PUBLISH_AT_ASC" | "PUBLISH_AT_DESC" | "START_AT_ASC" | "START_AT_DESC" | "created_at_asc" | "created_at_desc" | "end_at_asc" | "end_at_desc" | "name_asc" | "name_desc" | "publish_at_asc" | "publish_at_desc" | "start_at_asc" | "start_at_desc" | "%future added value";
-export type CVQueryRendererQueryVariables = {
+export type CVQueryVariables = {
     readonly artistID: string;
     readonly first: number;
     readonly sort?: PartnerShowSorts | null;
@@ -11,14 +11,14 @@ export type CVQueryRendererQueryVariables = {
     readonly is_reference?: boolean | null;
     readonly visible_to_public?: boolean | null;
 };
-export type CVQueryRendererQueryResponse = {
+export type CVQueryResponse = {
     readonly artist: ({}) | null;
 };
 
 
 
 /*
-query CVQueryRendererQuery(
+query CVQuery(
   $artistID: String!
   $sort: PartnerShowSorts
   $at_a_fair: Boolean
@@ -147,13 +147,13 @@ v5 = [
 return {
   "kind": "Request",
   "operationKind": "query",
-  "name": "CVQueryRendererQuery",
+  "name": "CVQuery",
   "id": null,
-  "text": "query CVQueryRendererQuery(\n  $artistID: String!\n  $sort: PartnerShowSorts\n  $at_a_fair: Boolean\n  $solo_show: Boolean\n  $is_reference: Boolean\n  $visible_to_public: Boolean\n) {\n  artist(id: $artistID) {\n    ...CVPaginationContainer_artist_39hiyk\n    __id\n  }\n}\n\nfragment CVPaginationContainer_artist_39hiyk on Artist {\n  id\n  showsConnection(first: 10, after: \"\", sort: $sort, at_a_fair: $at_a_fair, solo_show: $solo_show, is_reference: $is_reference, visible_to_public: $visible_to_public) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        __id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            __id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            __id\n          }\n        }\n        name\n        start_at(format: \"YYYY\")\n        city\n        __typename\n      }\n      cursor\n    }\n  }\n  __id\n}\n",
+  "text": "query CVQuery(\n  $artistID: String!\n  $sort: PartnerShowSorts\n  $at_a_fair: Boolean\n  $solo_show: Boolean\n  $is_reference: Boolean\n  $visible_to_public: Boolean\n) {\n  artist(id: $artistID) {\n    ...CVPaginationContainer_artist_39hiyk\n    __id\n  }\n}\n\nfragment CVPaginationContainer_artist_39hiyk on Artist {\n  id\n  showsConnection(first: 10, after: \"\", sort: $sort, at_a_fair: $at_a_fair, solo_show: $solo_show, is_reference: $is_reference, visible_to_public: $visible_to_public) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        __id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            __id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            __id\n          }\n        }\n        name\n        start_at(format: \"YYYY\")\n        city\n        __typename\n      }\n      cursor\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
-    "name": "CVQueryRendererQuery",
+    "name": "CVQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": v0,
@@ -216,7 +216,7 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "CVQueryRendererQuery",
+    "name": "CVQuery",
     "argumentDefinitions": v0,
     "selections": [
       {
@@ -455,5 +455,5 @@ return {
   }
 };
 })();
-(node as any).hash = '03bc61d3231b47d7f19f874e7d236722';
+(node as any).hash = '184521490e173b0efb81f60bf5616297';
 export default node;

--- a/src/__generated__/routesQuery.graphql.ts
+++ b/src/__generated__/routesQuery.graphql.ts
@@ -1,17 +1,17 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type ArtistHeaderQueryRendererQueryVariables = {
+export type routesQueryVariables = {
     readonly artistID: string;
 };
-export type ArtistHeaderQueryRendererQueryResponse = {
+export type routesQueryResponse = {
     readonly artist: ({}) | null;
 };
 
 
 
 /*
-query ArtistHeaderQueryRendererQuery(
+query routesQuery(
   $artistID: String!
 ) {
   artist(id: $artistID) {
@@ -61,13 +61,13 @@ v2 = {
 return {
   "kind": "Request",
   "operationKind": "query",
-  "name": "ArtistHeaderQueryRendererQuery",
+  "name": "routesQuery",
   "id": null,
-  "text": "query ArtistHeaderQueryRendererQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistHeader_artist\n    __id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  name\n  bio\n  carousel {\n    images {\n      resized(height: 300) {\n        url\n      }\n    }\n  }\n  __id\n}\n",
+  "text": "query routesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistHeader_artist\n    __id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  name\n  bio\n  carousel {\n    images {\n      resized(height: 300) {\n        url\n      }\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
-    "name": "ArtistHeaderQueryRendererQuery",
+    "name": "routesQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": v0,
@@ -93,7 +93,7 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "ArtistHeaderQueryRendererQuery",
+    "name": "routesQuery",
     "argumentDefinitions": v0,
     "selections": [
       {
@@ -173,5 +173,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'a4cb8fc68508c74d1db13949e2b01eb3';
+(node as any).hash = '8b0611d0ceca407ccd40da32d66ee36a';
 export default node;

--- a/src/__generated__/routes_ArticlesQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_ArticlesQueryRendererQuery.graphql.ts
@@ -1,0 +1,415 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type routes_ArticlesQueryRendererQueryVariables = {
+    readonly artistID: string;
+    readonly first: number;
+};
+export type routes_ArticlesQueryRendererQueryResponse = {
+    readonly artist: ({}) | null;
+};
+
+
+
+/*
+query routes_ArticlesQueryRendererQuery(
+  $artistID: String!
+  $first: Int!
+) {
+  artist(id: $artistID) {
+    ...ArticlesRefetchContainer_artist_3ASum4
+    __id
+  }
+}
+
+fragment ArticlesRefetchContainer_artist_3ASum4 on Artist {
+  id
+  articlesConnection(first: $first, sort: PUBLISHED_AT_DESC, in_editorial_feed: true) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    edges {
+      node {
+        href
+        thumbnail_title
+        author {
+          name
+          __id
+        }
+        published_at(format: "MMM d, YYYY")
+        thumbnail_image {
+          resized(width: 300) {
+            url
+          }
+        }
+        __id
+      }
+    }
+  }
+  __id
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "first",
+    "type": "Int!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "cursor",
+    "args": null,
+    "storageKey": null
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "page",
+    "args": null,
+    "storageKey": null
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "isCurrent",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_ArticlesQueryRendererQuery",
+  "id": null,
+  "text": "query routes_ArticlesQueryRendererQuery(\n  $artistID: String!\n  $first: Int!\n) {\n  artist(id: $artistID) {\n    ...ArticlesRefetchContainer_artist_3ASum4\n    __id\n  }\n}\n\nfragment ArticlesRefetchContainer_artist_3ASum4 on Artist {\n  id\n  articlesConnection(first: $first, sort: PUBLISHED_AT_DESC, in_editorial_feed: true) {\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        href\n        thumbnail_title\n        author {\n          name\n          __id\n        }\n        published_at(format: \"MMM d, YYYY\")\n        thumbnail_image {\n          resized(width: 300) {\n            url\n          }\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_ArticlesQueryRendererQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArticlesRefetchContainer_artist",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "first",
+                "type": null
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_ArticlesQueryRendererQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "articlesConnection",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "first",
+                "type": "Int"
+              },
+              {
+                "kind": "Literal",
+                "name": "in_editorial_feed",
+                "value": true,
+                "type": "Boolean"
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "PUBLISHED_AT_DESC",
+                "type": "ArticleSorts"
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasPreviousPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "startCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageCursors",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "around",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": true,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "first",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "last",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": v3
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArticleEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Article",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "thumbnail_title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "author",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Author",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "name",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          v2
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "published_at",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "MMM d, YYYY",
+                            "type": "String"
+                          }
+                        ],
+                        "storageKey": "published_at(format:\"MMM d, YYYY\")"
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "thumbnail_image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "resized",
+                            "storageKey": "resized(width:300)",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 300,
+                                "type": "Int"
+                              }
+                            ],
+                            "concreteType": "ResizedImageUrl",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      v2
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '68e8571876e15d082e4c089cac2358b3';
+export default node;

--- a/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
@@ -1,17 +1,17 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type routesQueryVariables = {
+export type routes_OverviewQueryRendererQueryVariables = {
     readonly artistID: string;
 };
-export type routesQueryResponse = {
+export type routes_OverviewQueryRendererQueryResponse = {
     readonly artist: ({}) | null;
 };
 
 
 
 /*
-query routesQuery(
+query routes_OverviewQueryRendererQuery(
   $artistID: String!
 ) {
   artist(id: $artistID) {
@@ -61,13 +61,13 @@ v2 = {
 return {
   "kind": "Request",
   "operationKind": "query",
-  "name": "routesQuery",
+  "name": "routes_OverviewQueryRendererQuery",
   "id": null,
-  "text": "query routesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistHeader_artist\n    __id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  name\n  bio\n  carousel {\n    images {\n      resized(height: 300) {\n        url\n      }\n    }\n  }\n  __id\n}\n",
+  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistHeader_artist\n    __id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  name\n  bio\n  carousel {\n    images {\n      resized(height: 300) {\n        url\n      }\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
-    "name": "routesQuery",
+    "name": "routes_OverviewQueryRendererQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": v0,
@@ -93,7 +93,7 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "routesQuery",
+    "name": "routes_OverviewQueryRendererQuery",
     "argumentDefinitions": v0,
     "selections": [
       {
@@ -173,5 +173,5 @@ return {
   }
 };
 })();
-(node as any).hash = '8b0611d0ceca407ccd40da32d66ee36a';
+(node as any).hash = '66f993cba7ef71fcc29a41bff000d2ee';
 export default node;

--- a/src/__generated__/routes_ResultsQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_ResultsQueryRendererQuery.graphql.ts
@@ -1,0 +1,461 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type AuctionResultSorts = "DATE_DESC" | "ESTIMATE_AND_DATE_DESC" | "PRICE_AND_DATE_DESC" | "%future added value";
+export type routes_ResultsQueryRendererQueryVariables = {
+    readonly artistID: string;
+    readonly first: number;
+    readonly sort?: AuctionResultSorts | null;
+};
+export type routes_ResultsQueryRendererQueryResponse = {
+    readonly artist: ({}) | null;
+};
+
+
+
+/*
+query routes_ResultsQueryRendererQuery(
+  $artistID: String!
+  $first: Int!
+  $sort: AuctionResultSorts
+) {
+  artist(id: $artistID) {
+    ...AuctionResultsRefetchContainer_artist_13W90y
+    __id
+  }
+}
+
+fragment AuctionResultsRefetchContainer_artist_13W90y on Artist {
+  id
+  auctionResults(first: $first, sort: $sort) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    edges {
+      node {
+        ...AuctionResultItem_auctionResult
+        __id
+      }
+    }
+  }
+  __id
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+}
+
+fragment AuctionResultItem_auctionResult on AuctionResult {
+  title
+  dimension_text
+  organization
+  images {
+    thumbnail {
+      url
+    }
+  }
+  description
+  date_text
+  sale_date_text
+  price_realized {
+    display
+    cents_usd
+  }
+  estimate {
+    display
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "first",
+    "type": "Int!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "sort",
+    "type": "AuctionResultSorts",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "cursor",
+    "args": null,
+    "storageKey": null
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "page",
+    "args": null,
+    "storageKey": null
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "isCurrent",
+    "args": null,
+    "storageKey": null
+  }
+],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "display",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_ResultsQueryRendererQuery",
+  "id": null,
+  "text": "query routes_ResultsQueryRendererQuery(\n  $artistID: String!\n  $first: Int!\n  $sort: AuctionResultSorts\n) {\n  artist(id: $artistID) {\n    ...AuctionResultsRefetchContainer_artist_13W90y\n    __id\n  }\n}\n\nfragment AuctionResultsRefetchContainer_artist_13W90y on Artist {\n  id\n  auctionResults(first: $first, sort: $sort) {\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...AuctionResultItem_auctionResult\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n}\n\nfragment AuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text\n  sale_date_text\n  price_realized {\n    display\n    cents_usd\n  }\n  estimate {\n    display\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_ResultsQueryRendererQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "AuctionResultsRefetchContainer_artist",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "first",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": null
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_ResultsQueryRendererQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "auctionResults",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "first",
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": "AuctionResultSorts"
+              }
+            ],
+            "concreteType": "AuctionResultConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasPreviousPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "startCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageCursors",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "around",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": true,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "first",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "last",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": v3
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "AuctionResultEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AuctionResult",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "dimension_text",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "organization",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "images",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "AuctionLotImages",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "thumbnail",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "description",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date_text",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "sale_date_text",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "price_realized",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "AuctionResultPriceRealized",
+                        "plural": false,
+                        "selections": [
+                          v4,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "cents_usd",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "estimate",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "AuctionLotEstimate",
+                        "plural": false,
+                        "selections": [
+                          v4
+                        ]
+                      },
+                      v2
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'b34fced6170e91388e84ba7db8c62b75';
+export default node;


### PR DESCRIPTION
Hosited up queries from QueryRenderers's to the router in order to bring us into a proper route-transition system. Notice no transition flash when moving from overview to various tabs. Things are loaded in the background and once complete we move to a new route. During this phase we can tap into an `isLoading` state and, in the future, actual % downloaded (via middleware): 

![loader](https://user-images.githubusercontent.com/236943/41806024-9d86196c-7669-11e8-8808-ee024dce0271.gif)

When user clicks nav item it loads the relay content and then transitions, all wired into overall router state. 

While this can be dried up a bit, this is a fairly representitive example of an app's `routes` file: https://github.com/damassi/reaction/blob/6def3e175bb0541671625aba5f5cee53c791d9ce/src/Styleguide/Pages/Artist/routes.tsx. There's a top query and fragments are passed in corresponding to the routes' tree requirements. 