### PR TITLE
@eessex: Mobile signup cta for articles

### DIFF
--- a/src/Components/Animation/SlideTransition.tsx
+++ b/src/Components/Animation/SlideTransition.tsx
@@ -1,0 +1,35 @@
+import * as React from "react"
+import { Transition } from "react-transition-group"
+
+const duration = 250
+
+export default props => {
+  const defaultStyle = {
+    transition: `height ${duration}ms ease-in-out`,
+    height: "0px",
+  }
+
+  const transitionStyles = {
+    entering: {
+      height: "0px",
+    },
+    entered: {
+      height: props.height,
+    },
+  }
+
+  return (
+    <Transition {...props}>
+      {state => (
+        <div
+          style={{
+            ...defaultStyle,
+            ...transitionStyles[state],
+          }}
+        >
+          {{ ...props.children }}
+        </div>
+      )}
+    </Transition>
+  )
+}

--- a/src/Components/MinimalCtaBanner.tsx
+++ b/src/Components/MinimalCtaBanner.tsx
@@ -1,55 +1,89 @@
 import React from "react"
 import styled from "styled-components"
 import { unica } from "../Assets/Fonts"
+import SlideTransition from "./Animation/SlideTransition"
 import Icon from "./Icon"
 
 export interface MinimalCtaBannerProps extends React.Props<HTMLDivElement> {
   backgroundColor?: string
   copy?: string
+  height?: string
   href?: string
   position: "top" | "bottom"
   textColor?: string
+  showCtaBanner?: boolean
 }
 
-const MinimalCtaBanner: React.SFC<MinimalCtaBannerProps> = props => (
-  <BannerContainer
-    position={props.position}
-    backgroundColor={props.backgroundColor}
-  >
-    <Banner href={props.href} textColor={props.textColor}>
-      <p>{props.copy}</p>
-      <IconContainer>
-        <Icon name="chevron-right" color={props.textColor} fontSize="12px" />
-      </IconContainer>
-    </Banner>
-  </BannerContainer>
-)
+export interface State {
+  showCta: boolean
+}
+
+export class MinimalCtaBanner extends React.Component<
+  MinimalCtaBannerProps,
+  State
+> {
+  state = {
+    showCta: this.props.showCtaBanner,
+  }
+
+  dismissCta = () => {
+    const showCta = false
+    this.setState({ showCta })
+  }
+
+  render() {
+    const ctaBanner = (
+      <SlideTransition
+        in={this.props.showCtaBanner}
+        timeout={{ enter: 10, exit: 250 }}
+        height={this.props.height}
+      >
+        <BannerContainer
+          position={this.props.position}
+          backgroundColor={this.props.backgroundColor}
+        >
+          <Banner textColor={this.props.textColor}>
+            <a href={this.props.href}>
+              <p>{this.props.copy}</p>
+            </a>
+            <IconContainer onClick={this.dismissCta as any}>
+              <Icon name="close" color={this.props.textColor} fontSize="16px" />
+            </IconContainer>
+          </Banner>
+        </BannerContainer>
+      </SlideTransition>
+    )
+
+    return this.state.showCta ? ctaBanner : <div />
+  }
+}
 
 const BannerContainer = styled.div.attrs<MinimalCtaBannerProps>({})`
   width: 100%;
-  height: 50px;
+  height: inherit;
   background-color: ${props => props.backgroundColor || "white"};
   display: flex;
-  position: absolute;
+  position: fixed;
   ${props => {
     if (props.position === "bottom") return "bottom: 0px;"
     if (props.position === "top") return "top: 0px;"
   }};
 `
 
-const Banner = styled.a.attrs<{ textColor: string }>({})`
+const Banner = styled.div.attrs<{ textColor: string }>({})`
   display: inline-flex;
   align-items: center;
-  text-decoration: none;
-  color: ${props => props.textColor || "black"};
   height: 100%;
   width: 100%;
   padding: 0 10px;
