### PR TITLE
Add font smoothing to global styles

### DIFF
--- a/src/Styleguide/Elements/GlobalStyles.tsx
+++ b/src/Styleguide/Elements/GlobalStyles.tsx
@@ -28,7 +28,9 @@ if (process.env.NODE_ENV !== "test") {
     html, body {
       font-family: 'AGaramondPro-Regular';
       font-size: 16px;
-      line-height: 24px;
+      line-height: 24px;    
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
     }
   `)
 }


### PR DESCRIPTION
@ds300 found this. 

Fonts in storybook looked thicker than the fonts in Zeplin. Turns out that force is enabling some extra CSS properties that makes fonts look a bit thinner on OSX. 

We added these to global styles so that it'll carry forward on pages without base styling from force. 