### PR TITLE
@mzikherman => Add generic loading screens across all loadable content

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -1,12 +1,14 @@
 import { RecentlyViewed_me } from "__generated__/RecentlyViewed_me.graphql"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Artist/Components/NavigationTabs"
 import React from "react"
+import { PreloadLinkState } from "Router/state"
 import { Footer } from "Styleguide/Components/Footer"
 import { RecentlyViewedFragmentContainer as RecentlyViewed } from "Styleguide/Components/RecentlyViewed"
 import { Box } from "Styleguide/Elements/Box"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Spacer } from "Styleguide/Elements/Spacer"
+import { Subscribe } from "unstated"
 import { ArtistHeaderFragmentContainer as ArtistHeader } from "./Components/ArtistHeader"
 import { LoadingArea } from "./Components/LoadingArea"
 
@@ -39,7 +41,16 @@ export const ArtistApp: React.SFC<ArtistAppProps> = props => {
 
           <Spacer mb={3} />
 
-          <LoadingArea>{children}</LoadingArea>
+          {/*
+           When clicking nav links, wait for fetch to complete before
+           transitioning to new route
+         */}
+
+          <Subscribe to={[PreloadLinkState]}>
+            {({ state: { isLoading } }: PreloadLinkState) => {
+              return <LoadingArea isLoading={isLoading}>{children}</LoadingArea>
+            }}
+          </Subscribe>
         </Col>
       </Row>
 

--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -10,12 +10,8 @@ import { Spacer } from "Styleguide/Elements/Spacer"
 import { ArtistHeaderFragmentContainer as ArtistHeader } from "./Components/ArtistHeader"
 import { LoadingArea } from "./Components/LoadingArea"
 
-// TODO:
-// Max width 1192
-// Inner content max width 1112
-
 export interface ArtistAppProps {
-  artist: any
+  artist: any // FIXME: ArtistHeader_artist | NavigationTabs_artist
   me: RecentlyViewed_me
   params: {
     artistID: string

--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -14,6 +14,7 @@ import { Responsive } from "Utils/Responsive"
 
 interface Props {
   artist: ArtistHeader_artist
+  currentUser?: User
   mediator?: {
     trigger: (action: string, config: object) => void
   }
@@ -23,16 +24,29 @@ export const ArtistHeader: SFC<Props> = props => {
   return (
     <Subscribe to={[AppState]}>
       {({ state }) => {
+        const {
+          mediator,
+          system: { currentUser },
+        } = state
+
         return (
           <Responsive>
             {({ xs }) => {
               if (xs) {
                 return (
-                  <SmallArtistHeader mediator={state.mediator} {...props} />
+                  <SmallArtistHeader
+                    mediator={mediator}
+                    currentUser={currentUser}
+                    {...props}
+                  />
                 )
               } else {
                 return (
-                  <LargeArtistHeader mediator={state.mediator} {...props} />
+                  <LargeArtistHeader
+                    mediator={mediator}
+                    currentUser={currentUser}
+                    {...props}
+                  />
                 )
               }
             }}
@@ -43,14 +57,11 @@ export const ArtistHeader: SFC<Props> = props => {
   )
 }
 
-ArtistHeader.defaultProps = {
-  mediator: {
-    trigger: x => x,
-  },
-}
-
 export const LargeArtistHeader: SFC<Props> = props => {
-  const { carousel } = props.artist
+  const {
+    artist: { carousel },
+    currentUser,
+  } = props
 
   return (
     <Box width="100%">
@@ -85,7 +96,9 @@ export const LargeArtistHeader: SFC<Props> = props => {
           </Flex>
         </Box>
         <FollowArtistButton
+          useDeprecatedButtonStyle={false}
           artist={props.artist as any}
+          currentUser={currentUser}
           onOpenAuthModal={() => {
             props.mediator.trigger("open:auth", {
               mode: "signup",
@@ -107,7 +120,10 @@ export const LargeArtistHeader: SFC<Props> = props => {
 }
 
 export const SmallArtistHeader: SFC<Props> = props => {
-  const { carousel } = props.artist
+  const {
+    artist: { carousel },
+    currentUser,
+  } = props
 
   return (
     <Flex flexDirection="column">
@@ -142,7 +158,9 @@ export const SmallArtistHeader: SFC<Props> = props => {
       </Flex>
       <Box my={2}>
         <FollowArtistButton
+          useDeprecatedButtonStyle={false}
           artist={props.artist as any}
+          currentUser={currentUser}
           onOpenAuthModal={() => {
             props.mediator.trigger("open:auth", {
               mode: "signup",

--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -158,8 +158,11 @@ export const SmallArtistHeader: SFC<Props> = props => {
       </Flex>
       <Box my={2}>
         <FollowArtistButton
-          useDeprecatedButtonStyle={false}
           artist={props.artist as any}
+          useDeprecatedButtonStyle={false}
+          buttonProps={{
+            width: "100%",
+          }}
           currentUser={currentUser}
           onOpenAuthModal={() => {
             props.mediator.trigger("open:auth", {

--- a/src/Apps/Artist/Components/LoadingArea.tsx
+++ b/src/Apps/Artist/Components/LoadingArea.tsx
@@ -1,30 +1,25 @@
 import Spinner from "Components/Spinner"
 import React, { SFC } from "react"
-import { PreloadLinkState } from "Router/state"
 import styled from "styled-components"
-import { Subscribe } from "unstated"
 
 interface Props {
   children: any
+  isLoading?: boolean
 }
 
+const TRANSITION_TIME = "0.0s"
+
 export const LoadingArea: SFC<Props> = props => {
+  const loaderClass = props.isLoading ? "loading" : ""
+
   return (
-    <Subscribe to={[PreloadLinkState]}>
-      {({ state: { isFetching } }: PreloadLinkState) => {
-        const loaderClass = isFetching ? "loading" : ""
+    <OuterContainer>
+      <SpinnerContainer>
+        <SpinnerToggle className={loaderClass} />
+      </SpinnerContainer>
 
-        return (
-          <OuterContainer>
-            <SpinnerContainer>
-              <SpinnerToggle className={loaderClass} />
-            </SpinnerContainer>
-
-            <Container className={loaderClass}>{props.children}</Container>
-          </OuterContainer>
-        )
-      }}
-    </Subscribe>
+      <Container className={loaderClass}>{props.children}</Container>
+    </OuterContainer>
   )
 }
 
@@ -43,7 +38,7 @@ const Container = styled.div`
   opacity: 1;
   position: relative;
 
-  transition: opacity 0.25s;
+  transition: opacity ${TRANSITION_TIME};
 
   &.loading {
     opacity: 0.1;
@@ -54,7 +49,7 @@ const SpinnerToggle = styled(Spinner)`
   position: absolute;
 
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity ${TRANSITION_TIME};
 
   &.loading {
     opacity: 1;

--- a/src/Apps/Artist/Components/LoadingArea.tsx
+++ b/src/Apps/Artist/Components/LoadingArea.tsx
@@ -1,26 +1,39 @@
 import Spinner from "Components/Spinner"
-import React, { SFC } from "react"
+import React, { ReactNode, SFC } from "react"
 import styled from "styled-components"
 
-interface Props {
-  children: any
-  isLoading?: boolean
+export interface LoadingAreaState {
+  isLoading: boolean
 }
 
-const TRANSITION_TIME = "0.0s"
+interface Props extends LoadingAreaState {
+  children: ReactNode
+  isLoading: boolean
+  transitionTime?: string
+}
 
 export const LoadingArea: SFC<Props> = props => {
+  const { transitionTime } = props
   const loaderClass = props.isLoading ? "loading" : ""
 
   return (
     <OuterContainer>
       <SpinnerContainer>
-        <SpinnerToggle className={loaderClass} />
+        <SpinnerToggle
+          transitionTime={transitionTime}
+          className={loaderClass}
+        />
       </SpinnerContainer>
 
-      <Container className={loaderClass}>{props.children}</Container>
+      <Container transitionTime={transitionTime} className={loaderClass}>
+        {props.children}
+      </Container>
     </OuterContainer>
   )
+}
+
+LoadingArea.defaultProps = {
+  transitionTime: "0.0s",
 }
 
 const OuterContainer = styled.div`
@@ -38,7 +51,7 @@ const Container = styled.div`
   opacity: 1;
   position: relative;
 
-  transition: opacity ${TRANSITION_TIME};
+  transition: opacity ${(props: Partial<Props>) => props.transitionTime};
 
   &.loading {
     opacity: 0.1;
@@ -49,7 +62,7 @@ const SpinnerToggle = styled(Spinner)`
   position: absolute;
 
   opacity: 0;
-  transition: opacity ${TRANSITION_TIME};
+  transition: opacity ${(props: Partial<Props>) => props.transitionTime};
 
   &.loading {
     opacity: 1;

--- a/src/Apps/Artist/Routes/Articles/ArtistArticles.tsx
+++ b/src/Apps/Artist/Routes/Articles/ArtistArticles.tsx
@@ -4,17 +4,28 @@ import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { PaginationFragmentContainer as Pagination } from "Styleguide/Components/Pagination"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
-import { LoadingArea } from "../../Components/LoadingArea"
 import { ArticleItem } from "./ArtistArticle"
+
+import {
+  LoadingArea,
+  LoadingAreaState,
+} from "Apps/Artist/Components/LoadingArea"
 
 const PAGE_SIZE = 10
 
-interface ArticlesProps {
+interface ArtistArticlesProps {
   relay: RelayRefetchProp
   artist: ArtistArticles_artist
 }
 
-export class ArtistArticles extends Component<ArticlesProps> {
+export class ArtistArticles extends Component<
+  ArtistArticlesProps,
+  LoadingAreaState
+> {
+  state = {
+    isLoading: false,
+  }
+
   loadNext = () => {
     const {
       artist: {
@@ -30,6 +41,8 @@ export class ArtistArticles extends Component<ArticlesProps> {
   }
 
   loadAfter = cursor => {
+    this.toggleLoading(true)
+
     this.props.relay.refetch(
       {
         first: PAGE_SIZE,
@@ -40,11 +53,19 @@ export class ArtistArticles extends Component<ArticlesProps> {
       },
       null,
       error => {
+        this.toggleLoading(false)
+
         if (error) {
           console.error(error)
         }
       }
     )
+  }
+
+  toggleLoading = isLoading => {
+    this.setState({
+      isLoading,
+    })
   }
 
   render() {
@@ -54,7 +75,7 @@ export class ArtistArticles extends Component<ArticlesProps> {
 
         <Row>
           <Col>
-            <LoadingArea isLoading>
+            <LoadingArea isLoading={this.state.isLoading}>
               {this.props.artist.articlesConnection.edges.map(
                 ({ node }, index) => {
                   return (

--- a/src/Apps/Artist/Routes/Articles/ArtistArticles.tsx
+++ b/src/Apps/Artist/Routes/Articles/ArtistArticles.tsx
@@ -4,6 +4,7 @@ import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { PaginationFragmentContainer as Pagination } from "Styleguide/Components/Pagination"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
+import { LoadingArea } from "../../Components/LoadingArea"
 import { ArticleItem } from "./ArtistArticle"
 
 const PAGE_SIZE = 10
@@ -53,20 +54,22 @@ export class ArtistArticles extends Component<ArticlesProps> {
 
         <Row>
           <Col>
-            {this.props.artist.articlesConnection.edges.map(
-              ({ node }, index) => {
-                return (
-                  <ArticleItem
-                    title={node.thumbnail_title}
-                    imageUrl={node.thumbnail_image.resized.url}
-                    date={node.published_at}
-                    author={node.author.name}
-                    href={node.href}
-                    key={index}
-                  />
-                )
-              }
-            )}
+            <LoadingArea isLoading>
+              {this.props.artist.articlesConnection.edges.map(
+                ({ node }, index) => {
+                  return (
+                    <ArticleItem
+                      title={node.thumbnail_title}
+                      imageUrl={node.thumbnail_image.resized.url}
+                      date={node.published_at}
+                      author={node.author.name}
+                      href={node.href}
+                      key={index}
+                    />
+                  )
+                }
+              )}
+            </LoadingArea>
           </Col>
         </Row>
         <Row>

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -7,6 +7,7 @@ import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Subscribe } from "unstated"
+import { LoadingArea } from "../../Components/LoadingArea"
 import { ArtistAuctionDetailsModal } from "./ArtistAuctionDetailsModal"
 import { AuctionResultItemFragmentContainer } from "./ArtistAuctionResultItem"
 import { AuctionResultsState } from "./state"
@@ -102,17 +103,19 @@ class AuctionResultsContainer extends Component<AuctionResultsProps> {
                     auctionResult={state.selectedAuction}
                   />
 
-                  {this.props.artist.auctionResults.edges.map(
-                    ({ node }, index) => {
-                      return (
-                        <React.Fragment key={index}>
-                          <AuctionResultItemFragmentContainer
-                            auctionResult={node as any}
-                          />
-                        </React.Fragment>
-                      )
-                    }
-                  )}
+                  <LoadingArea isLoading>
+                    {this.props.artist.auctionResults.edges.map(
+                      ({ node }, index) => {
+                        return (
+                          <React.Fragment key={index}>
+                            <AuctionResultItemFragmentContainer
+                              auctionResult={node as any}
+                            />
+                          </React.Fragment>
+                        )
+                      }
+                    )}
+                  </LoadingArea>
                 </Col>
               </Row>
 

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -7,12 +7,16 @@ import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Subscribe } from "unstated"
-import { LoadingArea } from "../../Components/LoadingArea"
 import { ArtistAuctionDetailsModal } from "./ArtistAuctionDetailsModal"
 import { AuctionResultItemFragmentContainer } from "./ArtistAuctionResultItem"
 import { AuctionResultsState } from "./state"
 import { TableColumns } from "./TableColumns"
 import { TableSidebar } from "./TableSidebar"
+
+import {
+  LoadingArea,
+  LoadingAreaState,
+} from "Apps/Artist/Components/LoadingArea"
 
 const PAGE_SIZE = 10
 
@@ -22,7 +26,14 @@ interface AuctionResultsProps {
   sort: string
 }
 
-class AuctionResultsContainer extends Component<AuctionResultsProps> {
+class AuctionResultsContainer extends Component<
+  AuctionResultsProps,
+  LoadingAreaState
+> {
+  state = {
+    isLoading: false,
+  }
+
   loadNext = () => {
     const {
       artist: {
@@ -63,6 +74,8 @@ class AuctionResultsContainer extends Component<AuctionResultsProps> {
   }
 
   loadAfter = cursor => {
+    this.toggleLoading(true)
+
     this.props.relay.refetch(
       {
         first: PAGE_SIZE,
@@ -74,11 +87,19 @@ class AuctionResultsContainer extends Component<AuctionResultsProps> {
       },
       null,
       error => {
+        this.toggleLoading(false)
+
         if (error) {
           console.error(error)
         }
       }
     )
+  }
+
+  toggleLoading = isLoading => {
+    this.setState({
+      isLoading,
+    })
   }
 
   render() {
@@ -103,7 +124,7 @@ class AuctionResultsContainer extends Component<AuctionResultsProps> {
                     auctionResult={state.selectedAuction}
                   />
 
-                  <LoadingArea isLoading>
+                  <LoadingArea isLoading={this.state.isLoading}>
                     {this.props.artist.auctionResults.edges.map(
                       ({ node }, index) => {
                         return (

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -7,6 +7,7 @@ import { PaginationFragmentContainer as Pagination } from "Styleguide/Components
 import { Flex } from "Styleguide/Elements/Flex"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Subscribe } from "unstated"
+import { LoadingArea } from "../../../../Components/LoadingArea"
 
 interface Props {
   filtered_artworks: ArtworkFilterArtworkGrid_filtered_artworks
@@ -55,7 +56,7 @@ class Artworks extends Component<Props> {
       <Subscribe to={[FilterState]}>
         {filters => {
           return (
-            <div>
+            <LoadingArea isLoading>
               <ArtworkGrid
                 artworks={this.props.filtered_artworks.artworks as any}
                 columnCount={this.props.columnCount}
@@ -74,7 +75,7 @@ class Artworks extends Component<Props> {
                   scrollTo="#jump--artistArtworkGrid"
                 />
               </Flex>
-            </div>
+            </LoadingArea>
           )
         }}
       </Subscribe>

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -7,7 +7,11 @@ import { PaginationFragmentContainer as Pagination } from "Styleguide/Components
 import { Flex } from "Styleguide/Elements/Flex"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Subscribe } from "unstated"
-import { LoadingArea } from "../../../../Components/LoadingArea"
+
+import {
+  LoadingArea,
+  LoadingAreaState,
+} from "Apps/Artist/Components/LoadingArea"
 
 interface Props {
   filtered_artworks: ArtworkFilterArtworkGrid_filtered_artworks
@@ -18,7 +22,11 @@ interface Props {
 
 const PAGE_SIZE = 10
 
-class Artworks extends Component<Props> {
+class Artworks extends Component<Props, LoadingAreaState> {
+  state = {
+    isLoading: false,
+  }
+
   loadNext = () => {
     const {
       filtered_artworks: {
@@ -34,6 +42,8 @@ class Artworks extends Component<Props> {
   }
 
   loadAfter = cursor => {
+    this.toggleLoading(true)
+
     this.props.relay.refetch(
       {
         first: PAGE_SIZE,
@@ -44,6 +54,8 @@ class Artworks extends Component<Props> {
       },
       null,
       error => {
+        this.toggleLoading(false)
+
         if (error) {
           console.error(error)
         }
@@ -51,12 +63,18 @@ class Artworks extends Component<Props> {
     )
   }
 
+  toggleLoading = isLoading => {
+    this.setState({
+      isLoading,
+    })
+  }
+
   render() {
     return (
       <Subscribe to={[FilterState]}>
         {filters => {
           return (
-            <LoadingArea isLoading>
+            <LoadingArea isLoading={this.state.isLoading}>
               <ArtworkGrid
                 artworks={this.props.filtered_artworks.artworks as any}
                 columnCount={this.props.columnCount}

--- a/src/Apps/Artist/Routes/RelatedArtists/RelatedArtistsList.tsx
+++ b/src/Apps/Artist/Routes/RelatedArtists/RelatedArtistsList.tsx
@@ -10,7 +10,11 @@ import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Subscribe } from "unstated"
 import { Responsive } from "Utils/Responsive"
-import { LoadingArea } from "../../Components/LoadingArea"
+
+import {
+  LoadingArea,
+  LoadingAreaState,
+} from "Apps/Artist/Components/LoadingArea"
 
 interface ShowProps {
   relay: RelayRefetchProp
@@ -21,7 +25,11 @@ interface ShowProps {
 
 export const PAGE_SIZE = 6
 
-class RelatedArtistsList extends Component<ShowProps> {
+class RelatedArtistsList extends Component<ShowProps, LoadingAreaState> {
+  state = {
+    isLoading: false,
+  }
+
   loadNext = () => {
     const {
       artist: {
@@ -39,6 +47,8 @@ class RelatedArtistsList extends Component<ShowProps> {
   }
 
   loadAfter = cursor => {
+    this.toggleLoading(true)
+
     this.props.relay.refetch(
       {
         first: PAGE_SIZE,
@@ -50,11 +60,19 @@ class RelatedArtistsList extends Component<ShowProps> {
       },
       null,
       error => {
+        this.toggleLoading(false)
+
         if (error) {
           console.error(error)
         }
       }
     )
+  }
+
+  toggleLoading = isLoading => {
+    this.setState({
+      isLoading,
+    })
   }
 
   renderPagination() {
@@ -94,7 +112,7 @@ class RelatedArtistsList extends Component<ShowProps> {
                   <React.Fragment>
                     <Row>
                       <Col>
-                        <LoadingArea isLoading>
+                        <LoadingArea isLoading={this.state.isLoading}>
                           <Flex flexWrap>
                             {this.props.artist.related.artists.edges.map(
                               ({ node }, index) => {

--- a/src/Apps/Artist/Routes/RelatedArtists/RelatedArtistsList.tsx
+++ b/src/Apps/Artist/Routes/RelatedArtists/RelatedArtistsList.tsx
@@ -10,6 +10,7 @@ import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Subscribe } from "unstated"
 import { Responsive } from "Utils/Responsive"
+import { LoadingArea } from "../../Components/LoadingArea"
 
 interface ShowProps {
   relay: RelayRefetchProp
@@ -93,21 +94,23 @@ class RelatedArtistsList extends Component<ShowProps> {
                   <React.Fragment>
                     <Row>
                       <Col>
-                        <Flex flexWrap>
-                          {this.props.artist.related.artists.edges.map(
-                            ({ node }, index) => {
-                              return (
-                                <Box pr={1} pb={1} width={width} key={index}>
-                                  <ArtistCard
-                                    artist={node as any}
-                                    mediator={mediator}
-                                    currentUser={currentUser}
-                                  />
-                                </Box>
-                              )
-                            }
-                          )}
-                        </Flex>
+                        <LoadingArea isLoading>
+                          <Flex flexWrap>
+                            {this.props.artist.related.artists.edges.map(
+                              ({ node }, index) => {
+                                return (
+                                  <Box pr={1} pb={1} width={width} key={index}>
+                                    <ArtistCard
+                                      artist={node as any}
+                                      mediator={mediator}
+                                      currentUser={currentUser}
+                                    />
+                                  </Box>
+                                )
+                              }
+                            )}
+                          </Flex>
+                        </LoadingArea>
                       </Col>
                     </Row>
 

--- a/src/Apps/Artist/Routes/RelatedArtists/RelatedArtistsList.tsx
+++ b/src/Apps/Artist/Routes/RelatedArtists/RelatedArtistsList.tsx
@@ -1,12 +1,14 @@
 import { RelatedArtistsList_artist } from "__generated__/RelatedArtistsList_artist.graphql"
 import React, { Component } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
-import { ArtistCardFragmentContainer } from "Styleguide/Components/ArtistCard"
-import { PaginationFragmentContainer } from "Styleguide/Components/Pagination"
+import { AppState } from "Router/state"
+import { ArtistCardFragmentContainer as ArtistCard } from "Styleguide/Components/ArtistCard"
+import { PaginationFragmentContainer as Pagination } from "Styleguide/Components/Pagination"
 import { Box } from "Styleguide/Elements/Box"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
+import { Subscribe } from "unstated"
 import { Responsive } from "Utils/Responsive"
 
 interface ShowProps {
@@ -56,69 +58,85 @@ class RelatedArtistsList extends Component<ShowProps> {
 
   renderPagination() {
     return (
-      <div>
-        <PaginationFragmentContainer
+      <Box>
+        <Pagination
           pageCursors={this.props.artist.related.artists.pageCursors as any}
           onClick={this.loadAfter}
           onNext={this.loadNext}
         />
-      </div>
+      </Box>
     )
   }
 
   render() {
     return (
-      <Responsive>
-        {({ xs, sm, md }) => {
-          let width
-          if (xs) {
-            width = "100%"
-          } else if (sm || md) {
-            width = "33%"
-          } else {
-            width = "25%"
-          }
+      <Subscribe to={[AppState]}>
+        {({ state }) => {
+          const {
+            mediator,
+            system: { currentUser },
+          } = state
 
           return (
-            <React.Fragment>
-              <Row>
-                <Col>
-                  <Flex flexWrap>
-                    {this.props.artist.related.artists.edges.map(
-                      ({ node }, index) => {
-                        return (
-                          <Box pr={1} pb={1} width={width} key={index}>
-                            <ArtistCardFragmentContainer artist={node as any} />
-                          </Box>
-                        )
-                      }
-                    )}
-                  </Flex>
-                </Col>
-              </Row>
+            <Responsive>
+              {({ xs, sm, md }) => {
+                let width
+                if (xs) {
+                  width = "100%"
+                } else if (sm || md) {
+                  width = "33%"
+                } else {
+                  width = "25%"
+                }
 
-              <Box py={2}>
-                <Separator />
-              </Box>
+                return (
+                  <React.Fragment>
+                    <Row>
+                      <Col>
+                        <Flex flexWrap>
+                          {this.props.artist.related.artists.edges.map(
+                            ({ node }, index) => {
+                              return (
+                                <Box pr={1} pb={1} width={width} key={index}>
+                                  <ArtistCard
+                                    artist={node as any}
+                                    mediator={mediator}
+                                    currentUser={currentUser}
+                                  />
+                                </Box>
+                              )
+                            }
+                          )}
+                        </Flex>
+                      </Col>
+                    </Row>
 
-              <Row>
-                <Col>
-                  <Flex justifyContent="flex-end">
-                    <PaginationFragmentContainer
-                      pageCursors={
-                        this.props.artist.related.artists.pageCursors as any
-                      }
-                      onClick={this.loadAfter}
-                      onNext={this.loadNext}
-                      scrollTo={this.props.scrollTo}
-                    />
-                  </Flex>
-                </Col>
-              </Row>
-            </React.Fragment>
+                    <Box py={2}>
+                      <Separator />
+                    </Box>
+
+                    <Row>
+                      <Col>
+                        <Flex justifyContent="flex-end">
+                          <Pagination
+                            pageCursors={
+                              this.props.artist.related.artists
+                                .pageCursors as any
+                            }
+                            onClick={this.loadAfter}
+                            onNext={this.loadNext}
+                            scrollTo={this.props.scrollTo}
+                          />
+                        </Flex>
+                      </Col>
+                    </Row>
+                  </React.Fragment>
+                )
+              }}
+            </Responsive>
           )
         }}
-      </Responsive>
+      </Subscribe>
     )
   }
 }

--- a/src/Apps/Artist/Routes/Shows/ArtistShows.tsx
+++ b/src/Apps/Artist/Routes/Shows/ArtistShows.tsx
@@ -7,9 +7,13 @@ import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Responsive } from "Utils/Responsive"
-import { LoadingArea } from "../../Components/LoadingArea"
 import { ArtistShowBlockItem } from "./ArtistShowBlockItem"
 import { ArtistShowListItem } from "./ArtistShowListItem"
+
+import {
+  LoadingArea,
+  LoadingAreaState,
+} from "Apps/Artist/Components/LoadingArea"
 
 interface ArtistShowsProps {
   relay: RelayRefetchProp
@@ -21,7 +25,11 @@ interface ArtistShowsProps {
 
 export const PAGE_SIZE = 4
 
-class ArtistShows extends Component<ArtistShowsProps> {
+class ArtistShows extends Component<ArtistShowsProps, LoadingAreaState> {
+  state = {
+    isLoading: false,
+  }
+
   loadNext = () => {
     const {
       artist: {
@@ -37,6 +45,8 @@ class ArtistShows extends Component<ArtistShowsProps> {
   }
 
   loadAfter = cursor => {
+    this.toggleLoading(true)
+
     this.props.relay.refetch(
       {
         first: PAGE_SIZE,
@@ -49,11 +59,19 @@ class ArtistShows extends Component<ArtistShowsProps> {
       },
       null,
       error => {
+        this.toggleLoading(false)
+
         if (error) {
           console.error(error)
         }
       }
     )
+  }
+
+  toggleLoading = isLoading => {
+    this.setState({
+      isLoading,
+    })
   }
 
   render() {
@@ -70,7 +88,7 @@ class ArtistShows extends Component<ArtistShowsProps> {
               <Col>
                 <Row>
                   <Col>
-                    <LoadingArea isLoading>
+                    <LoadingArea isLoading={this.state.isLoading}>
                       {this.props.status === "running" ? (
                         <ShowBlocks flexDirection={blockDirection} flexWrap>
                           {this.props.artist.showsConnection.edges.map(

--- a/src/Apps/Artist/Routes/Shows/ArtistShows.tsx
+++ b/src/Apps/Artist/Routes/Shows/ArtistShows.tsx
@@ -7,6 +7,7 @@ import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Separator } from "Styleguide/Elements/Separator"
 import { Responsive } from "Utils/Responsive"
+import { LoadingArea } from "../../Components/LoadingArea"
 import { ArtistShowBlockItem } from "./ArtistShowBlockItem"
 import { ArtistShowListItem } from "./ArtistShowListItem"
 
@@ -69,45 +70,47 @@ class ArtistShows extends Component<ArtistShowsProps> {
               <Col>
                 <Row>
                   <Col>
-                    {this.props.status === "running" ? (
-                      <ShowBlocks flexDirection={blockDirection} flexWrap>
-                        {this.props.artist.showsConnection.edges.map(
-                          ({ node }, edgeKey) => {
-                            return (
-                              <ArtistShowBlockItem
-                                key={edgeKey}
-                                blockWidth={blockWidth}
-                                imageUrl={node.cover_image.cropped.url}
-                                partner={node.partner.name}
-                                name={node.name}
-                                exhibitionInfo={node.exhibition_period}
-                                pr={pr}
-                                pb={pb}
-                                href={node.href}
-                                city={node.city}
-                              />
-                            )
-                          }
-                        )}
-                      </ShowBlocks>
-                    ) : (
-                      <ShowList>
-                        {this.props.artist.showsConnection.edges.map(
-                          ({ node }, edgeKey) => {
-                            return (
-                              <ArtistShowListItem
-                                key={edgeKey}
-                                city={node.city}
-                                partner={node.partner.name}
-                                name={node.name}
-                                exhibitionInfo={node.exhibition_period}
-                                href={node.href}
-                              />
-                            )
-                          }
-                        )}
-                      </ShowList>
-                    )}
+                    <LoadingArea isLoading>
+                      {this.props.status === "running" ? (
+                        <ShowBlocks flexDirection={blockDirection} flexWrap>
+                          {this.props.artist.showsConnection.edges.map(
+                            ({ node }, edgeKey) => {
+                              return (
+                                <ArtistShowBlockItem
+                                  key={edgeKey}
+                                  blockWidth={blockWidth}
+                                  imageUrl={node.cover_image.cropped.url}
+                                  partner={node.partner.name}
+                                  name={node.name}
+                                  exhibitionInfo={node.exhibition_period}
+                                  pr={pr}
+                                  pb={pb}
+                                  href={node.href}
+                                  city={node.city}
+                                />
+                              )
+                            }
+                          )}
+                        </ShowBlocks>
+                      ) : (
+                        <ShowList>
+                          {this.props.artist.showsConnection.edges.map(
+                            ({ node }, edgeKey) => {
+                              return (
+                                <ArtistShowListItem
+                                  key={edgeKey}
+                                  city={node.city}
+                                  partner={node.partner.name}
+                                  name={node.name}
+                                  exhibitionInfo={node.exhibition_period}
+                                  href={node.href}
+                                />
+                              )
+                            }
+                          )}
+                        </ShowList>
+                      )}
+                    </LoadingArea>
                   </Col>
                 </Row>
 

--- a/src/Apps/Artist/__static__/RelatedArtistsStaticLayout.tsx
+++ b/src/Apps/Artist/__static__/RelatedArtistsStaticLayout.tsx
@@ -32,6 +32,7 @@ export const RelatedArtists = () => {
                     return (
                       <Box p={1} width={width}>
                         <ArtistCard
+                          currentUser={null}
                           artist={{
                             id: "percy",
                             image: {

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -17,7 +17,7 @@ storiesOf("Apps", module)
     return (
       <StorybooksRouter
         routes={artistRoutes}
-        initialRoute="/artist2/andy-warhol/related-artists"
+        initialRoute="/artist2/andy-warhol"
         initialState={{
           mediator: {
             trigger: x => x,

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -17,9 +17,11 @@ storiesOf("Apps", module)
     return (
       <StorybooksRouter
         routes={artistRoutes}
-        initialRoute="/artist2/andy-warhol/auction-results"
+        initialRoute="/artist2/andy-warhol/related-artists"
         initialState={{
-          mediator: x => x,
+          mediator: {
+            trigger: x => x,
+          },
         }}
       />
     )

--- a/src/Components/FollowButton/Button.tsx
+++ b/src/Components/FollowButton/Button.tsx
@@ -1,11 +1,12 @@
-import Colors from "Assets/Colors"
-import { unica } from "Assets/Fonts"
 import React from "react"
-import styled, { StyledFunction } from "styled-components"
+import { Button } from "Styleguide/Elements"
+import { ButtonProps } from "Styleguide/Elements/Button"
+import { Responsive } from "Utils/Responsive"
 
 interface Props {
   handleFollow?: any
   isFollowed?: boolean
+  buttonProps?: Partial<ButtonProps>
 }
 
 interface State {
@@ -15,6 +16,7 @@ interface State {
 export class FollowButton extends React.Component<Props, State> {
   static defaultProps = {
     isFollowed: false,
+    buttonProps: {},
   }
 
   state = {
@@ -23,7 +25,7 @@ export class FollowButton extends React.Component<Props, State> {
 
   render() {
     const { showUnfollow } = this.state
-    const { handleFollow, isFollowed } = this.props
+    const { buttonProps, handleFollow, isFollowed } = this.props
 
     const text = isFollowed
       ? showUnfollow
@@ -31,42 +33,27 @@ export class FollowButton extends React.Component<Props, State> {
         : "Following"
       : "Follow"
 
+    const props = {
+      ...buttonProps,
+      onClick: handleFollow,
+      onMouseEnter: () => this.setState({ showUnfollow: true }),
+      onMouseLeave: () => this.setState({ showUnfollow: false }),
+    }
+
     return (
-      <FollowButtonContainer
-        isFollowed={isFollowed}
-        onClick={handleFollow}
-        onMouseEnter={() => this.setState({ showUnfollow: true })}
-        onMouseLeave={() => this.setState({ showUnfollow: false })}
-      >
-        {text}
-      </FollowButtonContainer>
+      <Responsive>
+        {({ xs }) => {
+          if (xs) {
+            return (
+              <Button width="100%" {...props}>
+                {text}
+              </Button>
+            )
+          } else {
+            return <Button {...props}>{text}</Button>
+          }
+        }}
+      </Responsive>
     )
   }
 }
-
-interface DivProps {
-  isFollowed: boolean
-}
-
-const Div: StyledFunction<DivProps & React.HTMLProps<HTMLDivElement>> =
-  styled.div
-
-const FollowButtonContainer = Div`
-  border: 1px solid ${Colors.grayRegular};
-  ${unica("s12", "medium")};
-  width: 80px;
-  height: 24px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: ${props => (props.isFollowed ? Colors.grayMedium : "black")}
-  cursor: pointer;
-  &:hover {
-    ${props =>
-      !props.isFollowed &&
-      `
-      border-color: black;`}
-    background: ${props => (props.isFollowed ? "white" : "black")}
-    color: ${props => (props.isFollowed ? Colors.redMedium : "white")}
-  }
-`

--- a/src/Components/FollowButton/Button.tsx
+++ b/src/Components/FollowButton/Button.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { Button } from "Styleguide/Elements"
 import { ButtonProps } from "Styleguide/Elements/Button"
-import { Responsive } from "Utils/Responsive"
 
 interface Props {
   handleFollow?: any
@@ -40,20 +39,6 @@ export class FollowButton extends React.Component<Props, State> {
       onMouseLeave: () => this.setState({ showUnfollow: false }),
     }
 
-    return (
-      <Responsive>
-        {({ xs }) => {
-          if (xs) {
-            return (
-              <Button width="100%" {...props}>
-                {text}
-              </Button>
-            )
-          } else {
-            return <Button {...props}>{text}</Button>
-          }
-        }}
-      </Responsive>
-    )
+    return <Button {...props}>{text}</Button>
   }
 }

--- a/src/Components/FollowButton/ButtonDeprecated.tsx
+++ b/src/Components/FollowButton/ButtonDeprecated.tsx
@@ -1,0 +1,73 @@
+import Colors from "Assets/Colors"
+import { unica } from "Assets/Fonts"
+import React from "react"
+import styled, { StyledFunction } from "styled-components"
+
+interface Props {
+  handleFollow?: any
+  isFollowed?: boolean
+  buttonProps?: object
+}
+
+interface State {
+  showUnfollow: boolean
+}
+
+export class FollowButtonDeprecated extends React.Component<Props, State> {
+  static defaultProps = {
+    isFollowed: false,
+  }
+
+  state = {
+    showUnfollow: false,
+  }
+
+  render() {
+    const { showUnfollow } = this.state
+    const { handleFollow, isFollowed } = this.props
+
+    const text = isFollowed
+      ? showUnfollow
+        ? "Unfollow"
+        : "Following"
+      : "Follow"
+
+    return (
+      <FollowButtonContainer
+        isFollowed={isFollowed}
+        onClick={handleFollow}
+        onMouseEnter={() => this.setState({ showUnfollow: true })}
+        onMouseLeave={() => this.setState({ showUnfollow: false })}
+      >
+        {text}
+      </FollowButtonContainer>
+    )
+  }
+}
+
+interface DivProps {
+  isFollowed: boolean
+}
+
+const Div: StyledFunction<DivProps & React.HTMLProps<HTMLDivElement>> =
+  styled.div
+
+const FollowButtonContainer = Div`
+  border: 1px solid ${Colors.grayRegular};
+  ${unica("s12", "medium")};
+  width: 80px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${props => (props.isFollowed ? Colors.grayMedium : "black")}
+  cursor: pointer;
+  &:hover {
+    ${props =>
+      !props.isFollowed &&
+      `
+      border-color: black;`}
+    background: ${props => (props.isFollowed ? "white" : "black")}
+    color: ${props => (props.isFollowed ? Colors.redMedium : "white")}
+  }
+`

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -1,16 +1,19 @@
 import { extend } from "lodash"
 import React from "react"
+import { FollowArtistButton_artist } from "../../__generated__/FollowArtistButton_artist.graphql"
+import { track } from "../../Utils/track"
+import * as Artsy from "../Artsy"
+import { FollowButton } from "./Button"
+import { FollowButtonDeprecated } from "./ButtonDeprecated"
+import { FollowTrackingData } from "./Typings"
+
 import {
   commitMutation,
   createFragmentContainer,
   graphql,
   RelayProp,
 } from "react-relay"
-import { FollowArtistButton_artist } from "../../__generated__/FollowArtistButton_artist.graphql"
-import { track } from "../../Utils/track"
-import * as Artsy from "../Artsy"
-import { FollowButton } from "./Button"
-import { FollowTrackingData } from "./Typings"
+import { ButtonProps } from "Styleguide/Elements/Button"
 
 interface Props
   extends React.HTMLProps<FollowArtistButton>,
@@ -20,9 +23,25 @@ interface Props
   tracking?: any
   trackingData?: FollowTrackingData
   onOpenAuthModal?: (type: "register" | "login", config?: Object) => void
+
+  /**
+   * FIXME: Default is true due to legacy code. If false, use new @artsy/palette
+   * design system <Button /> style.
+   */
+  useDeprecatedButtonStyle?: boolean
+  /**
+   * FIXME: If useDeprecatedButtonStyle is false pass <Button> style props along
+   * to new design-system buttons.
+   */
+  buttonProps?: Partial<ButtonProps>
 }
 
 export class FollowArtistButton extends React.Component<Props> {
+  static defaultProps = {
+    useDeprecatedButtonStyle: true,
+    buttonProps: {},
+  }
+
   trackFollow = () => {
     const {
       tracking,
@@ -36,7 +55,8 @@ export class FollowArtistButton extends React.Component<Props> {
 
   handleFollow = () => {
     const { artist, currentUser, relay, onOpenAuthModal } = this.props
-    if (relay && currentUser && currentUser.id) {
+
+    if (currentUser && currentUser.id) {
       commitMutation(relay.environment, {
         mutation: graphql`
           mutation FollowArtistButtonMutation($input: FollowArtistInput!) {
@@ -74,12 +94,18 @@ export class FollowArtistButton extends React.Component<Props> {
   }
 
   render() {
-    const { artist } = this.props
+    const { artist, useDeprecatedButtonStyle, buttonProps } = this.props
+
+    // FIXME: Unify design language
+    const Button = useDeprecatedButtonStyle
+      ? FollowButtonDeprecated
+      : FollowButton
 
     return (
-      <FollowButton
+      <Button
         isFollowed={artist && artist.is_followed}
         handleFollow={this.handleFollow}
+        buttonProps={buttonProps}
       />
     )
   }

--- a/src/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/Components/FollowButton/FollowGeneButton.tsx
@@ -9,7 +9,7 @@ import {
 import { FollowGeneButton_gene } from "../../__generated__/FollowGeneButton_gene.graphql"
 import { track } from "../../Utils/track"
 import * as Artsy from "../Artsy"
-import { FollowButton } from "./Button"
+import { FollowButtonDeprecated } from "./ButtonDeprecated"
 import { FollowTrackingData } from "./Typings"
 
 interface Props extends React.HTMLProps<FollowGeneButton>, Artsy.ContextProps {
@@ -75,7 +75,7 @@ export class FollowGeneButton extends React.Component<Props> {
     const { gene } = this.props
 
     return (
-      <FollowButton
+      <FollowButtonDeprecated
         isFollowed={gene && gene.is_followed}
         handleFollow={this.handleFollow}
       />

--- a/src/Components/FollowButton/__tests__/Button.test.tsx
+++ b/src/Components/FollowButton/__tests__/Button.test.tsx
@@ -1,12 +1,12 @@
 import { mount } from "enzyme"
 import "jest-styled-components"
-import renderer from "react-test-renderer"
 import React from "react"
-import { FollowButton } from "../Button"
+import renderer from "react-test-renderer"
+import { FollowButtonDeprecated } from "../ButtonDeprecated"
 
 describe("FollowButton", () => {
   const getWrapper = props => {
-    return mount(<FollowButton {...props} />)
+    return mount(<FollowButtonDeprecated {...props} />)
   }
 
   let props = {
@@ -16,7 +16,9 @@ describe("FollowButton", () => {
 
   describe("snapshots", () => {
     it("Renders FollowButton properly", () => {
-      const component = renderer.create(<FollowButton {...props} />).toJSON()
+      const component = renderer
+        .create(<FollowButtonDeprecated {...props} />)
+        .toJSON()
       expect(component).toMatchSnapshot()
     })
   })

--- a/src/Components/FollowButton/__tests__/FollowArtistButton.test.tsx
+++ b/src/Components/FollowButton/__tests__/FollowArtistButton.test.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { commitMutation } from "react-relay"
 import renderer from "react-test-renderer"
 import { ContextProvider } from "../../Artsy"
-import { FollowButton } from "../Button"
+import { FollowButtonDeprecated } from "../ButtonDeprecated"
 import FollowArtistButton from "../FollowArtistButton"
 
 jest.mock("react-relay", () => ({
@@ -58,7 +58,7 @@ describe("FollowArtistButton", () => {
   describe("unit", () => {
     it("Calls #onOpenAuthModal if no current user", () => {
       const component = getWrapper(props)
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
       const args = props.onOpenAuthModal.mock.calls[0]
 
       expect(args[0]).toBe("register")
@@ -69,7 +69,7 @@ describe("FollowArtistButton", () => {
 
     it("Follows an artist if current user", () => {
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
       const mutation = commitMutation.mock.calls[0][1].variables.input
 
       expect(mutation.artist_id).toBe("damon-zucconi")
@@ -79,7 +79,7 @@ describe("FollowArtistButton", () => {
     it("Unfollows an artist if current user", () => {
       props.artist.is_followed = true
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
       const mutation = commitMutation.mock.calls[1][1].variables.input
 
       expect(mutation.artist_id).toBe("damon-zucconi")
@@ -88,7 +88,7 @@ describe("FollowArtistButton", () => {
 
     it("Tracks follow click when following", () => {
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
 
       expect(props.tracking.trackEvent.mock.calls[0][0].action).toBe(
         "Followed Artist"
@@ -98,7 +98,7 @@ describe("FollowArtistButton", () => {
     it("Tracks unfollow click when unfollowing", () => {
       props.artist.is_followed = true
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
 
       expect(props.tracking.trackEvent.mock.calls[0][0].action).toBe(
         "Unfollowed Artist"
@@ -110,7 +110,7 @@ describe("FollowArtistButton", () => {
         context_module: "tooltip",
       }
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
 
       expect(props.tracking.trackEvent.mock.calls[0][0].context_module).toBe(
         "tooltip"

--- a/src/Components/FollowButton/__tests__/FollowGeneButton.test.tsx
+++ b/src/Components/FollowButton/__tests__/FollowGeneButton.test.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { commitMutation } from "react-relay"
 import renderer from "react-test-renderer"
 import { ContextProvider } from "../../Artsy"
-import { FollowButton } from "../Button"
+import { FollowButtonDeprecated } from "../ButtonDeprecated"
 import FollowGeneButton from "../FollowGeneButton"
 
 jest.mock("react-relay", () => ({
@@ -58,7 +58,7 @@ describe("FollowGeneButton", () => {
   describe("unit", () => {
     it("Calls #onOpenAuthModal if no current user", () => {
       const component = getWrapper(props)
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
       const args = props.onOpenAuthModal.mock.calls[0]
 
       expect(args[0]).toBe("register")
@@ -69,7 +69,7 @@ describe("FollowGeneButton", () => {
 
     it("Follows an gene if current user", () => {
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
       const mutation = commitMutation.mock.calls[0][1].variables.input
 
       expect(mutation.gene_id).toBe("modernism")
@@ -78,7 +78,7 @@ describe("FollowGeneButton", () => {
     it("Unfollows an gene if current user", () => {
       props.gene.is_followed = true
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
       const mutation = commitMutation.mock.calls[1][1].variables.input
 
       expect(mutation.gene_id).toBe("modernism")
@@ -86,7 +86,7 @@ describe("FollowGeneButton", () => {
 
     it("Tracks follow click when following", () => {
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
 
       expect(props.tracking.trackEvent.mock.calls[0][0].action).toBe(
         "Followed Gene"
@@ -96,7 +96,7 @@ describe("FollowGeneButton", () => {
     it("Tracks unfollow click when unfollowing", () => {
       props.gene.is_followed = true
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
 
       expect(props.tracking.trackEvent.mock.calls[0][0].action).toBe(
         "Unfollowed Gene"
@@ -108,7 +108,7 @@ describe("FollowGeneButton", () => {
         context_module: "tooltip",
       }
       const component = getWrapper(props, { id: "1234" })
-      component.find(FollowButton).simulate("click")
+      component.find(FollowButtonDeprecated).simulate("click")
 
       expect(props.tracking.trackEvent.mock.calls[0][0].context_module).toBe(
         "tooltip"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1681,11 +1681,11 @@ exports[`renders a sponsored series properly 1`] = `
   margin-bottom: 30px;
 }
 
-.dszFxs .c14 {
+.fuwlBz .c14 {
   margin-bottom: 90px;
 }
 
-.dszFxs .c40 {
+.fuwlBz .c40 {
   padding-top: 60px;
 }
 
@@ -1946,7 +1946,7 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media (max-width:900px) {
-  .dszFxs .c40 {
+  .fuwlBz .c40 {
     padding-top: 60px;
   }
 }

--- a/src/Router/PreloadLink.tsx
+++ b/src/Router/PreloadLink.tsx
@@ -206,11 +206,11 @@ export const PreloadLink = compose(
 
     handleClick = event => {
       event.preventDefault()
-      this.props.onToggleFetching(true)
+      this.props.onToggleLoading(true)
 
       this.fetchData().then(() => {
         const { router, replace, to } = this.props
-        this.props.onToggleFetching(false)
+        this.props.onToggleLoading(false)
 
         if (replace) {
           router.replace(replace)
@@ -244,7 +244,7 @@ export const PreloadLink = compose(
       {(app: AppState, preloadLink: PreloadLinkState) => {
         return (
           <Preloader
-            onToggleFetching={preloadLink.toggleFetching}
+            onToggleLoading={preloadLink.toggleLoading}
             system={app.state.system}
             {...preloadLinkProps}
           />

--- a/src/Router/buildClientApp.tsx
+++ b/src/Router/buildClientApp.tsx
@@ -23,13 +23,14 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
       } = config
 
       const relayBootstrap = JSON.parse(window.__RELAY_BOOTSTRAP__ || "{}")
+
       const currentUser = user || {
         id: process.env.USER_ID,
         accessToken: process.env.USER_ACCESS_TOKEN,
       }
+
       const relayEnvironment = createEnvironment({
         cache: relayBootstrap,
-        // FIXME: Might be a better way to do this...
         user: currentUser,
       })
 

--- a/src/Router/state.tsx
+++ b/src/Router/state.tsx
@@ -42,12 +42,12 @@ export class AppState extends Container<AppStateContainer> {
 
 export class PreloadLinkState extends Container<PreloadLinkContainer> {
   state = {
-    isFetching: false,
+    isLoading: false,
   }
 
-  toggleFetching = isFetching => {
+  toggleLoading = isLoading => {
     this.setState({
-      isFetching,
+      isLoading,
     })
   }
 }

--- a/src/Router/types.ts
+++ b/src/Router/types.ts
@@ -56,12 +56,12 @@ export interface PreloadLinkProps extends ContextProps, AppStateContainer {
   immediate?: boolean
   name?: string
   onClick?: () => void
-  onToggleFetching?: (isLoading: boolean) => void
+  onToggleLoading?: (isLoading: boolean) => void
   replace?: string
   router?: any // TODO, from found
   to?: string
 }
 
 export interface PreloadLinkContainer {
-  isFetching: boolean
+  isLoading: boolean
 }

--- a/src/Styleguide/Components/ArtistCard.tsx
+++ b/src/Styleguide/Components/ArtistCard.tsx
@@ -12,6 +12,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 
 interface Props {
   artist: ArtistCard_artist
+  currentUser: User
   mediator?: {
     trigger: (action: string, config: object) => void
   }
@@ -46,6 +47,13 @@ export const LargeArtistCard = (props: Props) => (
 
     <Flex flexDirection="column" alignItems="center">
       <FollowArtistButton
+        artist={props.artist as any}
+        currentUser={props.currentUser}
+        useDeprecatedButtonStyle={false}
+        buttonProps={{
+          variant: "secondaryOutline",
+          size: "small",
+        }}
         onOpenAuthModal={() => {
           props.mediator.trigger("open:auth", {
             mode: "signup",
@@ -58,7 +66,6 @@ export const LargeArtistCard = (props: Props) => (
             },
           })
         }}
-        artist={props.artist as any}
       >
         Follow
       </FollowArtistButton>
@@ -71,7 +78,15 @@ export const SmallArtistCard = (props: Props) => (
     <Flex flexDirection="column" justifyContent="center">
       <Serif size="3t">{props.artist.name}</Serif>
       <Sans size="1">{props.artist.formatted_nationality_and_birthday}</Sans>
+      <Spacer mb={1} />
       <FollowArtistButton
+        artist={props.artist as any}
+        currentUser={props.currentUser}
+        useDeprecatedButtonStyle={false}
+        buttonProps={{
+          variant: "secondaryOutline",
+          size: "small",
+        }}
         onOpenAuthModal={() => {
           props.mediator.trigger("open:auth", {
             mode: "signup",
@@ -84,7 +99,6 @@ export const SmallArtistCard = (props: Props) => (
             },
           })
         }}
-        artist={props.artist as any}
       >
         Follow
       </FollowArtistButton>

--- a/src/Styleguide/Components/__stories__/ArtistCard.story.tsx
+++ b/src/Styleguide/Components/__stories__/ArtistCard.story.tsx
@@ -19,16 +19,21 @@ const artist = {
 storiesOf("Styleguide/Components", module)
   .addDecorator(story => <RelayStubProvider>{story()}</RelayStubProvider>)
   .add("ArtistCard", () => {
+    const props = {
+      artist,
+      currentUser: null,
+    }
+
     return (
       <React.Fragment>
         <Section title="Responsive Artist Card">
-          <ArtistCard artist={artist} />
+          <ArtistCard {...props} />
         </Section>
         <Section title="Large Artist Card">
-          <LargeArtistCard artist={artist} />
+          <LargeArtistCard {...props} />
         </Section>
         <Section title="Small Artist Card">
-          <SmallArtistCard artist={artist} />
+          <SmallArtistCard {...props} />
         </Section>
       </React.Fragment>
     )

--- a/src/Utils/Responsive.tsx
+++ b/src/Utils/Responsive.tsx
@@ -154,7 +154,10 @@ export class ResponsiveProvider extends React.Component<
   }
 }
 
-export const Responsive: React.ComponentType<
+export type ResponsiveProps = React.ComponentType<
   React.ConsumerProps<BreakpointState>
-> =
-  ResponsiveContext.Consumer
+> & {
+  children?: any
+}
+
+export const Responsive: ResponsiveProps = ResponsiveContext.Consumer


### PR DESCRIPTION
**Branched from https://github.com/artsy/reaction/pull/938**

Abstracts our `<LoadingArea>` component so that it can be used wherever we need a loader to show during a fetch. 

![transition-time-3](https://user-images.githubusercontent.com/236943/42140392-a2956a3e-7d53-11e8-8a97-33207394d0ea.gif)
