### PR TITLE
[PATCH lib] Remove ref to Styled Grid fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-runtime-1.5.0-artsy.3.tgz",
     "serialize-javascript": "^1.5.0",
     "sharify": "^0.1.6",
-    "styled-bootstrap-grid": "damassi/styled-bootstrap-grid#respect-padding-in-fluid",
+    "styled-bootstrap-grid": "1.0.4",
     "styled-reset": "^1.3.5",
     "styled-system": "^2.2.5",
     "superagent": "^3.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12551,9 +12551,9 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
-  version "1.0.3-2"
-  resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
+styled-bootstrap-grid@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/styled-bootstrap-grid/-/styled-bootstrap-grid-1.0.4.tgz#43417a43097ab00a8f644829f0d11ca226f16455"
 
 styled-components@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
Removes my fork now that https://github.com/dragma/styled-bootstrap-grid/pull/17 was merged. 

I'd still like to rewrite this lib, perhaps from scratch, though we should keep the same API since its pretty idiomatic across various grid libs. I'm thinking something that we could seamlessly replace that's perhaps built on top of our new Responsive component. 

cc @zephraph 