### PR TITLE
@damassi => Add new set of commercial filtering options on artist page filter

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -22,6 +22,7 @@ const {
   METAPHYSICS_ENDPOINT,
   USER_ID,
   USER_ACCESS_TOKEN,
+  USER_LAB_FEATURES,
   XAPP_TOKEN,
 } = process.env
 
@@ -52,6 +53,7 @@ if (USER_ID && USER_ACCESS_TOKEN) {
       "process.env": {
         USER_ID: JSON.stringify(USER_ID),
         USER_ACCESS_TOKEN: JSON.stringify(USER_ACCESS_TOKEN),
+        USER_LAB_FEATURES: JSON.stringify(USER_LAB_FEATURES),
         XAPP_TOKEN: JSON.stringify(XAPP_TOKEN),
       },
     })

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -170,8 +170,10 @@ type Artist implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -428,8 +430,10 @@ type ArtistItem implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -713,6 +717,9 @@ type Artwork implements Node & Sellable {
     shallow: Boolean
   ): Partner
   price: String
+
+  # The string that describes domestic and international shipping.
+  shippingInfo: String
   provenance(format: Format): String
   publisher(format: Format): String
   related(size: Int): [Artwork]
@@ -1135,8 +1142,10 @@ type ArtworkFilterGene implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -1185,8 +1194,10 @@ type ArtworkFilterTag implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -1344,6 +1355,9 @@ type ArtworkItem implements Node & Sellable {
     shallow: Boolean
   ): Partner
   price: String
+
+  # The string that describes domestic and international shipping.
+  shippingInfo: String
   provenance(format: Format): String
   publisher(format: Format): String
   related(size: Int): [Artwork]
@@ -2040,19 +2054,19 @@ type CreateGeminiEntryForAssetPayload {
   clientMutationId: String
 }
 
