### PR TITLE
Make select options sentence case

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/TableSidebar.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/TableSidebar.tsx
@@ -13,7 +13,7 @@ import { AuctionResultsState } from "./state"
 const SORTS = [
   {
     value: "DATE_DESC",
-    text: "Most Recent",
+    text: "Most recent",
   },
   {
     value: "ESTIMATE_AND_DATE_DESC",
@@ -21,7 +21,7 @@ const SORTS = [
   },
   {
     value: "PRICE_AND_DATE_DESC",
-    text: "Sale Price",
+    text: "Sale price",
   },
 ]
 

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -134,9 +134,9 @@ class Filter extends Component<Props> {
                                 },
                                 {
                                   value: "-year",
-                                  text: "Artwork Year (desc.)",
+                                  text: "Artwork year (desc.)",
                                 },
-                                { value: "year", text: "Artwork Year (asc.)" },
+                                { value: "year", text: "Artwork year (asc.)" },
                               ] // Corrective spacing for line-height
                             }
                             selected={filters.state.sort}

--- a/src/Styleguide/Elements/Select.tsx
+++ b/src/Styleguide/Elements/Select.tsx
@@ -1,4 +1,5 @@
 import { color, Sans, space } from "@artsy/palette"
+import { capitalize } from "lodash"
 import React from "react"
 import styled, { css } from "styled-components"
 import { Responsive } from "Utils/Responsive"
@@ -43,7 +44,7 @@ export const LargeSelect = (props: SelectProps) => {
       <select onChange={event => props.onSelect(event.target.value)}>
         {props.options.map(({ value, text }) => (
           <option selected={value === props.selected} value={value} key={value}>
-            {text}
+            {capitalize(text)}
           </option>
         ))}
       </select>
@@ -66,7 +67,7 @@ export const SmallSelect = props => {
               value={value}
               key={value}
             >
-              {text}
+              {capitalize(text)}
             </option>
           ))}
         </select>

--- a/src/Styleguide/Elements/Select.tsx
+++ b/src/Styleguide/Elements/Select.tsx
@@ -1,5 +1,4 @@
 import { color, Sans, space } from "@artsy/palette"
-import { capitalize } from "lodash"
 import React from "react"
 import styled, { css } from "styled-components"
 import { Responsive } from "Utils/Responsive"
@@ -44,7 +43,7 @@ export const LargeSelect = (props: SelectProps) => {
       <select onChange={event => props.onSelect(event.target.value)}>
         {props.options.map(({ value, text }) => (
           <option selected={value === props.selected} value={value} key={value}>
-            {capitalize(text)}
+            {text}
           </option>
         ))}
       </select>
@@ -67,7 +66,7 @@ export const SmallSelect = props => {
               value={value}
               key={value}
             >
-              {capitalize(text)}
+              {text}
             </option>
           ))}
         </select>


### PR DESCRIPTION
Options in the select dropdown are generally supposed to be sentence case. There were a few instances where it wasn't. 