### PR TITLE
Limit access to tokens on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ workflows:
       - type-check
       - test
       - deploy:
+          context: npm-deploy
           <<: *filter_master
           requires:
             - test


### PR DESCRIPTION
Unfortunately NPM and the node ecosystem has some serious security flaws. It's not exactly an unknown topic, but given yesterday's [incident](https://status.npmjs.org/incidents/dn7c1fgrr7ng) it's important that we think about how we can be more defensive towards our registry usage. 

Yarn and npm allow the [arbitrarily execution of code](https://www.infoq.com/news/2016/03/npm-infection) on install via lifecycle hooks. That means if one of the ~7286 packages in Reaction were to be compromised, we'd have issues. This topic deserves a wider conversation, but for now I want to narrow it to the focus of CI. 

In our CI builds we expose some sensitive tokens via environment variables. Anything running during that process can read those environment variables. I'd like to start exploring using [contexts](https://circleci.com/docs/2.0/contexts) in CircleCI to restrict which jobs have access to certain tokens. 

I've created an example context called `npm-deploy`. The idea would be to remove our npm token from the reaction project (and ultimately all other projects) and instead only allow deployment workflows to have access to it. Essentially that token becomes an explicit grant that we have to give workflows. It has the added benefit that now the token is managed in a single place across all projects whereas now it's configured per project. 

When I converted reaction to CircleCI 2.0 I removed the `yarn install` step from the `deploy` workflow. It relies solely on CircleCI's cache for its dependencies. Given that, isolating the token to this step would eliminate the ability to scrape the token on a pre/post lifecycle event hook. We're running semantic-release which has [a lot of nested sub dependences](https://npm.anvaka.com/#/view/2d/semantic-release) _(403)_, but still the risk is reduced. 

It'd likely be worth auditing the other tokens to see what else we might be exposing. 

<hr/>

Some reading material to make you all sleep a little less easy at night
- https://blog.npmjs.org/post/141702881055/package-install-scripts-vulnerability
- https://hackernoon.com/im-harvesting-credit-card-numbers-and-passwords-from-your-site-here-s-how-9a8cb347c5b5
- https://jamie.build/how-to-build-an-npm-worm