### PR TITLE
@xtina-starr => Tooltip tracking fix

### DIFF
--- a/src/Components/Authentication/__tests__/Desktop/ForgotPasswordForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Desktop/ForgotPasswordForm.test.tsx
@@ -42,7 +42,10 @@ describe("ResetPasswordForm", () => {
 
   it("clears error after input change", done => {
     const wrapper = mount(
-      <ForgotPasswordForm error="Some global server error" />
+      <ForgotPasswordForm
+        error="Some global server error"
+        handleSubmit={jest.fn()}
+      />
     )
     const input = wrapper.find(`input[name="email"]`)
     expect(wrapper.state().error).toEqual("Some global server error")

--- a/src/Components/Authentication/__tests__/Desktop/LoginForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Desktop/LoginForm.test.tsx
@@ -32,7 +32,7 @@ describe("LoginForm", () => {
   })
 
   it("renders errors", done => {
-    const wrapper = mount(<LoginForm />)
+    const wrapper = mount(<LoginForm handleSubmit={jest.fn()} />)
     const input = wrapper.find(`input[name="email"]`)
     input.simulate("blur")
     wrapper.update()
@@ -43,7 +43,9 @@ describe("LoginForm", () => {
   })
 
   it("clears error after input change", done => {
-    const wrapper = mount(<LoginForm error="Some global server error" />)
+    const wrapper = mount(
+      <LoginForm error="Some global server error" handleSubmit={jest.fn()} />
+    )
     const input = wrapper.find(`input[name="email"]`)
     expect(wrapper.state().error).toEqual("Some global server error")
     input.simulate("change")

--- a/src/Components/Authentication/__tests__/Desktop/SignUpForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Desktop/SignUpForm.test.tsx
@@ -45,7 +45,9 @@ describe("SignUpForm", () => {
   })
 
   it("clears error after input change", done => {
-    const wrapper = mount(<SignUpForm error="Some global server error" />)
+    const wrapper = mount(
+      <SignUpForm error="Some global server error" handleSubmit={jest.fn()} />
+    )
     const input = wrapper.find(`input[name="email"]`)
     expect(wrapper.state().error).toEqual("Some global server error")
     input.simulate("change")

--- a/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
+++ b/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
@@ -19,7 +19,7 @@ describe("FormSwitcher", () => {
     mount(
       <FormSwitcher
         type={props.type || ModalType.login}
-        handleSubmit={null}
+        handleSubmit={jest.fn()}
         tracking={props.tracking}
         options={{
           contextModule: "Header",

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -76,7 +76,7 @@ export class Text extends Component<Props, State> {
   transformNode = (node, index) => {
     // Dont include relay components unless necessary
     // To avoid 'regeneratorRuntime' error
-    const { LinkWithTooltip } = require("../ToolTip/LinkWithTooltip")
+    const LinkWithTooltip = require("../ToolTip/LinkWithTooltip").default
 
     if (node.name === "p") {
       node.name = "div"


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-756

Was not using the correct import, and was missing the tracking props. Introduced by [this PR](https://github.com/artsy/reaction/pull/898). 

Also kills a few test warnings from the `/Authentication` directory.