### PR TITLE
@damassi => Include all results for filter aggregations, not just top 10

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -27,7 +27,7 @@ class Filter extends Component<Props> {
         ? filters.state.major_periods[0]
         : filters.state[category]
 
-    return counts.slice(0, 10).map((count, index) => {
+    return counts.map((count, index) => {
       return (
         <Radio
           my={0.3}

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -17,7 +17,7 @@ storiesOf("Apps", module)
     return (
       <StorybooksRouter
         routes={artistRoutes}
-        initialRoute="/artist/walter-gropius"
+        initialRoute="/artist/andy-warhol"
         initialState={{
           mediator: {
             trigger: x => x,


### PR DESCRIPTION
Each category in the filter sidebar was being truncated to only show the first 10 results (these aggregations are in order of counts, which is kind of nice. So the first 10 galleries are the 10 galleries with the most works by that artist, in order).

This just removes the `.slice(0, 10)`, since this was purely a client-side thing.