### PR TITLE
@zephraph => Prevent following a link when tapping a follow button

### DIFF
--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -54,7 +54,8 @@ export class FollowArtistButton extends React.Component<Props> {
     tracking.trackEvent(extend({ action }, trackingData))
   }
 
-  handleFollow = () => {
+  handleFollow = e => {
+    e.preventDefault() // If this button is part of a link, we _probably_ dont want to actually follow the link.
     const { artist, currentUser, relay, onOpenAuthModal } = this.props
 
     if (currentUser && currentUser.id) {


### PR DESCRIPTION
This feels like it might be ok, but also might not?

Basically, the thinking is the follow artist button either performs a follow (+ state change to represent 'followed', etc.), or the unfollow version. When there is no current user in the context/global app state, the `onAuthModal` callback occurs (which is typically a 'mediator'- a Force event bus which triggers the appropriate modals).

So, the follow button wholly handles its behavior when clicked, and shouldn't ever link. So, this makes sure that if the follow button itself is clicked (`handleFollow` called), you don't inadvertently link or do anything else.

What do you think?