### PR TITLE
adds basic routing for orders/shipping

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -1,10 +1,44 @@
 import React, { SFC } from "react"
+import { Col, Row } from "Styleguide/Elements/Grid"
+import { Separator } from "Styleguide/Elements/Separator"
+import { Spacer } from "Styleguide/Elements/Spacer"
 
 export interface OrderAppProps {
   me: {
     name: string
   }
+  params: {
+    orderID: string
+  }
 }
 
 // @ts-ignore
-export const OrderApp: SFC<OrderAppProps> = ({ me }) => <div>{me.name}</div>
+export const OrderApp: SFC<OrderAppProps> = ({ me, children, order }) => {
+  return (
+    <React.Fragment>
+      <Row>
+        <Col>
+          <div>This is the Order App!</div>
+        </Col>
+      </Row>
+
+      <Spacer mb={3} />
+      {children}
+
+      <Row>
+        <Col>
+          <span id="jumpto-RouteTabs" />
+
+          <Spacer mb={3} />
+        </Col>
+      </Row>
+
+      {me && (
+        <React.Fragment>
+          <Separator my={6} />
+          {me.name}
+        </React.Fragment>
+      )}
+    </React.Fragment>
+  )
+}

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -18,20 +18,12 @@ export const OrderApp: SFC<OrderAppProps> = ({ me, children, order }) => {
     <React.Fragment>
       <Row>
         <Col>
-          <div>This is the Order App!</div>
+          <div>Order App</div>
         </Col>
       </Row>
 
       <Spacer mb={3} />
       {children}
-
-      <Row>
-        <Col>
-          <span id="jumpto-RouteTabs" />
-
-          <Spacer mb={3} />
-        </Col>
-      </Row>
 
       {me && (
         <React.Fragment>

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -1,27 +1,27 @@
-import { Shipping_order } from "__generated__/Shipping_order.graphql"
+import { Payment_order } from "__generated__/Payment_order.graphql"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Link } from "Router"
 import { Button } from "Styleguide/Elements/Button"
 import { Spacer } from "Styleguide/Elements/Spacer"
 
-export interface ShippingProps {
-  order: Shipping_order
+export interface PaymentProps {
+  order: Payment_order
 }
 
-export class ShippingRoute extends Component<ShippingProps> {
+export class PaymentRoute extends Component<PaymentProps> {
   render() {
     const { order } = this.props
 
     return (
       <React.Fragment>
-        Shipping page
+        Payment Page
         <Spacer mb={1} />
         {`Order #${order.id}`}
         <Spacer mb={2} />
-        <Link to={`/order2/${order.id}/payment`}>
+        <Link to={`/order2/${order.id}/review`}>
           <Button variant="primaryBlack" size="medium" m={0.5}>
-            Go to payment page
+            Go to review page
           </Button>
         </Link>
       </React.Fragment>
@@ -29,10 +29,10 @@ export class ShippingRoute extends Component<ShippingProps> {
   }
 }
 
-export const ShippingFragmentContainer = createFragmentContainer(
-  ShippingRoute,
+export const PaymentFragmentContainer = createFragmentContainer(
+  PaymentRoute,
   graphql`
-    fragment Shipping_order on Order {
+    fragment Payment_order on Order {
       id
     }
   `

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -1,27 +1,27 @@
-import { Shipping_order } from "__generated__/Shipping_order.graphql"
+import { Review_order } from "__generated__/Review_order.graphql"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Link } from "Router"
 import { Button } from "Styleguide/Elements/Button"
 import { Spacer } from "Styleguide/Elements/Spacer"
 
-export interface ShippingProps {
-  order: Shipping_order
+export interface ReviewProps {
+  order: Review_order
 }
 
-export class ShippingRoute extends Component<ShippingProps> {
+export class ReviewRoute extends Component<ReviewProps> {
   render() {
     const { order } = this.props
 
     return (
       <React.Fragment>
-        Shipping page
+        Review Page
         <Spacer mb={1} />
         {`Order #${order.id}`}
         <Spacer mb={2} />
-        <Link to={`/order2/${order.id}/payment`}>
+        <Link to={`/order2/${order.id}/submission`}>
           <Button variant="primaryBlack" size="medium" m={0.5}>
-            Go to payment page
+            Go to submission page
           </Button>
         </Link>
       </React.Fragment>
@@ -29,10 +29,10 @@ export class ShippingRoute extends Component<ShippingProps> {
   }
 }
 
-export const ShippingFragmentContainer = createFragmentContainer(
-  ShippingRoute,
+export const ReviewFragmentContainer = createFragmentContainer(
+  ReviewRoute,
   graphql`
-    fragment Shipping_order on Order {
+    fragment Review_order on Order {
       id
     }
   `

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -1,0 +1,31 @@
+import { Shipping_order } from "__generated__/Shipping_order.graphql"
+import React, { Component } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Spacer } from "Styleguide/Elements/Spacer"
+
+export interface ShippingProps {
+  order: Shipping_order
+}
+
+export class ShippingRoute extends Component<ShippingProps> {
+  render() {
+    const { order } = this.props
+
+    return (
+      <React.Fragment>
+        I am on the shipping route!
+        <Spacer mb={1} />
+        {`Order #: ${order.id}`}
+      </React.Fragment>
+    )
+  }
+}
+
+export const ShippingFragmentContainer = createFragmentContainer(
+  ShippingRoute,
+  graphql`
+    fragment Shipping_order on Order {
+      id
+    }
+  `
+)

--- a/src/Apps/Order/Routes/Submission/index.tsx
+++ b/src/Apps/Order/Routes/Submission/index.tsx
@@ -1,0 +1,33 @@
+import { Submission_order } from "__generated__/Submission_order.graphql"
+import React, { Component } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Spacer } from "Styleguide/Elements/Spacer"
+
+export interface SubmissionProps {
+  order: Submission_order
+}
+
+export class SubmissionRoute extends Component<SubmissionProps> {
+  render() {
+    const { order } = this.props
+
+    return (
+      <React.Fragment>
+        Submission Page
+        <Spacer mb={1} />
+        {`Order #${order.id}`}
+        <Spacer mb={2} />
+        Submitted!
+      </React.Fragment>
+    )
+  }
+}
+
+export const SubmissionFragmentContainer = createFragmentContainer(
+  SubmissionRoute,
+  graphql`
+    fragment Submission_order on Order {
+      id
+    }
+  `
+)

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -2,13 +2,25 @@ import { graphql } from "react-relay"
 import { OrderApp } from "./OrderApp"
 
 // @ts-ignore
+import { PaymentFragmentContainer as PaymentRoute } from "Apps/Order/Routes/Payment"
+// @ts-ignore
+import { ReviewFragmentContainer as ReviewRoute } from "Apps/Order/Routes/Review"
+// @ts-ignore
 import { ShippingFragmentContainer as ShippingRoute } from "Apps/Order/Routes/Shipping"
+// @ts-ignore
+import { SubmissionFragmentContainer as SubmissionRoute } from "Apps/Order/Routes/Submission"
 
 // @ts-ignore
 import { ComponentClass, StatelessComponent } from "react"
 
 // @ts-ignore
+import { PaymentProps } from "./Routes/Payment"
+// @ts-ignore
+import { ReviewProps } from "./Routes/Review"
+// @ts-ignore
 import { ShippingProps } from "./Routes/Shipping"
+// @ts-ignore
+import { SubmissionProps } from "./Routes/Submission"
 
 export const routes = [
   {
@@ -29,6 +41,39 @@ export const routes = [
           query routes_ShippingQuery($orderID: String!) {
             order(id: $orderID) {
               ...Shipping_order
+            }
+          }
+        `,
+      },
+      {
+        path: "payment",
+        Component: PaymentRoute,
+        query: graphql`
+          query routes_PaymentQuery($orderID: String!) {
+            order(id: $orderID) {
+              ...Payment_order
+            }
+          }
+        `,
+      },
+      {
+        path: "review",
+        Component: ReviewRoute,
+        query: graphql`
+          query routes_ReviewQuery($orderID: String!) {
+            order(id: $orderID) {
+              ...Review_order
+            }
+          }
+        `,
+      },
+      {
+        path: "submission",
+        Component: SubmissionRoute,
+        query: graphql`
+          query routes_SubmissionQuery($orderID: String!) {
+            order(id: $orderID) {
+              ...Submission_order
             }
           }
         `,

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -2,7 +2,13 @@ import { graphql } from "react-relay"
 import { OrderApp } from "./OrderApp"
 
 // @ts-ignore
+import { ShippingFragmentContainer as ShippingRoute } from "Apps/Order/Routes/Shipping"
+
+// @ts-ignore
 import { ComponentClass, StatelessComponent } from "react"
+
+// @ts-ignore
+import { ShippingProps } from "./Routes/Shipping"
 
 export const routes = [
   {
@@ -10,13 +16,23 @@ export const routes = [
     Component: OrderApp,
     query: graphql`
       query routes_OrderQuery {
-        # order(id: $orderID) {
-        #   id
-        # }
         me {
           name
         }
       }
     `,
+    children: [
+      {
+        path: "shipping",
+        Component: ShippingRoute,
+        query: graphql`
+          query routes_ShippingQuery($orderID: String!) {
+            order(id: $orderID) {
+              ...Shipping_order
+            }
+          }
+        `,
+      },
+    ],
   },
 ]

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -24,5 +24,5 @@ storiesOf("Apps", module)
     )
   })
   .add("Order Page", () => (
-    <StorybooksRouter routes={orderRoutes} initialRoute="/order2/1234" />
+    <StorybooksRouter routes={orderRoutes} initialRoute="/order2/22/shipping" />
   ))

--- a/src/__generated__/Payment_order.graphql.ts
+++ b/src/__generated__/Payment_order.graphql.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type Payment_order = {
+    readonly id: string | null;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "Payment_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "__id",
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '85a24649ea395173de362675a7c1cdcd';
+export default node;

--- a/src/__generated__/Review_order.graphql.ts
+++ b/src/__generated__/Review_order.graphql.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type Review_order = {
+    readonly id: string | null;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "Review_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "__id",
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '1d0f4a95a73e73dddc9f7127c7919d90';
+export default node;

--- a/src/__generated__/Shipping_order.graphql.ts
+++ b/src/__generated__/Shipping_order.graphql.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type Shipping_order = {
+    readonly id: string | null;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "Shipping_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "__id",
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '6fc1d37a0891e8a8003f7392085deff2';
+export default node;

--- a/src/__generated__/Submission_order.graphql.ts
+++ b/src/__generated__/Submission_order.graphql.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type Submission_order = {
+    readonly id: string | null;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "Submission_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "__id",
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = 'a28eb158dd8a4b23df5ecca95a1d45e4';
+export default node;

--- a/src/__generated__/routes_PaymentQuery.graphql.ts
+++ b/src/__generated__/routes_PaymentQuery.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type routes_PaymentQueryVariables = {
+    readonly orderID: string;
+};
+export type routes_PaymentQueryResponse = {
+    readonly order: ({}) | null;
+};
+
+
+
+/*
+query routes_PaymentQuery(
+  $orderID: String!
+) {
+  order(id: $orderID) {
+    ...Payment_order
+    __id: id
+  }
+}
+
+fragment Payment_order on Order {
+  id
+  __id: id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "orderID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "orderID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_PaymentQuery",
+  "id": null,
+  "text": "query routes_PaymentQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Payment_order\n    __id: id\n  }\n}\n\nfragment Payment_order on Order {\n  id\n  __id: id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_PaymentQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "order",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Order",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Payment_order",
+            "args": null
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_PaymentQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "order",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Order",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '4ecce8cd32d5a28bb2c0167757eac4fd';
+export default node;

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type routes_ReviewQueryVariables = {
+    readonly orderID: string;
+};
+export type routes_ReviewQueryResponse = {
+    readonly order: ({}) | null;
+};
+
+
+
+/*
+query routes_ReviewQuery(
+  $orderID: String!
+) {
+  order(id: $orderID) {
+    ...Review_order
+    __id: id
+  }
+}
+
+fragment Review_order on Order {
+  id
+  __id: id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "orderID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "orderID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_ReviewQuery",
+  "id": null,
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  __id: id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_ReviewQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "order",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Order",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Review_order",
+            "args": null
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_ReviewQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "order",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Order",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '27ff94ce1a13a2d866e2f783949ba274';
+export default node;

--- a/src/__generated__/routes_ShippingQuery.graphql.ts
+++ b/src/__generated__/routes_ShippingQuery.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type routes_ShippingQueryVariables = {
+    readonly orderID: string;
+};
+export type routes_ShippingQueryResponse = {
+    readonly order: ({}) | null;
+};
+
+
+
+/*
+query routes_ShippingQuery(
+  $orderID: String!
+) {
+  order(id: $orderID) {
+    ...Shipping_order
+    __id: id
+  }
+}
+
+fragment Shipping_order on Order {
+  id
+  __id: id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "orderID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "orderID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_ShippingQuery",
+  "id": null,
+  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  __id: id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_ShippingQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "order",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Order",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Shipping_order",
+            "args": null
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_ShippingQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "order",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Order",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'a9eb2bc4e3a8c7df4af5c9dd68927880';
+export default node;

--- a/src/__generated__/routes_SubmissionQuery.graphql.ts
+++ b/src/__generated__/routes_SubmissionQuery.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type routes_SubmissionQueryVariables = {
+    readonly orderID: string;
+};
+export type routes_SubmissionQueryResponse = {
+    readonly order: ({}) | null;
+};
+
+
+
+/*
+query routes_SubmissionQuery(
+  $orderID: String!
+) {
+  order(id: $orderID) {
+    ...Submission_order
+    __id: id
+  }
+}
+
+fragment Submission_order on Order {
+  id
+  __id: id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "orderID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "orderID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_SubmissionQuery",
+  "id": null,
+  "text": "query routes_SubmissionQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Submission_order\n    __id: id\n  }\n}\n\nfragment Submission_order on Order {\n  id\n  __id: id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_SubmissionQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "order",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Order",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Submission_order",
+            "args": null
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_SubmissionQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "order",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Order",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '2327a8a5d5ec421c21ee604875374966';
+export default node;


### PR DESCRIPTION
This is super basic, but it adds the beginnings of route-handling in reaction. If this looks okay (it's all behind an admin flag anyways) then we can go ahead and release this version and merge the force side.

[Update] This now includes all routes with a button to navigate between them as described in the notion doc.

Rendered in force (storybooks also work, provided you are visiting the route of an order that you have created and you use your access token in the `.env`):
![order-routing](https://user-images.githubusercontent.com/2081340/43002912-7f9dc446-8bf8-11e8-9350-fce2ef790bbe.gif)

