### PR TITLE
@zephraph => Make sure to wrap bio html with typography

### DIFF
--- a/src/Styleguide/Components/ArtistBio.tsx
+++ b/src/Styleguide/Components/ArtistBio.tsx
@@ -1,3 +1,4 @@
+import { Serif } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Responsive } from "Utils/Responsive"
@@ -26,7 +27,7 @@ export class ArtistBio extends React.Component<Props> {
           if (xs) {
             return (
               <ReadMore onReadMoreClicked={this.props.onReadMoreClicked}>
-                {blurb}
+                <Serif size="3">{blurb}</Serif>
               </ReadMore>
             )
           } else {
@@ -35,7 +36,7 @@ export class ArtistBio extends React.Component<Props> {
                 onReadMoreClicked={this.props.onReadMoreClicked}
                 maxLineCount={7}
               >
-                {blurb}
+                <Serif size="3">{blurb}</Serif>
               </ReadMore>
             )
           }


### PR DESCRIPTION
This might be the desired effect.

The reason we use `dangerouslySet` is b/c bios are markdown (we only really support links and italic/bold/etc, and default styling is fine there), and MP returns the HTML version.