### PR TITLE
Update the height of the <LargeSelect> component to always be 40px

### DIFF
--- a/src/Styleguide/Elements/Select.tsx
+++ b/src/Styleguide/Elements/Select.tsx
@@ -101,7 +101,8 @@ const LargeSelectContainer = styled.div.attrs<SelectProps>({})`
     width: 100%;
     font-family: ${themeGet("fontFamily.serif.regular")};
     font-size: ${themeGet("typeSizes.serif.3.fontSize")}px;
-    line-height: ${themeGet("typeSizes.serif.3.lineHeight")}px;
+    line-height: ${themeGet("typeSizes.serif.3t.lineHeight")}px;
+    height: 40px;
     ${hideDefaultSkin};
     border: 1px solid ${color("black10")};
     border-radius: 0;


### PR DESCRIPTION
In the new Buy Now flow we have a use case for the existing `<LargeSelect>`component. Currently, the height of this component is `46px`, which makes it slightly larger than other existing components used in the form. This PR updates the component so the component of the height will always be `40px`. This component is used in [the auction results page](https://staging.artsy.net/artist/yayoi-kusama/auction-results). In zeplin, the height of the select box is also `40px`, so this will actually make the height consistent across design mockups and the actual implementation.

Here are some screenshots of what it's going to look like after this PR. As you can see, it makes the height consistent and there will be no significant visual issue in the auction results page.

## Shipping address form the purchase team is working on

<img width="1371" alt="shipping-address-form" src="https://user-images.githubusercontent.com/386234/43458653-06b30984-9499-11e8-972b-2139eb95dfa7.png">

## Auction results page

<img width="1133" alt="action-results" src="https://user-images.githubusercontent.com/386234/43458658-09bb8d90-9499-11e8-8239-844b1dc51f74.png">
