### PR TITLE
[Button] disable hover state for mobile devices

### DIFF
--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -214,6 +214,7 @@ const InputComponent = styled.input.attrs<{ showLabel: boolean }>({})`
   flex: 1;
   transition: all 0.25s;
   position: absolute;
+  top: 0;
   left: 0;
   width: 100%;
   height: 100%;

--- a/src/Styleguide/Elements/Button.tsx
+++ b/src/Styleguide/Elements/Button.tsx
@@ -65,6 +65,9 @@ export const Button = styled(
     getVariant() {
       const { variant } = this.props
 
+      // Allows us to disable hover states for devices that don't support them
+      const mobileMediaQuery = `@media not all and (pointer: coarse), not all and (-moz-touch-enabled: 1)`
+
       switch (variant) {
         case ButtonVariant.primaryBlack:
           return css`
@@ -76,10 +79,12 @@ export const Button = styled(
                 border-color: ${colors.black100};
                 color: ${colors.white100};
 
-                &:hover {
-                  background-color: ${colors.purple100};
-                  border-color: ${colors.purple100};
-                  color: ${colors.white100};
+                ${mobileMediaQuery} {
+                  &:hover {
+                    background-color: ${colors.purple100};
+                    border-color: ${colors.purple100};
+                    color: ${colors.white100};
+                  }
                 }
               `
             }};
@@ -94,10 +99,12 @@ export const Button = styled(
                 border-color: ${colors.white100};
                 color: ${colors.black100};
 
-                &:hover {
-                  background-color: ${colors.purple100};
-                  border-color: ${colors.purple100};
-                  color: ${colors.white100};
+                ${mobileMediaQuery} {
+                  &:hover {
+                    background-color: ${colors.purple100};
+                    border-color: ${colors.purple100};
+                    color: ${colors.white100};
+                  }
                 }
               `
             }};
@@ -112,10 +119,12 @@ export const Button = styled(
               border-color: ${colors.black10};
               color: ${colors.black100};
 
-              &:hover {
-                background-color: ${colors.black30};
-                border-color: ${colors.black30};
-                color: ${colors.black100};
+              ${mobileMediaQuery} {
+                &:hover {
+                  background-color: ${colors.black30};
+                  border-color: ${colors.black30};
+                  color: ${colors.black100};
+                }
               }
             `
             }};


### PR DESCRIPTION
The hover state on our system button needs to be disabled on mobile because it persists after a single tap.