### PR TITLE
[PATCH authentication] pass GDPR and analytic properties for social auth

### DIFF
--- a/src/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/Components/Authentication/Desktop/ModalManager.tsx
@@ -1,4 +1,5 @@
 import { FormikProps } from "formik"
+import qs from "querystring"
 import React, { Component } from "react"
 
 import { DesktopModal } from "Components/Authentication/Desktop/Components/DesktopModal"
@@ -110,6 +111,28 @@ export class ModalManager extends Component<
       ? this.props.handleSubmit.bind(this, currentType, options)
       : defaultHandleSubmit(submitUrls[currentType], csrf, redirectTo)
 
+    const queryData = Object.assign(
+      {},
+      options,
+      {
+        accepted_terms_of_service: true,
+        agreed_to_receive_emails: true,
+        "signup-referer": options.signupReferer || location.href,
+      },
+      options.redirectTo
+        ? {
+            "redirect-to": options.redirectTo,
+          }
+        : null,
+      options.intent
+        ? {
+            "signup-intent": options.intent,
+          }
+        : null
+    )
+
+    const authQueryData = qs.stringify(queryData)
+
     return (
       <DesktopModal
         blurContainerSelector={blurContainerSelector}
@@ -124,12 +147,10 @@ export class ModalManager extends Component<
           error={error}
           handleSubmit={handleSubmit}
           onFacebookLogin={() =>
-            (window.location.href =
-              submitUrls.facebook + "?redirect-to=" + options.redirectTo)
+            (window.location.href = submitUrls.facebook + `?${authQueryData}`)
           }
           onTwitterLogin={() =>
-            (window.location.href =
-              submitUrls.twitter + "?redirect-to=" + options.redirectTo)
+            (window.location.href = submitUrls.twitter + `?${authQueryData}`)
           }
           options={options}
           handleTypeChange={this.handleTypeChange}


### PR DESCRIPTION
Address the first item in https://artsyproduct.atlassian.net/browse/GROW-737

In this PR we make sure to pass in the GDPR and analytics properties (i.e. signup intent and signup referer) for social auth. 