### PR TITLE
[PATCH orderPage] Reference mediator from appstate + send artwork ID with inquiry modal

### DIFF
--- a/src/Apps/Order/Components/Summary.tsx
+++ b/src/Apps/Order/Components/Summary.tsx
@@ -3,7 +3,9 @@ import React, { Component } from "react"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Placeholder } from "Styleguide/Utils/Placeholder"
 
+import { AppState } from "Router/state"
 import styled from "styled-components"
+import { Subscribe } from "unstated"
 
 type Mediator = {
   trigger: (action: string, config?: object) => void
@@ -16,11 +18,17 @@ export interface SummaryProps {
 export class Summary extends Component<SummaryProps> {
   render() {
     return (
-      <>
-        <Placeholder height="390px" name="Sidebar" />
-        {this.props.children}
-        <Helper mediator={this.props.mediator} />
-      </>
+      <Subscribe to={[AppState]}>
+        {({ state }) => {
+          const { mediator } = state
+
+          return <>
+              <Placeholder height="390px" name="Sidebar" />
+              {this.props.children}
+              <Helper mediator={mediator} />
+            </>
+        }}
+      </Subscribe>
     )
   }
 }
@@ -35,14 +43,19 @@ const Helper: React.SFC<SummaryProps> = ({ mediator }) => (
     <Sans size="2" color="black60">
       Have a question?{" "}
       <Link
-        onClick={() => mediator && mediator.trigger("openOrdersBuyerFAQModal")}
+        onClick={() => {
+          mediator && mediator.trigger("openOrdersBuyerFAQModal")
+        }}
       >
         Read our FAQ
       </Link>{" "}
       or{" "}
       <Link
         onClick={() =>
-          mediator && mediator.trigger("openOrdersContactArtsyModal")
+          mediator &&
+          mediator.trigger("openOrdersContactArtsyModal", {
+            artworkId: "lisa-breslow-cactus",
+          })
         }
       >
         ask an Artsy Specialist

--- a/src/Apps/Order/Components/__tests__/Summary.test.tsx
+++ b/src/Apps/Order/Components/__tests__/Summary.test.tsx
@@ -1,19 +1,34 @@
 import { mount } from "enzyme"
 import React from "react"
 import renderer from "react-test-renderer"
-import { Summary } from "../Summary"
+import { AppState } from "Router/state"
+import { Provider } from "unstated"
+import { SummaryFragmentContainer as Summary } from "../Summary"
 
 describe("Order summary", () => {
+  const mediatorMock = {
+    trigger: jest.fn(),
+  }
   it("renders the summary properly", () => {
-    const summary = renderer.create(<Summary />).toJSON()
+    const appState = new AppState({ mediator: mediatorMock })
+    const summary = renderer
+      .create(
+        <Provider inject={[appState]}>
+          <Summary order={mockOrder} />
+        </Provider>
+      )
+      .toJSON()
     expect(summary).toMatchSnapshot()
   })
 
   it("handles FAQ modal", () => {
-    const mediatorMock = {
-      trigger: jest.fn(),
-    }
-    const summary = mount(<Summary mediator={mediatorMock} />)
+    const appState = new AppState({ mediator: mediatorMock })
+
+    const summary = mount(
+      <Provider inject={[appState]}>
+        <Summary order={mockOrder} mediator={mediatorMock} />
+      </Provider>
+    )
 
     summary
       .find("a")
@@ -24,10 +39,13 @@ describe("Order summary", () => {
   })
 
   it("handles contact specialist modal", () => {
-    const mediatorMock = {
-      trigger: jest.fn(),
-    }
-    const summary = mount(<Summary mediator={mediatorMock} />)
+    const appState = new AppState({ mediator: mediatorMock })
+
+    const summary = mount(
+      <Provider inject={[appState]}>
+        <Summary order={mockOrder} mediator={mediatorMock} />
+      </Provider>
+    )
 
     summary
       .find("a")
@@ -35,7 +53,22 @@ describe("Order summary", () => {
       .simulate("click")
 
     expect(mediatorMock.trigger).toHaveBeenCalledWith(
-      "openOrdersContactArtsyModal"
+      "openOrdersContactArtsyModal",
+      { artworkId: "lisa-breslow-cactus" }
     )
   })
+
+  const mockOrder = {
+    lineItems: {
+      edges: [
+        {
+          node: {
+            artwork: {
+              id: "lisa-breslow-cactus",
+            },
+          },
+        },
+      ],
+    },
+  }
 })

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -8,7 +8,7 @@ import { Join } from "Styleguide/Elements/Join"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Placeholder } from "Styleguide/Utils/Placeholder"
 import { Responsive } from "Utils/Responsive"
-import { Summary } from "../../Components/Summary"
+import { SummaryFragmentContainer as Summary } from "../../Components/Summary"
 
 export interface PaymentProps {
   order: Payment_order
@@ -41,7 +41,7 @@ export class PaymentRoute extends Component<PaymentProps> {
               </>
             }
             Sidebar={
-              <Summary mediator={this.props.mediator}>
+              <Summary mediator={this.props.mediator} order={order as any}>
                 {xs && (
                   <>
                     <Spacer mb={3} />
@@ -66,6 +66,7 @@ export const PaymentFragmentContainer = createFragmentContainer(
   graphql`
     fragment Payment_order on Order {
       id
+      ...Summary_order
     }
   `
 )

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -7,7 +7,7 @@ import { Join } from "Styleguide/Elements/Join"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Placeholder } from "Styleguide/Utils/Placeholder"
 import { Responsive } from "Utils/Responsive"
-import { Summary } from "../../Components/Summary"
+import { SummaryFragmentContainer as Summary } from "../../Components/Summary"
 import { TwoColumnLayout } from "../../Components/TwoColumnLayout"
 
 export interface ReviewProps {
@@ -44,7 +44,7 @@ export class ReviewRoute extends Component<ReviewProps> {
               </>
             }
             Sidebar={
-              <Summary mediator={this.props.mediator}>
+              <Summary mediator={this.props.mediator} order={order as any}>
                 {xs && (
                   <>
                     <Spacer mb={3} />
@@ -71,6 +71,7 @@ export const ReviewFragmentContainer = createFragmentContainer(
   graphql`
     fragment Review_order on Order {
       id
+      ...Summary_order
     }
   `
 )

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -13,7 +13,8 @@ import { RadioGroup } from "Styleguide/Elements/RadioGroup"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Responsive } from "Utils/Responsive"
 
-import { Summary } from "../../Components/Summary"
+import { SummaryFragmentContainer as Summary } from "../../Components/Summary"
+
 import {
   TwoColumnLayout,
   TwoColumnSplit,
@@ -105,7 +106,7 @@ export class ShippingRoute extends Component<ShippingProps> {
               </>
             }
             Sidebar={
-              <Summary mediator={this.props.mediator}>
+              <Summary mediator={this.props.mediator} order={order as any}>
                 {xs && (
                   <>
                     <Spacer mb={3} />
@@ -130,6 +131,7 @@ export const ShippingFragmentContainer = createFragmentContainer(
   graphql`
     fragment Shipping_order on Order {
       id
+      ...Summary_order
     }
   `
 )

--- a/src/__generated__/Payment_order.graphql.ts
+++ b/src/__generated__/Payment_order.graphql.ts
@@ -22,6 +22,11 @@ const node: ConcreteFragment = {
       "storageKey": null
     },
     {
+      "kind": "FragmentSpread",
+      "name": "Summary_order",
+      "args": null
+    },
+    {
       "kind": "ScalarField",
       "alias": "__id",
       "name": "id",
@@ -30,5 +35,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '85a24649ea395173de362675a7c1cdcd';
+(node as any).hash = 'e7b1db79b2e14c3ed826131814a97ed8';
 export default node;

--- a/src/__generated__/Review_order.graphql.ts
+++ b/src/__generated__/Review_order.graphql.ts
@@ -22,6 +22,11 @@ const node: ConcreteFragment = {
       "storageKey": null
     },
     {
+      "kind": "FragmentSpread",
+      "name": "Summary_order",
+      "args": null
+    },
+    {
       "kind": "ScalarField",
       "alias": "__id",
       "name": "id",
@@ -30,5 +35,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '1d0f4a95a73e73dddc9f7127c7919d90';
+(node as any).hash = '2bcbbf6dbe7025129e62f481d60e23f9';
 export default node;

--- a/src/__generated__/Shipping_order.graphql.ts
+++ b/src/__generated__/Shipping_order.graphql.ts
@@ -22,6 +22,11 @@ const node: ConcreteFragment = {
       "storageKey": null
     },
     {
+      "kind": "FragmentSpread",
+      "name": "Summary_order",
+      "args": null
+    },
+    {
       "kind": "ScalarField",
       "alias": "__id",
       "name": "id",
@@ -30,5 +35,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '6fc1d37a0891e8a8003f7392085deff2';
+(node as any).hash = 'bf7680b445d71bfcdbacb3dfc5a6314c';
 export default node;

--- a/src/__generated__/Summary_order.graphql.ts
+++ b/src/__generated__/Summary_order.graphql.ts
@@ -1,0 +1,97 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type Summary_order = {
+    readonly lineItems: ({
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly artwork: ({
+                    readonly id: string;
+                }) | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+};
+
+
+
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Fragment",
+  "name": "Summary_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "lineItems",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "OrderLineItemConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "OrderLineItemEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "OrderLineItem",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "artwork",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Artwork",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "__id",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                },
+                v0
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    v0
+  ]
+};
+})();
+(node as any).hash = '7f65c18384a5ea9e12796d2fb0284f65';
+export default node;

--- a/src/__generated__/routes_PaymentQuery.graphql.ts
+++ b/src/__generated__/routes_PaymentQuery.graphql.ts
@@ -22,6 +22,22 @@ query routes_PaymentQuery(
 
 fragment Payment_order on Order {
   id
+  ...Summary_order
+  __id: id
+}
+
+fragment Summary_order on Order {
+  lineItems {
+    edges {
+      node {
+        artwork {
+          id
+          __id
+        }
+        __id: id
+      }
+    }
+  }
   __id: id
 }
 */
@@ -49,13 +65,20 @@ v2 = {
   "name": "id",
   "args": null,
   "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
 };
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_PaymentQuery",
   "id": null,
-  "text": "query routes_PaymentQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Payment_order\n    __id: id\n  }\n}\n\nfragment Payment_order on Order {\n  id\n  __id: id\n}\n",
+  "text": "query routes_PaymentQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Payment_order\n    __id: id\n  }\n}\n\nfragment Payment_order on Order {\n  id\n  ...Summary_order\n  __id: id\n}\n\nfragment Summary_order on Order {\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -97,12 +120,59 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
+          v3,
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "id",
+            "name": "lineItems",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
+            "concreteType": "OrderLineItemConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "OrderLineItemEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "OrderLineItem",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
+                          v3,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "__id",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      v2
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           v2
         ]

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -22,6 +22,22 @@ query routes_ReviewQuery(
 
 fragment Review_order on Order {
   id
+  ...Summary_order
+  __id: id
+}
+
+fragment Summary_order on Order {
+  lineItems {
+    edges {
+      node {
+        artwork {
+          id
+          __id
+        }
+        __id: id
+      }
+    }
+  }
   __id: id
 }
 */
@@ -49,13 +65,20 @@ v2 = {
   "name": "id",
   "args": null,
   "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
 };
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  __id: id\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  ...Summary_order\n  __id: id\n}\n\nfragment Summary_order on Order {\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -97,12 +120,59 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
+          v3,
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "id",
+            "name": "lineItems",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
+            "concreteType": "OrderLineItemConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "OrderLineItemEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "OrderLineItem",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
+                          v3,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "__id",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      v2
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           v2
         ]

--- a/src/__generated__/routes_ShippingQuery.graphql.ts
+++ b/src/__generated__/routes_ShippingQuery.graphql.ts
@@ -22,6 +22,22 @@ query routes_ShippingQuery(
 
 fragment Shipping_order on Order {
   id
+  ...Summary_order
+  __id: id
+}
+
+fragment Summary_order on Order {
+  lineItems {
+    edges {
+      node {
+        artwork {
+          id
+          __id
+        }
+        __id: id
+      }
+    }
+  }
   __id: id
 }
 */
@@ -49,13 +65,20 @@ v2 = {
   "name": "id",
   "args": null,
   "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
 };
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_ShippingQuery",
   "id": null,
-  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  __id: id\n}\n",
+  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  ...Summary_order\n  __id: id\n}\n\nfragment Summary_order on Order {\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -97,12 +120,59 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
+          v3,
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "id",
+            "name": "lineItems",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
+            "concreteType": "OrderLineItemConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "OrderLineItemEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "OrderLineItem",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
+                          v3,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "__id",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      v2
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           v2
         ]


### PR DESCRIPTION
Will follow up with the force PR.

This goes over what we talked about in the knowledge share last week. The main changes are:
- Get the `mediator` from the global app state instead of from being passed in as props
- Add a fetch for the artwork id on the `Summary` component. We can expand this later to include more artwork data.