-input CreateOrderInput {
-  # ID of partner representing artwork
-  partnerId: String
+input CreateOrderWithArtworkInput {
+  # BSON ID of artwork
+  artworkId: String!
 
-  # Currency code
-  currencyCode: String!
+  # ID of artwork's edition set
+  editionSetId: String
 
-  # Line items in the order
-  lineItems: [LineItemInput]
+  # quantity of artwork
+  quantity: Int
   clientMutationId: String
 }
 
-type CreateOrderPayload {
+type CreateOrderWithArtworkPayload {
   result: OrderReturnType
   clientMutationId: String
 }
@@ -2485,17 +2499,6 @@ type FilterSaleArtworksCounts {
   ): FormattedNumber
 }
 
-input FinalizeOrderInput {
-  # Order ID
-  orderId: String!
-  clientMutationId: String
-}
-
-type FinalizeOrderPayload {
-  result: OrderReturnType
-  clientMutationId: String
-}
-
 type FollowArtist {
   artist: Artist
   auto: Boolean
@@ -2639,6 +2642,31 @@ enum Format {
 # a formatted String. It does not try to coerce the type.
 scalar FormattedNumber
 
+input FulfillmentInputType {
+  # Courier of the fulfiller
+  courier: String!
+
+  # Courier's Tracking ID of this fulfillment
+  trackingId: String
+
+  # Estimated delivery in YY-MM-DD format
+  estimatedDelivery: String
+}
+
+input FulfillOrderAtOnceInput {
+  # ID of the order
+  orderId: String!
+
+  # Fulfillment information of this order
+  fulfillment: FulfillmentInputType!
+  clientMutationId: String
+}
+
+type FulfillOrderAtOncePayload {
+  result: OrderReturnType
+  clientMutationId: String
+}
+
 # An entry from gemini
 type GeminiEntry {
   # The token that represents the gemini entry.
@@ -2662,8 +2690,10 @@ type Gene implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -2701,8 +2731,10 @@ type Gene implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -2827,8 +2859,10 @@ type GeneItem implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -2866,8 +2900,10 @@ type GeneItem implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -3300,8 +3336,10 @@ type HomePageModuleContextGene implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -3339,8 +3377,10 @@ type HomePageModuleContextGene implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -3585,17 +3625,6 @@ union Item = ArtistItem | ArtworkItem | FeaturedLinkItem | GeneItem
 
 # The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 scalar JSON
-
-input LineItemInput {
-  # ID of artwork
-  artworkId: String!
-
-  # quantity of artwork
-  quantity: Int!
-
-  # Price in cents
-  priceCents: Int!
-}
 
 type Location {
   # A globally unique ID.
@@ -3870,8 +3899,11 @@ type Mutation {
   # Update a conversation.
   updateConversation(input: UpdateConversationMutationInput!): UpdateConversationMutationPayload
 
-  # Creates an order with payment
-  createOrder(input: CreateOrderInput!): CreateOrderPayload
+  # Creates an order with an artwork
+  createOrderWithArtwork(input: CreateOrderWithArtworkInput!): CreateOrderWithArtworkPayload
+
+  # Sets shipping information for an order
+  setOrderShipping(input: SetOrderShippingInput!): SetOrderShippingPayload
 
   # Sets payment information on an order
   setOrderPayment(input: SetOrderPaymentInput!): SetOrderPaymentPayload
@@ -3879,8 +3911,8 @@ type Mutation {
   # Approves an order with payment
   approveOrder(input: ApproveOrderInput!): ApproveOrderPayload
 
-  # Finalizes an order
-  finalizeOrder(input: FinalizeOrderInput!): FinalizeOrderPayload
+  # Fulfills an Order with one fulfillment by setting this fulfillment to all line items of this order
+  fulfillOrderAtOnce(input: FulfillOrderAtOnceInput!): FulfillOrderAtOncePayload
 
   # Rejects an order
   rejectOrder(input: RejectOrderInput!): RejectOrderPayload
@@ -3983,8 +4015,32 @@ type Order {
   # Tracking code of the order
   code: String
 
+  # Fulfillment Type
+  fulfillmentType: OrderFulfillmentType
+
+  # Shipping address line 1
+  shippingAddressLine1: String
+
+  # Shipping address line 2
+  shippingAddressLine2: String
+
+  # Shipping city
+  shippingCity: String
+
+  # Shipping country
+  shippingCountry: String
+
+  # Shipping postal code
+  shippingPostalCode: String
+
+  # Shipping region
+  shippingRegion: String
+
+  # Item total in cents
+  itemsTotalCents: Int
+
   # A formatted price with various currency formatting options.
-  itemsTotalCents(
+  itemsTotal(
     decimal: String = "."
 
     # Allows control of symbol position (%v = value, %s = symbol)
@@ -3994,8 +4050,11 @@ type Order {
     thousand: String = ","
   ): String
 
+  # Shipping total in cents
+  shippingTotalCents: Int
+
   # A formatted price with various currency formatting options.
-  shippingTotalCents(
+  shippingTotal(
     decimal: String = "."
 
     # Allows control of symbol position (%v = value, %s = symbol)
@@ -4005,8 +4064,11 @@ type Order {
     thousand: String = ","
   ): String
 
+  # Tax total in cents
+  taxTotalCents: Int
+
   # A formatted price with various currency formatting options.
-  taxTotalCents(
+  taxTotal(
     decimal: String = "."
 
     # Allows control of symbol position (%v = value, %s = symbol)
@@ -4016,8 +4078,11 @@ type Order {
     thousand: String = ","
   ): String
 
+  # Transaction fee in cents
+  transactionFeeCents: Int
+
   # A formatted price with various currency formatting options.
-  transactionFeeCents(
+  transactionFee(
     decimal: String = "."
 
     # Allows control of symbol position (%v = value, %s = symbol)
@@ -4027,8 +4092,11 @@ type Order {
     thousand: String = ","
   ): String
 
+  # Commission fee in cents
+  commissionFeeCents: Int
+
   # A formatted price with various currency formatting options.
-  commissionFeeCents(
+  commissionFee(
     decimal: String = "."
 
     # Allows control of symbol position (%v = value, %s = symbol)
@@ -4038,8 +4106,11 @@ type Order {
     thousand: String = ","
   ): String
 
+  # Buyer total in cents
+  buyerTotalCents: Int
+
   # A formatted price with various currency formatting options.
-  buyerTotalCents(
+  buyerTotal(
     decimal: String = "."
 
     # Allows control of symbol position (%v = value, %s = symbol)
@@ -4049,8 +4120,11 @@ type Order {
     thousand: String = ","
   ): String
 
+  # Seller total in cents
+  sellerTotalCents: Int
+
   # A formatted price with various currency formatting options.
-  sellerTotalCents(
+  sellerTotal(
     decimal: String = "."
 
     # Allows control of symbol position (%v = value, %s = symbol)
@@ -4130,6 +4204,47 @@ type OrderedSet {
   name: String
 }
 
+type OrderFulfillment {
+  # ID of the fulfillment
+  id: ID
+
+  # Fulfillment Courier
+  courier: String
+
+  # Courier's tracking id
+  trackingId: String
+  estimatedDelivery(
+    convert_to_utc: Boolean
+    format: String
+
+    # Specify a tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+}
+
+# A connection to a list of items.
+type OrderFulfillmentConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [OrderFulfillmentEdge]
+}
+
+# An edge in a connection.
+type OrderFulfillmentEdge {
+  # The item at the end of the edge
+  node: OrderFulfillment
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
+enum OrderFulfillmentType {
+  SHIP
+  PICKUP
+}
+
 type OrderLineItem {
   # ID of the order line item
   id: ID
@@ -4139,6 +4254,9 @@ type OrderLineItem {
 
   # Edition set on the artwork
   editionSet: EditionSet
+
+  # Unit price in cents
+  priceCents: Int
 
   # A formatted price with various currency formatting options.
   price(
@@ -4167,6 +4285,9 @@ type OrderLineItem {
 
   # Quantity of items in this line item
   quantity: Int
+
+  # List of order line items
+  fulfillments: OrderFulfillmentConnection
 }
 
 # A connection to a list of items.
@@ -4190,6 +4311,14 @@ type OrderLineItemEdge {
 type OrderReturnType {
   order: Order
   errors: [String]
+}
+
+enum OrdersSortMethodType {
+  # Sort by latest timestamp order was updated in ascending order
+  UPDATED_AT_ASC
+
+  # Sort by latest timestamp order was updated in descending order
+  UPDATED_AT_DESC
 }
 
 type organizer {
@@ -4776,8 +4905,10 @@ type Query {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -4872,7 +5003,7 @@ type Query {
   order(id: String!): Order
 
   # Returns list of orders
-  orders(userId: String, partnerId: String, state: String): OrderConnection
+  orders(userId: String, partnerId: String, state: String, sort: OrdersSortMethodType): OrderConnection
 
   # An OrderedSet
   ordered_set(
@@ -5579,6 +5710,38 @@ type SetOrderPaymentPayload {
   clientMutationId: String
 }
 
+input SetOrderShippingInput {
+  # Id of the Order
+  orderId: ID
+
+  # Fulfillment Type of this Order
+  fulfillmentType: OrderFulfillmentType
+
+  # Shipping address line 1
+  shippingAddressLine1: String
+
+  # Shipping address line 2
+  shippingAddressLine2: String
+
+  # Shipping city
+  shippingCity: String
+
+  # Shipping region
+  shippingRegion: String
+
+  # Shipping country
+  shippingCountry: String
+
+  # Shipping postal code
+  shippingPostalCode: String
+  clientMutationId: String
+}
+
+type SetOrderShippingPayload {
+  result: OrderReturnType
+  clientMutationId: String
+}
+
 type Show implements Node {
   # A globally unique ID.
   __id: ID!
@@ -5824,8 +5987,10 @@ type Tag implements Node {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -6199,8 +6364,10 @@ type Viewer {
     aggregations: [ArtworkAggregation]
     artist_id: String
     artist_ids: [String]
+    at_auction: Boolean
     color: String
     dimension_range: String
+    ecommerce: Boolean
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
@@ -6295,7 +6462,7 @@ type Viewer {
   order(id: String!): Order
 
   # Returns list of orders
-  orders(userId: String, partnerId: String, state: String): OrderConnection
+  orders(userId: String, partnerId: String, state: String, sort: OrdersSortMethodType): OrderConnection
 
   # An OrderedSet
   ordered_set(

--- a/data/schema.json
+++ b/data/schema.json
@@ -737,6 +737,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -752,6 +762,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -1517,6 +1537,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrdersSortMethodType",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4895,6 +4925,18 @@
               "deprecationReason": null
             },
             {
+              "name": "shippingInfo",
+              "description": "The string that describes domestic and international shipping.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "provenance",
               "description": null,
               "args": [
@@ -6204,6 +6246,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -6219,6 +6271,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -16174,6 +16236,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -16189,6 +16261,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -16626,6 +16708,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -16641,6 +16733,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17087,6 +17189,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -17102,6 +17214,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17466,6 +17588,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -17481,6 +17613,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -26329,6 +26471,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -26344,6 +26496,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -26708,6 +26870,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -26723,6 +26895,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -33324,7 +33506,103 @@
               "deprecationReason": null
             },
             {
+              "name": "fulfillmentType",
+              "description": "Fulfillment Type",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderFulfillmentType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingAddressLine1",
+              "description": "Shipping address line 1",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingAddressLine2",
+              "description": "Shipping address line 2",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingCity",
+              "description": "Shipping city",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingCountry",
+              "description": "Shipping country",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingPostalCode",
+              "description": "Shipping postal code",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingRegion",
+              "description": "Shipping region",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "itemsTotalCents",
+              "description": "Item total in cents",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "itemsTotal",
               "description": "A formatted price with various currency formatting options.",
               "args": [
                 {
@@ -33388,6 +33666,18 @@
             },
             {
               "name": "shippingTotalCents",
+              "description": "Shipping total in cents",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingTotal",
               "description": "A formatted price with various currency formatting options.",
               "args": [
                 {
@@ -33451,6 +33741,18 @@
             },
             {
               "name": "taxTotalCents",
+              "description": "Tax total in cents",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxTotal",
               "description": "A formatted price with various currency formatting options.",
               "args": [
                 {
@@ -33514,6 +33816,18 @@
             },
             {
               "name": "transactionFeeCents",
+              "description": "Transaction fee in cents",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "transactionFee",
               "description": "A formatted price with various currency formatting options.",
               "args": [
                 {
@@ -33577,6 +33891,18 @@
             },
             {
               "name": "commissionFeeCents",
+              "description": "Commission fee in cents",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "commissionFee",
               "description": "A formatted price with various currency formatting options.",
               "args": [
                 {
@@ -33640,6 +33966,18 @@
             },
             {
               "name": "buyerTotalCents",
+              "description": "Buyer total in cents",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "buyerTotal",
               "description": "A formatted price with various currency formatting options.",
               "args": [
                 {
@@ -33703,6 +34041,18 @@
             },
             {
               "name": "sellerTotalCents",
+              "description": "Seller total in cents",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sellerTotal",
               "description": "A formatted price with various currency formatting options.",
               "args": [
                 {
@@ -33979,6 +34329,29 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "OrderFulfillmentType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SHIP",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PICKUP",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "OrderLineItemConnection",
           "description": "A connection to a list of items.",
@@ -34096,6 +34469,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "EditionSet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priceCents",
+              "description": "Unit price in cents",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34261,6 +34646,190 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "fulfillments",
+              "description": "List of order line items",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "OrderFulfillmentConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OrderFulfillmentConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderFulfillmentEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OrderFulfillmentEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "OrderFulfillment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OrderFulfillment",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": "ID of the fulfillment",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courier",
+              "description": "Fulfillment Courier",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "trackingId",
+              "description": "Courier's tracking id",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "estimatedDelivery",
+              "description": null,
+              "args": [
+                {
+                  "name": "convert_to_utc",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "format",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "timezone",
+                  "description": "Specify a tz database time zone, otherwise falls back to `X-TIMEZONE` header",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -34417,6 +34986,29 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrdersSortMethodType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "UPDATED_AT_ASC",
+              "description": "Sort by latest timestamp order was updated in ascending order",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_AT_DESC",
+              "description": "Sort by latest timestamp order was updated in descending order",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -35445,6 +36037,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -35460,6 +36062,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -37505,6 +38117,18 @@
               "deprecationReason": null
             },
             {
+              "name": "shippingInfo",
+              "description": "The string that describes domestic and international shipping.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "provenance",
               "description": null,
               "args": [
@@ -38130,6 +38754,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -38145,6 +38779,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -38509,6 +39153,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -38524,6 +39178,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -39798,6 +40462,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -39813,6 +40487,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -40897,6 +41581,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "at_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "color",
                   "description": null,
                   "type": {
@@ -40912,6 +41606,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ecommerce",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -41677,6 +42381,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrdersSortMethodType",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -43009,8 +43723,8 @@
               "deprecationReason": null
             },
             {
-              "name": "createOrder",
-              "description": "Creates an order with payment",
+              "name": "createOrderWithArtwork",
+              "description": "Creates an order with an artwork",
               "args": [
                 {
                   "name": "input",
@@ -43020,7 +43734,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "CreateOrderInput",
+                      "name": "CreateOrderWithArtworkInput",
                       "ofType": null
                     }
                   },
@@ -43029,7 +43743,34 @@
               ],
               "type": {
                 "kind": "OBJECT",
-                "name": "CreateOrderPayload",
+                "name": "CreateOrderWithArtworkPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setOrderShipping",
+              "description": "Sets shipping information for an order",
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SetOrderShippingInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SetOrderShippingPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -43090,8 +43831,8 @@
               "deprecationReason": null
             },
             {
-              "name": "finalizeOrder",
-              "description": "Finalizes an order",
+              "name": "fulfillOrderAtOnce",
+              "description": "Fulfills an Order with one fulfillment by setting this fulfillment to all line items of this order",
               "args": [
                 {
                   "name": "input",
@@ -43101,7 +43842,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "FinalizeOrderInput",
+                      "name": "FulfillOrderAtOnceInput",
                       "ofType": null
                     }
                   },
@@ -43110,7 +43851,7 @@
               ],
               "type": {
                 "kind": "OBJECT",
-                "name": "FinalizeOrderPayload",
+                "name": "FulfillOrderAtOncePayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -44809,23 +45550,13 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "CreateOrderInput",
+          "name": "CreateOrderWithArtworkInput",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "partnerId",
-              "description": "ID of partner representing artwork",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "currencyCode",
-              "description": "Currency code",
+              "name": "artworkId",
+              "description": "BSON ID of artwork",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -44838,16 +45569,22 @@
               "defaultValue": null
             },
             {
-              "name": "lineItems",
-              "description": "Line items in the order",
+              "name": "editionSetId",
+              "description": "ID of artwork's edition set",
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "LineItemInput",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "quantity",
+              "description": "quantity of artwork",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
               },
               "defaultValue": null
             },
@@ -44867,61 +45604,8 @@
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "LineItemInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "artworkId",
-              "description": "ID of artwork",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "quantity",
-              "description": "quantity of artwork",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "priceCents",
-              "description": "Price in cents",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
-          "name": "CreateOrderPayload",
+          "name": "CreateOrderWithArtworkPayload",
           "description": null,
           "fields": [
             {
@@ -44983,6 +45667,142 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderShippingInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "orderId",
+              "description": "Id of the Order",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fulfillmentType",
+              "description": "Fulfillment Type of this Order",
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderFulfillmentType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingAddressLine1",
+              "description": "Shipping address line 1",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingAddressLine2",
+              "description": "Shipping address line 2",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingCity",
+              "description": "Shipping city",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingRegion",
+              "description": "Shipping region",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingCountry",
+              "description": "Shipping country",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingPostalCode",
+              "description": "Shipping postal code",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SetOrderShippingPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "result",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "OrderReturnType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -45149,19 +45969,33 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "FinalizeOrderInput",
+          "name": "FulfillOrderAtOnceInput",
           "description": null,
           "fields": null,
           "inputFields": [
             {
               "name": "orderId",
-              "description": "Order ID",
+              "description": "ID of the order",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fulfillment",
+              "description": "Fulfillment information of this order",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "FulfillmentInputType",
                   "ofType": null
                 }
               },
@@ -45183,8 +46017,53 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "FulfillmentInputType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "courier",
+              "description": "Courier of the fulfiller",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "trackingId",
+              "description": "Courier's Tracking ID of this fulfillment",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "estimatedDelivery",
+              "description": "Estimated delivery in YY-MM-DD format",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
-          "name": "FinalizeOrderPayload",
+          "name": "FulfillOrderAtOncePayload",
           "description": null,
           "fields": [
             {

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterRefetch.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterRefetch.tsx
@@ -81,6 +81,8 @@ export const ArtworkFilterRefetchContainer = createRefetchContainer(
           major_periods: { type: "[String]" }
           partner_id: { type: "ID" }
           for_sale: { type: "Boolean" }
+          at_auction: { type: "Boolean" }
+          ecommerce: { type: "Boolean" }
           sort: { type: "String", defaultValue: "-partner_updated_at" }
         ) {
         __id
@@ -90,6 +92,8 @@ export const ArtworkFilterRefetchContainer = createRefetchContainer(
           major_periods: $major_periods
           partner_id: $partner_id
           for_sale: $for_sale
+          at_auction: $at_auction
+          ecommerce: $ecommerce
           size: 0
           sort: $sort
         ) {
@@ -104,6 +108,8 @@ export const ArtworkFilterRefetchContainer = createRefetchContainer(
       $medium: String
       $major_periods: [String]
       $partner_id: ID
+      $ecommerce: Boolean
+      $at_auction: Boolean
       $for_sale: Boolean
       $sort: String
     ) {
@@ -116,6 +122,8 @@ export const ArtworkFilterRefetchContainer = createRefetchContainer(
               partner_id: $partner_id
               for_sale: $for_sale
               sort: $sort
+              at_auction: $at_auction
+              ecommerce: $ecommerce
             )
         }
       }

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -108,6 +108,8 @@ export const OverviewRouteFragmentContainer = createFragmentContainer(
         major_periods: { type: "[String]" }
         partner_id: { type: "ID!" }
         for_sale: { type: "Boolean" }
+        at_auction: { type: "Boolean" }
+        ecommerce: { type: "Boolean" }
         sort: { type: "String", defaultValue: "-partner_updated_at" }
       ) {
       ...ArtistHeader_artist
@@ -139,6 +141,8 @@ export const OverviewRouteFragmentContainer = createFragmentContainer(
           partner_id: $partner_id
           for_sale: $for_sale
           sort: $sort
+          at_auction: $at_auction
+          ecommerce: $ecommerce
         )
     }
   `

--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -7,6 +7,8 @@ type State = {
   for_sale?: boolean
   page?: number
   sort?: string
+  ecommerce?: boolean
+  at_auction?: boolean
 }
 
 export class FilterState extends Container<State> {
@@ -17,6 +19,8 @@ export class FilterState extends Container<State> {
     major_periods: [],
     partner_id: null,
     sort: "-partner_updated_at",
+    ecommerce: null,
+    at_auction: null,
   }
 
   constructor(props: State) {
@@ -26,7 +30,9 @@ export class FilterState extends Container<State> {
         if (props[filter]) {
           if (filter === "major_periods") {
             this.state[filter] = [props[filter]]
-          } else if (filter === "for_sale") {
+          } else if (
+            ["for_sale", "ecommerce", "at_auction"].indexOf(filter) !== -1
+          ) {
             this.state.for_sale = props[filter] ? true : null
           } else {
             this.state[filter] = props[filter]
@@ -49,15 +55,15 @@ export class FilterState extends Container<State> {
   }
 
   unsetFilter(filter, mediator) {
-    let newPartialState
+    let newPartialState = {}
     if (filter === "major_periods") {
       newPartialState = { major_periods: [] }
     }
-    if (filter === "partner_id") {
-      newPartialState = { partner_id: null }
-    }
-    if (filter === "for_sale") {
-      newPartialState = { for_sale: null }
+    if (
+      ["for_sale", "ecommerce", "at_auction", "partner_id"].indexOf(filter) !==
+      -1
+    ) {
+      newPartialState[filter] = null
     }
     if (filter === "medium") {
       newPartialState = { medium: "*" }
@@ -69,7 +75,7 @@ export class FilterState extends Container<State> {
   }
 
   setFilter(filter, value, mediator) {
-    let newPartialState
+    let newPartialState = {}
     if (filter === "major_periods") {
       newPartialState = {
         partner_id: null,
@@ -84,11 +90,11 @@ export class FilterState extends Container<State> {
         medium: "*",
       }
     }
-    if (filter === "for_sale") {
+    if (["for_sale", "ecommerce", "at_auction"].indexOf(filter) !== -1) {
       if (value) {
-        newPartialState = { for_sale: true }
+        newPartialState[filter] = true
       } else {
-        newPartialState = { for_sale: null }
+        newPartialState[filter] = null
       }
     }
     if (filter === "medium") {

--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -73,6 +73,8 @@ export const routes = [
             $partner_id: ID
             $for_sale: Boolean
             $sort: String
+            $at_auction: Boolean
+            $ecommerce: Boolean
           ) {
             artist(id: $artistID) {
               ...Overview_artist
@@ -82,6 +84,8 @@ export const routes = [
                   partner_id: $partner_id
                   for_sale: $for_sale
                   sort: $sort
+                  at_auction: $at_auction
+                  ecommerce: $ecommerce
                 )
             }
           }

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -17,7 +17,7 @@ storiesOf("Apps", module)
     return (
       <StorybooksRouter
         routes={artistRoutes}
-        initialRoute="/artist/pablo-picasso"
+        initialRoute="/artist/walter-gropius"
         initialState={{
           mediator: {
             trigger: x => x,

--- a/src/Components/Artsy.tsx
+++ b/src/Components/Artsy.tsx
@@ -73,7 +73,10 @@ export class ContextProvider extends React.Component<ContextProps>
       const id = process.env.USER_ID
       const accessToken = process.env.USER_ACCESS_TOKEN
       if (id && accessToken) {
-        this.currentUser = { id, accessToken }
+        this.currentUser = {
+          id,
+          accessToken,
+        }
       }
     }
 

--- a/src/Router/buildClientApp.tsx
+++ b/src/Router/buildClientApp.tsx
@@ -30,6 +30,7 @@ export function buildClientApp(config: AppConfig): Promise<ClientResolveProps> {
         currentUser = currentUser || {
           id: process.env.USER_ID,
           accessToken: process.env.USER_ACCESS_TOKEN,
+          lab_features: (process.env.USER_LAB_FEATURES || "").split(","),
         }
       }
 

--- a/src/__generated__/ArtworkFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkFilterRefetchQuery.graphql.ts
@@ -6,6 +6,8 @@ export type ArtworkFilterRefetchQueryVariables = {
     readonly medium?: string | null;
     readonly major_periods?: ReadonlyArray<string | null> | null;
     readonly partner_id?: string | null;
+    readonly ecommerce?: boolean | null;
+    readonly at_auction?: boolean | null;
     readonly for_sale?: boolean | null;
     readonly sort?: string | null;
 };
@@ -21,21 +23,23 @@ query ArtworkFilterRefetchQuery(
   $medium: String
   $major_periods: [String]
   $partner_id: ID
+  $ecommerce: Boolean
+  $at_auction: Boolean
   $for_sale: Boolean
   $sort: String
 ) {
   node(__id: $artistNodeID) {
     __typename
     ... on Artist {
-      ...ArtworkFilterRefetch_artist_3vi6l5
+      ...ArtworkFilterRefetch_artist_461vLz
     }
     __id
   }
 }
 
-fragment ArtworkFilterRefetch_artist_3vi6l5 on Artist {
+fragment ArtworkFilterRefetch_artist_461vLz on Artist {
   __id
-  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0, sort: $sort) {
+  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, ecommerce: $ecommerce, size: 0, sort: $sort) {
     ...ArtworkFilterArtworkGrid_filtered_artworks
     __id
   }
@@ -205,6 +209,18 @@ var v0 = [
   },
   {
     "kind": "LocalArgument",
+    "name": "ecommerce",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "at_auction",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
     "name": "for_sale",
     "type": "Boolean",
     "defaultValue": null
@@ -290,7 +306,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkFilterRefetchQuery",
   "id": null,
-  "text": "query ArtworkFilterRefetchQuery(\n  $artistNodeID: ID!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n) {\n  node(__id: $artistNodeID) {\n    __typename\n    ... on Artist {\n      ...ArtworkFilterRefetch_artist_3vi6l5\n    }\n    __id\n  }\n}\n\nfragment ArtworkFilterRefetch_artist_3vi6l5 on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query ArtworkFilterRefetchQuery(\n  $artistNodeID: ID!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $ecommerce: Boolean\n  $at_auction: Boolean\n  $for_sale: Boolean\n  $sort: String\n) {\n  node(__id: $artistNodeID) {\n    __typename\n    ... on Artist {\n      ...ArtworkFilterRefetch_artist_461vLz\n    }\n    __id\n  }\n}\n\nfragment ArtworkFilterRefetch_artist_461vLz on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, ecommerce: $ecommerce, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -317,6 +333,18 @@ return {
                 "kind": "FragmentSpread",
                 "name": "ArtworkFilterRefetch_artist",
                 "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "at_auction",
+                    "variableName": "at_auction",
+                    "type": null
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "ecommerce",
+                    "variableName": "ecommerce",
+                    "type": null
+                  },
                   {
                     "kind": "Variable",
                     "name": "for_sale",
@@ -394,6 +422,18 @@ return {
                       "TOTAL"
                     ],
                     "type": "[ArtworkAggregation]"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "at_auction",
+                    "variableName": "at_auction",
+                    "type": "Boolean"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "ecommerce",
+                    "variableName": "ecommerce",
+                    "type": "Boolean"
                   },
                   {
                     "kind": "Variable",
@@ -811,5 +851,5 @@ return {
   }
 };
 })();
-(node as any).hash = '0bfe3dfe636f7b80b0f4e8f42bf48a4e';
+(node as any).hash = '459ff01780062b0e6dd38f9f245177c9';
 export default node;

--- a/src/__generated__/ArtworkFilterRefetch_artist.graphql.ts
+++ b/src/__generated__/ArtworkFilterRefetch_artist.graphql.ts
@@ -48,6 +48,18 @@ return {
     },
     {
       "kind": "LocalArgument",
+      "name": "at_auction",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "ecommerce",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
       "name": "sort",
       "type": "String",
       "defaultValue": "-partner_updated_at"
@@ -68,6 +80,18 @@ return {
             "TOTAL"
           ],
           "type": "[ArtworkAggregation]"
+        },
+        {
+          "kind": "Variable",
+          "name": "at_auction",
+          "variableName": "at_auction",
+          "type": "Boolean"
+        },
+        {
+          "kind": "Variable",
+          "name": "ecommerce",
+          "variableName": "ecommerce",
+          "type": "Boolean"
         },
         {
           "kind": "Variable",
@@ -120,5 +144,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'de43afce03555aa787c10bd8b7cb01b4';
+(node as any).hash = 'a6c047290a5a5e2dbdfecccc63977d4e';
 export default node;

--- a/src/__generated__/ArtworkFilter_artist.graphql.ts
+++ b/src/__generated__/ArtworkFilter_artist.graphql.ts
@@ -67,6 +67,18 @@ return {
     },
     {
       "kind": "LocalArgument",
+      "name": "at_auction",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "ecommerce",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
       "name": "aggregations",
       "type": "[ArtworkAggregation]",
       "defaultValue": [
@@ -173,6 +185,18 @@ return {
       "args": [
         {
           "kind": "Variable",
+          "name": "at_auction",
+          "variableName": "at_auction",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "ecommerce",
+          "variableName": "ecommerce",
+          "type": null
+        },
+        {
+          "kind": "Variable",
           "name": "for_sale",
           "variableName": "for_sale",
           "type": null
@@ -207,5 +231,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '7aa8463969ba2cec97c26499dfe486b1';
+(node as any).hash = '6c0c7a9145ed1a703cd9d8cc77b0dbc5';
 export default node;

--- a/src/__generated__/Overview_artist.graphql.ts
+++ b/src/__generated__/Overview_artist.graphql.ts
@@ -57,6 +57,18 @@ return {
     },
     {
       "kind": "LocalArgument",
+      "name": "at_auction",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "ecommerce",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
       "name": "sort",
       "type": "String",
       "defaultValue": "-partner_updated_at"
@@ -195,6 +207,18 @@ return {
       "args": [
         {
           "kind": "Variable",
+          "name": "at_auction",
+          "variableName": "at_auction",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "ecommerce",
+          "variableName": "ecommerce",
+          "type": null
+        },
+        {
+          "kind": "Variable",
           "name": "for_sale",
           "variableName": "for_sale",
           "type": null
@@ -229,5 +253,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'ab374d4d3831f140622a4ec12a7d0fc7';
+(node as any).hash = 'fb07391a52364bb9dce5c1383d7d641b';
 export default node;

--- a/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
@@ -8,6 +8,8 @@ export type routes_OverviewQueryRendererQueryVariables = {
     readonly partner_id?: string | null;
     readonly for_sale?: boolean | null;
     readonly sort?: string | null;
+    readonly at_auction?: boolean | null;
+    readonly ecommerce?: boolean | null;
 };
 export type routes_OverviewQueryRendererQueryResponse = {
     readonly artist: ({}) | null;
@@ -23,14 +25,16 @@ query routes_OverviewQueryRendererQuery(
   $partner_id: ID
   $for_sale: Boolean
   $sort: String
+  $at_auction: Boolean
+  $ecommerce: Boolean
 ) {
   artist(id: $artistID) {
-    ...Overview_artist_3vi6l5
+    ...Overview_artist_461vLz
     __id
   }
 }
 
-fragment Overview_artist_3vi6l5 on Artist {
+fragment Overview_artist_461vLz on Artist {
   ...ArtistHeader_artist
   ...ArtistBio_bio
   ...CurrentEvent_artist
@@ -50,7 +54,7 @@ fragment Overview_artist_3vi6l5 on Artist {
   href
   is_consignable
   ...Genes_artist
-  ...ArtworkFilter_artist_3vi6l5
+  ...ArtworkFilter_artist_461vLz
   __id
 }
 
@@ -178,7 +182,7 @@ fragment Genes_artist on Artist {
   __id
 }
 
-fragment ArtworkFilter_artist_3vi6l5 on Artist {
+fragment ArtworkFilter_artist_461vLz on Artist {
   id
   counts {
     for_sale_artworks
@@ -194,13 +198,13 @@ fragment ArtworkFilter_artist_3vi6l5 on Artist {
     }
     __id
   }
-  ...ArtworkFilterRefetch_artist_3vi6l5
+  ...ArtworkFilterRefetch_artist_461vLz
   __id
 }
 
-fragment ArtworkFilterRefetch_artist_3vi6l5 on Artist {
+fragment ArtworkFilterRefetch_artist_461vLz on Artist {
   __id
-  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0, sort: $sort) {
+  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, ecommerce: $ecommerce, size: 0, sort: $sort) {
     ...ArtworkFilterArtworkGrid_filtered_artworks
     __id
   }
@@ -388,6 +392,18 @@ var v0 = [
     "name": "sort",
     "type": "String",
     "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "at_auction",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "ecommerce",
+    "type": "Boolean",
+    "defaultValue": null
   }
 ],
 v1 = [
@@ -518,7 +534,7 @@ return {
   "operationKind": "query",
   "name": "routes_OverviewQueryRendererQuery",
   "id": null,
-  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_3vi6l5\n    __id\n  }\n}\n\nfragment Overview_artist_3vi6l5 on Artist {\n  ...ArtistHeader_artist\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsightsArtistPage_artist\n  id\n  exhibition_highlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  counts {\n    partner_shows\n  }\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  href\n  is_consignable\n  ...Genes_artist\n  ...ArtworkFilter_artist_3vi6l5\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  _id\n  id\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 300) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        __id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n  __id\n}\n\nfragment MarketInsightsArtistPage_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilter_artist_3vi6l5 on Artist {\n  id\n  counts {\n    for_sale_artworks\n  }\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_3vi6l5\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_3vi6l5 on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $ecommerce: Boolean\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_461vLz\n    __id\n  }\n}\n\nfragment Overview_artist_461vLz on Artist {\n  ...ArtistHeader_artist\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsightsArtistPage_artist\n  id\n  exhibition_highlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  counts {\n    partner_shows\n  }\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  href\n  is_consignable\n  ...Genes_artist\n  ...ArtworkFilter_artist_461vLz\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  _id\n  id\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 300) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        __id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n  __id\n}\n\nfragment MarketInsightsArtistPage_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilter_artist_461vLz on Artist {\n  id\n  counts {\n    for_sale_artworks\n  }\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_461vLz\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_461vLz on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, ecommerce: $ecommerce, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -540,6 +556,18 @@ return {
             "kind": "FragmentSpread",
             "name": "Overview_artist",
             "args": [
+              {
+                "kind": "Variable",
+                "name": "at_auction",
+                "variableName": "at_auction",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "ecommerce",
+                "variableName": "ecommerce",
+                "type": null
+              },
               {
                 "kind": "Variable",
                 "name": "for_sale",
@@ -1218,6 +1246,18 @@ return {
               },
               {
                 "kind": "Variable",
+                "name": "at_auction",
+                "variableName": "at_auction",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "ecommerce",
+                "variableName": "ecommerce",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
                 "name": "for_sale",
                 "variableName": "for_sale",
                 "type": "Boolean"
@@ -1608,5 +1648,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'e37e85cc5f07e1664dd224c9efed91b6';
+(node as any).hash = '083f76d320ca2a81d72545a46cd0af71';
 export default node;

--- a/typings/gravity.d.ts
+++ b/typings/gravity.d.ts
@@ -2,4 +2,5 @@ interface User {
   id?: string
   accessToken?: string
   appToken?: string
+  lab_features?: string[]
 }


### PR DESCRIPTION
controlled by lab feature

For storybook purposes, you can set `USER_LAB_FEATURES=Lab1,Lab2,Lab3` a comma separate string of lab features to turn on (since we're not fetching current user).

When coming from Force, `req.user` will have a `lab_features` array.