### PR TITLE
@mzikherman => Use total show count instead of length of fetched exhibitions

### DIFF
--- a/src/Styleguide/Components/SelectedExhibitions.tsx
+++ b/src/Styleguide/Components/SelectedExhibitions.tsx
@@ -106,7 +106,7 @@ export class SelectedExhibitionsContainer extends React.Component<
   render() {
     if (
       !this.props.exhibitions ||
-      this.props.exhibitions.length < MIN_EXHIBITIONS
+      this.props.totalExhibitions < MIN_EXHIBITIONS
     )
       return null
     return (


### PR DESCRIPTION
to determine if module should be shown. Will help with artists that happen to have blacklisted partners in the first few results.