### PR TITLE
@alloy => Parse filters from URL and pass into overview query

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -209,6 +209,7 @@ export const ArtworkFilterFragmentContainer = createFragmentContainer(
           type: "[ArtworkAggregation]"
           defaultValue: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]
         }
+        sort: { type: "String", defaultValue: "-partner_updated_at" }
       ) {
       id
       filtered_artworks(aggregations: $aggregations, size: 0) {
@@ -221,6 +222,13 @@ export const ArtworkFilterFragmentContainer = createFragmentContainer(
         }
       }
       ...ArtworkFilterRefetch_artist
+        @arguments(
+          medium: $medium
+          major_periods: $major_periods
+          partner_id: $partner_id
+          for_sale: $for_sale
+          sort: $sort
+        )
     }
   `
 )

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -70,7 +70,14 @@ const OverviewRoute: SFC<OverviewRouteProps> = props => {
 export const OverviewRouteFragmentContainer = createFragmentContainer(
   OverviewRoute,
   graphql`
-    fragment Overview_artist on Artist {
+    fragment Overview_artist on Artist
+      @argumentDefinitions(
+        medium: { type: "String", defaultValue: "*" }
+        major_periods: { type: "[String]" }
+        partner_id: { type: "ID!" }
+        for_sale: { type: "Boolean" }
+        sort: { type: "String", defaultValue: "-partner_updated_at" }
+      ) {
       ...ArtistHeader_artist
       ...ArtistBio_bio
       ...CurrentEvent_artist
@@ -88,6 +95,13 @@ export const OverviewRouteFragmentContainer = createFragmentContainer(
       ...Genes_artist
 
       ...ArtworkFilter_artist
+        @arguments(
+          medium: $medium
+          major_periods: $major_periods
+          partner_id: $partner_id
+          for_sale: $for_sale
+          sort: $sort
+        )
     }
   `
 )

--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -47,10 +47,27 @@ export const routes = [
       {
         path: "/",
         Component: OverviewRoute,
+        prepareVariables: (params, props) => {
+          return { ...props.location.query, ...params }
+        },
         query: graphql`
-          query routes_OverviewQueryRendererQuery($artistID: String!) {
+          query routes_OverviewQueryRendererQuery(
+            $artistID: String!
+            $medium: String
+            $major_periods: [String]
+            $partner_id: ID
+            $for_sale: Boolean
+            $sort: String
+          ) {
             artist(id: $artistID) {
               ...Overview_artist
+                @arguments(
+                  medium: $medium
+                  major_periods: $major_periods
+                  partner_id: $partner_id
+                  for_sale: $for_sale
+                  sort: $sort
+                )
             }
           }
         `,

--- a/src/Router/buildServerApp.tsx
+++ b/src/Router/buildServerApp.tsx
@@ -46,7 +46,13 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
 
       const bootProps = {
         initialBreakpoint,
-        system: { ...config, relayEnvironment, resolver, routes, currentUser },
+        system: {
+          ...config,
+          relayEnvironment,
+          resolver,
+          routes,
+          currentUser,
+        },
       }
 
       const AppContainer = props => {

--- a/src/__generated__/ArtworkFilter_artist.graphql.ts
+++ b/src/__generated__/ArtworkFilter_artist.graphql.ts
@@ -73,6 +73,12 @@ return {
         "INSTITUTION",
         "MAJOR_PERIOD"
       ]
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "sort",
+      "type": "String",
+      "defaultValue": "-partner_updated_at"
     }
   ],
   "selections": [
@@ -143,11 +149,42 @@ return {
     {
       "kind": "FragmentSpread",
       "name": "ArtworkFilterRefetch_artist",
-      "args": null
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "for_sale",
+          "variableName": "for_sale",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "major_periods",
+          "variableName": "major_periods",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "medium",
+          "variableName": "medium",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "partner_id",
+          "variableName": "partner_id",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "sort",
+          "variableName": "sort",
+          "type": null
+        }
+      ]
     },
     v1
   ]
 };
 })();
-(node as any).hash = '71971f5ceac417e08f77d9a15d870ecb';
+(node as any).hash = '7aea3b086ed388df1c218fe0c117f3ca';
 export default node;

--- a/src/__generated__/Overview_artist.graphql.ts
+++ b/src/__generated__/Overview_artist.graphql.ts
@@ -25,7 +25,38 @@ return {
   "name": "Overview_artist",
   "type": "Artist",
   "metadata": null,
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "medium",
+      "type": "String",
+      "defaultValue": "*"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "major_periods",
+      "type": "[String]",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "partner_id",
+      "type": "ID!",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "for_sale",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "sort",
+      "type": "String",
+      "defaultValue": "-partner_updated_at"
+    }
+  ],
   "selections": [
     {
       "kind": "LinkedField",
@@ -111,11 +142,42 @@ return {
     {
       "kind": "FragmentSpread",
       "name": "ArtworkFilter_artist",
-      "args": null
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "for_sale",
+          "variableName": "for_sale",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "major_periods",
+          "variableName": "major_periods",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "medium",
+          "variableName": "medium",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "partner_id",
+          "variableName": "partner_id",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "sort",
+          "variableName": "sort",
+          "type": null
+        }
+      ]
     },
     v0
   ]
 };
 })();
-(node as any).hash = '1c01b7541f53768bcccbdd6bb2d29cd2';
+(node as any).hash = 'f76e35dafdaf17427243681d6cdad9f5';
 export default node;

--- a/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
@@ -3,6 +3,11 @@
 import { ConcreteRequest } from "relay-runtime";
 export type routes_OverviewQueryRendererQueryVariables = {
     readonly artistID: string;
+    readonly medium?: string | null;
+    readonly major_periods?: ReadonlyArray<string | null> | null;
+    readonly partner_id?: string | null;
+    readonly for_sale?: boolean | null;
+    readonly sort?: string | null;
 };
 export type routes_OverviewQueryRendererQueryResponse = {
     readonly artist: ({}) | null;
@@ -13,14 +18,19 @@ export type routes_OverviewQueryRendererQueryResponse = {
 /*
 query routes_OverviewQueryRendererQuery(
   $artistID: String!
+  $medium: String
+  $major_periods: [String]
+  $partner_id: ID
+  $for_sale: Boolean
+  $sort: String
 ) {
   artist(id: $artistID) {
-    ...Overview_artist
+    ...Overview_artist_3vi6l5
     __id
   }
 }
 
-fragment Overview_artist on Artist {
+fragment Overview_artist_3vi6l5 on Artist {
   ...ArtistHeader_artist
   ...ArtistBio_bio
   ...CurrentEvent_artist
@@ -35,7 +45,7 @@ fragment Overview_artist on Artist {
   }
   is_consignable
   ...Genes_artist
-  ...ArtworkFilter_artist
+  ...ArtworkFilter_artist_3vi6l5
   __id
 }
 
@@ -156,7 +166,7 @@ fragment Genes_artist on Artist {
   __id
 }
 
-fragment ArtworkFilter_artist on Artist {
+fragment ArtworkFilter_artist_3vi6l5 on Artist {
   id
   filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {
     aggregations {
@@ -169,13 +179,13 @@ fragment ArtworkFilter_artist on Artist {
     }
     __id
   }
-  ...ArtworkFilterRefetch_artist
+  ...ArtworkFilterRefetch_artist_3vi6l5
   __id
 }
 
-fragment ArtworkFilterRefetch_artist on Artist {
+fragment ArtworkFilterRefetch_artist_3vi6l5 on Artist {
   __id
-  grid: filtered_artworks(aggregations: [TOTAL], medium: "*", size: 0, sort: "-partner_updated_at") {
+  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0, sort: $sort) {
     ...ArtworkFilterArtworkGrid_filtered_artworks
     __id
   }
@@ -333,6 +343,36 @@ var v0 = [
     "name": "artistID",
     "type": "String!",
     "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "medium",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "major_periods",
+    "type": "[String]",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "partner_id",
+    "type": "ID",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "for_sale",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "sort",
+    "type": "String",
+    "defaultValue": null
   }
 ],
 v1 = [
@@ -456,7 +496,7 @@ return {
   "operationKind": "query",
   "name": "routes_OverviewQueryRendererQuery",
   "id": null,
-  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Overview_artist\n    __id\n  }\n}\n\nfragment Overview_artist on Artist {\n  ...ArtistHeader_artist\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsightsArtistPage_artist\n  id\n  exhibition_highlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  counts {\n    partner_shows\n  }\n  is_consignable\n  ...Genes_artist\n  ...ArtworkFilter_artist\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  name\n  id\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 300) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n  __id\n}\n\nfragment MarketInsightsArtistPage_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilter_artist on Artist {\n  id\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_3vi6l5\n    __id\n  }\n}\n\nfragment Overview_artist_3vi6l5 on Artist {\n  ...ArtistHeader_artist\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsightsArtistPage_artist\n  id\n  exhibition_highlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  counts {\n    partner_shows\n  }\n  is_consignable\n  ...Genes_artist\n  ...ArtworkFilter_artist_3vi6l5\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  name\n  id\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 300) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n  __id\n}\n\nfragment MarketInsightsArtistPage_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilter_artist_3vi6l5 on Artist {\n  id\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_3vi6l5\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_3vi6l5 on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -477,7 +517,38 @@ return {
           {
             "kind": "FragmentSpread",
             "name": "Overview_artist",
-            "args": null
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "for_sale",
+                "variableName": "for_sale",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "major_periods",
+                "variableName": "major_periods",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "medium",
+                "variableName": "medium",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "partner_id",
+                "variableName": "partner_id",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "sort",
+                "variableName": "sort",
+                "type": null
+              }
+            ]
           },
           v2
         ]
@@ -1098,7 +1169,7 @@ return {
             "kind": "LinkedField",
             "alias": "grid",
             "name": "filtered_artworks",
-            "storageKey": "filtered_artworks(aggregations:[\"TOTAL\"],medium:\"*\",size:0,sort:\"-partner_updated_at\")",
+            "storageKey": null,
             "args": [
               {
                 "kind": "Literal",
@@ -1109,16 +1180,34 @@ return {
                 "type": "[ArtworkAggregation]"
               },
               {
-                "kind": "Literal",
+                "kind": "Variable",
+                "name": "for_sale",
+                "variableName": "for_sale",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "major_periods",
+                "variableName": "major_periods",
+                "type": "[String]"
+              },
+              {
+                "kind": "Variable",
                 "name": "medium",
-                "value": "*",
+                "variableName": "medium",
                 "type": "String"
+              },
+              {
+                "kind": "Variable",
+                "name": "partner_id",
+                "variableName": "partner_id",
+                "type": "ID"
               },
               v12,
               {
-                "kind": "Literal",
+                "kind": "Variable",
                 "name": "sort",
-                "value": "-partner_updated_at",
+                "variableName": "sort",
                 "type": "String"
               }
             ],
@@ -1482,5 +1571,5 @@ return {
   }
 };
 })();
-(node as any).hash = '9d5f140e13f7d74ff36cfe75d842d250';
+(node as any).hash = 'e37e85cc5f07e1664dd224c9efed91b6';
 export default node;


### PR DESCRIPTION
This is part 1 of accepting an initial filter state (from URL).

This uses found-relay `prepareVariables` to pass that in, so `?medium=photography`, etc. will work.

Because there's a query, and many nested fragments, I added `@argumentDefinitions` and `@arguments` to keep passing those variables down. I thought I noticed in the GraphQL docs it read that fragments should be able to access root query variables, and the generated query _doesnt_ seem to keep passing the variables down, however w/o all of these the Relay compiler complains about missing variables.

So for now, I left them.


Part II is to get this to be actually passed in as initial props to the component, so that the UI can accurately reflect this (ie- 'for sale' should be checked, etc.)