### PR TITLE
[Router] Refactor API to allow host app to interact with state

### DIFF
--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -10,7 +10,7 @@ type State = {
 }
 
 export class FilterState extends Container<State> {
-  state = {
+  state: State = {
     medium: "*",
     for_sale: null,
     page: 1,

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -3,6 +3,7 @@ import { routes as artistRoutes } from "Apps/Artist/routes"
 import { routes as artworkRoutes } from "Apps/Artwork/routes"
 import React from "react"
 import { StorybooksRouter } from "Router/StorybooksRouter"
+import { FilterState } from "../Artist/Routes/Overview/state"
 
 storiesOf("Apps", module)
   .add("Artwork Page", () => {
@@ -14,11 +15,16 @@ storiesOf("Apps", module)
     )
   })
   .add("Artist Page", () => {
+    const filterState = new FilterState()
+    // TODO: This currently only changes the UI, the first fetch isn’t taking
+    //       this state into account.
+    filterState.state.for_sale = true
     return (
       <StorybooksRouter
         routes={artistRoutes}
         initialRoute="/artist2/andy-warhol"
         initialAppState={{ mediator: { trigger: x => x } }}
+        initialState={[filterState]}
       />
     )
   })

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -25,6 +25,12 @@ storiesOf("Apps", module)
         initialRoute="/artist2/andy-warhol"
         initialAppState={{ mediator: { trigger: x => x } }}
         initialState={[filterState]}
-      />
+        subscribeTo={[FilterState]}
+      >
+        {x => {
+          // tslint:disable-next-line:no-console
+          console.log(x.state)
+        }}
+      </StorybooksRouter>
     )
   })

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -25,12 +25,13 @@ storiesOf("Apps", module)
         initialRoute="/artist2/andy-warhol"
         initialAppState={{ mediator: { trigger: x => x } }}
         initialState={[filterState]}
-        subscribeTo={[FilterState]}
-      >
-        {x => {
-          // tslint:disable-next-line:no-console
-          console.log(x.state)
+        subscribe={{
+          to: [FilterState],
+          onChange: x => {
+            // tslint:disable-next-line:no-console
+            console.log(x.state)
+          },
         }}
-      </StorybooksRouter>
+      />
     )
   })

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -18,7 +18,7 @@ storiesOf("Apps", module)
       <StorybooksRouter
         routes={artistRoutes}
         initialRoute="/artist2/andy-warhol"
-        initialState={{ mediator: { trigger: x => x } }}
+        initialAppState={{ mediator: { trigger: x => x } }}
       />
     )
   })

--- a/src/Router/AppShell.tsx
+++ b/src/Router/AppShell.tsx
@@ -1,6 +1,12 @@
 import React, { SFC } from "react"
 import serialize from "serialize-javascript"
