### PR TITLE
Update palette to latest version

### DIFF
--- a/src/Components/Publishing/Byline/Author.tsx
+++ b/src/Components/Publishing/Byline/Author.tsx
@@ -1,5 +1,5 @@
 import { Sans } from "@artsy/palette"
-import { SansSizes } from "@artsy/palette"
+import { SansSize } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { getAuthorByline } from "../Constants"
@@ -9,7 +9,7 @@ interface AuthorProps {
   authors?: any
   color?: string
   layout?: BylineLayout
-  size?: SansSizes
+  size?: SansSize
 }
 
 export const Author: React.SFC<AuthorProps> = props => {

--- a/src/Components/Publishing/Byline/Author.tsx
+++ b/src/Components/Publishing/Byline/Author.tsx
@@ -1,5 +1,5 @@
 import { Sans } from "@artsy/palette"
-import { TypeSizes } from "@artsy/palette/dist/elements/Typography"
+import { SansSizes } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { getAuthorByline } from "../Constants"
@@ -9,7 +9,7 @@ interface AuthorProps {
   authors?: any
   color?: string
   layout?: BylineLayout
-  size?: keyof TypeSizes["sans"]
+  size?: SansSizes
 }
 
 export const Author: React.SFC<AuthorProps> = props => {

--- a/src/Components/Publishing/Byline/Byline.tsx
+++ b/src/Components/Publishing/Byline/Byline.tsx
@@ -1,4 +1,4 @@
-import { TypeSizes } from "@artsy/palette/dist/elements/Typography"
+import { SansSizes } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { getArticleFullHref } from "../Constants"
@@ -12,7 +12,7 @@ interface BylineProps {
   color?: string
   date?: string
   layout?: BylineLayout
-  size?: keyof TypeSizes["sans"]
+  size?: SansSizes
 }
 
 export const Byline: React.SFC<BylineProps> = props => {

--- a/src/Components/Publishing/Byline/Byline.tsx
+++ b/src/Components/Publishing/Byline/Byline.tsx
@@ -1,4 +1,4 @@
-import { SansSizes } from "@artsy/palette"
+import { SansSize } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { getArticleFullHref } from "../Constants"
@@ -12,7 +12,7 @@ interface BylineProps {
   color?: string
   date?: string
   layout?: BylineLayout
-  size?: SansSizes
+  size?: SansSize
 }
 
 export const Byline: React.SFC<BylineProps> = props => {

--- a/src/Components/Publishing/Byline/Date.tsx
+++ b/src/Components/Publishing/Byline/Date.tsx
@@ -1,5 +1,5 @@
 import { Sans } from "@artsy/palette"
-import { SansSizes } from "@artsy/palette"
+import { SansSize } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { getDate } from "../Constants"
@@ -9,7 +9,7 @@ interface DateProps {
   date?: string
   format?: DateFormat
   layout?: BylineLayout
-  size?: SansSizes
+  size?: SansSize
 }
 
 export const Date: React.SFC<DateProps> = props => {

--- a/src/Components/Publishing/Byline/Date.tsx
+++ b/src/Components/Publishing/Byline/Date.tsx
@@ -1,5 +1,5 @@
 import { Sans } from "@artsy/palette"
-import { TypeSizes } from "@artsy/palette/dist/elements/Typography"
+import { SansSizes } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { getDate } from "../Constants"
@@ -9,7 +9,7 @@ interface DateProps {
   date?: string
   format?: DateFormat
   layout?: BylineLayout
-  size?: keyof TypeSizes["sans"]
+  size?: SansSizes
 }
 
 export const Date: React.SFC<DateProps> = props => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@artsy/palette@^2.3.4":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.6.1.tgz#629db4002c1b08a6853865b2ddb5734b7219d8da"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.6.2.tgz#7cc6e7df1ea64c27cb45b295c9fafb4bbdd51121"
   dependencies:
     react "^16.3.2"
     styled-system "^2.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@artsy/palette@^2.3.4":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.6.2.tgz#7cc6e7df1ea64c27cb45b295c9fafb4bbdd51121"
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.6.3.tgz#dc2efcd875ab1aaba5bf361d9e305451f4c76b9b"
   dependencies:
     react "^16.3.2"
     styled-system "^2.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,13 +3,11 @@
 
 
 "@artsy/palette@^2.3.4":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.4.2.tgz#994967a52e4869192be5fe84b24b6346db6a3ef2"
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.6.1.tgz#629db4002c1b08a6853865b2ddb5734b7219d8da"
   dependencies:
     react "^16.3.2"
-    react-primitives "^0.5.0"
     styled-system "^2.2.5"
-    yarn "^1.3.2"
 
 "@babel/cli@^7.0.0-beta.40":
   version "7.0.0-beta.40"
@@ -1296,13 +1294,6 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-animated@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/animated/-/animated-0.1.5.tgz#83df8dc443d57abab7b0bb04818b0b655b31c9b9"
-  dependencies:
-    invariant "^2.2.0"
-    normalize-css-color "^1.0.1"
-
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
@@ -1462,7 +1453,7 @@ array-filter@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
 
-array-find-index@^1.0.1, array-find-index@^1.0.2:
+array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 
@@ -1543,11 +1534,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-art@^0.10.1:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/art/-/art-0.10.2.tgz#55c3738d82a3a07e0623943f070ebe86297253d9"
-
-asap@^2.0.0, asap@^2.0.5, asap@~2.0.3:
+asap@^2.0.0, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -4186,10 +4173,6 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
-debounce@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.1.0.tgz#6a1a4ee2a9dc4b7c24bb012558dbcdb05b37f408"
-
 debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -4226,12 +4209,6 @@ decompress-response@^3.3.0:
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
   dependencies:
     mimic-response "^1.0.0"
-
-deep-assign@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-2.0.0.tgz#ebe06b1f07f08dae597620e3dd1622f371a1c572"
-  dependencies:
-    is-obj "^1.0.0"
 
 deep-eql@^3.0.0:
   version "3.0.1"
@@ -4316,10 +4293,6 @@ delayed-stream@~1.0.0:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-
-deline@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/deline/-/deline-1.0.4.tgz#6c05c87836926e1a1c63e47882f3d2eb2c6f14c9"
 
 dentist@1.0.3:
   version "1.0.3"
@@ -5317,10 +5290,6 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
-
-flexibility@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flexibility/-/flexibility-2.0.1.tgz#ad323aafc40f469ce624286518fc4d7cd72b7c77"
 
 flow-runtime@0.14.0:
   version "0.14.0"
@@ -6444,13 +6413,6 @@ inline-style-prefixer@^3.0.6:
     bowser "^1.7.3"
     css-in-js-utils "^2.0.0"
 
-inline-style-prefixer@^4.0.0, inline-style-prefixer@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz#d390957d26f281255fe101da863158ac6eb60911"
-  dependencies:
-    bowser "^1.7.3"
-    css-in-js-utils "^2.0.0"
-
 inquirer@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
@@ -7335,6 +7297,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.3.1, js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -7912,7 +7878,13 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
+loose-envify@^1.2.0, loose-envify@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -8637,10 +8609,6 @@ nopt@^4.0.0, nopt@^4.0.1, nopt@~4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
-
-normalize-css-color@^1.0.1, normalize-css-color@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.4.0, "normalize-package-data@~1.0.1 || ^2.0.0", normalize-package-data@~2.4.0:
   version "2.4.0"
@@ -10229,21 +10197,6 @@ react-addons-test-utils@^15.5.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
 
-react-art@^16.2.0:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-art/-/react-art-16.4.1.tgz#3544c13038d7ddfe8b1cc1170b02d99492c03b50"
-  dependencies:
-    art "^0.10.1"
-    create-react-class "^15.6.2"
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
-react-css-property-operations@^15.4.1:
-  version "15.4.1"
-  resolved "https://registry.yarnpkg.com/react-css-property-operations/-/react-css-property-operations-15.4.1.tgz#4c0e305df4cc35f0f5fd2d65a79214c8b012db35"
-
 react-css-transition-replace@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/react-css-transition-replace/-/react-css-transition-replace-3.0.3.tgz#23d3ed17f54e41435c0485300adb75d2e6e24aad"
@@ -10389,22 +10342,6 @@ react-modal@^3.3.2:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-native-web@^0.3.2:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.3.4.tgz#b73a483f3c37a37ed832903e02d9c3c96f3ea109"
-  dependencies:
-    array-find-index "^1.0.2"
-    create-react-class "^15.6.2"
-    debounce "^1.1.0"
-    deep-assign "^2.0.0"
-    fbjs "^0.8.16"
-    hyphenate-style-name "^1.0.2"
-    inline-style-prefixer "^4.0.0"
-    normalize-css-color "^1.0.2"
-    prop-types "^15.6.0"
-    react-art "^16.2.0"
-    react-timer-mixin "^0.13.3"
-
 react-oembed-container@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/react-oembed-container/-/react-oembed-container-0.3.0.tgz#6fcfc145d1a392fd27e801d19adcaeeb3f5b6865"
@@ -10421,24 +10358,6 @@ react-overlays@^0.8.3:
     prop-types-extra "^1.0.1"
     react-transition-group "^2.2.0"
     warning "^3.0.0"
-
-react-primitives@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/react-primitives/-/react-primitives-0.5.1.tgz#caa466afd029e7d024f48b5be7c5717fe94fc703"
-  dependencies:
-    animated "^0.1.5"
-    asap "^2.0.5"
-    create-react-class "^15.6.2"
-    deline "^1.0.4"
-    flexibility "^2.0.1"
-    inline-style-prefixer "^4.0.2"
-    invariant "^2.2.1"
-    normalize-css-color "^1.0.1"
-    prop-types "^15.5.10"
-    react-css-property-operations "^15.4.1"
-    react-native-web "^0.3.2"
-    react-timer-mixin "^0.13.3"
-    string-hash "^1.1.3"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -10559,10 +10478,6 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
     react-is "^16.4.0"
-
-react-timer-mixin@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz#0da8b9f807ec07dc3e854d082c737c65605b3d22"
 
 react-toggle@^4.0.2:
   version "4.0.2"
@@ -12000,10 +11915,6 @@ strict-uri-encode@^2.0.0:
 string-convert@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
-
-string-hash@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -13587,10 +13498,6 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-
-yarn@^1.3.2:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.7.0.tgz#0076b9fde6010e01950526a609bc53bc175ef925"
 
 yup@^0.24.1:
   version "0.24.1"


### PR DESCRIPTION
Updating palette to the latest version. Latest release removes `react-primitives` as a dependency that I didn't realize was still being pulled in... 