### PR TITLE
@mzikherman => Wrap artist name on artist cards, and errant separator when no RVA

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -53,9 +53,12 @@ export const ArtistApp: React.SFC<ArtistAppProps> = props => {
         </Col>
       </Row>
 
-      <Separator my={6} />
-
-      {me && <RecentlyViewed me={me} />}
+      {me && (
+        <React.Fragment>
+          <Separator my={6} />
+          <RecentlyViewed me={me} />
+        </React.Fragment>
+      )}
 
       <Separator mt={6} mb={3} />
 

--- a/src/Components/Publishing/Byline/__tests__/NewsByline.test.tsx
+++ b/src/Components/Publishing/Byline/__tests__/NewsByline.test.tsx
@@ -6,6 +6,15 @@ import { NewsArticle } from "../../Fixtures/Articles"
 import { NewsByline } from "../NewsByline"
 
 describe("News Byline", () => {
+  const dateNow = Date.now
+
+  beforeAll(() => {
+    Date.now = () => Date.parse("01 Jan 2009 00:00:00 EST")
+  })
+
+  afterAll(() => {
+    Date.now = dateNow
+  })
   it("renders properly", () => {
     const byline = renderer.create(<NewsByline article={NewsArticle} />)
     expect(byline).toMatchSnapshot()

--- a/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.tsx
@@ -17,6 +17,15 @@ jest.mock("../../../../Utils/track.ts", () => ({
 }))
 
 describe("News Layout", () => {
+  const dateNow = Date.now
+
+  beforeAll(() => {
+    Date.now = () => Date.parse("01 Jan 2009 00:00:00 EST")
+  })
+
+  afterAll(() => {
+    Date.now = dateNow
+  })
   it("renders the news layout properly", () => {
     const series = renderer
       .create(<NewsLayout article={NewsArticle} />)

--- a/src/Components/Publishing/News/__tests__/NewsDateDivider.test.tsx
+++ b/src/Components/Publishing/News/__tests__/NewsDateDivider.test.tsx
@@ -7,34 +7,46 @@ import renderer from "react-test-renderer"
 import { NewsArticle } from "../../Fixtures/Articles"
 import { NewsDateDivider } from "../NewsDateDivider"
 
-it("renders a news date header properly", () => {
-  const component = renderer
-    .create(<NewsDateDivider date={NewsArticle.published_at} />)
-    .toJSON()
-  expect(component).toMatchSnapshot()
-})
+describe("NewsDateDivider", () => {
+  const dateNow = Date.now
 
-it("Renders 'today' if date is today", () => {
-  const date = moment().toISOString()
-  const wrapper = mount(<NewsDateDivider date={date} />)
-  expect(wrapper.text()).toMatch("Today")
-})
+  beforeAll(() => {
+    Date.now = () => Date.parse("01 Jan 2009 00:00:00 EST")
+  })
 
-// FIXME: Reenable (Fails in CI)
-xit("Renders date with no year if in current year", () => {
-  const date = moment()
-    .subtract(1, "week")
-    .toISOString()
-  const wrapper = mount(<NewsDateDivider date={date} />)
-  expect(wrapper.text()).toMatch(moment(date).format("MMM D"))
-  expect(wrapper.text()).not.toMatch(moment(date).format("YYYY"))
-})
+  afterAll(() => {
+    Date.now = dateNow
+  })
 
-// FIXME: Reenable (Fails in CI)
-xit("Renders date with year if not in current year", () => {
-  const date = moment()
-    .subtract(1, "year")
-    .toISOString()
-  const wrapper = mount(<NewsDateDivider date={date} />)
-  expect(wrapper.text()).toMatch(moment(date).format("MMM D, YYYY"))
+  it("renders a news date header properly", () => {
+    const component = renderer
+      .create(<NewsDateDivider date={NewsArticle.published_at} />)
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
+
+  it("Renders 'today' if date is today", () => {
+    const date = moment().toISOString()
+    const wrapper = mount(<NewsDateDivider date={date} />)
+    expect(wrapper.text()).toMatch("Today")
+  })
+
+  // FIXME: Reenable (Fails in CI)
+  xit("Renders date with no year if in current year", () => {
+    const date = moment()
+      .subtract(1, "week")
+      .toISOString()
+    const wrapper = mount(<NewsDateDivider date={date} />)
+    expect(wrapper.text()).toMatch(moment(date).format("MMM D"))
+    expect(wrapper.text()).not.toMatch(moment(date).format("YYYY"))
+  })
+
+  // FIXME: Reenable (Fails in CI)
+  xit("Renders date with year if not in current year", () => {
+    const date = moment()
+      .subtract(1, "year")
+      .toISOString()
+    const wrapper = mount(<NewsDateDivider date={date} />)
+    expect(wrapper.text()).toMatch(moment(date).format("MMM D, YYYY"))
+  })
 })

--- a/src/Components/Publishing/News/__tests__/__snapshots__/NewsDateDivider.test.tsx.snap
+++ b/src/Components/Publishing/News/__tests__/__snapshots__/NewsDateDivider.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a news date header properly 1`] = `
+exports[`NewsDateDivider renders a news date header properly 1`] = `
 .c1 {
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -42,7 +42,7 @@ exports[`renders a news date header properly 1`] = `
   <div
     className="c1"
   >
-    Jul 19
+    Jul 19, 2018
   </div>
 </div>
 `;

--- a/src/Styleguide/Components/ArtistCard.tsx
+++ b/src/Styleguide/Components/ArtistCard.tsx
@@ -1,6 +1,7 @@
 import { Sans, Serif, space } from "@artsy/palette"
 import { ArtistCard_artist } from "__generated__/ArtistCard_artist.graphql"
 import FollowArtistButton from "Components/FollowButton/FollowArtistButton"
+import { Truncator } from "Components/Truncator"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
@@ -44,7 +45,7 @@ export const LargeArtistCard = (props: Props) => (
         <Avatar src={props.artist.image.cropped.url} mb={1} />
       )}
       <Serif size="3t" weight="semibold" textAlign="center">
-        {props.artist.name}
+        <Truncator maxLineCount={2}>{props.artist.name}</Truncator>
       </Serif>
       <Sans size="2">{props.artist.formatted_nationality_and_birthday}</Sans>
     </Flex>
@@ -83,7 +84,9 @@ export const LargeArtistCard = (props: Props) => (
 export const SmallArtistCard = (props: Props) => (
   <BorderBox hover width="100%" justifyContent="space-between">
     <Flex flexDirection="column" justifyContent="center">
-      <Serif size="3t">{props.artist.name}</Serif>
+      <Serif size="3t">
+        <Truncator maxLineCount={2}>{props.artist.name}</Truncator>
+      </Serif>
       <Sans size="1">{props.artist.formatted_nationality_and_birthday}</Sans>
       <Spacer mb={1} />
       <FollowArtistButton


### PR DESCRIPTION
cc @zephraph 

I was futzing with `text-overflow: ellipsis`, and possible truncation via `props.name.slice(0, MAX_LENGTH)`, when I realized, why not just use `Truncator`?

Seems to be decent!

<img width="245" alt="screen shot 2018-07-19 at 9 50 02 am" src="https://user-images.githubusercontent.com/1457859/42946608-48c12ab8-8b39-11e8-89b2-638b87a1fc76.png">
