### PR TITLE
@xtina-starr => Analytics contextModule for Tooltips

### DIFF
--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -99,7 +99,7 @@ export class FollowArtistButton extends React.Component<Props> {
     } else {
       onOpenAuthModal &&
         onOpenAuthModal("register", {
-          context_module: "intext tooltip",
+          contextModule: "intext tooltip",
           intent: "follow artist",
           copy: "Sign up to follow artists",
         })

--- a/src/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/Components/FollowButton/FollowGeneButton.tsx
@@ -64,7 +64,7 @@ export class FollowGeneButton extends React.Component<Props> {
     } else {
       onOpenAuthModal &&
         onOpenAuthModal("register", {
-          context_module: "intext tooltip",
+          contextModule: "intext tooltip",
           intent: "follow gene",
           copy: "Sign up to follow categories",
         })

--- a/src/Components/FollowButton/Typings.tsx
+++ b/src/Components/FollowButton/Typings.tsx
@@ -1,5 +1,5 @@
 export type FollowTrackingData = {
-  context_module?: string
+  contextModule?: string
   entity_id?: string
   entity_slug?: string
   entity_type?: string

--- a/src/Components/FollowButton/__tests__/FollowArtistButton.test.tsx
+++ b/src/Components/FollowButton/__tests__/FollowArtistButton.test.tsx
@@ -65,7 +65,7 @@ describe("FollowArtistButton", () => {
       const args = props.onOpenAuthModal.mock.calls[0]
 
       expect(args[0]).toBe("register")
-      expect(args[1].context_module).toBe("intext tooltip")
+      expect(args[1].contextModule).toBe("intext tooltip")
       expect(args[1].intent).toBe("follow artist")
       expect(args[1].copy).toBe("Sign up to follow artists")
     })
@@ -110,12 +110,12 @@ describe("FollowArtistButton", () => {
 
     it("Tracks with custom trackingData if provided", () => {
       props.trackingData = {
-        context_module: "tooltip",
+        contextModule: "tooltip",
       }
       const component = getWrapper(props, { id: "1234" })
       component.find(FollowButtonDeprecated).simulate("click")
 
-      expect(props.tracking.trackEvent.mock.calls[0][0].context_module).toBe(
+      expect(props.tracking.trackEvent.mock.calls[0][0].contextModule).toBe(
         "tooltip"
       )
     })

--- a/src/Components/FollowButton/__tests__/FollowGeneButton.test.tsx
+++ b/src/Components/FollowButton/__tests__/FollowGeneButton.test.tsx
@@ -62,7 +62,7 @@ describe("FollowGeneButton", () => {
       const args = props.onOpenAuthModal.mock.calls[0]
 
       expect(args[0]).toBe("register")
-      expect(args[1].context_module).toBe("intext tooltip")
+      expect(args[1].contextModule).toBe("intext tooltip")
       expect(args[1].intent).toBe("follow gene")
       expect(args[1].copy).toBe("Sign up to follow categories")
     })
@@ -105,12 +105,12 @@ describe("FollowGeneButton", () => {
 
     it("Tracks with custom trackingData if provided", () => {
       props.trackingData = {
-        context_module: "tooltip",
+        contextModule: "tooltip",
       }
       const component = getWrapper(props, { id: "1234" })
       component.find(FollowButtonDeprecated).simulate("click")
 
-      expect(props.tracking.trackEvent.mock.calls[0][0].context_module).toBe(
+      expect(props.tracking.trackEvent.mock.calls[0][0].contextModule).toBe(
         "tooltip"
       )
     })

--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -136,25 +136,28 @@ export class CanvasContainerComponent extends React.Component<
       // Video / Image
     } else {
       const [asset] = unit.assets
-      const isVideo = asset && asset.url.includes("mp4")
+      const src = (asset && asset.url) || ""
+      const isVideo = src.includes("mp4")
 
       return (
         <CanvasLink {...linkProps}>
           {isVideo ? (
             <CanvasVideo
               coverUrl={cover_image_url}
-              src={asset.url}
+              src={src}
               campaign={campaign}
               onInit={h => (this.canvasVideoHandlers = h)}
             />
           ) : (
-            <Image
-              src={crop(asset.url, {
-                width: 1200,
-                height: 760,
-                isDisplayAd: true,
-              })}
-            />
+            src && (
+              <Image
+                src={crop(src, {
+                  width: 1200,
+                  height: 760,
+                  isDisplayAd: true,
+                })}
+              />
+            )
           )}
 
           <StandardContainer>

--- a/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
@@ -31,7 +31,7 @@ export class ArtistToolTip extends React.Component<ArtistToolTipProps> {
       action: "Click",
       flow: "tooltip",
       type: "artist stub",
-      context_module: "intext tooltip",
+      contextModule: "intext tooltip",
       destination_path: href,
     })
   }
@@ -64,7 +64,7 @@ export class ArtistToolTip extends React.Component<ArtistToolTipProps> {
     const description = blurb || this.renderArtistGenes()
 
     const trackingData: FollowTrackingData = {
-      context_module: "intext tooltip",
+      contextModule: "intext tooltip",
       entity_id: _id,
       entity_slug: id,
       entity_type: "artist",

--- a/src/Components/Publishing/ToolTip/GeneToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/GeneToolTip.tsx
@@ -30,7 +30,7 @@ export class GeneToolTip extends React.Component<GeneProps> {
       action: "Click",
       flow: "tooltip",
       type: "gene stub",
-      context_module: "intext tooltip",
+      contextModule: "intext tooltip",
       destination_path: href,
     })
   }
@@ -44,7 +44,7 @@ export class GeneToolTip extends React.Component<GeneProps> {
     } = this.context
 
     const trackingData: FollowTrackingData = {
-      context_module: "tooltip",
+      contextModule: "tooltip",
       entity_id: _id,
       entity_slug: id,
       entity_type: "gene",

--- a/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
+++ b/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
@@ -76,7 +76,7 @@ describe("ArtistToolTip", () => {
     expect(trackingData.action).toBe("Click")
     expect(trackingData.flow).toBe("tooltip")
     expect(trackingData.type).toBe("artist stub")
-    expect(trackingData.context_module).toBe("intext tooltip")
+    expect(trackingData.contextModule).toBe("intext tooltip")
     expect(trackingData.destination_path).toBe("/artist/nick-mauss")
   })
 
@@ -92,7 +92,7 @@ describe("ArtistToolTip", () => {
       const args = context.onOpenAuthModal.mock.calls[0]
 
       expect(args[0]).toBe("register")
-      expect(args[1].context_module).toBe("intext tooltip")
+      expect(args[1].contextModule).toBe("intext tooltip")
       expect(args[1].intent).toBe("follow artist")
     })
   })

--- a/src/Components/Publishing/ToolTip/__tests__/GeneToolTip.test.tsx
+++ b/src/Components/Publishing/ToolTip/__tests__/GeneToolTip.test.tsx
@@ -1,12 +1,12 @@
-import PropTypes from "prop-types"
 import { mount } from "enzyme"
 import "jest-styled-components"
+import PropTypes from "prop-types"
 import React from "react"
-import { wrapperWithContext } from "../../Fixtures/Helpers"
-import { Genes } from "../../Fixtures/Components"
-import { GeneToolTip } from "../GeneToolTip"
 import { ContextProvider } from "../../../Artsy"
 import { FollowGeneButton } from "../../../FollowButton/FollowGeneButton"
+import { Genes } from "../../Fixtures/Components"
+import { wrapperWithContext } from "../../Fixtures/Helpers"
+import { GeneToolTip } from "../GeneToolTip"
 
 describe("GeneTooltip", () => {
   const getWrapper = (props, context = {}) => {
@@ -49,7 +49,7 @@ describe("GeneTooltip", () => {
       const args = context.onOpenAuthModal.mock.calls[0]
 
       expect(args[0]).toBe("register")
-      expect(args[1].context_module).toBe("intext tooltip")
+      expect(args[1].contextModule).toBe("intext tooltip")
       expect(args[1].intent).toBe("follow gene")
     })
   })


### PR DESCRIPTION
Related to [GROW-779](https://artsyproduct.atlassian.net/browse/GROW-779)
Updates Tooltip auth analytics to use new camelCase `contextModule` arg. 
Also addresses a minor bug in CanvasContainer for missing url.

Will follow up with point 2 from the Jira ticket on Force after this is merged.