-import { AppShellProps } from "./types"
+
+export interface AppShellProps {
+  loadableState?: {
+    getScriptTag: () => string
+  }
+  data?: Array<object>
+}
 
 export const AppShell: SFC<AppShellProps> = props => {
   const { loadableState, data = {}, children } = props

--- a/src/Router/Boot.tsx
+++ b/src/Router/Boot.tsx
@@ -3,40 +3,35 @@ import React from "react"
 import { GridThemeProvider } from "styled-bootstrap-grid"
 import { GlobalStyles } from "Styleguide/Elements/GlobalStyles"
 import { Grid } from "Styleguide/Elements/Grid"
-import { Provider as StateProvider } from "unstated"
+import { Container, Provider as StateProvider } from "unstated"
 import { ResponsiveProvider } from "Utils/Responsive"
+import { Breakpoint } from "Utils/Responsive"
 import { ContextProvider } from "../Components/Artsy"
-import { AppState } from "./state"
-import { BootProps } from "./types"
+import { AppStateContainer } from "./types"
 
-export const Boot: React.SFC<BootProps> = ({ children, ...props }) => {
-  const appState = new AppState(props)
+export interface BootProps extends AppStateContainer {
+  initialBreakpoint?: Breakpoint
+  initialState: Array<Container<any>>
+}
 
-  return (
-    <StateProvider inject={[appState]}>
-      <ContextProvider
-        relayEnvironment={props.relayEnvironment}
-        currentUser={props.currentUser}
+export const Boot: React.SFC<BootProps> = ({ children, ...props }) => (
+  <StateProvider inject={props.initialState}>
+    <ContextProvider
+      relayEnvironment={props.system.relayEnvironment}
+      currentUser={props.system.currentUser}
+    >
+      <ResponsiveProvider
+        initialBreakpoint={props.initialBreakpoint}
+        breakpoints={themeProps.mediaQueries}
       >
-        <ResponsiveProvider
-          initialBreakpoint={props.initialBreakpoint}
-          breakpoints={themeProps.mediaQueries}
-        >
-          <GlobalStyles>
-            <Theme>
-              <GridThemeProvider gridTheme={themeProps.grid}>
-                <Grid fluid>{children}</Grid>
-              </GridThemeProvider>
-            </Theme>
-          </GlobalStyles>
-        </ResponsiveProvider>
-      </ContextProvider>
-    </StateProvider>
-  )
-}
-
-Boot.defaultProps = {
-  initialBreakpoint: null,
-  relayEnvironment: null,
-  currentUser: null,
-}
+        <GlobalStyles>
+          <Theme>
+            <GridThemeProvider gridTheme={themeProps.grid}>
+              <Grid fluid>{children}</Grid>
+            </GridThemeProvider>
+          </Theme>
+        </GlobalStyles>
+      </ResponsiveProvider>
+    </ContextProvider>
+  </StateProvider>
+)

--- a/src/Router/StorybooksRouter.tsx
+++ b/src/Router/StorybooksRouter.tsx
@@ -1,10 +1,12 @@
 import React from "react"
 import { buildClientApp } from "Router"
+import { Container } from "unstated"
 
 interface Props {
   routes: Array<object>
   initialRoute?: string
-  initialState?: object
+  initialState?: Array<Container<any>>
+  initialAppState?: object
 }
 
 export class StorybooksRouter extends React.Component<Props> {
@@ -22,6 +24,8 @@ export class StorybooksRouter extends React.Component<Props> {
         routes: this.props.routes,
         historyProtocol: "memory",
         initialRoute: this.props.initialRoute,
+        initialAppState: this.props.initialAppState,
+        initialState: this.props.initialState,
       })
 
       this.setState({
@@ -35,10 +39,6 @@ export class StorybooksRouter extends React.Component<Props> {
   render() {
     const { ClientApp } = this.state
 
-    return (
-      <React.Fragment>
-        {ClientApp && <ClientApp {...this.props.initialState} />}
-      </React.Fragment>
-    )
+    return <React.Fragment>{ClientApp && <ClientApp />}</React.Fragment>
   }
 }

--- a/src/Router/StorybooksRouter.tsx
+++ b/src/Router/StorybooksRouter.tsx
@@ -1,14 +1,8 @@
 import React from "react"
 import { buildClientApp } from "Router"
-import { Container } from "unstated"
-import { App, AppProps } from "./types"
+import { App, AppConfig } from "./types"
 
-interface Props extends Partial<AppProps> {
-  routes: Array<object>
-  initialRoute?: string
-  initialState?: Array<Container<any>>
-  initialAppState?: object
-}
+interface Props extends AppConfig {}
 
 interface State {
   ClientApp: App
@@ -20,15 +14,12 @@ export class StorybooksRouter extends React.Component<Props, State> {
   }
 
   async componentDidMount() {
+    const { children, ...props } = this.props
     try {
       const { ClientApp } = await buildClientApp({
-        routes: this.props.routes,
         historyProtocol: "memory",
-        initialRoute: this.props.initialRoute,
-        initialAppState: this.props.initialAppState,
-        initialState: this.props.initialState,
+        ...props,
       })
-
       this.setState({
         ClientApp,
       })
@@ -40,14 +31,6 @@ export class StorybooksRouter extends React.Component<Props, State> {
   render() {
     const ClientApp = this.state && this.state.ClientApp
 
-    return (
-      <React.Fragment>
-        {ClientApp && (
-          <ClientApp subscribeTo={this.props.subscribeTo}>
-            {this.props.children}
-          </ClientApp>
-        )}
-      </React.Fragment>
-    )
+    return <React.Fragment>{ClientApp && <ClientApp />}</React.Fragment>
   }
 }

--- a/src/Router/StorybooksRouter.tsx
+++ b/src/Router/StorybooksRouter.tsx
@@ -1,19 +1,20 @@
 import React from "react"
 import { buildClientApp } from "Router"
 import { Container } from "unstated"
+import { App, AppProps } from "./types"
 
-interface Props {
+interface Props extends Partial<AppProps> {
   routes: Array<object>
   initialRoute?: string
   initialState?: Array<Container<any>>
   initialAppState?: object
 }
 
-export class StorybooksRouter extends React.Component<Props> {
-  state = {
-    ClientApp: null,
-  }
+interface State {
+  ClientApp: App
+}
 
+export class StorybooksRouter extends React.Component<Props, State> {
   static defaultProps = {
     initialRoute: "/",
   }
@@ -37,8 +38,16 @@ export class StorybooksRouter extends React.Component<Props> {
   }
 
   render() {
-    const { ClientApp } = this.state
+    const ClientApp = this.state && this.state.ClientApp
 
-    return <React.Fragment>{ClientApp && <ClientApp />}</React.Fragment>
+    return (
+      <React.Fragment>
+        {ClientApp && (
+          <ClientApp subscribeTo={this.props.subscribeTo}>
+            {this.props.children}
+          </ClientApp>
+        )}
+      </React.Fragment>
+    )
   }
 }

--- a/src/Router/__test__/Boot.test.tsx
+++ b/src/Router/__test__/Boot.test.tsx
@@ -5,18 +5,23 @@ import { Boot } from "../Boot"
 import { AppState } from "../state"
 
 describe("Boot", () => {
-  const bootProps: any = {
-    system: {
-      relayEnvironment: false,
-    },
+  const system: any = {
+    relayEnvironment: false,
   }
 
-  const getWrapper = () => mount(<Boot {...bootProps} />)
+  const getWrapper = () => mount(<Boot initialState={[]} system={system} />)
 
   it("injects global state", () => {
     const App = () => {
       return (
-        <Boot welcomeMessage="Found global state" {...bootProps}>
+        <Boot
+          system={system}
+          initialState={[
+            new AppState({
+              welcomeMessage: "Found global state",
+            } as any),
+          ]}
+        >
           <SomeOtherComponent />
         </Boot>
       )
@@ -52,6 +57,6 @@ describe("Boot", () => {
   })
 
   it("injects Grid", () => {
-    expect(mount(<Boot {...bootProps} />).find("Grid").length).toEqual(1)
+    expect(getWrapper().find("Grid").length).toEqual(1)
   })
 })

--- a/src/Router/__test__/Boot.test.tsx
+++ b/src/Router/__test__/Boot.test.tsx
@@ -1,8 +1,9 @@
 import { mount } from "enzyme"
 import React from "react"
-import { Subscribe } from "unstated"
+import { Container, Subscribe } from "unstated"
 import { Boot } from "../Boot"
-import { AppState } from "../state"
+
+class WelcomeState extends Container<{ welcomeMessage: string }> {}
 
 describe("Boot", () => {
   const system: any = {
@@ -13,15 +14,12 @@ describe("Boot", () => {
 
   it("injects global state", () => {
     const App = () => {
+      const welcome = new WelcomeState()
+      welcome.state = {
+        welcomeMessage: "Found global state",
+      }
       return (
-        <Boot
-          system={system}
-          initialState={[
-            new AppState({
-              welcomeMessage: "Found global state",
-            } as any),
-          ]}
-        >
+        <Boot system={system} initialState={[welcome]}>
           <SomeOtherComponent />
         </Boot>
       )
@@ -29,7 +27,7 @@ describe("Boot", () => {
 
     const SomeOtherComponent = () => {
       return (
-        <Subscribe to={[AppState]}>
+        <Subscribe to={[WelcomeState]}>
           {app => {
             return <div>{app.state.welcomeMessage}</div>
           }}

--- a/src/Router/buildClientApp.tsx
+++ b/src/Router/buildClientApp.tsx
@@ -10,7 +10,8 @@ import React from "react"
 import { createEnvironment } from "../Relay/createEnvironment"
 import { AppShell } from "./AppShell"
 import { Boot } from "./Boot"
-import { AppConfig, ClientResolveProps } from "./types"
+import { AppState } from "./state"
+import { AppConfig, ClientResolveProps, Router } from "./types"
 
 export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
   return new Promise(async (resolve, reject) => {
@@ -61,25 +62,25 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
         render,
       })
 
-      const bootProps = {
-        system: {
-          ...config,
-          relayEnvironment,
-          resolver,
-          routes,
-          currentUser,
-        },
-      }
-
       try {
         await loadComponents()
       } catch (error) {
         // FIXME: https://github.com/smooth-code/loadable-components/pull/93
       }
 
+      const system: Router = {
+        relayEnvironment,
+        resolver,
+        routes,
+        currentUser,
+      }
+
       const ClientApp = props => {
         return (
-          <Boot {...bootProps} {...props}>
+          <Boot
+            system={system}
+            initialState={[new AppState({ ...props, system })]}
+          >
             <AppShell>
               <Router resolver={resolver} />
             </AppShell>

--- a/src/Router/buildClientApp.tsx
+++ b/src/Router/buildClientApp.tsx
@@ -79,7 +79,7 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
         currentUser,
       }
 
-      const ClientApp: App = props => {
+      const ClientApp: App = () => {
         return (
           <Boot
             system={system}
@@ -89,11 +89,12 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
               ...initialState,
             ]}
           >
-            {props.subscribeTo &&
-              props.children && (
-                <Subscribe to={props.subscribeTo}>
+            {config.subscribe &&
+              config.subscribe.to &&
+              config.subscribe.onChange && (
+                <Subscribe to={config.subscribe.to}>
                   {(...args) => {
-                    props.children(...args)
+                    config.subscribe.onChange(...args)
                     return null
                   }}
                 </Subscribe>

--- a/src/Router/buildClientApp.tsx
+++ b/src/Router/buildClientApp.tsx
@@ -7,11 +7,12 @@ import createInitialFarceRouter from "found/lib/createInitialFarceRouter"
 import createRender from "found/lib/createRender"
 import { loadComponents } from "loadable-components"
 import React from "react"
+import { Subscribe } from "unstated"
 import { createEnvironment } from "../Relay/createEnvironment"
 import { AppShell } from "./AppShell"
 import { Boot } from "./Boot"
 import { AppState } from "./state"
-import { AppConfig, ClientResolveProps, Router } from "./types"
+import { App, AppConfig, ClientResolveProps, Router } from "./types"
 
 export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
   return new Promise(async (resolve, reject) => {
@@ -78,7 +79,7 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
         currentUser,
       }
 
-      const ClientApp = props => {
+      const ClientApp: App = props => {
         return (
           <Boot
             system={system}
@@ -88,6 +89,15 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
               ...initialState,
             ]}
           >
+            {props.subscribeTo &&
+              props.children && (
+                <Subscribe to={props.subscribeTo}>
+                  {(...args) => {
+                    props.children(...args)
+                    return null
+                  }}
+                </Subscribe>
+              )}
             <AppShell>
               <Router resolver={resolver} />
             </AppShell>

--- a/src/Router/buildClientApp.tsx
+++ b/src/Router/buildClientApp.tsx
@@ -18,6 +18,7 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
     try {
       const {
         historyProtocol = "browser",
+        initialAppState = {},
         initialBreakpoint,
         initialRoute = "/",
         initialState = [],
@@ -82,7 +83,10 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
           <Boot
             system={system}
             initialBreakpoint={initialBreakpoint}
-            initialState={[new AppState({ ...props, system }), ...initialState]}
+            initialState={[
+              new AppState({ ...initialAppState, system }),
+              ...initialState,
+            ]}
           >
             <AppShell>
               <Router resolver={resolver} />

--- a/src/Router/buildClientApp.tsx
+++ b/src/Router/buildClientApp.tsx
@@ -17,10 +17,12 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
   return new Promise(async (resolve, reject) => {
     try {
       const {
+        historyProtocol = "browser",
+        initialBreakpoint,
+        initialRoute = "/",
+        initialState = [],
         routes,
         user,
-        historyProtocol = "browser",
-        initialRoute = "/",
       } = config
 
       const relayBootstrap = JSON.parse(window.__RELAY_BOOTSTRAP__ || "{}")
@@ -79,7 +81,8 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
         return (
           <Boot
             system={system}
-            initialState={[new AppState({ ...props, system })]}
+            initialBreakpoint={initialBreakpoint}
+            initialState={[new AppState({ ...props, system }), ...initialState]}
           >
             <AppShell>
               <Router resolver={resolver} />

--- a/src/Router/buildServerApp.tsx
+++ b/src/Router/buildServerApp.tsx
@@ -14,7 +14,7 @@ import { AppConfig, Router, ServerResolveProps } from "./types"
 export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
   return new Promise(async (resolve, reject) => {
     try {
-      const { routes, url, user } = config
+      const { initialBreakpoint, initialState = [], routes, url, user } = config
 
       let currentUser = user
       if (process.env.USER_ID && process.env.USER_ACCESS_TOKEN) {
@@ -51,7 +51,8 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
         return (
           <Boot
             system={system}
-            initialState={[new AppState({ ...props, system })]}
+            initialBreakpoint={initialBreakpoint}
+            initialState={[new AppState({ ...props, system }), ...initialState]}
           >
             <AppShell
               data={props.relayData}

--- a/src/Router/buildServerApp.tsx
+++ b/src/Router/buildServerApp.tsx
@@ -5,11 +5,12 @@ import { getFarceResult } from "found/lib/server"
 import { getLoadableState } from "loadable-components/server"
 import React from "react"
 import ReactDOMServer from "react-dom/server"
+import { Subscribe } from "../../node_modules/unstated"
 import { createEnvironment } from "../Relay/createEnvironment"
-import { AppShell } from "./AppShell"
+import { AppShell, AppShellProps } from "./AppShell"
 import { Boot } from "./Boot"
 import { AppState } from "./state"
-import { AppConfig, Router, ServerResolveProps } from "./types"
+import { AppConfig, AppProps, Router, ServerResolveProps } from "./types"
 
 export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
   return new Promise(async (resolve, reject) => {
@@ -54,7 +55,7 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
 
       const system: Router = { relayEnvironment, resolver, routes, currentUser }
 
-      const AppContainer = props => {
+      const AppContainer: React.SFC<AppProps & AppShellProps> = props => {
         return (
           <Boot
             system={system}
@@ -64,10 +65,16 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
               ...initialState,
             ]}
           >
-            <AppShell
-              data={props.relayData}
-              loadableState={props.loadableState}
-            >
+            {props.subscribeTo &&
+              props.children && (
+                <Subscribe to={props.subscribeTo}>
+                  {(...args) => {
+                    props.children(...args)
+                    return null
+                  }}
+                </Subscribe>
+              )}
+            <AppShell data={props.data} loadableState={props.loadableState}>
               {element}
             </AppShell>
           </Boot>

--- a/src/Router/buildServerApp.tsx
+++ b/src/Router/buildServerApp.tsx
@@ -8,7 +8,8 @@ import ReactDOMServer from "react-dom/server"
 import { createEnvironment } from "../Relay/createEnvironment"
 import { AppShell } from "./AppShell"
 import { Boot } from "./Boot"
-import { AppConfig, ServerResolveProps } from "./types"
+import { AppState } from "./state"
+import { AppConfig, Router, ServerResolveProps } from "./types"
 
 export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
   return new Promise(async (resolve, reject) => {
@@ -44,13 +45,14 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
         return
       }
 
-      const bootProps = {
-        system: { ...config, relayEnvironment, resolver, routes, currentUser },
-      }
+      const system: Router = { relayEnvironment, resolver, routes, currentUser }
 
       const AppContainer = props => {
         return (
-          <Boot {...bootProps} {...props}>
+          <Boot
+            system={system}
+            initialState={[new AppState({ ...props, system })]}
+          >
             <AppShell
               data={props.relayData}
               loadableState={props.loadableState}

--- a/src/Router/buildServerApp.tsx
+++ b/src/Router/buildServerApp.tsx
@@ -10,7 +10,7 @@ import { createEnvironment } from "../Relay/createEnvironment"
 import { AppShell, AppShellProps } from "./AppShell"
 import { Boot } from "./Boot"
 import { AppState } from "./state"
-import { AppConfig, AppProps, Router, ServerResolveProps } from "./types"
+import { AppConfig, Router, ServerResolveProps } from "./types"
 
 export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
   return new Promise(async (resolve, reject) => {
@@ -55,7 +55,7 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
 
       const system: Router = { relayEnvironment, resolver, routes, currentUser }
 
-      const AppContainer: React.SFC<AppProps & AppShellProps> = props => {
+      const AppContainer: React.SFC<AppShellProps> = props => {
         return (
           <Boot
             system={system}
@@ -65,11 +65,12 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
               ...initialState,
             ]}
           >
-            {props.subscribeTo &&
-              props.children && (
-                <Subscribe to={props.subscribeTo}>
+            {config.subscribe &&
+              config.subscribe.to &&
+              config.subscribe.onChange && (
+                <Subscribe to={config.subscribe.to}>
                   {(...args) => {
-                    props.children(...args)
+                    config.subscribe.onChange(...args)
                     return null
                   }}
                 </Subscribe>

--- a/src/Router/buildServerApp.tsx
+++ b/src/Router/buildServerApp.tsx
@@ -14,7 +14,14 @@ import { AppConfig, Router, ServerResolveProps } from "./types"
 export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
   return new Promise(async (resolve, reject) => {
     try {
-      const { initialBreakpoint, initialState = [], routes, url, user } = config
+      const {
+        initialAppState = {},
+        initialBreakpoint,
+        initialState = [],
+        routes,
+        url,
+        user,
+      } = config
 
       let currentUser = user
       if (process.env.USER_ID && process.env.USER_ACCESS_TOKEN) {
@@ -52,7 +59,10 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
           <Boot
             system={system}
             initialBreakpoint={initialBreakpoint}
-            initialState={[new AppState({ ...props, system }), ...initialState]}
+            initialState={[
+              new AppState({ ...initialAppState, system }),
+              ...initialState,
+            ]}
           >
             <AppShell
               data={props.relayData}

--- a/src/Router/state.tsx
+++ b/src/Router/state.tsx
@@ -34,7 +34,7 @@ export class AppState extends Container<AppStateContainer> {
     system: null,
   }
 
-  constructor(props: any = {}) {
+  constructor(props: AppStateContainer) {
     super()
     this.state = props
   }

--- a/src/Router/types.ts
+++ b/src/Router/types.ts
@@ -1,6 +1,7 @@
 import { RouteConfig } from "found"
 import { ComponentType } from "react"
 import { Environment } from "relay-runtime"
+import { Container } from "unstated"
 import { Breakpoint } from "Utils/Responsive"
 import { ContextProps } from "../Components/Artsy"
 
@@ -11,7 +12,10 @@ export interface AppConfig {
   historyProtocol?: HistoryProtocol
   initialBreakpoint?: Breakpoint
   initialRoute?: string
+  initialState?: Array<Container<any>>
   routes: RouteConfig
+
+  // TODO: What is this used for?
   url?: string
   user?: User
 }
@@ -40,14 +44,11 @@ export interface Router {
   resolver: any // FIXME
 }
 
-export interface BootProps extends AppStateContainer {
-  initialBreakpoint?: Breakpoint
-  system?: Router
-  [x: string]: any // User can pass in any properties on boot
-}
-
+// TODO: Neither of these things should be state, they should use the Artsy
+//       context.
 export interface AppStateContainer {
-  system?: Router
+  mediator?: any
+  system: Router
 }
 
 export interface PreloadLinkProps extends ContextProps, AppStateContainer {
@@ -58,8 +59,8 @@ export interface PreloadLinkProps extends ContextProps, AppStateContainer {
   onClick?: () => void
   onToggleLoading?: (isLoading: boolean) => void
   replace?: string
-  router?: any // TODO, from found
   to?: string
+  router?: any // TODO: found
 }
 
 export interface PreloadLinkContainer {

--- a/src/Router/types.ts
+++ b/src/Router/types.ts
@@ -13,6 +13,7 @@ export interface AppConfig {
   initialBreakpoint?: Breakpoint
   initialRoute?: string
   initialState?: Array<Container<any>>
+  initialAppState?: object // TODO: Deprecated
   routes: RouteConfig
 
   // TODO: What is this used for?

--- a/src/Router/types.ts
+++ b/src/Router/types.ts
@@ -13,19 +13,18 @@ export interface AppConfig {
   initialState?: Array<Container<any>>
   initialAppState?: object // TODO: Deprecated
   routes: RouteConfig
+  user?: User
+
+  subscribe?: {
+    to: SubscribeProps["to"]
+    onChange: (...instances: Array<Container<any>>) => void
+  }
 
   // TODO: What is this used for?
   url?: string
-  user?: User
 }
 
-export interface AppProps {
-  subscribeTo?: SubscribeProps["to"]
-  // Copied to change return type
-  children?: (...instances: Array<Container<any>>) => void
-}
-
-export type App = React.SFC<AppProps>
+export type App = React.ComponentType<{}>
 
 export interface ClientResolveProps {
   ClientApp: App

--- a/src/Router/types.ts
+++ b/src/Router/types.ts
@@ -1,11 +1,9 @@
 import { RouteConfig } from "found"
-import { ComponentType } from "react"
 import { Environment } from "relay-runtime"
-import { Container } from "unstated"
+import { Container, SubscribeProps } from "unstated"
 import { Breakpoint } from "Utils/Responsive"
 import { ContextProps } from "../Components/Artsy"
 
-type ReactComponent = ComponentType<any>
 type HistoryProtocol = "browser" | "hash" | "memory"
 
 export interface AppConfig {
@@ -21,21 +19,22 @@ export interface AppConfig {
   user?: User
 }
 
+export interface AppProps {
+  subscribeTo?: SubscribeProps["to"]
+  // Copied to change return type
+  children?: (...instances: Array<Container<any>>) => void
+}
+
+export type App = React.SFC<AppProps>
+
 export interface ClientResolveProps {
-  ClientApp: ReactComponent
+  ClientApp: App
 }
 
 export interface ServerResolveProps {
-  ServerApp?: ReactComponent
+  ServerApp?: App
   redirect?: string
   status?: string
-}
-
-export interface AppShellProps {
-  loadableState?: {
-    getScriptTag: () => string
-  }
-  data?: Array<object>
 }
 
 export interface Router {

--- a/src/__stories__/storiesOf.js
+++ b/src/__stories__/storiesOf.js
@@ -1,13 +1,29 @@
+// @ts-check
+
 import React from "react"
 import { storiesOf as _storiesOf } from "@storybook/react"
-import { Boot } from "Router/Boot"
+import { Boot } from "../Router/Boot"
+import { AppState } from "../Router/state"
 
-const bootProps = {
-  mediator: x => x,
-}
+/**
+ * @type {any}
+ */
+const system = {}
 
 export function storiesOf(desc, mod) {
   return _storiesOf(desc, mod).addDecorator(storyFn => {
-    return <Boot {...bootProps}>{storyFn()}</Boot>
+    return (
+      <Boot
+        system={system}
+        initialState={[
+          new AppState({
+            system,
+            mediator: x => x,
+          }),
+        ]}
+      >
+        {storyFn()}
+      </Boot>
+    )
   })
 }


### PR DESCRIPTION
The host app can now inject initial state (e.g. filter state parsed from URL) and subscribe to state changes (e.g. update URL based on filter state changes).

Will comment inline.

----

Force needs to be updated before deploying this code.

https://github.com/artsy/force/blob/fbefcd1a13a0ed2c3e6f4eb376001579adf38a38/src/desktop/apps/artist2/client.js:

```tsx
buildClientApp({
  routes,
  user: sd.CURRENT_USER,
  initialAppState: { mediator },
  subscribe: {
    to: [FilterState],
    onChange(filter => console.log(filter.state)),
  },
}).then(({ ClientApp }) => {
    ReactDOM.hydrate(
      <Container>
        <ClientApp />{/* mediator prop moved up to initialAppState */}
      </Container>,
      document.getElementById('react-root')
    )
  })
```