### PR TITLE
@zephraph => Boot artist page for logged out users

### DIFF
--- a/src/Router/buildClientApp.tsx
+++ b/src/Router/buildClientApp.tsx
@@ -24,9 +24,12 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
 
       const relayBootstrap = JSON.parse(window.__RELAY_BOOTSTRAP__ || "{}")
 
-      const currentUser = user || {
-        id: process.env.USER_ID,
-        accessToken: process.env.USER_ACCESS_TOKEN,
+      let currentUser = user
+      if (process.env.USER_ID && process.env.USER_ACCESS_TOKEN) {
+        currentUser = currentUser || {
+          id: process.env.USER_ID,
+          accessToken: process.env.USER_ACCESS_TOKEN,
+        }
       }
 
       const relayEnvironment = createEnvironment({

--- a/src/Router/buildServerApp.tsx
+++ b/src/Router/buildServerApp.tsx
@@ -15,11 +15,14 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
     try {
       const { routes, url, user } = config
 
-      // FIXME: Might be a better way to do this...
-      const currentUser = user || {
-        id: process.env.USER_ID,
-        accessToken: process.env.USER_ACCESS_TOKEN,
+      let currentUser = user
+      if (process.env.USER_ID && process.env.USER_ACCESS_TOKEN) {
+        currentUser = currentUser || {
+          id: process.env.USER_ID,
+          accessToken: process.env.USER_ACCESS_TOKEN,
+        }
       }
+
       const relayEnvironment = createEnvironment({
         user: currentUser,
       })


### PR DESCRIPTION
Looking to remove the admin only guard in Force, was noticing a crash on the page.

It was this setup for users, when logged out this isn't passed in to the Reaction app, and so you wound up with something like:

```
currentUser = {
  accessToken: undefined
  id: undefined
}
```

vs. what the Relay `createEnvironment` method can work with, which is to pass in something not truthy for `currentUser`.

This needs a Reaction bump -> Force bump, plus relaxing of the admin-only flag, and then we can QA the logged out page in Force on staging.