### PR TITLE
Scrollable tabs, body doesn't scroll

### DIFF
--- a/src/Apps/Artist/Components/NavigationTabs.tsx
+++ b/src/Apps/Artist/Components/NavigationTabs.tsx
@@ -2,6 +2,7 @@ import { NavigationTabs_artist } from "__generated__/NavigationTabs_artist.graph
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouteTab, RouteTabs } from "Styleguide/Components/RouteTabs"
+import { Responsive } from "Utils/Responsive"
 
 interface Props {
   artist: NavigationTabs_artist
@@ -12,22 +13,36 @@ export const NavigationTabs: React.SFC<Props> = props => {
   const route = (path = "") => `/artist2/${props.artist.id}${path}`
 
   return (
-    <RouteTabs>
-      <RouteTab to={route()} exact>
-        Overview
-      </RouteTab>
-      {statuses.cv && <RouteTab to={route("/cv")}>CV</RouteTab>}
-      {statuses.articles && (
-        <RouteTab to={route("/articles")}>Articles</RouteTab>
-      )}
-      {statuses.shows && <RouteTab to={route("/shows")}>Shows</RouteTab>}
-      {statuses.auction_lots && (
-        <RouteTab to={route("/auction-results")}>Auction results</RouteTab>
-      )}
-      {(statuses.artists || statuses.contemporary) && (
-        <RouteTab to={route("/related-artists")}>Related artists</RouteTab>
-      )}
-    </RouteTabs>
+    <Responsive>
+      {({ xs }) => {
+        return (
+          <RouteTabs
+            mx={xs ? -4 : 0}
+            pl={xs ? 4 : 0}
+            style={{ overflow: xs ? "scroll" : "" }}
+          >
+            <RouteTab to={route()} exact>
+              Overview
+            </RouteTab>
+            {statuses.cv && <RouteTab to={route("/cv")}>CV</RouteTab>}
+            {statuses.articles && (
+              <RouteTab to={route("/articles")}>Articles</RouteTab>
+            )}
+            {statuses.shows && <RouteTab to={route("/shows")}>Shows</RouteTab>}
+            {statuses.auction_lots && (
+              <RouteTab to={route("/auction-results")}>
+                Auction results
+              </RouteTab>
+            )}
+            {(statuses.artists || statuses.contemporary) && (
+              <RouteTab to={route("/related-artists")}>
+                Related artists
+              </RouteTab>
+            )}
+          </RouteTabs>
+        )
+      }}
+    </Responsive>
   )
 }
 

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -1,4 +1,4 @@
-import { color, Sans } from "@artsy/palette"
+import { color, Sans, space } from "@artsy/palette"
 import React from "react"
 import styled, { css } from "styled-components"
 import { borders, JustifyContentProps, WidthProps } from "styled-system"
@@ -134,16 +134,20 @@ export const styles = {
     cursor: pointer;
     padding-bottom: 13px;
     margin-bottom: -1px;
-    margin-right: 20px;
+    margin-right: ${space(2)}px;
     white-space: nowrap;
     ${borders};
+
+    &:last-child {
+      padding-right: ${space(4)}px;
+    }
   `,
 
   activeTabContainer: css`
     pointer-events: none;
     padding-bottom: 13px;
     margin-bottom: -1px;
-    margin-right: 20px;
+    margin-right: ${space(2)}px;
     white-space: nowrap;
     border-bottom: 1px solid ${color("black60")};
   `,

--- a/src/Styleguide/Elements/Grid.tsx
+++ b/src/Styleguide/Elements/Grid.tsx
@@ -8,6 +8,7 @@ import styled, { StyledComponentClass } from "styled-components"
 const DEBUG = false
 
 export const Grid = styled(StyledGrid.Container)`
+  overflow: hidden;
   ${space};
 `
 export const Row = styled(StyledGrid.Row)`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@artsy/palette@^2.3.4":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.6.3.tgz#dc2efcd875ab1aaba5bf361d9e305451f4c76b9b"
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.7.0.tgz#e3648d5d9bfd642ddd0ea969a70544810c2de887"
   dependencies:
     react "^16.3.2"
     styled-system "^2.2.5"


### PR DESCRIPTION
Fixes [DISCO-104](https://artsyproduct.atlassian.net/browse/DISCO-104).

Makes entire page not scrollable. Does this in a few ways. 

1. Makes the grid have `overflow: hidden`. It'll never be scrollable because of that (for better or worse)
2. Updates the tabs to be scrollable on xs. This is the main thing that was forcing the site to be too wide on xs. 