### PR TITLE
@damassi => Small updates for Positron

### DIFF
--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -76,7 +76,7 @@ export class Text extends Component<Props, State> {
   transformNode = (node, index) => {
     // Dont include relay components unless necessary
     // To avoid 'regeneratorRuntime' error
-    const LinkWithTooltip = require("../ToolTip/LinkWithTooltip")
+    const { LinkWithTooltip } = require("../ToolTip/LinkWithTooltip")
 
     if (node.name === "p") {
       node.name = "div"

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -1,7 +1,6 @@
 import { startsWith } from "lodash"
 import React, { Component } from "react"
 import ReactHtmlParser, { convertNodeToElement } from "react-html-parser"
-import LinkWithTooltip from "../ToolTip/LinkWithTooltip"
 import { ArticleLayout } from "../Typings"
 import { StyledText } from "./StyledText"
 
@@ -75,6 +74,10 @@ export class Text extends Component<Props, State> {
   }
 
   transformNode = (node, index) => {
+    // Dont include relay components unless necessary
+    // To avoid 'regeneratorRuntime' error
+    const LinkWithTooltip = require("../ToolTip/LinkWithTooltip")
+
     if (node.name === "p") {
       node.name = "div"
       node.attribs.class = "paragraph"

--- a/src/Components/Truncator.tsx
+++ b/src/Components/Truncator.tsx
@@ -1,6 +1,6 @@
-import { ErrorBoundary } from "Components/ErrorBoundary"
 import React from "react"
 import ReactDOM from "react-dom/server"
+import { ErrorBoundary } from "./ErrorBoundary"
 
 interface Props {
   maxLineCount?: number


### PR DESCRIPTION
Necessary to bump Reaction in Positron:
- In `Text` component, moves require for Relay `LinkWithTooltip` so it is only imported if needed.
- Updates path for imported `ErrorBoundary` in `Truncator`, which was not resolving correctly.