### PR TITLE
@zephraph => Update Payoff page to have layout

### DIFF
--- a/src/Apps/Order/Components/BuyNowStepper.tsx
+++ b/src/Apps/Order/Components/BuyNowStepper.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { Step, Stepper } from "Styleguide/Components/Stepper"
+
+const steps = ["Shipping", "Payment", "Review"]
+
+const getStepIndex = pathname =>
+  steps.findIndex(step => pathname.includes(step.toLowerCase()))
+
+interface BuyNowStepperProps {
+  currentStep: "shipping" | "payment" | "review"
+}
+
+export const BuyNowStepper: React.SFC<BuyNowStepperProps> = ({
+  currentStep,
+}) => {
+  const stepIndex = getStepIndex(currentStep)
+  return (
+    <Stepper initialTabIndex={stepIndex} currentStepIndex={stepIndex}>
+      {steps.map(step => <Step name={step} key={step} />)}
+    </Stepper>
+  )
+}

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -1,12 +1,4 @@
 import React, { SFC } from "react"
-import { Step, Stepper } from "Styleguide/Components/Stepper"
-import { Col, Row } from "Styleguide/Elements/Grid"
-import { Spacer } from "Styleguide/Elements/Spacer"
-
-const steps = ["Shipping", "Payment", "Review"]
-
-const getStepIndex = pathname =>
-  steps.findIndex(step => pathname.includes(step.toLowerCase()))
 
 export interface OrderAppProps {
   me: {
@@ -24,20 +16,5 @@ export const OrderApp: SFC<OrderAppProps> = ({
   location,
   ...props
 }) => {
-  const stepIndex = getStepIndex(location.pathname)
-  return (
-    <>
-      <Row>
-        <Col>
-          <Stepper initialTabIndex={stepIndex} currentStepIndex={stepIndex}>
-            {steps.map(step => <Step name={step} key={step} />)}
-          </Stepper>
-        </Col>
-      </Row>
-
-      <Spacer mb={3} />
-
-      {children}
-    </>
-  )
+  return <>{children}</>
 }

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -1,9 +1,11 @@
 import { Payment_order } from "__generated__/Payment_order.graphql"
+import { BuyNowStepper } from "Apps/Order/Components/BuyNowStepper"
 import { TwoColumnLayout } from "Apps/Order/Components/TwoColumnLayout"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Link } from "Router"
 import { Button } from "Styleguide/Elements/Button"
+import { Col, Row } from "Styleguide/Elements/Grid"
 import { Join } from "Styleguide/Elements/Join"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Placeholder } from "Styleguide/Utils/Placeholder"
@@ -21,42 +23,52 @@ export class PaymentRoute extends Component<PaymentProps> {
   render() {
     const { order } = this.props
     return (
-      <Responsive>
-        {({ xs }) => (
-          <TwoColumnLayout
-            Content={
-              <>
-                <Join separator={<Spacer mb={3} />}>
-                  <Placeholder height="68px" name="Credit Card" />
-                  <Placeholder height="20px" name="Billing/Shipping Check" />
-                  {!xs && (
-                    <Link to={`/order2/${order.id}/review`}>
-                      <Button size="large" width="100%">
-                        Continue
-                      </Button>
-                    </Link>
+      <>
+        <Row>
+          <Col>
+            <BuyNowStepper currentStep={"payment"} />
+          </Col>
+        </Row>
+
+        <Spacer mb={3} />
+
+        <Responsive>
+          {({ xs }) => (
+            <TwoColumnLayout
+              Content={
+                <>
+                  <Join separator={<Spacer mb={3} />}>
+                    <Placeholder height="68px" name="Credit Card" />
+                    <Placeholder height="20px" name="Billing/Shipping Check" />
+                    {!xs && (
+                      <Link to={`/order2/${order.id}/review`}>
+                        <Button size="large" width="100%">
+                          Continue
+                        </Button>
+                      </Link>
+                    )}
+                  </Join>
+                  <Spacer mb={3} />
+                </>
+              }
+              Sidebar={
+                <Summary mediator={this.props.mediator} order={order as any}>
+                  {xs && (
+                    <>
+                      <Spacer mb={3} />
+                      <Link to={`/order2/${order.id}/review`}>
+                        <Button size="large" width="100%">
+                          Continue
+                        </Button>
+                      </Link>
+                    </>
                   )}
-                </Join>
-                <Spacer mb={3} />
-              </>
-            }
-            Sidebar={
-              <Summary mediator={this.props.mediator} order={order as any}>
-                {xs && (
-                  <>
-                    <Spacer mb={3} />
-                    <Link to={`/order2/${order.id}/review`}>
-                      <Button size="large" width="100%">
-                        Continue
-                      </Button>
-                    </Link>
-                  </>
-                )}
-              </Summary>
-            }
-          />
-        )}
-      </Responsive>
+                </Summary>
+              }
+            />
+          )}
+        </Responsive>
+      </>
     )
   }
 }

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -1,8 +1,10 @@
 import { Review_order } from "__generated__/Review_order.graphql"
+import { BuyNowStepper } from "Apps/Order/Components/BuyNowStepper"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Link } from "Router"
 import { Button } from "Styleguide/Elements/Button"
+import { Col, Row } from "Styleguide/Elements/Grid"
 import { Join } from "Styleguide/Elements/Join"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Placeholder } from "Styleguide/Utils/Placeholder"
