### PR TITLE
Correct artist show's margin on images

### DIFF
--- a/src/Styleguide/Elements/Box.tsx
+++ b/src/Styleguide/Elements/Box.tsx
@@ -75,4 +75,5 @@ export const Box = styled.div.attrs<BoxProps>({})`
   ${left};
   ${color};
   ${textAlign};
+  ${maxWidth};
 `

--- a/src/Styleguide/Elements/Image.tsx
+++ b/src/Styleguide/Elements/Image.tsx
@@ -5,6 +5,10 @@ import styled from "styled-components"
 import {
   height,
   HeightProps,
+  maxWidth,
+  MaxWidthProps,
+  ratio,
+  RatioProps,
   space,
   SpaceProps,
   width,
@@ -33,17 +37,20 @@ export const Image = styled.img.attrs<ImageProps>({})`
 export interface ResponsiveImageProps
   extends BaseImageProps,
     SpaceProps,
-    WidthProps {}
+    WidthProps,
+    RatioProps,
+    MaxWidthProps {}
 export const ResponsiveImage = styled.div.attrs<ResponsiveImageProps>({})`
-  height: auto;
-  padding-top: 100%;
   background: url(${props => props.src});
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
+  ${ratio};
   ${space};
   ${width};
+  ${maxWidth};
 `
 ResponsiveImage.defaultProps = {
   width: "100%",
+  ratio: 1,
 }

--- a/src/Styleguide/Pages/Artist/Routes/Shows/ShowBlockItem.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Shows/ShowBlockItem.tsx
@@ -1,7 +1,7 @@
 import { Serif } from "@artsy/palette"
 import React from "react"
 import { Box } from "Styleguide/Elements/Box"
-import { ResponsiveImage } from "Styleguide/Elements/Image"
+import { Image } from "Styleguide/Elements/Image"
 
 interface Props {
   imageUrl: string
@@ -26,7 +26,7 @@ export const ShowBlockItem = (props: Props) => {
       pb={props.pb}
     >
       <a href={FIXME_DOMAIN + props.href} className="noUnderline">
-        <ResponsiveImage src={props.imageUrl} my={-30} />
+        <Image width="100%" src={props.imageUrl} />
         <Serif size="3t">{props.name}</Serif>
       </a>
       <Serif size="2" color="black60">

--- a/src/Styleguide/Pages/Artist/Routes/Shows/ShowBlockItem.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Shows/ShowBlockItem.tsx
@@ -19,7 +19,6 @@ export const ShowBlockItem = (props: Props) => {
   const FIXME_DOMAIN = "https://www.artsy.net"
   return (
     <Box
-      maxWidth="460px"
       width={props.blockWidth}
       height="auto" // FIXME
       pr={props.pr}

--- a/src/Styleguide/Pages/Artist/Routes/Shows/ShowsRefetchContainer.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Shows/ShowsRefetchContainer.tsx
@@ -117,9 +117,10 @@ export const ShowsRefetchContainer = createRefetchContainer(
                       {this.props.status === "running" ? (
                         <ShowBlocks flexDirection={blockDirection} flexWrap>
                           {this.props.artist.showsConnection.edges.map(
-                            ({ node }) => {
+                            ({ node }, edgeKey) => {
                               return (
                                 <ShowBlockItem
+                                  key={edgeKey}
                                   blockWidth={blockWidth}
                                   imageUrl={node.cover_image.cropped.url}
                                   partner={node.partner.name}


### PR DESCRIPTION
This corrects a few issues. 

1.) It changes the show images from a responsive image to a normal image
2.) Removes the max width of the show item. The only thing with a max width should be the grid itself.
3.) Cleans up some minor issues in the `Image` and `Box` elements to make them a bit more consistent across the board. 
4.) Fixes a rouge missing key error

Remaining work is to apply the max width to the grid container.