### PR TITLE
Adds superscript to tabs

### DIFF
--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -40,6 +40,9 @@ export interface TabsProps extends WidthProps, JustifyContentProps {
 
   separator?: JSX.Element
 
+  /** selects which property of tab data object to be displayed as superscript */
+  superscriptSelector?: (data: any) => any
+
   children: TabLike[]
 }
 
@@ -58,15 +61,11 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
     super(props)
 
     const activeTabIndex = props.initialTabIndex || 0
-    this.state = {
-      activeTabIndex,
-    }
+    this.state = { activeTabIndex }
   }
 
   setActiveTab = activeTabIndex => {
-    this.setState({
-      activeTabIndex,
-    })
+    this.setState({ activeTabIndex })
     if (this.props.onChange) {
       this.props.onChange({
         tabIndex: activeTabIndex,
@@ -76,17 +75,33 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
     }
   }
 
-  renderTab = (tab, index) => {
-    const { name } = tab.props
+  renderTab = (tab, index, superscriptSelector) => {
+    const { name, data } = tab.props
     return this.state.activeTabIndex === index
       ? this.props.transformTabBtn(
-          <ActiveTabButton key={index}>{name}</ActiveTabButton>,
+          <ActiveTabButton key={index}>
+            {name}
+            {data && superscriptSelector ? (
+              <SuperScript>
+                <Sans size="1" weight="medium" color="black100">
+                  {superscriptSelector(data)}
+                </Sans>
+              </SuperScript>
+            ) : null}
+          </ActiveTabButton>,
           index,
           this.props
         )
       : this.props.transformTabBtn(
           <TabButton key={index} onClick={() => this.setActiveTab(index)}>
             {name}
+            {data && superscriptSelector ? (
+              <SuperScript>
+                <Sans size="1" weight="medium" color="black30">
+                  {superscriptSelector(data)}
+                </Sans>
+              </SuperScript>
+            ) : null}
           </TabButton>,
           index,
           this.props
@@ -94,12 +109,21 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
   }
 
   render() {
-    const { children = [], justifyContent, separator } = this.props
+    const {
+      children = [],
+      justifyContent,
+      separator,
+      superscriptSelector,
+    } = this.props
 
     return (
       <React.Fragment>
         <TabsContainer mb={0.5} width="100%" justifyContent={justifyContent}>
-          <Join separator={separator}>{children.map(this.renderTab)}</Join>
+          <Join separator={separator}>
+            {children.map((tab, index) =>
+              this.renderTab(tab, index, superscriptSelector)
+            )}
+          </Join>
         </TabsContainer>
         <Box pt={3}>{children[this.state.activeTabIndex]}</Box>
       </React.Fragment>
@@ -184,4 +208,10 @@ const TabContainer = styled.div`
 
 const ActiveTabContainer = styled.div`
   ${styles.activeTabContainer};
+`
+
+const SuperScript = styled.div`
+  display: inline-block;
+  vertical-align: top;
+  margin-left: 2px;
 `

--- a/src/Styleguide/Components/__stories__/Tabs.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.story.tsx
@@ -58,10 +58,17 @@ storiesOf("Styleguide/Components", module).add("Tabs (Simple)", () => {
         </Tabs>
       </Section>
       <Section title="With separator">
-        <Tabs justifyContent="center" separator={<Box pr={"20px"}>*</Box>}>
+        <Tabs justifyContent="center" separator={<Box mx={1}>♞</Box>}>
           <Tab name="About" />
           <Tab name="Pricing" />
           <Tab name="Condition" />
+        </Tabs>
+      </Section>
+      <Section title="With superscript">
+        <Tabs superscriptSelector={d => d.count}>
+          <Tab data={{ count: 2 }} name="Open" />
+          <Tab data={{ count: 3 }} name="Ready to ship" />
+          <Tab data={{ count: 20 }} name="Complete" />
         </Tabs>
       </Section>
     </React.Fragment>

--- a/src/Styleguide/Components/__tests__/Tabs.test.tsx
+++ b/src/Styleguide/Components/__tests__/Tabs.test.tsx
@@ -26,7 +26,7 @@ describe("Tabs", () => {
     expect(wrapper.find("ActiveTabButton").html()).toContain("CV")
   })
 
-  it("toggls tab content on click", () => {
+  it("toggles tab content on click", () => {
     const getWrapper = tabIndex =>
       mount(
         <div>
@@ -88,5 +88,17 @@ describe("Tabs", () => {
 
     expect(wrapper.html()).toContain("foundTabSeparator")
     expect(wrapper.html()).toContain("foo|bar")
+  })
+
+  it("renders superscripts after tab text", () => {
+    const wrapper = mount(
+      <Tabs superscriptSelector={d => d.count}>
+        <Tab data={{ count: 2 }} name="Open" />
+        <Tab data={{ count: 3 }} name="Ready to ship" />
+        <Tab data={{ count: 20 }} name="Complete" />
+      </Tabs>
+    )
+
+    expect(wrapper.text()).toContain("Open2Ready to ship3Complete20")
   })
 })


### PR DESCRIPTION
<img width="317" alt="screen shot 2018-08-06 at 2 30 54 pm" src="https://user-images.githubusercontent.com/687513/43734820-f18e9cb0-9986-11e8-8046-9e97a5a9e724.png">

By passing `superscriptSelector`  function to `<tabs />`, you can select witch property of `<tab />` `data` prop to be displayed as superscript. (any other suggestion for the function name?)

```
<Tabs superscriptSelector={d => d.count}>
  <Tab data={{ count: 2 }} name="Open" />
  <Tab data={{ count: 3 }} name="Ready to ship" />
  <Tab data={{ count: 20 }} name="Complete" />
</Tabs>
```