### PR TITLE
@zephraph => Only allow one selected radio button at a time for artwork filter

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -20,99 +20,15 @@ interface Props {
 }
 
 class Filter extends Component<Props> {
-  renderCurrentlySelected(filter, state) {
-    let selectedFilter = null
-
-    if (
-      (filter === "institution" || filter === "gallery") &&
-      state.partner_id
-    ) {
-      selectedFilter = state.partner_id
-    }
-    if (filter === "major_period" && state.major_periods) {
-      selectedFilter = state.major_periods[0]
-    } else {
-      selectedFilter = state[filter]
-    }
-
-    return selectedFilter
-  }
-
-  renderFilters(filters) {
-    return this.props.artist.filtered_artworks.aggregations.map(
-      (aggregation, index) => {
-        return (
-          <div key={index}>
-            <div>
-              {aggregation.slice} -{" "}
-              {this.renderCurrentlySelected(
-                aggregation.slice.toLowerCase(),
-                filters.state
-              )}
-              {this.renderSection(aggregation, filters)}
-            </div>
-            <br />
-          </div>
-        )
-      }
-    )
-  }
-
-  renderForSale(filters) {
-    return (
-      <div>
-        <div>
-          Currently selected: {filters.state.for_sale ? "Only for sale" : "All"}
-        </div>
-        <div
-          onClick={() => {
-            filters.setFilter("for_sale", true)
-          }}
-        >
-          For sale
-        </div>
-        <div
-          onClick={() => {
-            filters.setFilter("for_sale", null)
-          }}
-        >
-          All
-        </div>
-        <br />
-      </div>
-    )
-  }
-
-  renderSidebar(filters) {
-    return (
-      <div>
-        {this.renderForSale(filters)}
-        {this.renderFilters(filters)}
-      </div>
-    )
-  }
-
-  renderSection(aggregation, filters) {
-    return aggregation.counts.slice(0, 10).map((count, index) => {
-      return (
-        <div
-          key={index}
-          onClick={() => {
-            filters.setFilter(aggregation.slice.toLowerCase(), count.id)
-          }}
-        >
-          <span>{count.name}</span>
-          <span>({count.count})</span>
-        </div>
-      )
-    })
-  }
-
   renderCategory(filters, category, counts) {
+    const currentFilter =
+      category === "major_periods"
+        ? filters.state.major_periods[0]
+        : filters.state[category]
     return counts.slice(0, 10).map((count, index) => {
       return (
         <Radio
-          selected={filters.state[category] === count.id}
+          selected={currentFilter === count.id}
           value={count.id}
           onSelect={selected => {
             if (selected) {
@@ -187,7 +103,7 @@ class Filter extends Component<Props> {
                               <Checkbox
                                 selected={filters.state.for_sale}
                                 onSelect={value => {
-                                  return filters.setFilter("for_sale", !value)
+                                  return filters.setFilter("for_sale", value)
                                 }}
                               >
                                 For sale

--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -20,11 +20,21 @@ export class FilterState extends Container<State> {
   }
 
   setMajorPeriods(value) {
-    this.setState({ major_periods: [value], page: 1 })
+    this.setState({
+      partner_id: null,
+      major_periods: [value],
+      page: 1,
+      medium: "*",
+    })
   }
 
   setPartner(value) {
-    this.setState({ partner_id: value, page: 1 })
+    this.setState({
+      major_periods: [],
+      partner_id: value,
+      medium: "*",
+      page: 1,
+    })
   }
 
   setPage(page) {
@@ -54,9 +64,23 @@ export class FilterState extends Container<State> {
     if (filter === "major_periods") {
       return this.setMajorPeriods(value)
     }
-    if (filter === "gallery" || filter === "institution") {
+    if (filter === "partner_id") {
       return this.setPartner(value)
     }
-    this.setState({ [filter.toLowerCase()]: value, page: 1 })
+    if (filter === "for_sale") {
+      if (value) {
+        this.setState({ page: 1, for_sale: true })
+      } else {
+        this.setState({ page: 1, for_sale: null })
+      }
+    }
+    if (filter === "medium") {
+      this.setState({
+        medium: value,
+        page: 1,
+        partner_id: null,
+        major_periods: [],
+      })
+    }
   }
 }

--- a/src/Styleguide/Elements/Radio.tsx
+++ b/src/Styleguide/Elements/Radio.tsx
@@ -55,6 +55,10 @@ export class Radio extends React.Component<RadioProps, RadioState> {
     }
   }
 
+  componentWillReceiveProps() {
+    this.setState({ selected: this.props.selected })
+  }
+
   render() {
     const { selected } = this.state
     const { children, disabled, hover } = this.props


### PR DESCRIPTION
This allows the radio buttons to be re-rendered properly with correct props. This also fixes some irregularities in filtering, which generally feels better.

However, it's still not perfect- the aggregations/sidebar are being refetched and rerendered, and I'm noticing that when you select a medium/other filter we get 2 duplicate Metaphysics queries being kicked off simultaneously :((