### PR TITLE
[ArtworkGrid] Limit image size by breakpoint

### DIFF
--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -30,8 +30,7 @@ interface Props extends RelayProps, React.HTMLProps<ArtworkGridItemContainer> {
 }
 
 interface State {
-  width: number
-  height: number
+  isMounted: boolean
 }
 
 const IMAGE_QUALITY = 80
@@ -44,37 +43,52 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
   private image: HTMLImageElement = null
 
   state = {
-    width: 1,
-    height: 1,
+    isMounted: false,
   }
 
   componentDidMount() {
-    const scale = window.devicePixelRatio
-    const width = this.image.width * scale
-    const height =
-      (this.image.width / this.props.artwork.image.aspect_ratio) * scale
-
     this.setState({
-      width,
-      height,
+      isMounted: true,
     })
   }
 
-  get imageURL() {
+  getImageUrl(breakpoints) {
     const imageURL = this.props.artwork.image.url
-    if (imageURL) {
+
+    if (!imageURL) {
+      return null
+    }
+
+    if (this.state.isMounted) {
+      const [[match]] = Object.entries(breakpoints).filter(([key, val]) => val)
+
+      const getWidth = () => {
+        switch (match) {
+          case "xs":
+          case "sm":
+          case "md":
+            return 400
+          case "lg":
+          case "xl":
+          default:
+            return 300
+        }
+      }
+
+      const scale = window.devicePixelRatio
+      const width = String(getWidth() * scale)
+      const height = String(
+        (this.image.width / this.props.artwork.image.aspect_ratio) * scale
+      )
+
       // Either scale or crop, based on if an aspect ratio is available.
       const type = this.props.artwork.image.aspect_ratio ? "fit" : "fill"
-      const width = String(this.state.width)
-      const height = String(this.state.height)
       // tslint:disable-next-line:max-line-length
       return `${
         sd.GEMINI_CLOUDFRONT_URL
       }/?resize_to=${type}&width=${width}&height=${height}&quality=${IMAGE_QUALITY}&src=${encodeURIComponent(
         imageURL
       )}`
-    } else {
-      return null
     }
   }
 
@@ -88,32 +102,38 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
       currentUserSpread = { currentUser }
     }
     return (
-      <div className={className} style={style}>
-        <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
-          <a href={artwork.href}>
-            <Image src={this.imageURL} innerRef={img => (this.image = img)} />
-          </a>
-          <Responsive>
-            {({ hover }) =>
-              hover && (
-                <SaveButtonBlock
-                  className="artwork-save"
-                  artwork={artwork as any}
-                  style={{
-                    position: "absolute",
-                    right: "10px",
-                    bottom: "10px",
-                  }}
-                  useRelay={useRelay}
-                  {...currentUserSpread}
-                  mediator={this.props.mediator}
-                />
-              )
-            }
-          </Responsive>
-        </Placeholder>
-        <MetadataBlock artwork={artwork} useRelay={useRelay} />
-      </div>
+      <Responsive>
+        {({ hover, ...breakpoints }) => {
+          return (
+            <div className={className} style={style}>
+              <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
+                <a href={artwork.href}>
+                  <Image
+                    src={this.getImageUrl(breakpoints)}
+                    innerRef={img => (this.image = img)}
+                  />
+                </a>
+
+                {hover && (
+                  <SaveButtonBlock
+                    className="artwork-save"
+                    artwork={artwork as any}
+                    style={{
+                      position: "absolute",
+                      right: "10px",
+                      bottom: "10px",
+                    }}
+                    useRelay={useRelay}
+                    {...currentUserSpread}
+                    mediator={this.props.mediator}
+                  />
+                )}
+              </Placeholder>
+              <MetadataBlock artwork={artwork} useRelay={useRelay} />
+            </div>
+          )
+        }}
+      </Responsive>
     )
   }
 }

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -40,8 +40,6 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
     useRelay: true,
   }
 
-  private image: HTMLImageElement = null
-
   state = {
     isMounted: false,
   }
@@ -75,11 +73,8 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
         }
       }
 
-      const scale = window.devicePixelRatio
-      const width = String(getWidth() * scale)
-      const height = String(
-        (this.image.width / this.props.artwork.image.aspect_ratio) * scale
-      )
+      const width = Math.floor(getWidth())
+      const height = Math.floor(width / this.props.artwork.image.aspect_ratio)
 
       // Either scale or crop, based on if an aspect ratio is available.
       const type = this.props.artwork.image.aspect_ratio ? "fit" : "fill"
@@ -108,10 +103,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
             <div className={className} style={style}>
               <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
                 <a href={artwork.href}>
-                  <Image
-                    src={this.getImageUrl(breakpoints)}
-                    innerRef={img => (this.image = img)}
-                  />
+                  <Image src={this.getImageUrl(breakpoints)} />
                 </a>
 
                 {hover && (


### PR DESCRIPTION
Caps column image widths to 400 and 300, depending on breakpoint size. 

```js
        switch (match) {
          case "xs":
          case "sm":
          case "md":
            return 400
          case "lg":
          case "xl":
          default:
            return 300
        }
```