@@ -22,46 +24,56 @@ export class ReviewRoute extends Component<ReviewProps> {
     const { order } = this.props
 
     return (
-      <Responsive>
-        {({ xs }) => (
-          <TwoColumnLayout
-            Content={
-              <>
-                <Join separator={<Spacer mb={3} />}>
-                  <Placeholder height="68px" name="Step summary item" />
-                  <Placeholder height="68px" name="Step summary item" />
-                  <Placeholder height="80px" name="Item review" />
-                  <Placeholder height="20px" name="Terms and conditions" />
-                  {!xs && (
-                    <Link to={`/order2/${order.id}/summary`}>
-                      <Button size="large" width="100%">
-                        Submit Order
-                      </Button>
-                    </Link>
-                  )}
-                </Join>
-                <Spacer mb={3} />
-              </>
-            }
-            Sidebar={
-              <Summary mediator={this.props.mediator} order={order as any}>
-                {xs && (
-                  <>
-                    <Spacer mb={3} />
+      <>
+        <Row>
+          <Col>
+            <BuyNowStepper currentStep={"review"} />
+          </Col>
+        </Row>
+
+        <Spacer mb={3} />
+
+        <Responsive>
+          {({ xs }) => (
+            <TwoColumnLayout
+              Content={
+                <>
+                  <Join separator={<Spacer mb={3} />}>
+                    <Placeholder height="68px" name="Step summary item" />
+                    <Placeholder height="68px" name="Step summary item" />
+                    <Placeholder height="80px" name="Item review" />
                     <Placeholder height="20px" name="Terms and conditions" />
-                    <Spacer mb={3} />
-                    <Link to={`/order2/${order.id}/summary`}>
-                      <Button size="large" width="100%">
-                        Continue
-                      </Button>
-                    </Link>
-                  </>
-                )}
-              </Summary>
-            }
-          />
-        )}
-      </Responsive>
+                    {!xs && (
+                      <Link to={`/order2/${order.id}/summary`}>
+                        <Button size="large" width="100%">
+                          Submit Order
+                        </Button>
+                      </Link>
+                    )}
+                  </Join>
+                  <Spacer mb={3} />
+                </>
+              }
+              Sidebar={
+                <Summary mediator={this.props.mediator} order={order as any}>
+                  {xs && (
+                    <>
+                      <Spacer mb={3} />
+                      <Placeholder height="20px" name="Terms and conditions" />
+                      <Spacer mb={3} />
+                      <Link to={`/order2/${order.id}/summary`}>
+                        <Button size="large" width="100%">
+                          Continue
+                        </Button>
+                      </Link>
+                    </>
+                  )}
+                </Summary>
+              }
+            />
+          )}
+        </Responsive>
+      </>
     )
   }
 }

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -15,6 +15,8 @@ import { Responsive } from "Utils/Responsive"
 
 import { SummaryFragmentContainer as Summary } from "../../Components/Summary"
 
