### PR TITLE
@mzikherman => [ArtworkGrid] Add support for dynamic image resizing

### DIFF
--- a/.env.oss
+++ b/.env.oss
@@ -1,3 +1,4 @@
+GEMINI_CLOUDFRONT_URL=https://d7hftxdivxxvm.cloudfront.net
 METAPHYSICS_ENDPOINT=https://metaphysics-staging.artsy.net
 NODE_ENV=development
 WEBPACK_DEVTOOL=cheap-module-eval-source-map

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -18,6 +18,7 @@ env.load()
  */
 const {
   WEBPACK_DEVTOOL = "cheap-module-eval-source-map",
+  GEMINI_CLOUDFRONT_URL,
   METAPHYSICS_ENDPOINT,
   USER_ID,
   USER_ACCESS_TOKEN,
@@ -25,6 +26,7 @@ const {
 } = process.env
 
 const sharifyPath = sharify({
+  GEMINI_CLOUDFRONT_URL,
   METAPHYSICS_ENDPOINT,
   XAPP_TOKEN,
 })
@@ -47,9 +49,11 @@ const plugins = [
 if (USER_ID && USER_ACCESS_TOKEN) {
   plugins.push(
     new webpack.DefinePlugin({
-      "process.env.USER_ID": JSON.stringify(USER_ID),
-      "process.env.USER_ACCESS_TOKEN": JSON.stringify(USER_ACCESS_TOKEN),
-      "process.env.XAPP_TOKEN": JSON.stringify(XAPP_TOKEN),
+      "process.env": {
+        USER_ID: JSON.stringify(USER_ID),
+        USER_ACCESS_TOKEN: JSON.stringify(USER_ACCESS_TOKEN),
+        XAPP_TOKEN: JSON.stringify(XAPP_TOKEN),
+      },
     })
   )
 } else {

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -15,6 +15,7 @@ declare module "sharify" {
      * These properties are set by Force and configured through environment variables.
      */
     export interface GlobalData {
+      readonly GEMINI_CLOUDFRONT_URL: string
       readonly METAPHYSICS_ENDPOINT: string
       readonly XAPP_TOKEN: string
     }


### PR DESCRIPTION
Updates the `GridItem` component to support dynamic image sizing via Gemini. 

**Before** (arbitrary browser size): 
<img width="89" alt="screen shot 2018-07-30 at 2 37 42 pm" src="https://user-images.githubusercontent.com/236943/43425166-9cf4c4e8-9406-11e8-9d0e-c5b3cec3ca42.png">

**After**:
<img width="166" alt="screen shot 2018-07-30 at 2 36 58 pm" src="https://user-images.githubusercontent.com/236943/43425189-ad9c834e-9406-11e8-82fd-146a517d01f4.png">

