### PR TITLE
@zephraph  => Get artwork filter in a semi working state again

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -1,12 +1,10 @@
 import { ArtworkFilterArtworkGrid_filtered_artworks } from "__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql"
-import { FilterState } from "Apps/Artist/Routes/Overview/state"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React, { Component } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { PaginationFragmentContainer as Pagination } from "Styleguide/Components/Pagination"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Spacer } from "Styleguide/Elements/Spacer"
-import { Subscribe } from "unstated"
 
 import {
   LoadingArea,
@@ -71,32 +69,26 @@ class Artworks extends Component<Props, LoadingAreaState> {
 
   render() {
     return (
-      <Subscribe to={[FilterState]}>
-        {filters => {
-          return (
-            <LoadingArea isLoading={this.state.isLoading}>
-              <ArtworkGrid
-                artworks={this.props.filtered_artworks.artworks as any}
-                columnCount={this.props.columnCount}
-                itemMargin={40}
-              />
+      <LoadingArea isLoading={this.state.isLoading}>
+        <ArtworkGrid
+          artworks={this.props.filtered_artworks.artworks as any}
+          columnCount={this.props.columnCount}
+          itemMargin={40}
+        />
 
-              <Spacer mb={4} />
+        <Spacer mb={4} />
 
-              <Flex justifyContent="flex-end">
-                <Pagination
-                  pageCursors={
-                    this.props.filtered_artworks.artworks.pageCursors as any
-                  }
-                  onClick={this.loadAfter}
-                  onNext={this.loadNext}
-                  scrollTo="#jump--artistArtworkGrid"
-                />
-              </Flex>
-            </LoadingArea>
-          )
-        }}
-      </Subscribe>
+        <Flex justifyContent="flex-end">
+          <Pagination
+            pageCursors={
+              this.props.filtered_artworks.artworks.pageCursors as any
+            }
+            onClick={this.loadAfter}
+            onNext={this.loadNext}
+            scrollTo="#jump--artistArtworkGrid"
+          />
+        </Flex>
+      </LoadingArea>
     )
   }
 }

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -1,6 +1,6 @@
 import { Sans } from "@artsy/palette"
 import { Overview_artist } from "__generated__/Overview_artist.graphql"
-import { ArtworkFilterFragmentContainer as ArtworkFilter } from "Apps/Artist/Routes/Overview/Components/ArtworkFilter"
+import { ArtworkFilterRefetchContainer as ArtworkFilter } from "Apps/Artist/Routes/Overview/Components/ArtworkFilter"
 import { GenesFragmentContainer as Genes } from "Apps/Artist/Routes/Overview/Components/Genes"
 import React, { SFC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"

--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -13,6 +13,8 @@ export class FilterState extends Container<State> {
     medium: "*",
     for_sale: null,
     page: 1,
+    major_periods: [],
+    partner_id: null,
   }
 
   setMajorPeriods(value) {
@@ -27,8 +29,23 @@ export class FilterState extends Container<State> {
     this.setState({ page })
   }
 
+  unsetFilter(filter) {
+    if (filter === "major_periods") {
+      return this.setState({ page: 1, major_periods: [] })
+    }
+    if (filter === "partner_id") {
+      return this.setState({ page: 1, partner_id: null })
+    }
+    if (filter === "for_sale") {
+      return this.setState({ page: 1, for_sale: null })
+    }
+    if (filter === "medium") {
+      return this.setState({ page: 1, medium: "*" })
+    }
+  }
+
   setFilter(filter, value) {
-    if (filter === "major_period") {
+    if (filter === "major_periods") {
       return this.setMajorPeriods(value)
     }
     if (filter === "gallery" || filter === "institution") {

--- a/src/__generated__/ArtworkFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkFilterRefetchQuery.graphql.ts
@@ -1,0 +1,825 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type ArtworkFilterRefetchQueryVariables = {
+    readonly artistID: string;
+    readonly medium?: string | null;
+    readonly major_periods?: ReadonlyArray<string | null> | null;
+    readonly partner_id?: string | null;
+    readonly for_sale?: boolean | null;
+};
+export type ArtworkFilterRefetchQueryResponse = {
+    readonly artist: ({}) | null;
+};
+
+
+
+/*
+query ArtworkFilterRefetchQuery(
+  $artistID: String!
+  $medium: String
+  $major_periods: [String]
+  $partner_id: ID
+  $for_sale: Boolean
+) {
+  artist(id: $artistID) {
+    ...ArtworkFilter_artist_81Ela
+    __id
+  }
+}
+
+fragment ArtworkFilter_artist_81Ela on Artist {
+  id
+  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0) {
+    aggregations {
+      slice
+      counts {
+        name
+        count
+        id
+        __id
+      }
+    }
+    ...ArtworkFilterArtworkGrid_filtered_artworks
+    __id
+  }
+  __id
+}
+
+fragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {
+  __id
+  artworks: artworks_connection(first: 10, after: "") {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    ...ArtworkGrid_artworks
+    edges {
+      node {
+        __id
+      }
+    }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnection {
+  edges {
+    node {
+      __id
+      image {
+        aspect_ratio
+      }
+      ...GridItem_artwork
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  __id
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  __id
+}
+
+fragment Save_artwork on Artwork {
+  __id
+  id
+  is_saved
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message
+  cultural_maker
+  artists(shallow: true) {
+    __id
+    href
+    name
+  }
+  collecting_institution
+  partner(shallow: true) {
+    name
+    href
+    __id
+  }
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  __id
+}
+
+fragment Contact_artwork on Artwork {
+  _id
+  href
+  is_inquireable
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  partner(shallow: true) {
+    type
+    __id
+  }
+  sale_artwork {
+    highest_bid {
+      display
+      __id: id
+    }
+    opening_bid {
+      display
+    }
+    counts {
+      bidder_positions
+    }
+    __id
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "medium",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "major_periods",
+    "type": "[String]",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "partner_id",
+    "type": "ID",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "for_sale",
+    "type": "Boolean",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v6 = [
+  v5,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "page",
+    "args": null,
+    "storageKey": null
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "isCurrent",
+    "args": null,
+    "storageKey": null
+  }
+],
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v8 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "display",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "ArtworkFilterRefetchQuery",
+  "id": null,
+  "text": "query ArtworkFilterRefetchQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtworkFilter_artist_81Ela\n    __id\n  }\n}\n\nfragment ArtworkFilter_artist_81Ela on Artist {\n  id\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        count\n        id\n        __id\n      }\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n  __id\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtworkFilterRefetchQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtworkFilter_artist",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "for_sale",
+                "variableName": "for_sale",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "major_periods",
+                "variableName": "major_periods",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "medium",
+                "variableName": "medium",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "partner_id",
+                "variableName": "partner_id",
+                "type": null
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtworkFilterRefetchQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          v3,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "filtered_artworks",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "aggregations",
+                "value": [
+                  "MEDIUM",
+                  "TOTAL",
+                  "GALLERY",
+                  "INSTITUTION",
+                  "MAJOR_PERIOD"
+                ],
+                "type": "[ArtworkAggregation]"
+              },
+              {
+                "kind": "Variable",
+                "name": "for_sale",
+                "variableName": "for_sale",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "major_periods",
+                "variableName": "major_periods",
+                "type": "[String]"
+              },
+              {
+                "kind": "Variable",
+                "name": "medium",
+                "variableName": "medium",
+                "type": "String"
+              },
+              {
+                "kind": "Variable",
+                "name": "partner_id",
+                "variableName": "partner_id",
+                "type": "ID"
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 0,
+                "type": "Int"
+              }
+            ],
+            "concreteType": "FilterArtworks",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      v4,
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v3,
+                      v2
+                    ]
+                  }
+                ]
+              },
+              v2,
+              {
+                "kind": "LinkedField",
+                "alias": "artworks",
+                "name": "artworks_connection",
+                "storageKey": "artworks_connection(after:\"\",first:10)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "after",
+                    "value": "",
+                    "type": "String"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 10,
+                    "type": "Int"
+                  }
+                ],
+                "concreteType": "ArtworkConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "pageInfo",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "hasNextPage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "endCursor",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "pageCursors",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursors",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "around",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "PageCursor",
+                        "plural": true,
+                        "selections": v6
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "first",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "PageCursor",
+                        "plural": false,
+                        "selections": v6
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "last",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "PageCursor",
+                        "plural": false,
+                        "selections": v6
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "previous",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "PageCursor",
+                        "plural": false,
+                        "selections": [
+                          v5
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtworkEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "collecting_institution",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          v2,
+                          v7,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "title",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "date",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "sale_message",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "cultural_maker",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "artists",
+                            "storageKey": "artists(shallow:true)",
+                            "args": v8,
+                            "concreteType": "Artist",
+                            "plural": true,
+                            "selections": [
+                              v2,
+                              v7,
+                              v4
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "partner",
+                            "storageKey": "partner(shallow:true)",
+                            "args": v8,
+                            "concreteType": "Partner",
+                            "plural": false,
+                            "selections": [
+                              v4,
+                              v7,
+                              v2,
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "type",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "sale",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Sale",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "is_auction",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "is_live_open",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "is_open",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "is_closed",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              v2
+                            ]
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_inquireable",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "sale_artwork",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "highest_bid",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "SaleArtworkHighestBid",
+                                "plural": false,
+                                "selections": [
+                                  v9,
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": "__id",
+                                    "name": "id",
+                                    "args": null,
+                                    "storageKey": null
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "opening_bid",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "SaleArtworkOpeningBid",
+                                "plural": false,
+                                "selections": [
+                                  v9
+                                ]
+                              },
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "counts",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "SaleArtworkCounts",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "bidder_positions",
+                                    "args": null,
+                                    "storageKey": null
+                                  }
+                                ]
+                              },
+                              v2
+                            ]
+                          },
+                          v3,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_saved",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '9ec5b38327ce1a7fcace464380d16c97';
+export default node;


### PR DESCRIPTION
This gets the artwork filters working again, (the way they were), before we ripped out all the query renderers. So this actually filters.

Main to-dos:
- all of these filters should deselect the other ones (probably will handle this just via state, all of the `setState` triggers should _also_ set the others back to the default)
- no need to refetch the sidebar and re-render it as you filter (this will be tricky, probably will have to refactor sidebar/grid)
- hook up sort
- hook up 'loading area' when selecting a filter

![bp](https://user-images.githubusercontent.com/1457859/42188024-3860ecc4-7e20-11e8-9978-31fad62e01da.gif)
