### PR TITLE
@eessex => Remove `shouldComponentUpdate` on Modal

### DIFF
--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -43,10 +43,6 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     }
   }
 
-  shouldComponentUpdate(newProps) {
-    return this.props.show !== newProps.show
-  }
-
   componentWillUnmount() {
     this.removeBlurToContainers()
   }


### PR DESCRIPTION
We should be allowed to update on any changes to the modal such as type changes in `FormSwitcher`