### PR TITLE
@zephraph => Propagate current user/mediator and enable saving artworks in grid

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -74,6 +74,7 @@ class Artworks extends Component<Props, LoadingAreaState> {
       <Subscribe to={[AppState]}>
         {({ state }) => {
           const {
+            mediator,
             system: { currentUser },
           } = state
 
@@ -84,6 +85,7 @@ class Artworks extends Component<Props, LoadingAreaState> {
                 columnCount={this.props.columnCount}
                 itemMargin={40}
                 currentUser={currentUser}
+                mediator={mediator}
               />
 
               <Spacer mb={3} />

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -2,9 +2,11 @@ import { ArtworkFilterArtworkGrid_filtered_artworks } from "__generated__/Artwor
 import ArtworkGrid from "Components/ArtworkGrid"
 import React, { Component } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
+import { AppState } from "Router/state"
 import { PaginationFragmentContainer as Pagination } from "Styleguide/Components/Pagination"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Spacer } from "Styleguide/Elements/Spacer"
+import { Subscribe } from "unstated"
 
 import {
   LoadingArea,
@@ -69,26 +71,37 @@ class Artworks extends Component<Props, LoadingAreaState> {
 
   render() {
     return (
-      <LoadingArea isLoading={this.state.isLoading}>
-        <ArtworkGrid
-          artworks={this.props.filtered_artworks.artworks as any}
-          columnCount={this.props.columnCount}
-          itemMargin={40}
-        />
+      <Subscribe to={[AppState]}>
+        {({ state }) => {
+          const {
+            system: { currentUser },
+          } = state
 
-        <Spacer mb={3} />
+          return (
+            <LoadingArea isLoading={this.state.isLoading}>
+              <ArtworkGrid
+                artworks={this.props.filtered_artworks.artworks as any}
+                columnCount={this.props.columnCount}
+                itemMargin={40}
+                currentUser={currentUser}
+              />
 
-        <Flex justifyContent="flex-end">
-          <Pagination
-            pageCursors={
-              this.props.filtered_artworks.artworks.pageCursors as any
-            }
-            onClick={this.loadAfter}
-            onNext={this.loadNext}
-            scrollTo="#jump--artistArtworkGrid"
-          />
-        </Flex>
-      </LoadingArea>
+              <Spacer mb={3} />
+
+              <Flex justifyContent="flex-end">
+                <Pagination
+                  pageCursors={
+                    this.props.filtered_artworks.artworks.pageCursors as any
+                  }
+                  onClick={this.loadAfter}
+                  onNext={this.loadNext}
+                  scrollTo="#jump--artistArtworkGrid"
+                />
+              </Flex>
+            </LoadingArea>
+          )
+        }}
+      </Subscribe>
     )
   }
 }

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -22,6 +22,7 @@ const Placeholder = styled.div`
 interface Props extends RelayProps, React.HTMLProps<ArtworkGridItemContainer> {
   useRelay?: boolean
   style?: any
+  currentUser?: any
 }
 
 class ArtworkGridItemContainer extends React.Component<Props, null> {
@@ -30,10 +31,14 @@ class ArtworkGridItemContainer extends React.Component<Props, null> {
   }
 
   render() {
-    const { style, className, artwork, useRelay } = this.props
+    const { style, className, artwork, useRelay, currentUser } = this.props
     const SaveButtonBlock = useRelay ? RelaySaveButton : SaveButton
     const MetadataBlock = useRelay ? RelayMetadata : Metadata
 
+    let currentUserSpread = {}
+    if (currentUser) {
+      currentUserSpread = { currentUser }
+    }
     return (
       <div className={className} style={style}>
         <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
@@ -45,6 +50,7 @@ class ArtworkGridItemContainer extends React.Component<Props, null> {
             artwork={artwork as any}
             style={{ position: "absolute", right: "10px", bottom: "10px" }}
             useRelay={useRelay}
+            {...currentUserSpread}
           />
         </Placeholder>
         <MetadataBlock artwork={artwork} useRelay={useRelay} />

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -23,6 +23,9 @@ interface Props extends RelayProps, React.HTMLProps<ArtworkGridItemContainer> {
   useRelay?: boolean
   style?: any
   currentUser?: any
+  mediator?: {
+    trigger: (action: string, config: object) => void
+  }
 }
 
 class ArtworkGridItemContainer extends React.Component<Props, null> {
@@ -51,6 +54,7 @@ class ArtworkGridItemContainer extends React.Component<Props, null> {
             style={{ position: "absolute", right: "10px", bottom: "10px" }}
             useRelay={useRelay}
             {...currentUserSpread}
+            mediator={this.props.mediator}
           />
         </Placeholder>
         <MetadataBlock artwork={artwork} useRelay={useRelay} />

--- a/src/Components/Artwork/Save.tsx
+++ b/src/Components/Artwork/Save.tsx
@@ -23,6 +23,9 @@ export interface Props
   relay?: RelayProp
   relayEnvironment?: RelayRuntimeTypes.Environment
   useRelay?: boolean
+  mediator?: {
+    trigger: (action: string, config: object) => void
+  }
 }
 
 // TODO: This will be refactored out once Artworks / Grids are full Relay in Force
@@ -122,7 +125,21 @@ export const SaveButtonContainer = Artsy.ContextConsumer(
           },
         })
       } else {
-        window.location.href = "/login"
+        if (this.props.mediator) {
+          this.props.mediator.trigger("open:auth", {
+            mode: "signup",
+            copy: `Sign up to save artworks`,
+            intent: "save artwork",
+            signupIntent: "save artwork",
+            trigger: "click",
+            afterSignUpAction: {
+              action: "save",
+              objectId: this.props.artwork.id,
+            },
+          })
+        } else {
+          window.location.href = "/login"
+        }
       }
     }
 

--- a/src/Components/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid.tsx
@@ -14,6 +14,7 @@ export interface ArtworkGridContainerProps
   itemMargin?: number
   onLoadMore?: () => any
   useRelay?: boolean
+  currentUser?: any
 }
 
 export interface ArtworkGridContainerState {
@@ -119,6 +120,7 @@ export class ArtworkGridContainer extends React.Component<
             artwork={artwork as any}
             key={"artwork-" + j + "-" + artwork.__id}
             useRelay={this.props.useRelay}
+            currentUser={this.props.currentUser}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.

--- a/src/Components/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid.tsx
@@ -15,6 +15,9 @@ export interface ArtworkGridContainerProps
   onLoadMore?: () => any
   useRelay?: boolean
   currentUser?: any
+  mediator?: {
+    trigger: (action: string, config: object) => void
+  }
 }
 
 export interface ArtworkGridContainerState {
@@ -121,6 +124,7 @@ export class ArtworkGridContainer extends React.Component<
             key={"artwork-" + j + "-" + artwork.__id}
             useRelay={this.props.useRelay}
             currentUser={this.props.currentUser}
+            mediator={this.props.mediator}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.


### PR DESCRIPTION
Rather than subscribe to the app state further down the tree and closer to the actual save button, I wound up passing thru current user and mediator, being careful not to overwrite another use case of the grid/save button (where `currentUser` is injected in).

As a bonus, propagates the mediator as well, and so we get better CTA when you click the save button and are logged out

![bp](https://user-images.githubusercontent.com/1457859/42599257-aa168db6-852c-11e8-96bd-cf0174c5135d.gif)
