### PR TITLE
Resolve error causing boot component to fail

### DIFF
--- a/src/Router/Boot.tsx
+++ b/src/Router/Boot.tsx
@@ -11,12 +11,12 @@ import { BootProps } from "./types"
 
 export const Boot: React.SFC<BootProps> = ({ children, ...props }) => {
   const globalState = new GlobalState(props)
+  const relayEnvironment =
+    globalState.state.system && globalState.state.system.relayEnvironment
 
   return (
     <StateProvider inject={[globalState]}>
-      <ContextProvider
-        relayEnvironment={globalState.state.system.relayEnvironment}
-      >
+      <ContextProvider relayEnvironment={relayEnvironment}>
         <ResponsiveProvider
           initialBreakpoint={props.initialBreakpoint}
           breakpoints={themeProps.mediaQueries}

--- a/src/__stories__/storiesOf.js
+++ b/src/__stories__/storiesOf.js
@@ -1,14 +1,9 @@
 import React from "react"
 import { storiesOf as _storiesOf } from "@storybook/react"
 import { Boot } from "Router/Boot"
-import { ContextProvider } from "Components/Artsy"
 
 export function storiesOf(desc, mod) {
   return _storiesOf(desc, mod).addDecorator(storyFn => {
-    return (
-      <ContextProvider>
-        <Boot>{storyFn()}</Boot>
-      </ContextProvider>
-    )
+    return <Boot>{storyFn()}</Boot>
   })
 }


### PR DESCRIPTION
Resolves an issue that was preventing all the component stories to fail to render to an error in the boot component. 