-  ${unica("s12")};
+  a {
+    color: ${props => props.textColor || "black"};
+    text-decoration: none;
+    ${unica("s12")};
+    margin: auto auto auto 0;
+  }
 `
 
 const IconContainer = styled.div`
   margin-left: auto;
 `
-
-export default MinimalCtaBanner

--- a/src/Components/MinimalCtaBanner.tsx
+++ b/src/Components/MinimalCtaBanner.tsx
@@ -11,11 +11,11 @@ export interface MinimalCtaBannerProps extends React.Props<HTMLDivElement> {
   href?: string
   position: "top" | "bottom"
   textColor?: string
-  showCtaBanner?: boolean
+  show?: boolean
 }
 
 export interface State {
-  showCta: boolean
+  dismissed: boolean
 }
 
 export class MinimalCtaBanner extends React.Component<
@@ -23,18 +23,17 @@ export class MinimalCtaBanner extends React.Component<
   State
 > {
   state = {
-    showCta: this.props.showCtaBanner,
+    dismissed: false,
   }
 
   dismissCta = () => {
-    const showCta = false
-    this.setState({ showCta })
+    this.setState({ dismissed: true })
   }
 
   render() {
     const ctaBanner = (
       <SlideTransition
-        in={this.props.showCtaBanner}
+        in={this.props.show}
         timeout={{ enter: 10, exit: 250 }}
         height={this.props.height}
       >
@@ -54,7 +53,7 @@ export class MinimalCtaBanner extends React.Component<
       </SlideTransition>
     )
 
-    return this.state.showCta ? ctaBanner : <div />
+    return !this.state.dismissed ? ctaBanner : <div />
   }
 }
 

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -61,32 +61,36 @@ export enum CtaCopy {
 )
 export class Article extends React.Component<ArticleProps, State> {
   state = {
-    showCtaBanner: true,
+    showCtaBanner: false,
+  }
+  lastScrollPosition: number = 0
+
+  handleScroll() {
+    const newScrollPosition = window.scrollY
+    let showCtaBanner = this.state.showCtaBanner
+
+    if (newScrollPosition <= this.lastScrollPosition) {
+      // scrolling up the page
+      if (this.state.showCtaBanner) {
+        showCtaBanner = false
+      }
+    } else {
+      // scrolling down the page
+      if (!this.state.showCtaBanner) {
+        showCtaBanner = true
+      }
+    }
+
+    if (this.state.showCtaBanner !== showCtaBanner) {
+      this.setState({ showCtaBanner })
+    }
+    this.lastScrollPosition = newScrollPosition
   }
 
   componentDidMount() {
     if (window) {
-      let lastScrollPosition = 0
       window.addEventListener("scroll", e => {
-        const newScrollPosition = window.scrollY
-        let showCtaBanner = this.state.showCtaBanner
-
-        if (newScrollPosition < lastScrollPosition) {
-          // scrolling up the page
-          if (this.state.showCtaBanner) {
-            showCtaBanner = false
-          }
-        } else {
-          // scrolling down the page
-          if (this.state.showCtaBanner === false) {
-            showCtaBanner = true
-          }
-        }
-
-        if (this.state.showCtaBanner !== showCtaBanner) {
-          this.setState({ showCtaBanner })
-        }
-        lastScrollPosition = newScrollPosition
+        this.handleScroll()
       })
     }
   }
@@ -131,7 +135,7 @@ export class Article extends React.Component<ArticleProps, State> {
             position="bottom"
             textColor="white"
             backgroundColor="black"
-            showCtaBanner={this.state.showCtaBanner}
+            show={this.state.showCtaBanner}
           />
         )}
       </FullScreenProvider>

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import track from "react-tracking"
 import Events from "../../Utils/Events"
 
+import { debounce } from "lodash"
 import { MinimalCtaBanner } from "../MinimalCtaBanner"
 import ArticleWithFullScreen from "./Layouts/ArticleWithFullScreen"
 import { ClassicLayout } from "./Layouts/ClassicLayout"
@@ -87,9 +88,10 @@ export class Article extends React.Component<ArticleProps, State> {
 
   componentDidMount() {
     if (window) {
-      window.addEventListener("scroll", e => {
-        this.handleScroll()
-      })
+      window.addEventListener(
+        "scroll",
+        debounce(() => this.handleScroll(), 250)
+      )
     }
   }
 
@@ -122,8 +124,10 @@ export class Article extends React.Component<ArticleProps, State> {
   }
 
   render() {
-    const copy =
-      this.props.article.layout === "news" ? CtaCopy.news : CtaCopy.default
+    const { layout } = this.props.article
+    const copy = layout === "news" ? CtaCopy.news : CtaCopy.default
+    const backgroundColor = layout === "video" ? "white" : "black"
+    const textColor = layout === "video" ? "black" : "white"
 
     return (
       <FullScreenProvider>
@@ -134,8 +138,8 @@ export class Article extends React.Component<ArticleProps, State> {
             height="50px"
             copy={copy}
             position="bottom"
-            textColor="white"
-            backgroundColor="black"
+            textColor={textColor}
+            backgroundColor={backgroundColor}
             show={this.state.showCtaBanner}
           />
         )}

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -42,8 +42,6 @@ export interface State {
 
 export enum CtaCopy {
   news = "Sign up for the best in art world news",
-  standard = "Sign up to get our best stories everyday",
-  feature = "Sign up to get our best stories everyday",
   default = "Sign up to get our best stories everyday",
 }
 
@@ -124,6 +122,9 @@ export class Article extends React.Component<ArticleProps, State> {
   }
 
   render() {
+    const copy =
+      this.props.article.layout === "news" ? CtaCopy.news : CtaCopy.default
+
     return (
       <FullScreenProvider>
         {this.getArticleLayout()}
@@ -131,7 +132,7 @@ export class Article extends React.Component<ArticleProps, State> {
           <MinimalCtaBanner
             href="/sign_up"
             height="50px"
-            copy={CtaCopy[this.props.article.layout] || CtaCopy.default}
+            copy={copy}
             position="bottom"
             textColor="white"
             backgroundColor="black"

--- a/src/Components/Publishing/__tests__/Article.test.tsx
+++ b/src/Components/Publishing/__tests__/Article.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme"
+import { mount, shallow } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import { Article } from "../Article"
@@ -10,6 +10,7 @@ import {
   VideoArticle,
 } from "../Fixtures/Articles"
 
+import { MinimalCtaBanner } from "../../MinimalCtaBanner"
 import { ArticleWithFullScreen } from "../Layouts/ArticleWithFullScreen"
 import { NewsLayout } from "../Layouts/NewsLayout"
 import { SeriesLayout } from "../Layouts/SeriesLayout"
@@ -42,4 +43,43 @@ it("renders video articles in video layout", () => {
 it("renders news articles in news layout", () => {
   const article = mount(<Article article={NewsArticle} />)
   expect(article.find(NewsLayout).length).toBe(1)
+})
+
+it("renders mobile MinimalCtaBanner for standard article layouts", () => {
+  const article = shallow(
+    <Article article={StandardArticle} isMobile isLoggedIn={false} />
+  )
+  expect(article.find(MinimalCtaBanner).length).toBe(1)
+})
+
+it("does not renders mobile MinimalCtaBanner for standard article layouts for desktop", () => {
+  const article = shallow(
+    <Article article={StandardArticle} isMobile={false} isLoggedIn={false} />
+  )
+  expect(article.find(MinimalCtaBanner).length).toBe(0)
+})
+
+it("does not renders mobile MinimalCtaBanner for standard article layouts for logged in users", () => {
+  const article = shallow(
+    <Article article={StandardArticle} isMobile isLoggedIn />
+  )
+  expect(article.find(MinimalCtaBanner).length).toBe(0)
+})
+
+it("it sets state appropriately based on scroll direction", () => {
+  const aWindow: any = window
+
+  const wrapper = shallow(
+    <Article article={StandardArticle} isMobile isLoggedIn />
+  )
+  const article = wrapper.instance() as any
+
+  // User scrolls back up which should show the banner
+  article.handleScroll()
+  expect(article.state.showCtaBanner).toBe(false)
+
+  aWindow.scrollY = 500
+  article.handleScroll()
+  wrapper.update()
+  expect(article.state.showCtaBanner).toBe(true)
 })

--- a/src/Components/Publishing/__tests__/Article.test.tsx
+++ b/src/Components/Publishing/__tests__/Article.test.tsx
@@ -52,6 +52,20 @@ it("renders mobile MinimalCtaBanner for standard article layouts", () => {
   expect(article.find(MinimalCtaBanner).length).toBe(1)
 })
 
+it("renders mobile MinimalCtaBanner for news article layouts", () => {
+  const article = shallow(
+    <Article article={NewsArticle} isMobile isLoggedIn={false} />
+  )
+  expect(article.find(MinimalCtaBanner).length).toBe(1)
+})
+
+it("renders mobile MinimalCtaBanner for video article layouts", () => {
+  const article = shallow(
+    <Article article={VideoArticle} isMobile isLoggedIn={false} />
+  )
+  expect(article.find(MinimalCtaBanner).length).toBe(1)
+})
+
 it("does not renders mobile MinimalCtaBanner for standard article layouts for desktop", () => {
   const article = shallow(
     <Article article={StandardArticle} isMobile={false} isLoggedIn={false} />
@@ -62,6 +76,13 @@ it("does not renders mobile MinimalCtaBanner for standard article layouts for de
 it("does not renders mobile MinimalCtaBanner for standard article layouts for logged in users", () => {
   const article = shallow(
     <Article article={StandardArticle} isMobile isLoggedIn />
+  )
+  expect(article.find(MinimalCtaBanner).length).toBe(0)
+})
+
+it("does not renders mobile MinimalCtaBanner for series article layouts for logged in users", () => {
+  const article = shallow(
+    <Article article={SeriesArticle} isMobile isLoggedIn={false} />
   )
   expect(article.find(MinimalCtaBanner).length).toBe(0)
 })

--- a/src/Components/__stories__/CtaBanner.story.tsx
+++ b/src/Components/__stories__/CtaBanner.story.tsx
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
 
-import MinimalCtaBanner from "../MinimalCtaBanner"
+import { MinimalCtaBanner } from "../MinimalCtaBanner"
 
 storiesOf("Components/MinimalCtaBanner", module).add(
   "Minimal CTA Banner",


### PR DESCRIPTION
This addresses https://artsyproduct.atlassian.net/browse/GROW-705.

- It implements the CTA on the article page.
- Updates the MinimalCtaBanner to include animations per the spec.
- Allows the user to dismiss the CTA Banner .

![signup cta](https://user-images.githubusercontent.com/5201004/43801169-4f2e8950-9a60-11e8-8269-0de4a30c8a62.gif)