+import { BuyNowStepper } from "Apps/Order/Components/BuyNowStepper"
+import { Col, Row } from "Styleguide/Elements/Grid"
 import {
   TwoColumnLayout,
   TwoColumnSplit,
@@ -31,97 +33,111 @@ export class ShippingRoute extends Component<ShippingProps> {
   render() {
     const { order } = this.props
     return (
-      <Responsive>
-        {({ xs }) => (
-          <TwoColumnLayout
-            Content={
-              <>
-                <RadioGroup
-                  onSelect={id => id}
-                  options={[
-                    { label: "Provide shipping address", id: "SHIP" },
-                    { label: "Arrange for pickup", id: "PICKUP" },
-                  ]}
-                />
-                <Spacer mb={3} />
+      <>
+        <Row>
+          <Col>
+            <BuyNowStepper currentStep={"shipping"} />
+          </Col>
+        </Row>
 
-                <Join separator={<Spacer mb={2} />}>
-                  <Flex flexDirection="column">
-                    <Input
-                      placeholder="Add full name"
-                      title="Full name"
-                      block
-                    />
-                  </Flex>
+        <Spacer mb={3} />
+        <Responsive>
+          {({ xs }) => (
+            <TwoColumnLayout
+              Content={
+                <>
+                  <RadioGroup
+                    onSelect={id => id}
+                    options={[
+                      { label: "Provide shipping address", id: "SHIP" },
+                      { label: "Arrange for pickup", id: "PICKUP" },
+                    ]}
+                  />
+                  <Spacer mb={3} />
 
-                  <TwoColumnSplit>
-                    <Flex flexDirection="column" pb={1}>
-                      <Serif mb={1} size="3t" color="black100" lineHeight={18}>
-                        Country
-                      </Serif>
-                      <CountrySelect selected="US" />
-                    </Flex>
-
+                  <Join separator={<Spacer mb={2} />}>
                     <Flex flexDirection="column">
                       <Input
-                        placeholder="Add postal code"
-                        title="Postal code"
-                        block
-                      />
-                    </Flex>
-                  </TwoColumnSplit>
-                  <TwoColumnSplit>
-                    <Flex flexDirection="column">
-                      <Input
-                        placeholder="Add street address"
-                        title="Address line 1"
+                        placeholder="Add full name"
+                        title="Full name"
                         block
                       />
                     </Flex>
 
-                    <Flex flexDirection="column">
-                      <Input
-                        placeholder="Add apt, floor, suite, etc."
-                        title="Address line 2 (optional)"
-                        block
-                      />
-                    </Flex>
-                  </TwoColumnSplit>
-                  <TwoColumnSplit>
-                    <Flex flexDirection="column">
-                      <Input placeholder="Add city" title="City" block />
-                    </Flex>
+                    <TwoColumnSplit>
+                      <Flex flexDirection="column" pb={1}>
+                        <Serif
+                          mb={1}
+                          size="3t"
+                          color="black100"
+                          lineHeight={18}
+                        >
+                          Country
+                        </Serif>
+                        <CountrySelect selected="US" />
+                      </Flex>
 
-                    <Flex flexDirection="column">
-                      <Input
-                        placeholder="Add State, province, or region"
-                        title="State, province, or region"
-                        block
-                      />
-                    </Flex>
-                  </TwoColumnSplit>
-                </Join>
+                      <Flex flexDirection="column">
+                        <Input
+                          placeholder="Add postal code"
+                          title="Postal code"
+                          block
+                        />
+                      </Flex>
+                    </TwoColumnSplit>
+                    <TwoColumnSplit>
+                      <Flex flexDirection="column">
+                        <Input
+                          placeholder="Add street address"
+                          title="Address line 1"
+                          block
+                        />
+                      </Flex>
 
-                <Spacer mb={3} />
-              </>
-            }
-            Sidebar={
-              <Summary mediator={this.props.mediator} order={order as any}>
-                {xs && (
-                  <>
-                    <Spacer mb={3} />
-                    <Link to={`/order2/${order.id}/payment`}>
-                      <Button size="large" width="100%">
-                        Continue
-                      </Button>
-                    </Link>
-                  </>
-                )}
-              </Summary>
-            }
-          />
-        )}
-      </Responsive>
+                      <Flex flexDirection="column">
+                        <Input
+                          placeholder="Add apt, floor, suite, etc."
+                          title="Address line 2 (optional)"
+                          block
+                        />
+                      </Flex>
+                    </TwoColumnSplit>
+                    <TwoColumnSplit>
+                      <Flex flexDirection="column">
+                        <Input placeholder="Add city" title="City" block />
+                      </Flex>
+
+                      <Flex flexDirection="column">
+                        <Input
+                          placeholder="Add State, province, or region"
+                          title="State, province, or region"
+                          block
+                        />
+                      </Flex>
+                    </TwoColumnSplit>
+                  </Join>
+
+                  <Spacer mb={3} />
+                </>
+              }
+              Sidebar={
+                <Summary mediator={this.props.mediator} order={order as any}>
+                  {xs && (
+                    <>
+                      <Spacer mb={3} />
+                      <Link to={`/order2/${order.id}/payment`}>
+                        <Button size="large" width="100%">
+                          Continue
+                        </Button>
+                      </Link>
+                    </>
+                  )}
+                </Summary>
+              }
+            />
+          )}
+        </Responsive>
+      </>
     )
   }
 }

--- a/src/Apps/Order/Routes/Submission/index.tsx
+++ b/src/Apps/Order/Routes/Submission/index.tsx
@@ -1,10 +1,20 @@
+import { Sans, Serif } from "@artsy/palette"
 import { Submission_order } from "__generated__/Submission_order.graphql"
+import { TwoColumnLayout } from "Apps/Order/Components/TwoColumnLayout"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { Join } from "Styleguide/Elements/Join"
+import { Message } from "Styleguide/Elements/Message"
 import { Spacer } from "Styleguide/Elements/Spacer"
+import { Placeholder } from "Styleguide/Utils/Placeholder"
+import { Responsive } from "Utils/Responsive"
+import { SummaryFragmentContainer as Summary } from "../../Components/Summary"
 
 export interface SubmissionProps {
   order: Submission_order
+  mediator?: {
+    trigger: (action: string, config: object) => void
+  }
 }
 
 export class SubmissionRoute extends Component<SubmissionProps> {
@@ -12,13 +22,37 @@ export class SubmissionRoute extends Component<SubmissionProps> {
     const { order } = this.props
 
     return (
-      <>
-        Submission Page
-        <Spacer mb={1} />
-        {`Order #${order.id}`}
-        <Spacer mb={2} />
-        Submitted!
-      </>
+      <Responsive>
+        {() => (
+          <TwoColumnLayout
+            Content={
+              <>
+                <Join separator={<Spacer mb={3} />}>
+                  <>
+                    <Serif size="6" weight="regular" color="black100">
+                      Your order has been submitted
+                    </Serif>
+                    <Sans size="2" weight="regular" color="black60">
+                      Order #{order.code}
+                    </Sans>
+                    <Message mt={3}>
+                      Thank you for your order. You’ll receive a confirmation
+                      email shortly. If you have questions, please contact{" "}
+                      <a href="#">orders@artsy.net</a>.
+                    </Message>
+                  </>
+                  <Placeholder height="80px" name="Item Summary" />
+                  <Placeholder height="80px" name="Price Summary" />
+                </Join>
+                <Spacer mb={3} />
+              </>
+            }
+            Sidebar={
+              <Summary mediator={this.props.mediator} order={order as any} />
+            }
+          />
+        )}
+      </Responsive>
     )
   }
 }
@@ -28,6 +62,7 @@ export const SubmissionFragmentContainer = createFragmentContainer(
   graphql`
     fragment Submission_order on Order {
       id
+      code
     }
   `
 )

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -12,6 +12,7 @@ const mock = {
   Order: (_, { id }) => {
     return {
       id,
+      code: "abcdefg",
     }
   },
 }

--- a/src/__generated__/Submission_order.graphql.ts
+++ b/src/__generated__/Submission_order.graphql.ts
@@ -3,6 +3,7 @@
 import { ConcreteFragment } from "relay-runtime";
 export type Submission_order = {
     readonly id: string | null;
+    readonly code: string | null;
 };
 
 
@@ -23,6 +24,13 @@ const node: ConcreteFragment = {
     },
     {
       "kind": "ScalarField",
+      "alias": null,
+      "name": "code",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
       "alias": "__id",
       "name": "id",
       "args": null,
@@ -30,5 +38,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'a28eb158dd8a4b23df5ecca95a1d45e4';
+(node as any).hash = 'ca1abbe36144eb62277e125aba18723a';
 export default node;

--- a/src/__generated__/routes_SubmissionQuery.graphql.ts
+++ b/src/__generated__/routes_SubmissionQuery.graphql.ts
@@ -22,6 +22,7 @@ query routes_SubmissionQuery(
 
 fragment Submission_order on Order {
   id
+  code
   __id: id
 }
 */
@@ -55,7 +56,7 @@ return {
   "operationKind": "query",
   "name": "routes_SubmissionQuery",
   "id": null,
-  "text": "query routes_SubmissionQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Submission_order\n    __id: id\n  }\n}\n\nfragment Submission_order on Order {\n  id\n  __id: id\n}\n",
+  "text": "query routes_SubmissionQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Submission_order\n    __id: id\n  }\n}\n\nfragment Submission_order on Order {\n  id\n  code\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -101,6 +102,13 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "code",
             "args": null,
             "storageKey": null
           },


### PR DESCRIPTION
This updates the payoff screen to have the correct layout.

Pretty standard except I did end up moving (after talking to @zephraph) the stepper component into its own `BuyNowStepper` which is rendered only on the pages that have a stepper (meaning, not on the payoff page).

Open to other ideas about naming, etc.!

![image](https://user-images.githubusercontent.com/2081340/43924692-440c250c-9bf3-11e8-9867-3048249932e5.png)
