### PR TITLE
@xtina-starr => Deprecate ToolTip artist market data variant

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -28,7 +28,6 @@ export interface ArticleProps {
     canvas: any
   }
   showTooltips?: boolean
-  showToolTipMarketData?: boolean
   slideIndex?: number
   closeViewer?: () => void
   viewerIsOpen?: boolean

--- a/src/Components/Publishing/Layouts/ArticleWithFullScreen.tsx
+++ b/src/Components/Publishing/Layouts/ArticleWithFullScreen.tsx
@@ -42,7 +42,6 @@ export class ArticleWithFullScreen extends React.Component<
     article: {},
     isTruncated: false,
     showTooltips: false,
-    showToolTipMarketData: false,
   }
 
   constructor(props) {

--- a/src/Components/Publishing/Layouts/FeatureLayout.tsx
+++ b/src/Components/Publishing/Layouts/FeatureLayout.tsx
@@ -18,7 +18,6 @@ export interface ArticleProps {
   marginTop?: string
   relatedArticlesForCanvas?: any
   showTooltips?: boolean
-  showToolTipMarketData?: boolean
 }
 
 export class FeatureLayout extends React.Component<ArticleProps> {
@@ -30,7 +29,6 @@ export class FeatureLayout extends React.Component<ArticleProps> {
       isSuper,
       relatedArticlesForCanvas,
       showTooltips,
-      showToolTipMarketData,
     } = this.props
     const { seriesArticle } = article
 
@@ -59,7 +57,6 @@ export class FeatureLayout extends React.Component<ArticleProps> {
             article={article}
             isMobile={isMobile}
             showTooltips={showTooltips}
-            showToolTipMarketData={showToolTipMarketData}
           />
         </FeatureLayoutContent>
 

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -49,7 +49,6 @@ export class StandardLayout extends React.Component<
       relatedArticlesForPanel,
       renderTime,
       showTooltips,
-      showToolTipMarketData,
     } = this.props
     const { isTruncated } = this.state
 
@@ -91,7 +90,6 @@ export class StandardLayout extends React.Component<
                       article={article}
                       isMobile={isMobile}
                       showTooltips={showTooltips}
-                      showToolTipMarketData={showToolTipMarketData}
                     />
                     <Sidebar
                       emailSignupUrl={emailSignupUrl}

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -17,7 +17,6 @@ interface Props {
   article: ArticleData
   isMobile?: boolean
   showTooltips?: boolean
-  showToolTipMarketData?: boolean
 }
 
 interface State {
@@ -142,7 +141,7 @@ export class Sections extends Component<Props, State> {
   }
 
   getSection(section, index) {
-    const { article, showTooltips, showToolTipMarketData } = this.props
+    const { article, showTooltips } = this.props
 
     const sections = {
       image_collection: (
@@ -164,7 +163,6 @@ export class Sections extends Component<Props, State> {
           isContentStart={index === this.getContentStartIndex()}
           isContentEnd={index === this.getContentEndIndex()}
           showTooltips={showTooltips}
-          showToolTipMarketData={showToolTipMarketData}
         />
       ),
       default: false,

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -12,7 +12,6 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
   layout: ArticleLayout
   postscript?: boolean
   showTooltips?: boolean
-  showToolTipMarketData?: boolean
 }
 
 interface State {
@@ -23,7 +22,6 @@ export class Text extends Component<Props, State> {
   static defaultProps = {
     color: "black",
     showToolTip: false,
-    showToolTipMarketData: false,
   }
 
   state = {
@@ -87,15 +85,10 @@ export class Text extends Component<Props, State> {
     if (node.name === "a" && this.shouldShowTooltipForURL(node)) {
       const href = node.attribs.href
       const text = node.children[0] && node.children[0].data
-      const { showToolTipMarketData } = this.props
 
       if (text) {
         return (
-          <LinkWithTooltip
-            key={href + index}
-            url={href}
-            showMarketData={showToolTipMarketData}
-          >
+          <LinkWithTooltip key={href + index} url={href}>
             {text}
           </LinkWithTooltip>
         )

--- a/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
@@ -60,8 +60,8 @@ export class ArtistToolTip extends React.Component<ArtistToolTipProps> {
       onOpenAuthModal,
     } = this.context
     const displayImages = map(carousel.images.slice(0, 2), "resized")
-
     const images = fillwidthDimensions(displayImages, 320, 15, 150)
+    const description = blurb || this.renderArtistGenes()
 
     const trackingData: FollowTrackingData = {
       context_module: "intext tooltip",
@@ -98,7 +98,7 @@ export class ArtistToolTip extends React.Component<ArtistToolTipProps> {
           </Header>
 
           <a href={href} target="_blank" onClick={this.trackClick}>
-            {blurb && <ToolTipDescription text={blurb} />}
+            {description && <ToolTipDescription text={description} />}
           </a>
         </ArtistContainer>
 

--- a/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
@@ -7,16 +7,12 @@ import styled from "styled-components"
 import { ArtistToolTip_artist } from "../../../__generated__/ArtistToolTip_artist.graphql"
 import fillwidthDimensions from "../../../Utils/fillwidth"
 import { track } from "../../../Utils/track"
-import MarketDataSummary, {
-  MarketDataSummaryContainer,
-} from "../../Artist/MarketDataSummary/MarketDataSummary"
 import FollowArtistButton from "../../FollowButton/FollowArtistButton"
 import { FollowTrackingData } from "../../FollowButton/Typings"
 import { ToolTipDescription } from "./Components/Description"
 import { NewFeature } from "./Components/NewFeature"
 
 export interface ArtistToolTipProps {
-  showMarketData?: boolean
   artist: ArtistToolTip_artist
   tracking?: any
 }
@@ -49,7 +45,7 @@ export class ArtistToolTip extends React.Component<ArtistToolTipProps> {
   }
 
   render() {
-    const { showMarketData, artist } = this.props
+    const { artist } = this.props
     const {
       blurb,
       carousel,
@@ -102,14 +98,7 @@ export class ArtistToolTip extends React.Component<ArtistToolTipProps> {
           </Header>
 
           <a href={href} target="_blank" onClick={this.trackClick}>
-            {showMarketData ? (
-              <MarketDataSummary
-                artist={artists[id] as any}
-                onEmptyText={this.renderArtistGenes()}
-              />
-            ) : (
-              blurb && <ToolTipDescription text={blurb} />
-            )}
+            {blurb && <ToolTipDescription text={blurb} />}
           </a>
         </ArtistContainer>
 
@@ -131,10 +120,6 @@ export const ArtistContainer = styled.div`
     &:hover {
       color: black;
     }
-  }
-  ${MarketDataSummaryContainer} {
-    ${unica("s12")};
-    padding-bottom: 10px;
   }
 `
 

--- a/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
+++ b/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
@@ -11,7 +11,6 @@ import { ToolTip } from "./ToolTip"
 
 interface Props {
   url: string
-  showMarketData?: boolean
   tracking?: any
 }
 
@@ -180,7 +179,7 @@ export class LinkWithTooltip extends Component<Props, State> {
   }
 
   render() {
-    const { showMarketData, url } = this.props
+    const { url } = this.props
     const { activeToolTip, waitForFade } = this.context
     const { orientation } = this.state
 
@@ -219,7 +218,6 @@ export class LinkWithTooltip extends Component<Props, State> {
             <ToolTip
               entity={entity}
               model={entityType}
-              showMarketData={showMarketData}
               onMouseLeave={this.hideToolTip}
               onMouseEnter={() => {
                 this.setState({ inToolTip: true })

--- a/src/Components/Publishing/ToolTip/ToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/ToolTip.tsx
@@ -9,7 +9,6 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
   entity: object
   orientation?: string
   model: string
-  showMarketData?: boolean
   onMouseEnter?: any
   onMouseLeave?: any
   positionLeft?: number
@@ -17,16 +16,11 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
 
 export class ToolTip extends React.Component<Props> {
   getToolTip = () => {
-    const { entity, model, showMarketData } = this.props
+    const { entity, model } = this.props
 
     switch (model) {
       case "artist": {
-        return (
-          <ArtistTooltipContainer
-            showMarketData={showMarketData}
-            artist={entity as any}
-          />
-        )
+        return <ArtistTooltipContainer artist={entity as any} />
       }
       case "gene": {
         return <GeneToolTipContainer gene={entity as any} />

--- a/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
+++ b/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
@@ -1,12 +1,12 @@
-import PropTypes from "prop-types"
 import { mount } from "enzyme"
 import "jest-styled-components"
+import PropTypes from "prop-types"
 import React from "react"
-import { wrapperWithContext } from "../../Fixtures/Helpers"
-import { Artists } from "../../Fixtures/Components"
-import { ArtistToolTip, TitleDate } from "../ArtistToolTip"
 import { ContextProvider } from "../../../Artsy"
 import { FollowArtistButton } from "../../../FollowButton/FollowArtistButton"
+import { Artists } from "../../Fixtures/Components"
+import { wrapperWithContext } from "../../Fixtures/Helpers"
+import { ArtistToolTip, TitleDate } from "../ArtistToolTip"
 
 describe("ArtistToolTip", () => {
   const getWrapper = (props, context = {}) => {
@@ -37,7 +37,6 @@ describe("ArtistToolTip", () => {
         trackEvent: jest.fn(),
       },
       artist: Artists[0].artist,
-      showMarketData: false,
     }
   })
 

--- a/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
+++ b/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
@@ -56,6 +56,15 @@ describe("ArtistToolTip", () => {
     expect(component.find("img").length).toBe(2)
   })
 
+  it("Renders genes if no bio present", () => {
+    delete props.artist.blurb
+    const component = getWrapper(props)
+
+    expect(component.text()).toMatch(
+      "United States, Abstract Art, 21st Century"
+    )
+  })
+
   it("Tracks clicks to artist page", () => {
     const component = getWrapper(props)
     component

--- a/src/Components/Publishing/__stories__/ArticleFeature.story.tsx
+++ b/src/Components/Publishing/__stories__/ArticleFeature.story.tsx
@@ -111,25 +111,13 @@ story
       </ContextProvider>
     )
   })
-  .add("With tooltips (bio)", () => {
+  .add("With tooltips", () => {
     return (
       <ContextProvider>
         <Article
           article={FeatureArticle}
           relatedArticlesForCanvas={RelatedCanvas}
           showTooltips
-        />
-      </ContextProvider>
-    )
-  })
-  .add("With tooltips (data)", () => {
-    return (
-      <ContextProvider>
-        <Article
-          article={FeatureArticle}
-          relatedArticlesForCanvas={RelatedCanvas}
-          showTooltips
-          showToolTipMarketData
         />
       </ContextProvider>
     )

--- a/src/Components/Publishing/__stories__/ArticleStandard.story.tsx
+++ b/src/Components/Publishing/__stories__/ArticleStandard.story.tsx
@@ -64,7 +64,7 @@ const story = storiesOf("Publishing/Articles/Standard", module)
       </ContextProvider>
     )
   })
-  .add("With tooltips (bio)", () => {
+  .add("With tooltips", () => {
     return (
       <ContextProvider>
         <Article
@@ -73,20 +73,6 @@ const story = storiesOf("Publishing/Articles/Standard", module)
           relatedArticlesForCanvas={RelatedCanvas}
           emailSignupUrl="#"
           showTooltips
-        />
-      </ContextProvider>
-    )
-  })
-  .add("With tooltips (data)", () => {
-    return (
-      <ContextProvider>
-        <Article
-          article={StandardArticle}
-          relatedArticlesForPanel={RelatedPanel}
-          relatedArticlesForCanvas={RelatedCanvas}
-          emailSignupUrl="#"
-          showTooltips
-          showToolTipMarketData
         />
       </ContextProvider>
     )

--- a/src/Components/Publishing/__stories__/ToolTip.story.tsx
+++ b/src/Components/Publishing/__stories__/ToolTip.story.tsx
@@ -8,8 +8,8 @@ import React from "react"
 
 const tracking = { trackEvent: x => x }
 
-storiesOf("Publishing/ToolTips/Artist", module)
-  .add("With Bio", () => {
+storiesOf("Publishing/ToolTips/", module)
+  .add("Artist", () => {
     return (
       <div style={{ maxWidth: 580, margin: "50px auto 0 auto" }}>
         <ContextProvider>
@@ -41,34 +41,24 @@ storiesOf("Publishing/ToolTips/Artist", module)
       </div>
     )
   })
-  .add("With Market data", () => {
+  .add("Gene", () => {
     return (
-      <div style={{ maxWidth: 580, margin: "50px auto 0 auto" }}>
+      <div style={{ maxWidth: 580, margin: "50px auto" }}>
         <ContextProvider>
           <TooltipsData article={StandardArticle}>
             <StyledText layout="standard">
               <LinkWithTooltip
-                url="https://artsy.net/artist/fra-angelico"
-                showMarketData
+                url="https://artsy.net/gene/art-nouveau"
                 tracking={tracking}
               >
-                Fra Angelico
+                Art Nouveau
               </LinkWithTooltip>
-              {`, `}
+              {` and `}
               <LinkWithTooltip
-                url="https://artsy.net/artist/judy-chicago"
-                showMarketData
+                url="https://artsy.net/gene/art-deco"
                 tracking={tracking}
               >
-                Judy Chicago
-              </LinkWithTooltip>
-              {`, and `}
-              <LinkWithTooltip
-                url="https://artsy.net/artist/alfred-stieglitz"
-                showMarketData
-                tracking={tracking}
-              >
-                Alfred Stieglitz
+                Art Deco
               </LinkWithTooltip>
             </StyledText>
           </TooltipsData>
@@ -76,28 +66,3 @@ storiesOf("Publishing/ToolTips/Artist", module)
       </div>
     )
   })
-storiesOf("Publishing/ToolTips/Gene", module).add("Gene", () => {
-  return (
-    <div style={{ maxWidth: 580, margin: "50px auto" }}>
-      <ContextProvider>
-        <TooltipsData article={StandardArticle}>
-          <StyledText layout="standard">
-            <LinkWithTooltip
-              url="https://artsy.net/gene/art-nouveau"
-              tracking={tracking}
-            >
-              Art Nouveau
-            </LinkWithTooltip>
-            {` and `}
-            <LinkWithTooltip
-              url="https://artsy.net/gene/art-deco"
-              tracking={tracking}
-            >
-              Art Deco
-            </LinkWithTooltip>
-          </StyledText>
-        </TooltipsData>
-      </ContextProvider>
-    </div>
-  )
-})


### PR DESCRIPTION
Related to https://github.com/artsy/force/pull/2688

- Removes artist market data variant from article tooltips
- Adds genes as backup if no artist-bio is present