### PR TITLE
[PATCH authentication] add missing analytics properties for social auth

### DIFF
--- a/src/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/Components/Authentication/Desktop/ModalManager.tsx
@@ -1,5 +1,4 @@
 import { FormikProps } from "formik"
-import qs from "querystring"
 import React, { Component } from "react"
 
 import { DesktopModal } from "Components/Authentication/Desktop/Components/DesktopModal"
@@ -28,6 +27,7 @@ export interface ModalManagerProps {
     formikBag: FormikProps<InputValues>
   ) => void
   blurContainerSelector?: string
+  onSocialAuthEvent?: (options) => void
 }
 
 export interface ModalManagerState {
@@ -111,28 +111,6 @@ export class ModalManager extends Component<
       ? this.props.handleSubmit.bind(this, currentType, options)
       : defaultHandleSubmit(submitUrls[currentType], csrf, redirectTo)
 
-    const queryData = Object.assign(
-      {},
-      options,
-      {
-        accepted_terms_of_service: true,
-        agreed_to_receive_emails: true,
-        "signup-referer": options.signupReferer || location.href,
-      },
-      options.redirectTo
-        ? {
-            "redirect-to": options.redirectTo,
-          }
-        : null,
-      options.intent
-        ? {
-            "signup-intent": options.intent,
-          }
-        : null
-    )
-
-    const authQueryData = qs.stringify(queryData)
-
     return (
       <DesktopModal
         blurContainerSelector={blurContainerSelector}
@@ -146,14 +124,10 @@ export class ModalManager extends Component<
           type={currentType}
           error={error}
           handleSubmit={handleSubmit}
-          onFacebookLogin={() =>
-            (window.location.href = submitUrls.facebook + `?${authQueryData}`)
-          }
-          onTwitterLogin={() =>
-            (window.location.href = submitUrls.twitter + `?${authQueryData}`)
-          }
+          submitUrls={submitUrls}
           options={options}
           handleTypeChange={this.handleTypeChange}
+          onSocialAuthEvent={this.props.onSocialAuthEvent}
         />
       </DesktopModal>
     )

--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -28,7 +28,12 @@ export interface FormSwitcherProps {
   options: ModalOptions
   tracking?: any
   type: ModalType
+  submitUrls?: { [P in ModalType]: string } & {
+    facebook?: string
+    twitter?: string
+  }
   values?: InputValues
+  onSocialAuthEvent?: (options) => void
 }
 
 export interface State {
@@ -108,7 +113,29 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
   }
 
   render() {
-    const { error, isMobile, onFacebookLogin, onTwitterLogin } = this.props
+    const { error, isMobile, options } = this.props
+
+    const queryData = Object.assign(
+      {},
+      options,
+      {
+        accepted_terms_of_service: true,
+        agreed_to_receive_emails: true,
+        "signup-referer": options.signupReferer || location.href,
+      },
+      options.redirectTo
+        ? {
+            "redirect-to": options.redirectTo,
+          }
+        : null,
+      options.intent
+        ? {
+            "signup-intent": options.intent,
+          }
+        : null
+    )
+
+    const authQueryData = qs.stringify(queryData)
 
     let Form: FormComponentType
     switch (this.state.type) {
@@ -139,8 +166,30 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
         values={defaultValues}
         handleTypeChange={this.handleTypeChange}
         handleSubmit={handleSubmit}
-        onFacebookLogin={onFacebookLogin}
-        onTwitterLogin={onTwitterLogin}
+        onFacebookLogin={() => {
+          if (this.props.onSocialAuthEvent) {
+            this.props.onSocialAuthEvent({
+              ...options,
+              service: "facebook",
+            })
+          }
+
+          window.location.href =
+            this.props.submitUrls.facebook +
+            `?${authQueryData}` +
+            "&service=facebook"
+        }}
+        onTwitterLogin={() => {
+          if (this.props.onSocialAuthEvent) {
+            this.props.onSocialAuthEvent({
+              ...options,
+              service: "twitter",
+            })
+          }
+
+          window.location.href =
+            this.props.submitUrls + `?${authQueryData}` + "&service=twitter"
+        }}
       />
     )
   }


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-737 and https://artsyproduct.atlassian.net/browse/GROW-780 by adding support for tracking social auth analytics properties. We are explicitly passing the service provider the user authenticated with as well fixing the 'create account' and 'successfully logged in' events.