### PR TITLE
Removes 'deg' from chevron transform rotation

### DIFF
--- a/src/Assets/Icons/ChevronIcon.tsx
+++ b/src/Assets/Icons/ChevronIcon.tsx
@@ -2,10 +2,10 @@ import { color } from "@artsy/palette"
 import React from "react"
 
 export enum Direction {
-  LEFT = "rotate(0deg)",
-  RIGHT = "rotate(180deg)",
-  UP = "rotate(90deg)",
-  DOWN = "rotate(270deg)",
+  LEFT = "rotate(0)",
+  RIGHT = "rotate(180)",
+  UP = "rotate(90)",
+  DOWN = "rotate(270)",
 }
 
 interface IconProps {


### PR DESCRIPTION
@jonallured found out that unlike [css transform rotation](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/rotate) svg [transform](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform#Rotate) doesn't work with `deg`. This PR fixes that.