### PR TITLE
@zephraph => Tweak artwork brick save/hover state

### DIFF
--- a/src/Components/Artwork/Save.tsx
+++ b/src/Components/Artwork/Save.tsx
@@ -32,6 +32,7 @@ export interface Props
 // and intermediate local state becomes unnecessary
 interface State {
   is_saved: boolean
+  isHovered: boolean
 }
 
 export const SaveButtonContainer = Artsy.ContextConsumer(
@@ -42,6 +43,7 @@ export const SaveButtonContainer = Artsy.ContextConsumer(
 
     state = {
       is_saved: null,
+      isHovered: false,
     }
 
     get isSaved() {
@@ -145,18 +147,30 @@ export const SaveButtonContainer = Artsy.ContextConsumer(
 
     render() {
       const { style } = this.props
+      const saveStyle = this.isSaved ? { opacity: 1.0 } : {}
+      const fullStyle = { ...style, ...saveStyle }
+      const iconName =
+        this.isSaved && this.state.isHovered ? "remove-small" : "heart"
+      const iconFontSize = iconName === "heart" ? "24px" : "16px"
 
       return (
         <div
           className={this.props.className}
-          style={style}
+          style={fullStyle}
           onClick={() => this.handleSave()}
           data-saved={this.isSaved}
+          onMouseEnter={() => {
+            this.setState({ isHovered: true })
+          }}
+          onMouseLeave={() => {
+            this.setState({ isHovered: false })
+          }}
         >
           <Icon
-            name="heart"
+            name={iconName}
             height={SIZE}
             color="white"
+            fontSize={iconFontSize}
             style={{ verticalAlign: "middle" }}
           />
         </div>
@@ -183,7 +197,7 @@ export const SaveButton = styled(SaveButtonContainer)`
   &[data-saved="true"] {
     background-color: ${colors.purpleRegular};
     &:hover {
-      background-color: ${colors.redBold};
+      background-color: ${colors.redMedium};
     }
   }
 `


### PR DESCRIPTION
cc @briansw 

![bp](https://user-images.githubusercontent.com/1457859/42905926-775e2ba6-8aa7-11e8-89ee-b72e11da9851.gif)

We always show the 'heart' icon if its saved, adjusted the red color, and also switched to the 'x' icon when you hover over and it is saved (possible can fully be accomplished using CSS, but went with state/JS).