### PR TITLE
Remove yarn step from deploy process to speed up package deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
     steps: 
       - checkout
       - <<: *restore_cache
-      - <<: *verify_dependencies
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: yarn semantic-release
   test:


### PR DESCRIPTION
The `deploy` job has a dependency on the `update-cache` job. After `update-cache` runs the `node_modules` for the current `yarn.lock` file will be installed. That means the deploy task doesn't need to double check like all the other jobs which may only get a stale version of the `node_modules`. 

It's not much, but it'll kill around 20s of runtime. 

Example deploy step:
https://circleci.com/gh/artsy/reaction/4801?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

It's workflow:
https://circleci.com/workflow-run/cac8f4e7-d4ba-4948-9787-4920a7d8c4f9
