### PR TITLE
@l2succes => [FIX publishing] Put back list styles in article text

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
@@ -237,6 +237,14 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   padding-left: 1em;
 }
 
+.c13 ul {
+  list-style: disc;
+}
+
+.c13 ol {
+  list-style: decimal;
+}
+
 .c13 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -1152,6 +1160,14 @@ exports[`News Layout renders the news layout properly 1`] = `
 .c13 ul,
 .c13 ol {
   padding-left: 1em;
+}
+
+.c13 ul {
+  list-style: disc;
+}
+
+.c13 ol {
+  list-style: decimal;
 }
 
 .c13 li {

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -382,6 +382,14 @@ exports[`renders a series properly 1`] = `
   padding-left: 1em;
 }
 
+.c40 ul {
+  list-style: disc;
+}
+
+.c40 ol {
+  list-style: decimal;
+}
+
 .c40 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -1500,6 +1508,14 @@ exports[`renders a sponsored series properly 1`] = `
 .c47 ul,
 .c47 ol {
   padding-left: 1em;
+}
+
+.c47 ul {
+  list-style: disc;
+}
+
+.c47 ol {
+  list-style: decimal;
 }
 
 .c47 li {

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -443,6 +443,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   padding-left: 1em;
 }
 
+.c50 ul {
+  list-style: disc;
+}
+
+.c50 ol {
+  list-style: decimal;
+}
+
 .c50 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -619,6 +627,14 @@ exports[`Video Layout matches the snapshot 1`] = `
 .c61 ul,
 .c61 ol {
   padding-left: 1em;
+}
+
+.c61 ul {
+  list-style: disc;
+}
+
+.c61 ol {
+  list-style: decimal;
 }
 
 .c61 li {

--- a/src/Components/Publishing/Sections/StyledText.tsx
+++ b/src/Components/Publishing/Sections/StyledText.tsx
@@ -81,6 +81,12 @@ export const StyledText = div`
   ul, ol {
     padding-left: 1em;
   }
+  ul {
+    list-style: disc;
+  }
+  ol {
+    list-style: decimal;
+  }
   li {
     ${props => (props.layout === "classic" ? garamond("s19") : garamond("s23"))}
     padding-top: .5em;

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/SectionContainer.test.tsx.snap
@@ -70,6 +70,14 @@ exports[`renders column_width properly 1`] = `
   padding-left: 1em;
 }
 
+.c1 ul {
+  list-style: disc;
+}
+
+.c1 ol {
+  list-style: decimal;
+}
+
 .c1 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -353,6 +361,14 @@ exports[`renders fillwidth properly 1`] = `
   padding-left: 1em;
 }
 
+.c1 ul {
+  list-style: disc;
+}
+
+.c1 ol {
+  list-style: decimal;
+}
+
 .c1 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -634,6 +650,14 @@ exports[`renders overflow_fillwidth properly 1`] = `
 .c1 ul,
 .c1 ol {
   padding-left: 1em;
+}
+
+.c1 ul {
+  list-style: disc;
+}
+
+.c1 ol {
+  list-style: decimal;
 }
 
 .c1 li {

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -459,6 +459,14 @@ exports[`Sections snapshots renders properly 1`] = `
   padding-left: 1em;
 }
 
+.c2 ul {
+  list-style: disc;
+}
+
+.c2 ol {
+  list-style: decimal;
+}
+
 .c2 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Text.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Text.test.tsx.snap
@@ -59,6 +59,14 @@ exports[`Text Snapshots renders classic text properly 1`] = `
   padding-left: 1em;
 }
 
+.c0 ul {
+  list-style: disc;
+}
+
+.c0 ol {
+  list-style: decimal;
+}
+
 .c0 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 19px;
@@ -314,6 +322,14 @@ exports[`Text Snapshots renders feature text properly 1`] = `
   padding-left: 1em;
 }
 
+.c0 ul {
+  list-style: disc;
+}
+
+.c0 ol {
+  list-style: decimal;
+}
+
 .c0 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -565,6 +581,14 @@ exports[`Text Snapshots renders news text properly 1`] = `
 .c0 ul,
 .c0 ol {
   padding-left: 1em;
+}
+
+.c0 ul {
+  list-style: disc;
+}
+
+.c0 ol {
+  list-style: decimal;
 }
 
 .c0 li {
@@ -826,6 +850,14 @@ exports[`Text Snapshots renders standard text properly 1`] = `
 .c0 ul,
 .c0 ol {
   padding-left: 1em;
+}
+
+.c0 ul {
+  list-style: disc;
+}
+
+.c0 ol {
+  list-style: decimal;
 }
 
 .c0 li {

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -96,6 +96,14 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   padding-left: 1em;
 }
 
+.c6 ul {
+  list-style: disc;
+}
+
+.c6 ol {
+  list-style: decimal;
+}
+
 .c6 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -501,6 +509,14 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   padding-left: 1em;
 }
 
+.c6 ul {
+  list-style: disc;
+}
+
+.c6 ol {
+  list-style: decimal;
+}
+
 .c6 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -897,6 +913,14 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
 .c6 ul,
 .c6 ol {
   padding-left: 1em;
+}
+
+.c6 ul {
+  list-style: disc;
+}
+
+.c6 ol {
+  list-style: decimal;
 }
 
 .c6 li {
@@ -1324,6 +1348,14 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
 .c10 ul,
 .c10 ol {
   padding-left: 1em;
+}
+
+.c10 ul {
+  list-style: disc;
+}
+
+.c10 ol {
+  list-style: decimal;
 }
 
 .c10 li {

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
@@ -135,6 +135,14 @@ exports[`Video About matches the snapshot 1`] = `
   padding-left: 1em;
 }
 
+.c4 ul {
+  list-style: disc;
+}
+
+.c4 ol {
+  list-style: decimal;
+}
+
 .c4 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
@@ -908,6 +916,14 @@ exports[`Video About matches the snapshot with editable props 1`] = `
 .c4 ul,
 .c4 ol {
   padding-left: 1em;
+}
+
+.c4 ul {
+  list-style: disc;
+}
+
+.c4 ol {
+  list-style: decimal;
 }
 
 .c4 li {


### PR DESCRIPTION
Noticed while assembling Article type presentation, list styles are missing from Article text. This was also noted by Alex Forbes. 