### PR TITLE
@l2succes => Article can render classic layouts

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import Events from "../../Utils/Events"
 import track from "../../Utils/track"
 import ArticleWithFullScreen from "./Layouts/ArticleWithFullScreen"
+import { ClassicLayout } from "./Layouts/ClassicLayout"
 import { NewsLayout } from "./Layouts/NewsLayout"
 import { SeriesLayout } from "./Layouts/SeriesLayout"
 import { VideoLayout } from "./Layouts/VideoLayout"
@@ -53,6 +54,9 @@ export class Article extends React.Component<ArticleProps> {
     const { article } = this.props
 
     switch (article.layout) {
+      case "classic": {
+        return <ClassicLayout {...this.props} />
+      }
       case "series": {
         return <SeriesLayout {...this.props} />
       }

--- a/src/Components/Publishing/Layouts/ClassicLayout.tsx
+++ b/src/Components/Publishing/Layouts/ClassicLayout.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import styled from "styled-components"
+import { Header } from "../Header/Header"
+import { Sections } from "../Sections/Sections"
+import { ArticleData } from "../Typings"
+
+export interface ArticleProps {
+  article: ArticleData
+  isMobile?: boolean
+}
+
+export const ClassicLayout: React.SFC<ArticleProps> = props => {
+  return (
+    <ClassicLayoutContainer>
+      <Header {...props} />
+      <Sections {...props} />
+    </ClassicLayoutContainer>
+  )
+}
+
+const ClassicLayoutContainer = styled.div`
+  position: relative;
+`

--- a/src/Components/Publishing/Layouts/__tests__/ClassicLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/ClassicLayout.test.tsx
@@ -1,0 +1,14 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import { ClassicArticle } from "../../Fixtures/Articles"
+import { Header } from "../../Header/Header"
+import { Sections } from "../../Sections/Sections"
+import { ClassicLayout } from "../ClassicLayout"
+
+it("Renders article header and sections", () => {
+  const component = mount(<ClassicLayout article={ClassicArticle} />)
+
+  expect(component.find(Header)).toHaveLength(1)
+  expect(component.find(Sections)).toHaveLength(1)
+})

--- a/src/Components/Publishing/__stories__/ArticleClassic.story.tsx
+++ b/src/Components/Publishing/__stories__/ArticleClassic.story.tsx
@@ -1,0 +1,8 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Article } from "../Article"
+import { ClassicArticle } from "../Fixtures/Articles"
+
+storiesOf("Publishing/Articles/Classic", module).add("Classic", () => {
+  return <Article article={ClassicArticle} />
+})


### PR DESCRIPTION
Experimental -- adds 'ClassicLayout' component, and adds ability to render 'classic' layout articles from top level article component. 

This is not yet used in production, but will allow us to view classic articles in storybooks.

This also gives us ability to spike on killing Backbone article pages, or using stitch to render this component rather than backbone views where `/mobile/components/article` is still used. 