### PR TITLE
@alloy => Correct prop name to fix rehydration

### DIFF
--- a/src/Router/buildServerApp.tsx
+++ b/src/Router/buildServerApp.tsx
@@ -78,7 +78,7 @@ export function buildServerApp(config: AppConfig): Promise<ServerResolveProps> {
       resolve({
         ServerApp: props => (
           <AppContainer
-            data={relayData}
+            relayData={relayData}
             loadableState={loadableState}
             {...props}
           />


### PR DESCRIPTION
Before the larger refactor, this now works! No client-side Metaphysics requests at all (verified via `yarn link/watch`), only once you select a filter, or do something like that, do we fire one off.