### PR TITLE
Add Message component

### DIFF
--- a/src/Styleguide/Elements/Message.tsx
+++ b/src/Styleguide/Elements/Message.tsx
@@ -5,6 +5,7 @@ import { Flex, FlexProps } from "Styleguide/Elements/Flex"
 
 export const StyledFlex = Flex.extend`
   background-color: ${color("black5")};
+  border-radius: 2px;
 `
 
 interface MessageProps extends FlexProps {

--- a/src/Styleguide/Elements/Message.tsx
+++ b/src/Styleguide/Elements/Message.tsx
@@ -1,0 +1,22 @@
+import { color } from "@artsy/palette"
+import { Sans } from "@artsy/palette"
+import React from "react"
+import { Flex, FlexProps } from "Styleguide/Elements/Flex"
+
+export const StyledFlex = Flex.extend`
+  background-color: ${color("black5")};
+`
+
+interface MessageProps extends FlexProps {
+  children: React.ReactNode | null
+}
+
+export function Message({ children, ...others }: MessageProps) {
+  return (
+    <StyledFlex p={2} {...others}>
+      <Sans size="3t" color="black60" weight="regular">
+        {children}
+      </Sans>
+    </StyledFlex>
+  )
+}

--- a/src/Styleguide/Elements/__stories__/Message.story.tsx
+++ b/src/Styleguide/Elements/__stories__/Message.story.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Message } from "Styleguide/Elements/Message"
+import { Section } from "Styleguide/Utils/Section"
+
+storiesOf("Styleguide/Elements", module).add("Message", () => {
+  return (
+    <Section title="Message">
+      <Message>
+        Thank you for your order. You’ll receive a confirmation email shortly.
+        If you have questions, please contact <a href="#">orders@artsy.net</a>.
+      </Message>
+    </Section>
+  )
+})


### PR DESCRIPTION
[jira](https://artsyproduct.atlassian.net/browse/PURCHASE-310)

![image](https://user-images.githubusercontent.com/1242537/43406910-3fc4d990-93eb-11e8-84e9-519263af2921.png)

This was originally called 'Messenger' in the designs, but @zephraph @katarinabatina and I discussed renaming it to sound less like an interactive chat thing. I'm proposing 'Message', but definitely open to other suggestions.