### PR TITLE
@mzikherman => Make <Slider> more flexible by adding render prop

### DIFF
--- a/src/Styleguide/Components/Slider.tsx
+++ b/src/Styleguide/Components/Slider.tsx
@@ -1,22 +1,16 @@
-import React from "react"
+import React, { ReactNode } from "react"
 import Slick from "react-slick"
 import styled from "styled-components"
 import { left, LeftProps, right, RightProps } from "styled-system"
 import { Arrow } from "Styleguide/Elements/Arrow"
 import { Box } from "Styleguide/Elements/Box"
 import { Flex } from "Styleguide/Elements/Flex"
-import { Image } from "Styleguide/Elements/Image"
 import { Responsive } from "Styleguide/Utils/Responsive"
 
 interface Props {
   height?: number
-  images: Array<{
-    resized: {
-      url: string
-      width: number
-      height: number
-    }
-  }>
+  data: Array<object> // This is designed to handle any shape of data passed, as long as its an array
+  render: (slide) => ReactNode
 }
 
 export class Slider extends React.Component<Props> {
@@ -55,13 +49,8 @@ export const LargeSlider = (props: Props) => {
 
       <SliderContainer>
         <Slick {...slickConfig} ref={slider => (slickRef = slider)}>
-          {props.images.map((image, index) => {
-            const { url, width, height } = image.resized
-            return (
-              <Box key={index}>
-                <Image px={5} src={url} width={width} height={height} />
-              </Box>
-            )
+          {props.data.map((slide, index) => {
+            return <Box key={index}>{props.render(slide)}</Box>
           })}
         </Slick>
       </SliderContainer>
@@ -90,13 +79,8 @@ export const SmallSlider = (props: Props) => {
     <Flex justifyContent="space-around" alignItems="center">
       <SliderContainer>
         <Slick {...slickConfig}>
-          {props.images.map((image, index) => {
-            const { url, width, height } = image.resized
-            return (
-              <Box key={index}>
-                <Image px={5} src={url} width={width} height={height} />
-              </Box>
-            )
+          {props.data.map((slide, index) => {
+            return <Box key={index}>{props.render(slide)}</Box>
           })}
         </Slick>
       </SliderContainer>

--- a/src/Styleguide/Components/__stories__/Slider.story.tsx
+++ b/src/Styleguide/Components/__stories__/Slider.story.tsx
@@ -2,25 +2,79 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { LargeSlider, Slider, SmallSlider } from "Styleguide/Components/Slider"
 import { Box } from "Styleguide/Elements/Box"
+import { Image } from "Styleguide/Elements/Image"
 import { images } from "Styleguide/Pages/Fixtures/Slider"
 import { Section } from "Styleguide/Utils/Section"
 
 storiesOf("Styleguide/Components", module).add("Slider", () => {
   return (
     <React.Fragment>
+      <Section title="Custom Slide">
+        <Box width="70%">
+          <Slider
+            data={images}
+            render={props => {
+              return (
+                <Image
+                  px={5}
+                  src={props.resized.url}
+                  width={props.resized.width}
+                  height={props.resized.height}
+                />
+              )
+            }}
+          />
+        </Box>
+      </Section>
       <Section title="Responsive Slider">
         <Box width="70%">
-          <Slider images={images} />
+          <Slider
+            data={images}
+            render={props => {
+              return (
+                <Image
+                  px={5}
+                  src={props.resized.url}
+                  width={props.resized.width}
+                  height={props.resized.height}
+                />
+              )
+            }}
+          />
         </Box>
       </Section>
       <Section title="Small Slider">
         <Box width="50%">
-          <SmallSlider images={images} />
+          <SmallSlider
+            data={images}
+            render={props => {
+              return (
+                <Image
+                  px={5}
+                  src={props.resized.url}
+                  width={props.resized.width}
+                  height={props.resized.height}
+                />
+              )
+            }}
+          />
         </Box>
       </Section>
       <Section title="Large Slider">
         <Box width="70%">
-          <LargeSlider images={images} />
+          <LargeSlider
+            data={images}
+            render={props => {
+              return (
+                <Image
+                  px={5}
+                  src={props.resized.url}
+                  width={props.resized.width}
+                  height={props.resized.height}
+                />
+              )
+            }}
+          />
         </Box>
       </Section>
     </React.Fragment>

--- a/src/Styleguide/Pages/Artist/Components/ArtistHeader.tsx
+++ b/src/Styleguide/Pages/Artist/Components/ArtistHeader.tsx
@@ -6,6 +6,7 @@ import { Slider } from "Styleguide/Components/Slider"
 import { Box } from "Styleguide/Elements/Box"
 import { Button } from "Styleguide/Elements/Button"
 import { Flex } from "Styleguide/Elements/Flex"
+import { Image } from "Styleguide/Elements/Image"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Responsive } from "Styleguide/Utils/Responsive"
 
@@ -31,7 +32,20 @@ export const LargeArtistHeader = (props: Props) => {
 
   return (
     <Box width="100%">
-      <Slider height={200} images={carousel.images as any} />
+      <Slider
+        height={200}
+        data={carousel.images as any}
+        render={slide => {
+          return (
+            <Image
+              px={5}
+              src={slide.resized.url}
+              width={slide.resized.width}
+              height={slide.resized.height}
+            />
+          )
+        }}
+      />
       <Spacer my={2} />
 
       <Flex justifyContent="space-between">
@@ -55,7 +69,19 @@ export const SmallArtistHeader = (props: Props) => {
   const { carousel } = props.artist
   return (
     <Flex flexDirection="column">
-      <Slider images={carousel.images as any} />
+      <Slider
+        data={carousel.images as any}
+        render={slide => {
+          return (
+            <Image
+              px={5}
+              src={slide.resized.url}
+              width={slide.resized.width}
+              height={slide.resized.height}
+            />
+          )
+        }}
+      />
       <Spacer my={2} />
 
       <Flex flexDirection="column" alignItems="center">


### PR DESCRIPTION
Allows us to pass in any kind of component to render, following this API:

```jsx
     <Slider
        data={carousel.images}
        render={slide => {
          return (
            <Image
              px={5}
              src={slide.resized.url}
              width={slide.resized.width}
              height={slide.resized.height}
            />
          )
        }}
      />
```