### PR TITLE
Adds Stepper Component

### DIFF
--- a/src/Assets/Icons/CheckIcon.tsx
+++ b/src/Assets/Icons/CheckIcon.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+
+interface IconProps {
+  fill: string
+}
+
+export const CheckIcon = ({ fill }: IconProps) => (
+  <svg width="10px" height="8px" viewBox="0 0 10 8" version="1.1">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+      <g transform="translate(-416.000000, -960.000000)" fill="#000000">
+        <g transform="translate(416.000000, 918.000000)">
+          <polygon
+            fill={fill}
+            points="7.97385698 42 9.14742868 42.8908963 3.39210448 50.0024371 0 46.7045578 1.06103742 45.6729936 3.26349389 47.8142707"
+          />
+        </g>
+      </g>
+    </g>
+  </svg>
+)

--- a/src/Assets/Icons/ChevronIcon.tsx
+++ b/src/Assets/Icons/ChevronIcon.tsx
@@ -1,13 +1,16 @@
 import { color } from "@artsy/palette"
 import React from "react"
 
-enum Direction {
+export enum Direction {
   LEFT,
   RIGHT,
 }
 
 interface IconProps {
+  /** default is RIGHT */
   direction?: Direction
+
+  /** default is black10 */
   fill?: string
 }
 
@@ -17,7 +20,7 @@ export const ChevronIcon = ({ direction, fill }: IconProps) => (
     viewBox="0 0 12 12"
     width="8px"
     height="8px"
-    transform={direction === Direction.RIGHT ? "scale(-1, 1)" : ""}
+    transform={direction === Direction.LEFT ? "" : "scale(-1, 1)"}
   >
     <path
       fill={fill ? fill : color("black10")}

--- a/src/Assets/Icons/ChevronIcon.tsx
+++ b/src/Assets/Icons/ChevronIcon.tsx
@@ -1,0 +1,28 @@
+import { color } from "@artsy/palette"
+import React from "react"
+
+enum Direction {
+  LEFT,
+  RIGHT,
+}
+
+interface IconProps {
+  direction?: Direction
+  fill?: string
+}
+
+export const ChevronIcon = ({ direction, fill }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 12 12"
+    width="8px"
+    height="8px"
+    transform={direction === Direction.RIGHT ? "scale(-1, 1)" : ""}
+  >
+    <path
+      fill={fill ? fill : color("black10")}
+      fill-rule="evenodd"
+      d="M9.091 10.758l-.788.771-5.832-5.708L8.303.113l.788.771-5.044 4.937 5.044 4.937"
+    />
+  </svg>
+)

--- a/src/Styleguide/Components/Stepper.tsx
+++ b/src/Styleguide/Components/Stepper.tsx
@@ -7,8 +7,10 @@ import { Flex } from "Styleguide/Elements/Flex"
 interface StepperProps extends TabsProps {
   initialTabIndex: number
 
-  /* the step user currently is at */
+  /* the step user currently is at (e.g. previous steps completed) */
   currentStepIndex: number
+
+  disableNavigation?: boolean
 }
 
 const transformTabBtn = (
@@ -16,27 +18,28 @@ const transformTabBtn = (
   tabIndex: number,
   props: any
 ): JSX.Element => {
-  const { currentStepIndex } = props
+  const { currentStepIndex, disableNavigation } = props
+  const elementWithoutNav = React.cloneElement(element, {
+    ...element.props,
+    onClick: () => {
+      null
+    },
+  })
   if (tabIndex > currentStepIndex) {
     // don't allow users to jump ahead
-    const newElement = React.cloneElement(element, {
-      ...element.props,
-      onClick: () => {
-        null
-      },
-    })
-    return newElement
+
+    return elementWithoutNav
   } else if (currentStepIndex && tabIndex < currentStepIndex) {
     return (
       <Flex>
         <CheckMarkWrapper>
           <CheckMark />
         </CheckMarkWrapper>
-        {element}
+        {disableNavigation ? elementWithoutNav : element}
         <div /> {/* hack for getting rid of last-child in Tabs.tsx */}
       </Flex>
     )
-  } else return element
+  } else return disableNavigation ? elementWithoutNav : element
 }
 
 export const Stepper = (props: StepperProps) => {

--- a/src/Styleguide/Components/Stepper.tsx
+++ b/src/Styleguide/Components/Stepper.tsx
@@ -1,0 +1,33 @@
+import { color, space } from "@artsy/palette"
+import React from "react"
+import styled from "styled-components"
+import { Tab, Tabs, TabsProps } from "Styleguide/Components/Tabs"
+
+interface StepperProps extends TabsProps {
+  currentIndex?: number
+}
+export const Stepper = (props: StepperProps) => {
+  return <Tabs separator={<Chevron />} {...props} />
+}
+
+export const Step = props => <Tab {...props} />
+
+const ChevronWrapper = styled.svg`
+  margin: ${space(0.5)}px ${space(1)}px;
+`
+
+const Chevron = () => (
+  <ChevronWrapper
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 12 12"
+    width="8px"
+    height="8px"
+    transform="scale(-1, 1)"
+  >
+    <path
+      fill={color("black10")}
+      fill-rule="evenodd"
+      d="M9.091 10.758l-.788.771-5.832-5.708L8.303.113l.788.771-5.044 4.937 5.044 4.937"
+    />
+  </ChevronWrapper>
+)

--- a/src/Styleguide/Components/Stepper.tsx
+++ b/src/Styleguide/Components/Stepper.tsx
@@ -1,4 +1,6 @@
 import { color, space } from "@artsy/palette"
+import { CheckIcon } from "Assets/Icons/CheckIcon"
+import { ChevronIcon } from "Assets/Icons/ChevronIcon"
 import React from "react"
 import styled from "styled-components"
 import { Tab, Tabs, TabsProps } from "Styleguide/Components/Tabs"
@@ -33,7 +35,7 @@ const transformTabBtn = (
     return (
       <Flex>
         <CheckMarkWrapper>
-          <CheckMark />
+          <CheckIcon fill={color("green100")} />
         </CheckMarkWrapper>
         {disableNavigation ? elementWithoutNav : element}
         <div /> {/* hack for getting rid of last-child in Tabs.tsx */}
@@ -47,7 +49,7 @@ export const Stepper = (props: StepperProps) => {
     <Tabs
       separator={
         <ChevronWrapper>
-          <Chevron />
+          <ChevronIcon />
         </ChevronWrapper>
       }
       transformTabBtn={transformTabBtn}
@@ -67,34 +69,3 @@ const CheckMarkWrapper = styled.span`
   margin-right: ${space(1)}px;
   line-height: normal;
 `
-
-const CheckMark = () => (
-  <svg width="10px" height="8px" viewBox="0 0 10 8" version="1.1">
-    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-      <g transform="translate(-416.000000, -960.000000)" fill="#000000">
-        <g transform="translate(416.000000, 918.000000)">
-          <polygon
-            fill={color("green100")}
-            points="7.97385698 42 9.14742868 42.8908963 3.39210448 50.0024371 0 46.7045578 1.06103742 45.6729936 3.26349389 47.8142707"
-          />
-        </g>
-      </g>
-    </g>
-  </svg>
-)
-
-const Chevron = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 12 12"
-    width="8px"
-    height="8px"
-    transform="scale(-1, 1)"
-  >
-    <path
-      fill={color("black10")}
-      fill-rule="evenodd"
-      d="M9.091 10.758l-.788.771-5.832-5.708L8.303.113l.788.771-5.044 4.937 5.044 4.937"
-    />
-  </svg>
-)

--- a/src/Styleguide/Components/Stepper.tsx
+++ b/src/Styleguide/Components/Stepper.tsx
@@ -17,7 +17,16 @@ const transformTabBtn = (
   props: any
 ): JSX.Element => {
   const { currentStepIndex } = props
-  if (currentStepIndex && tabIndex < currentStepIndex) {
+  if (tabIndex > currentStepIndex) {
+    // don't allow users to jump ahead
+    const newElement = React.cloneElement(element, {
+      ...element.props,
+      onClick: () => {
+        null
+      },
+    })
+    return newElement
+  } else if (currentStepIndex && tabIndex < currentStepIndex) {
     return (
       <Flex>
         <CheckMarkWrapper>

--- a/src/Styleguide/Components/Stepper.tsx
+++ b/src/Styleguide/Components/Stepper.tsx
@@ -56,7 +56,7 @@ export const Stepper = (props: StepperProps) => {
 export const Step = props => <Tab {...props} />
 
 const ChevronWrapper = styled.span`
-  margin: 0 ${space(1)}px;
+  margin: 0 ${space(2)}px;
   line-height: normal;
 `
 

--- a/src/Styleguide/Components/Stepper.tsx
+++ b/src/Styleguide/Components/Stepper.tsx
@@ -1,15 +1,17 @@
-import { color, space } from "@artsy/palette"
+import { color, Sans, space } from "@artsy/palette"
 import { CheckIcon } from "Assets/Icons/CheckIcon"
 import { ChevronIcon } from "Assets/Icons/ChevronIcon"
 import React from "react"
 import styled from "styled-components"
 import { Tab, Tabs, TabsProps } from "Styleguide/Components/Tabs"
 import { Flex } from "Styleguide/Elements/Flex"
+import { styles } from "./Tabs"
 
 interface StepperProps extends TabsProps {
+  /** The initial step stepper renders */
   initialTabIndex: number
 
-  /* the step user currently is at (e.g. previous steps completed) */
+  /** The step user currently is at (e.g. previous steps completed) */
   currentStepIndex: number
 
   disableNavigation?: boolean
@@ -20,28 +22,33 @@ const transformTabBtn = (
   tabIndex: number,
   props: any
 ): JSX.Element => {
-  const { currentStepIndex, disableNavigation } = props
-  const elementWithoutNav = React.cloneElement(element, {
-    ...element.props,
-    onClick: () => {
-      null
-    },
-  })
+  const { currentStepIndex, initialTabIndex, disableNavigation } = props
+  const returnDisabledButton = disableNavigation && tabIndex !== initialTabIndex
+  const disabledButton = (
+    <DisabledStepButton key={tabIndex}>
+      {element.props.children}
+    </DisabledStepButton>
+  )
   if (tabIndex > currentStepIndex) {
     // don't allow users to jump ahead
-
-    return elementWithoutNav
+    return disabledButton
   } else if (currentStepIndex && tabIndex < currentStepIndex) {
     return (
       <Flex>
         <CheckMarkWrapper>
           <CheckIcon fill={color("green100")} />
         </CheckMarkWrapper>
-        {disableNavigation ? elementWithoutNav : element}
+        {returnDisabledButton && tabIndex !== initialTabIndex
+          ? disabledButton
+          : element}
         <div /> {/* hack for getting rid of last-child in Tabs.tsx */}
       </Flex>
     )
-  } else return disableNavigation ? elementWithoutNav : element
+  } else if (returnDisabledButton) {
+    return disabledButton
+  } else {
+    return element
+  }
 }
 
 export const Stepper = (props: StepperProps) => {
@@ -60,6 +67,14 @@ export const Stepper = (props: StepperProps) => {
 
 export const Step = props => <Tab {...props} />
 
+const DisabledStepButton = ({ children }) => (
+  <DisabledStepContainer>
+    <Sans size="3t" color="black30">
+      {children}
+    </Sans>
+  </DisabledStepContainer>
+)
+
 const ChevronWrapper = styled.span`
   margin: 0 ${space(2)}px;
   line-height: normal;
@@ -68,4 +83,9 @@ const ChevronWrapper = styled.span`
 const CheckMarkWrapper = styled.span`
   margin-right: ${space(1)}px;
   line-height: normal;
+`
+
+const DisabledStepContainer = styled.div`
+  ${styles.tabContainer};
+  cursor: default;
 `

--- a/src/Styleguide/Components/Stepper.tsx
+++ b/src/Styleguide/Components/Stepper.tsx
@@ -2,22 +2,77 @@ import { color, space } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { Tab, Tabs, TabsProps } from "Styleguide/Components/Tabs"
+import { Flex } from "Styleguide/Elements/Flex"
 
 interface StepperProps extends TabsProps {
-  currentIndex?: number
+  initialTabIndex: number
+
+  /* the step user currently is at */
+  currentStepIndex: number
 }
+
+const transformTabBtn = (
+  element: JSX.Element,
+  tabIndex: number,
+  props: any
+): JSX.Element => {
+  const { currentStepIndex } = props
+  if (currentStepIndex && tabIndex < currentStepIndex) {
+    return (
+      <Flex>
+        <CheckMarkWrapper>
+          <CheckMark />
+        </CheckMarkWrapper>
+        {element}
+        <div /> {/* hack for getting rid of last-child in Tabs.tsx */}
+      </Flex>
+    )
+  } else return element
+}
+
 export const Stepper = (props: StepperProps) => {
-  return <Tabs separator={<Chevron />} {...props} />
+  return (
+    <Tabs
+      separator={
+        <ChevronWrapper>
+          <Chevron />
+        </ChevronWrapper>
+      }
+      transformTabBtn={transformTabBtn}
+      {...props}
+    />
+  )
 }
 
 export const Step = props => <Tab {...props} />
 
-const ChevronWrapper = styled.svg`
-  margin: ${space(0.5)}px ${space(1)}px;
+const ChevronWrapper = styled.span`
+  margin: 0 ${space(1)}px;
+  line-height: normal;
 `
 
+const CheckMarkWrapper = styled.span`
+  margin-right: ${space(1)}px;
+  line-height: normal;
+`
+
+const CheckMark = () => (
+  <svg width="10px" height="8px" viewBox="0 0 10 8" version="1.1">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+      <g transform="translate(-416.000000, -960.000000)" fill="#000000">
+        <g transform="translate(416.000000, 918.000000)">
+          <polygon
+            fill={color("green100")}
+            points="7.97385698 42 9.14742868 42.8908963 3.39210448 50.0024371 0 46.7045578 1.06103742 45.6729936 3.26349389 47.8142707"
+          />
+        </g>
+      </g>
+    </g>
+  </svg>
+)
+
 const Chevron = () => (
-  <ChevronWrapper
+  <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 12 12"
     width="8px"
@@ -29,5 +84,5 @@ const Chevron = () => (
       fill-rule="evenodd"
       d="M9.091 10.758l-.788.771-5.832-5.708L8.303.113l.788.771-5.044 4.937 5.044 4.937"
     />
-  </ChevronWrapper>
+  </svg>
 )

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -51,6 +51,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
   public static defaultProps: Partial<TabsProps> = {
     justifyContent: "left",
     transformTabBtn: Button => Button,
+    separator: <Box ml={2} />,
   }
 
   state = {
@@ -149,12 +150,10 @@ export const styles = {
   tabsContainer: css`
     border-bottom: 1px solid ${color("black10")};
   `,
-
   tabContainer: css`
     cursor: pointer;
     padding-bottom: 13px;
     margin-bottom: -1px;
-    margin-right: ${space(3)}px;
     white-space: nowrap;
     ${borders};
 
@@ -166,12 +165,10 @@ export const styles = {
       }
     `};
   `,
-
   activeTabContainer: css`
     pointer-events: none;
     padding-bottom: 13px;
     margin-bottom: -1px;
-    margin-right: ${space(3)}px;
     white-space: nowrap;
     border-bottom: 1px solid ${color("black60")};
 

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -29,6 +29,15 @@ export interface TabsProps extends WidthProps, JustifyContentProps {
   /** Index of the Tab that should be pre-selected */
   initialTabIndex?: number
 
+  /** To be able to extend or modify the way tab btns are getting rendered
+   * default value is an identity function
+   */
+  transformTabBtn?: (
+    Button: JSX.Element,
+    tabIndex?: number,
+    props?: any
+  ) => JSX.Element
+
   separator?: JSX.Element
 
   children: TabLike[]
@@ -41,6 +50,7 @@ export interface TabsState {
 export class Tabs extends React.Component<TabsProps, TabsState> {
   public static defaultProps: Partial<TabsProps> = {
     justifyContent: "left",
+    transformTabBtn: Button => Button,
   }
 
   state = {
@@ -71,13 +81,19 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
 
   renderTab = (tab, index) => {
     const { name } = tab.props
-    return this.state.activeTabIndex === index ? (
-      <ActiveTabButton key={index}>{name}</ActiveTabButton>
-    ) : (
-      <TabButton key={index} onClick={() => this.setActiveTab(index)}>
-        {name}
-      </TabButton>
-    )
+    return this.state.activeTabIndex === index
+      ? this.props.transformTabBtn(
+          <ActiveTabButton key={index}>{name}</ActiveTabButton>,
+          index,
+          this.props
+        )
+      : this.props.transformTabBtn(
+          <TabButton key={index} onClick={() => this.setActiveTab(index)}>
+            {name}
+          </TabButton>,
+          index,
+          this.props
+        )
   }
 
   render() {

--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -5,6 +5,7 @@ import { borders, JustifyContentProps, WidthProps } from "styled-system"
 import { Box } from "Styleguide/Elements/Box"
 import { Flex } from "Styleguide/Elements/Flex"
 import { media } from "Styleguide/Elements/Grid"
+import { Join } from "Styleguide/Elements/Join"
 
 export interface TabLike extends JSX.Element {
   props: TabProps
@@ -27,6 +28,8 @@ export interface TabsProps extends WidthProps, JustifyContentProps {
 
   /** Index of the Tab that should be pre-selected */
   initialTabIndex?: number
+
+  separator?: JSX.Element
 
   children: TabLike[]
 }
@@ -78,12 +81,12 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
   }
 
   render() {
-    const { children = [], justifyContent } = this.props
+    const { children = [], justifyContent, separator } = this.props
 
     return (
       <React.Fragment>
         <TabsContainer mb={0.5} width="100%" justifyContent={justifyContent}>
-          {children.map(this.renderTab)}
+          <Join separator={separator}>{children.map(this.renderTab)}</Join>
         </TabsContainer>
         <Box pt={3}>{children[this.state.activeTabIndex]}</Box>
       </React.Fragment>

--- a/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
@@ -48,6 +48,13 @@ storiesOf("Styleguide/Components", module).add("Stepper", () => {
           <Step name="Pay" />
         </Stepper>
       </Section>
+      <Section title="Stepper (disabled navigation)">
+        <Stepper initialTabIndex={1} currentStepIndex={2} disableNavigation>
+          <Step name="Review" />
+          <Step name="Confirm" />
+          <Step name="Pay" />
+        </Stepper>
+      </Section>{" "}
     </React.Fragment>
   )
 })

--- a/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Step, Stepper } from "Styleguide/Components/Stepper"
+import { Section } from "Styleguide/Utils/Section"
+
+storiesOf("Styleguide/Components", module).add("Stepper", () => {
+  return (
+    <React.Fragment>
+      <Section title="Artist">
+        <Stepper>
+          <Step name="Review" />
+          <Step name="Confirm" />
+          <Step name="Pay" />
+        </Stepper>
+      </Section>
+    </React.Fragment>
+  )
+})

--- a/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
@@ -6,10 +6,38 @@ import { Section } from "Styleguide/Utils/Section"
 storiesOf("Styleguide/Components", module).add("Stepper", () => {
   return (
     <React.Fragment>
-      <Section title="Stepper">
+      <Section title="Stepper (1st step)">
+        <Stepper
+          initialTabIndex={0}
+          currentStepIndex={0}
+          onChange={activeTab => {
+            // tslint:disable-next-line
+            console.log(activeTab)
+          }}
+        >
+          <Step name="Review" />
+          <Step name="Confirm" />
+          <Step name="Pay" />
+        </Stepper>
+      </Section>
+      <Section title="Stepper (2nd step)">
         <Stepper
           initialTabIndex={1}
           currentStepIndex={1}
+          onChange={activeTab => {
+            // tslint:disable-next-line
+            console.log(activeTab)
+          }}
+        >
+          <Step name="Review" />
+          <Step name="Confirm" />
+          <Step name="Pay" />
+        </Stepper>
+      </Section>
+      <Section title="Stepper (all steps done currently on second)">
+        <Stepper
+          initialTabIndex={1}
+          currentStepIndex={3}
           onChange={activeTab => {
             // tslint:disable-next-line
             console.log(activeTab)

--- a/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
@@ -6,8 +6,15 @@ import { Section } from "Styleguide/Utils/Section"
 storiesOf("Styleguide/Components", module).add("Stepper", () => {
   return (
     <React.Fragment>
-      <Section title="Artist">
-        <Stepper initialTabIndex={1} currentStepIndex={2}>
+      <Section title="Stepper">
+        <Stepper
+          initialTabIndex={1}
+          currentStepIndex={1}
+          onChange={activeTab => {
+            // tslint:disable-next-line
+            console.log(activeTab)
+          }}
+        >
           <Step name="Review" />
           <Step name="Confirm" />
           <Step name="Pay" />

--- a/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.Stepper.story.tsx
@@ -7,7 +7,7 @@ storiesOf("Styleguide/Components", module).add("Stepper", () => {
   return (
     <React.Fragment>
       <Section title="Artist">
-        <Stepper>
+        <Stepper initialTabIndex={1} currentStepIndex={2}>
           <Step name="Review" />
           <Step name="Confirm" />
           <Step name="Pay" />

--- a/src/Styleguide/Components/__stories__/Tabs.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.story.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
+import { Box } from "Styleguide/Elements/Box"
 import { Section } from "Styleguide/Utils/Section"
 import { Tab, Tabs } from "../Tabs"
 
@@ -51,6 +52,13 @@ storiesOf("Styleguide/Components", module).add("Tabs (Simple)", () => {
       </Section>
       <Section title="With custom justification">
         <Tabs justifyContent="center">
+          <Tab name="About" />
+          <Tab name="Pricing" />
+          <Tab name="Condition" />
+        </Tabs>
+      </Section>
+      <Section title="With separator">
+        <Tabs justifyContent="center" separator={<Box pr={"20px"}>*</Box>}>
           <Tab name="About" />
           <Tab name="Pricing" />
           <Tab name="Condition" />


### PR DESCRIPTION
[zeplin link]( zpl.io/VxY0J0g)

Sell ticket: https://artsyproduct.atlassian.net/browse/SELL-744

<img width="1247" alt="screen shot 2018-07-26 at 2 54 30 pm" src="https://user-images.githubusercontent.com/687513/43282392-036f4354-90e4-11e8-884f-814eae84e0d7.png">

Paired with @zephraph and we decided to reuse `Tabs` component and extend it to accept a *separator* component and a *transformer* function to modify the tab buttons.