### PR TITLE
Allow Tabs to have user-specified data and justification 

### DIFF
--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -22,7 +22,7 @@ export interface TabInfo {
   tabIndex: number
 
   /** Data associated with the newly selected Tab */
-  data: object
+  data: any
 }
 
 export interface TabsProps extends WidthProps, JustifyContentProps {
@@ -100,7 +100,7 @@ interface TabProps {
    *
    * Will be passed to the parent <Tabs>'s onChange handler.
    */
-  data?: object
+  data?: any
 }
 
 export class Tab extends React.Component<TabProps> {

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -1,7 +1,12 @@
 import { Sans } from "@artsy/palette"
 import React from "react"
 import styled, { css } from "styled-components"
-import { borders, themeGet, WidthProps } from "styled-system"
+import {
+  borders,
+  JustifyContentProps,
+  themeGet,
+  WidthProps,
+} from "styled-system"
 import { Box } from "Styleguide/Elements/Box"
 import { Flex } from "Styleguide/Elements/Flex"
 
@@ -20,7 +25,7 @@ export interface TabInfo {
   data: object
 }
 
-export interface TabsProps extends WidthProps {
+export interface TabsProps extends WidthProps, JustifyContentProps {
   /** Function that will be called when a new Tab is selected */
   onChange?: (tabInfo?: TabInfo) => void
 
@@ -73,11 +78,11 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
   }
 
   render() {
-    const { children = [] } = this.props
+    const { children = [], justifyContent = "left" } = this.props
 
     return (
       <React.Fragment>
-        <TabsContainer mb={0.5} width="100%">
+        <TabsContainer mb={0.5} width="100%" justifyContent={justifyContent}>
           {children.map(this.renderTab)}
         </TabsContainer>
         <Box pt={3}>{children[this.state.activeTabIndex]}</Box>

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -15,6 +15,9 @@ export interface TabInfo {
 
   /** Index of the newly selected Tab */
   tabIndex: number
+
+  /** Data associated with the newly selected Tab */
+  data: object
 }
 
 export interface TabsProps extends WidthProps {
@@ -53,6 +56,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
       this.props.onChange({
         tabIndex: activeTabIndex,
         name: this.props.children[activeTabIndex].props.name,
+        data: this.props.children[activeTabIndex].props.data,
       })
     }
   }
@@ -85,6 +89,13 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
 interface TabProps {
   /** Display name of the Tab */
   name: string
+
+  /**
+   * Arbitrary data that can be associated with a Tab.
+   *
+   * Will be passed to the parent <Tabs>'s onChange handler.
+   */
+  data?: object
 }
 
 export class Tab extends React.Component<TabProps> {

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -8,13 +8,22 @@ import { Flex } from "Styleguide/Elements/Flex"
 export interface TabLike extends JSX.Element {
   props: TabProps
 }
+
 export interface TabInfo {
+  /** Display name of the newly selected Tab */
   name: string
+
+  /** Index of the newly selected Tab */
   tabIndex: number
 }
+
 export interface TabsProps extends WidthProps {
+  /** Function that will be called when a new Tab is selected */
   onChange?: (tabInfo?: TabInfo) => void
+
+  /** Index of the Tab that should be pre-selected */
   initialTabIndex?: number
+
   children: TabLike[]
 }
 
@@ -74,8 +83,10 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
 }
 
 interface TabProps {
+  /** Display name of the Tab */
   name: string
 }
+
 export class Tab extends React.Component<TabProps> {
   render() {
     return this.props.children || null

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -40,6 +40,10 @@ export interface TabsState {
 }
 
 export class Tabs extends React.Component<TabsProps, TabsState> {
+  public static defaultProps: Partial<TabsProps> = {
+    justifyContent: "left",
+  }
+
   state = {
     activeTabIndex: 0,
   }
@@ -78,7 +82,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
   }
 
   render() {
-    const { children = [], justifyContent = "left" } = this.props
+    const { children = [], justifyContent } = this.props
 
     return (
       <React.Fragment>

--- a/src/Styleguide/Components/__stories__/Tabs.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.story.tsx
@@ -37,6 +37,18 @@ storiesOf("Styleguide/Components", module).add("Tabs", () => {
           <Tab name="You?">You?</Tab>
         </Tabs>
       </Section>
+      <Section title="With arbitrary data and onChange handler">
+        <Tabs
+          onChange={activeTab => {
+            // tslint:disable-next-line
+            console.log(activeTab.data)
+          }}
+        >
+          <Tab data={{ target: "#about" }} name="About" />
+          <Tab data={{ target: "#pricing" }} name="Pricing" />
+          <Tab data={{ target: "#condition" }} name="Condition" />
+        </Tabs>
+      </Section>
     </React.Fragment>
   )
 })

--- a/src/Styleguide/Components/__stories__/Tabs.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.story.tsx
@@ -49,6 +49,13 @@ storiesOf("Styleguide/Components", module).add("Tabs", () => {
           <Tab data={{ target: "#condition" }} name="Condition" />
         </Tabs>
       </Section>
+      <Section title="With custom justification">
+        <Tabs justifyContent="center">
+          <Tab name="About" />
+          <Tab name="Pricing" />
+          <Tab name="Condition" />
+        </Tabs>
+      </Section>
     </React.Fragment>
   )
 })


### PR DESCRIPTION
Reaction noob in the house!

This is the first example of consuming a design system component in CMS, and then customizing it  here per our needs in the design spec.

I'm open to the possibility that everything here is done wrong 😛 , but this is where I've gotten so far.

Example usage below…

![gif](https://cl.ly/2Z2g1b2f1t3H/Screen%20Recording%202018-06-27%20at%2001.54%20PM.gif)

H/t @orta for the suggestion to start documenting the props interfaces, and seeing that flow through to the Volt side in VS Code.

cc @jonallured 