### PR TITLE
Lazy-load recently viewed

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "qs": "^6.5.0",
     "react-css-transition-replace": "^3.0.2",
     "react-html-parser": "^2.0.2",
+    "react-lazy-load-image-component": "^1.1.1",
     "react-lines-ellipsis": "xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a",
     "react-markdown": "^2.5.0",
     "react-oembed-container": "^0.3.0",

--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -4,6 +4,7 @@ import { track } from "Analytics"
 import * as Schema from "Analytics/Schema"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Artist/Components/NavigationTabs"
 import React from "react"
+import { LazyLoadComponent } from "react-lazy-load-image-component"
 import { createFragmentContainer, graphql } from "react-relay"
 import { PreloadLinkState } from "Router/state"
 import { Footer } from "Styleguide/Components/Footer"
@@ -67,7 +68,9 @@ export class ArtistApp extends React.Component<ArtistAppProps> {
         {me && (
           <React.Fragment>
             <Separator my={6} />
-            <RecentlyViewed me={me as any} />
+            <LazyLoadComponent>
+              <RecentlyViewed me={me as any} />
+            </LazyLoadComponent>
           </React.Fragment>
         )}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10791,6 +10791,13 @@ react-is@^16.3.2, react-is@^16.4.0:
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.0.tgz#cc9fdc855ac34d2e7d9d2eb7059bbc240d35ffcf"
 
+react-lazy-load-image-component@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.1.1.tgz#41e10defa52adf7c0ab9212cf0a94d46899ceff4"
+  dependencies:
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"


### PR DESCRIPTION
The recently viewed component currently shows up at the _bottom_ of the artist paged for an authenticated user. Being that it's behind a login, it has _no_ value for SEO. Currently, every image in the component is configured as the large and there's no lazy loading happening. 

This PR is a quick and dirty fix that adds a new js dependency to the bundle but has significant impact on the above-the-fold performance of the artist page for an authenticated user. 

This isn't the only work that needs to happen. The images need to be properly sized and preferably individually lazy loaded. For now, this'll do. 

If one of us gets time, we can write our own lazy loading component and remove the js dependency. Until now, it gives us a capability that we need and I think is worth the cost.

This is a drive by optimization on my part, and I haven't done a deep dive in verifying this. In particular, it'd be really beneficial if someone could help verify that it works okay w/ SSR. If not, I can take a stab at a super simple lazy-loader w/ SSR compatibility. 

With recently viewed

![image 2](https://user-images.githubusercontent.com/3087225/43935971-70dec9e6-9c24-11e8-98eb-f02b2fcc65f7.png)

Without recently viewed

![Not authenticated](https://user-images.githubusercontent.com/3087225/43935954-51883136-9c24-11e8-87e9-9dabaea546c7.png)

