### PR TITLE
@damassi => Make current event on overview dynamic, using new Metaphysics schema

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -143,6 +143,7 @@ type Artist implements Node {
   ): [Artist]
   consignable: Boolean @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
   counts: ArtistCounts
+  currentEvent: CurrentEvent
   deathday: String
   display_auction_link: Boolean @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
 
@@ -400,6 +401,7 @@ type ArtistItem implements Node {
   ): [Artist]
   consignable: Boolean @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
   counts: ArtistCounts
+  currentEvent: CurrentEvent
   deathday: String
   display_auction_link: Boolean @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
 
@@ -2133,6 +2135,13 @@ type CroppedImageUrl {
   width: Int
   height: Int
   url: String
+}
+
+type CurrentEvent {
+  image: Image
+  headline: String
+  subHeadline: String
+  name: String
 }
 
 type DaySchedule {
@@ -5355,9 +5364,6 @@ type Show implements Node {
   counts: ShowCounts
   description: String
   displayable: Boolean @deprecated(reason: "Prefix Boolean returning fields with `is_`")
-
-  # Either fair, show, or partner location
-  display_city: String
   end_at(
     convert_to_utc: Boolean
     format: String

--- a/data/schema.json
+++ b/data/schema.json
@@ -5878,6 +5878,18 @@
               "deprecationReason": null
             },
             {
+              "name": "currentEvent",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CurrentEvent",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "deathday",
               "description": null,
               "args": [],
@@ -8587,6 +8599,65 @@
         },
         {
           "kind": "OBJECT",
+          "name": "CurrentEvent",
+          "description": null,
+          "fields": [
+            {
+              "name": "image",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "headline",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subHeadline",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Show",
           "description": null,
           "fields": [
@@ -8941,18 +9012,6 @@
               },
               "isDeprecated": true,
               "deprecationReason": "Prefix Boolean returning fields with `is_`"
-            },
-            {
-              "name": "display_city",
-              "description": "Either fair, show, or partner location",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
             },
             {
               "name": "end_at",
@@ -34432,6 +34491,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ArtistCounts",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentEvent",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CurrentEvent",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/src/Styleguide/Pages/Artist/Routes/Overview/Components/CurrentEvent.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Overview/Components/CurrentEvent.tsx
@@ -1,16 +1,13 @@
 import { Sans, Serif } from "@artsy/palette"
+import { CurrentEvent_artist } from "__generated__/CurrentEvent_artist.graphql"
 import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Image } from "Styleguide/Elements/Image"
 import { Responsive } from "Styleguide/Utils/Responsive"
 
 export interface CurrentEventProps {
-  src: string
-  label: string
-  title: string
-  gallery: string
-  location: string
-  date: string
+  artist: CurrentEvent_artist
 }
 
 export class CurrentEvent extends React.Component<CurrentEventProps> {
@@ -26,20 +23,37 @@ export class CurrentEvent extends React.Component<CurrentEventProps> {
   }
 }
 
-export const LargeCurrentEvent = props => {
+export const LargeCurrentEvent = (props: CurrentEventProps) => {
+  const { currentEvent } = props.artist
+
   return (
     <Flex flexDirection="column">
-      <Image src={props.src} mb={1} />
+      <Image src={currentEvent.image.resized.url} mb={1} />
       <Sans size="2" weight="medium" my={0.5}>
-        {props.label}
+        {currentEvent.headline}
       </Sans>
-      <Serif size="3t">{props.title}</Serif>
+      <Serif size="3t">{currentEvent.name}</Serif>
       <Serif size="2" color="black60">
-        {props.gallery}
-      </Serif>
-      <Serif size="2" color="black60">
-        {props.location}, {props.date}
+        {currentEvent.subHeadline}
       </Serif>
     </Flex>
   )
 }
+
+export const CurrentEventFragmentContainer = createFragmentContainer(
+  CurrentEvent,
+  graphql`
+    fragment CurrentEvent_artist on Artist {
+      currentEvent {
+        image {
+          resized(width: 300) {
+            url
+          }
+        }
+        name
+        subHeadline
+        headline
+      }
+    }
+  `
+)

--- a/src/Styleguide/Pages/Artist/Routes/Overview/index.tsx
+++ b/src/Styleguide/Pages/Artist/Routes/Overview/index.tsx
@@ -13,7 +13,7 @@ import { Spacer } from "Styleguide/Elements/Spacer"
 import { ArtworkFilterFragmentContainer as ArtworkFilter } from "Styleguide/Pages/Artist/Routes/Overview/Components/ArtworkFilter"
 import { insights } from "Styleguide/Pages/Fixtures/MarketInsights"
 import { Subscribe } from "unstated"
-import { CurrentEvent } from "./Components/CurrentEvent"
+import { CurrentEventFragmentContainer as CurrentEvent } from "./Components/CurrentEvent"
 import { FilterState } from "./state"
 
 export interface OverviewRouteProps {
@@ -83,14 +83,7 @@ const OverviewRoute = (props: OverviewRouteProps) => {
               </Col>
               <Col sm={3}>
                 <Box pl={2}>
-                  <CurrentEvent
-                    src="https://picsum.photos/300/200/?random"
-                    label="Currently on view"
-                    title="Brancusi: Pioneer of American Minimalism"
-                    gallery="Paul Kasmin Gallery"
-                    location="Miami"
-                    date="May 3 – 21, 2018"
-                  />
+                  <CurrentEvent artist={props.artist as any} />
                 </Box>
               </Col>
             </Row>
@@ -121,6 +114,7 @@ export const OverviewRouteFragmentContainer = createFragmentContainer(
     fragment Overview_artist on Artist {
       ...ArtistHeader_artist
       ...ArtistBio_bio
+      ...CurrentEvent_artist
 
       exhibition_highlights(size: 15) {
         ...SelectedExhibitions_exhibitions

--- a/src/Styleguide/Pages/Artist/__stories__/CurrentEvent.story.tsx
+++ b/src/Styleguide/Pages/Artist/__stories__/CurrentEvent.story.tsx
@@ -7,28 +7,25 @@ import {
   LargeCurrentEvent,
 } from "Styleguide/Pages/Artist/Routes/Overview/Components/CurrentEvent"
 
+const props = {
+  artist: {
+    currentEvent: {
+      image: { resized: { url: "https://picsum.photos/300/200/?random" } },
+      name: "Brancusi: Pioneer of American Minimalism",
+      headline: "Currently on view",
+      subHeadline: "Paul Kasmin Gallery" + "\n" + "Miami, May 3 - 21, 2018",
+    },
+  },
+}
+
 storiesOf("Styleguide/Artist/CurrentEvent", module).add("Current Event", () => {
   return (
     <React.Fragment>
       <Section title="Responsive Current Event">
-        <CurrentEvent
-          src="https://picsum.photos/300/200/?random"
-          label="Currently on view"
-          title="Brancusi: Pioneer of American Minimalism"
-          gallery="Paul Kasmin Gallery"
-          location="Miami"
-          date="May 3 – 21, 2018"
-        />
+        <CurrentEvent {...props} />
       </Section>
       <Section title="Large Current Event">
-        <LargeCurrentEvent
-          src="https://picsum.photos/300/200/?random"
-          label="Currently on view"
-          title="Brancusi: Pioneer of American Minimalism"
-          gallery="Paul Kasmin Gallery"
-          location="Miami"
-          date="May 3 – 21, 2018"
-        />
+        <LargeCurrentEvent {...props} />
       </Section>
       <Section title="Small Current Event">Hidden</Section>
     </React.Fragment>

--- a/src/__generated__/CurrentEvent_artist.graphql.ts
+++ b/src/__generated__/CurrentEvent_artist.graphql.ts
@@ -1,0 +1,104 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type CurrentEvent_artist = {
+    readonly currentEvent: ({
+        readonly image: ({
+            readonly resized: ({
+                readonly url: string | null;
+            }) | null;
+        }) | null;
+        readonly name: string | null;
+        readonly subHeadline: string | null;
+        readonly headline: string | null;
+    }) | null;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "CurrentEvent_artist",
+  "type": "Artist",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "currentEvent",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CurrentEvent",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "image",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Image",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "resized",
+              "storageKey": "resized(width:300)",
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 300,
+                  "type": "Int"
+                }
+              ],
+              "concreteType": "ResizedImageUrl",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "url",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "name",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "subHeadline",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "headline",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "__id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '01d406d93a42c61447ada1192b1ca71c';
+export default node;

--- a/src/__generated__/Overview_artist.graphql.ts
+++ b/src/__generated__/Overview_artist.graphql.ts
@@ -54,6 +54,11 @@ return {
       "args": null
     },
     {
+      "kind": "FragmentSpread",
+      "name": "CurrentEvent_artist",
+      "args": null
+    },
+    {
       "kind": "LinkedField",
       "alias": null,
       "name": "exhibition_highlights",
@@ -111,5 +116,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '6fc171060ec9987d2b32e50661b275c8';
+(node as any).hash = 'cfe97bc7c38690363887dd42dcfebbce';
 export default node;

--- a/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
@@ -31,6 +31,7 @@ query routes_OverviewQueryRendererQuery(
 fragment Overview_artist on Artist {
   ...ArtistHeader_artist
   ...ArtistBio_bio
+  ...CurrentEvent_artist
   exhibition_highlights(size: 15) {
     ...SelectedExhibitions_exhibitions
     __id
@@ -58,6 +59,20 @@ fragment ArtistBio_bio on Artist {
   biography_blurb(format: HTML, partner_bio: true) {
     text
     credit
+  }
+  __id
+}
+
+fragment CurrentEvent_artist on Artist {
+  currentEvent {
+    image {
+      resized(width: 300) {
+        url
+      }
+    }
+    name
+    subHeadline
+    headline
   }
   __id
 }
@@ -303,24 +318,27 @@ v4 = {
   "storageKey": null
 },
 v5 = [
+  v4
+],
+v6 = [
   v3
 ],
-v6 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v8 = [
-  v7,
+v9 = [
+  v8,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -336,14 +354,14 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v10 = [
+v11 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -351,7 +369,7 @@ v10 = [
     "type": "Boolean"
   }
 ],
-v11 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -363,7 +381,7 @@ return {
   "operationKind": "query",
   "name": "routes_OverviewQueryRendererQuery",
   "id": null,
-  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n) {\n  artist(id: $artistID) {\n    ...Overview_artist\n    __id\n  }\n}\n\nfragment Overview_artist on Artist {\n  ...ArtistHeader_artist\n  ...ArtistBio_bio\n  exhibition_highlights(size: 15) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  ...ArtworkFilter_artist_81Ela\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  name\n  bio\n  carousel {\n    images {\n      resized(height: 300) {\n        url\n        width\n        height\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment ArtworkFilter_artist_81Ela on Artist {\n  id\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        count\n        id\n        __id\n      }\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n  __id\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n) {\n  artist(id: $artistID) {\n    ...Overview_artist\n    __id\n  }\n}\n\nfragment Overview_artist on Artist {\n  ...ArtistHeader_artist\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  exhibition_highlights(size: 15) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  ...ArtworkFilter_artist_81Ela\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  name\n  bio\n  carousel {\n    images {\n      resized(height: 300) {\n        url\n        width\n        height\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    subHeadline\n    headline\n  }\n  __id\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment ArtworkFilter_artist_81Ela on Artist {\n  id\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        count\n        id\n        __id\n      }\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n  __id\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -510,6 +528,60 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "currentEvent",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CurrentEvent",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "resized",
+                    "storageKey": "resized(width:300)",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 300,
+                        "type": "Int"
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
+                    "plural": false,
+                    "selections": v5
+                  }
+                ]
+              },
+              v3,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "subHeadline",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "headline",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "exhibition_highlights",
             "storageKey": "exhibition_highlights(size:15)",
             "args": [
@@ -543,12 +615,12 @@ return {
                   {
                     "kind": "InlineFragment",
                     "type": "Partner",
-                    "selections": v5
+                    "selections": v6
                   },
                   {
                     "kind": "InlineFragment",
                     "type": "ExternalPartner",
-                    "selections": v5
+                    "selections": v6
                   }
                 ]
               },
@@ -597,9 +669,7 @@ return {
                     ],
                     "concreteType": "CroppedImageUrl",
                     "plural": false,
-                    "selections": [
-                      v4
-                    ]
+                    "selections": v5
                   }
                 ]
               },
@@ -613,7 +683,7 @@ return {
               v2
             ]
           },
-          v6,
+          v7,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -699,7 +769,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      v6,
+                      v7,
                       v2
                     ]
                   }
@@ -770,7 +840,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": true,
-                        "selections": v8
+                        "selections": v9
                       },
                       {
                         "kind": "LinkedField",
@@ -780,7 +850,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v8
+                        "selections": v9
                       },
                       {
                         "kind": "LinkedField",
@@ -790,7 +860,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v8
+                        "selections": v9
                       },
                       {
                         "kind": "LinkedField",
@@ -801,7 +871,7 @@ return {
                         "concreteType": "PageCursor",
                         "plural": false,
                         "selections": [
-                          v7
+                          v8
                         ]
                       }
                     ]
@@ -832,7 +902,7 @@ return {
                             "storageKey": null
                           },
                           v2,
-                          v9,
+                          v10,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -866,12 +936,12 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v10,
+                            "args": v11,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
                               v2,
-                              v9,
+                              v10,
                               v3
                             ]
                           },
@@ -919,12 +989,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v10,
+                            "args": v11,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
                               v3,
-                              v9,
+                              v10,
                               v2,
                               {
                                 "kind": "ScalarField",
@@ -1007,7 +1077,7 @@ return {
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
                                 "selections": [
-                                  v11,
+                                  v12,
                                   {
                                     "kind": "ScalarField",
                                     "alias": "__id",
@@ -1026,7 +1096,7 @@ return {
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
                                 "selections": [
-                                  v11
+                                  v12
                                 ]
                               },
                               {
@@ -1050,7 +1120,7 @@ return {
                               v2
                             ]
                           },
-                          v6,
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,


### PR DESCRIPTION
The current implementation of this in Force winds up querying for both auctions and shows, and then doing a bunch of munging to determine what to show + how to show it on the page.

I added a new schema for this in Metaphysics, that basically does that. This keeps the Reaction side pretty clean.

Looks like:

<img width="354" alt="screen shot 2018-06-27 at 11 28 27 am" src="https://user-images.githubusercontent.com/1457859/41984229-2ca82f3a-79fe-11e8-9508-5a513c348d03.png">
