### PR TITLE
Adds superscript to tabs (2)

### DIFF
--- a/src/Styleguide/Components/Tabs.tsx
+++ b/src/Styleguide/Components/Tabs.tsx
@@ -11,9 +11,10 @@ export interface TabLike extends JSX.Element {
   props: TabProps
 }
 
+type TabNameType = string | JSX.Element
 export interface TabInfo {
   /** Display name of the newly selected Tab */
-  name: string
+  name: TabNameType
 
   /** Index of the newly selected Tab */
   tabIndex: number
@@ -109,8 +110,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
 
 interface TabProps {
   /** Display name of the Tab */
-  name: string
-
+  name: TabNameType
   /**
    * Arbitrary data that can be associated with a Tab.
    *
@@ -185,3 +185,15 @@ const TabContainer = styled.div`
 const ActiveTabContainer = styled.div`
   ${styles.activeTabContainer};
 `
+
+const TabSuperScriptWrapper = styled.sup`
+  margin-left: 2px;
+`
+
+export const TabSuperscript = ({ children }: { children?: any }) => (
+  <TabSuperScriptWrapper>
+    <Sans size="1" weight="medium" display="inline">
+      {children}
+    </Sans>
+  </TabSuperScriptWrapper>
+)

--- a/src/Styleguide/Components/__stories__/Tabs.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.story.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Box } from "Styleguide/Elements/Box"
 import { Section } from "Styleguide/Utils/Section"
-import { Tab, Tabs } from "../Tabs"
+import { Tab, Tabs, TabSuperscript } from "../Tabs"
 
 storiesOf("Styleguide/Components", module).add("Tabs (Simple)", () => {
   return (
@@ -58,10 +58,35 @@ storiesOf("Styleguide/Components", module).add("Tabs (Simple)", () => {
         </Tabs>
       </Section>
       <Section title="With separator">
-        <Tabs justifyContent="center" separator={<Box pr={"20px"}>*</Box>}>
+        <Tabs justifyContent="center" separator={<Box mx={1}>♞</Box>}>
           <Tab name="About" />
           <Tab name="Pricing" />
           <Tab name="Condition" />
+        </Tabs>
+      </Section>
+      <Section title="With superscript">
+        <Tabs justifyContent="center">
+          <Tab
+            name={
+              <React.Fragment>
+                Open<TabSuperscript>100</TabSuperscript>
+              </React.Fragment>
+            }
+          />
+          <Tab
+            name={
+              <React.Fragment>
+                Ready to ship<TabSuperscript>4</TabSuperscript>
+              </React.Fragment>
+            }
+          />
+          <Tab
+            name={
+              <React.Fragment>
+                Complete<TabSuperscript />
+              </React.Fragment>
+            }
+          />
         </Tabs>
       </Section>
     </React.Fragment>

--- a/src/Styleguide/Components/__tests__/Tabs.test.tsx
+++ b/src/Styleguide/Components/__tests__/Tabs.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { Tab, Tabs } from "../Tabs"
+import { Tab, Tabs, TabSuperscript } from "../Tabs"
 
 describe("Tabs", () => {
   it("renders tabs by via name prop", () => {
@@ -88,5 +88,29 @@ describe("Tabs", () => {
 
     expect(wrapper.html()).toContain("foundTabSeparator")
     expect(wrapper.html()).toContain("foo|bar")
+  })
+
+  it("renders superscripts after tab text", () => {
+    const wrapper = mount(
+      <Tabs justifyContent="center">
+        <Tab
+          name={
+            <React.Fragment>
+              Open<TabSuperscript>100</TabSuperscript>
+            </React.Fragment>
+          }
+        />
+        <Tab
+          name={
+            <React.Fragment>
+              Ready to ship<TabSuperscript>4</TabSuperscript>
+            </React.Fragment>
+          }
+        />
+        <Tab name="Complete" />
+      </Tabs>
+    )
+
+    expect(wrapper.text()).toContain("Open100Ready to ship4Complete")
   })
 })


### PR DESCRIPTION
<img width="1045" alt="screen shot 2018-08-06 at 6 39 52 pm" src="https://user-images.githubusercontent.com/687513/43744549-848e04c6-99a8-11e8-9c6b-23bbc3ff23cb.png">

As per @damassi and @zephraph feedback closing https://github.com/artsy/reaction/pull/1084 in favor of this one which doesn't require new component API 🎉 . 

Usage:
```
<Tabs justifyContent="center">
  <Tab
    name={
      <React.Fragment>
        Open<TabSuperscript>100</TabSuperscript>
      </React.Fragment>
    }
  />
  <Tab
    name={
      <React.Fragment>
        Ready to ship<TabSuperscript>4</TabSuperscript>
      </React.Fragment>
    }
  />
  <Tab
    name={
      <React.Fragment>
        Complete<TabSuperscript />
      </React.Fragment>
    }
  />
</Tabs>
```