### PR TITLE
deprecating is_purchasable and purchase_request fields

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -696,8 +696,6 @@ type Artwork implements Node & Sellable {
   is_price_hidden: Boolean
   is_price_range: Boolean
 
-  # True for inquireable artworks that have an exact price.
-  is_purchasable: Boolean
   is_saved: Boolean
   is_shareable: Boolean
   is_sold: Boolean
@@ -1327,8 +1325,6 @@ type ArtworkItem implements Node & Sellable {
   is_price_hidden: Boolean
   is_price_range: Boolean
 
-  # True for inquireable artworks that have an exact price.
-  is_purchasable: Boolean
   is_saved: Boolean
   is_shareable: Boolean
   is_sold: Boolean
@@ -1913,7 +1909,6 @@ type Conversation implements Node {
     # Specify a tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
-  purchase_request: Boolean
   from_last_viewed_message_id: String
   initial_message: String!
 

--- a/data/schema.json
+++ b/data/schema.json
@@ -4691,18 +4691,6 @@
               "deprecationReason": null
             },
             {
-              "name": "is_purchasable",
-              "description": "True for inquireable artworks that have an exact price.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "is_saved",
               "description": null,
               "args": [],
@@ -30944,18 +30932,6 @@
               "deprecationReason": null
             },
             {
-              "name": "purchase_request",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "from_last_viewed_message_id",
               "description": null,
               "args": [],
@@ -37291,18 +37267,6 @@
             {
               "name": "is_price_range",
               "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "is_purchasable",
-              "description": "True for inquireable artworks that have an exact price.",
               "args": [],
               "type": {
                 "kind": "SCALAR",


### PR DESCRIPTION
I'm pretty sure nothing but force was using those fields so I think it's safe to just kill it here once https://github.com/artsy/force/pull/2714 is merged.