### PR TITLE
Add the ability to override the width for <Separator>

### DIFF
--- a/src/Styleguide/Elements/Separator.tsx
+++ b/src/Styleguide/Elements/Separator.tsx
@@ -3,12 +3,16 @@ import React from "react"
 
 import { color } from "@artsy/palette"
 import styled from "styled-components"
-import { space, SpaceProps } from "styled-system"
+import { space, SpaceProps, width, WidthProps } from "styled-system"
 
-interface SeparatorProps extends SpaceProps {}
+interface SeparatorProps extends SpaceProps, WidthProps {}
 
 export const Separator = styled.div.attrs<SeparatorProps>({})`
   ${space};
+  ${width};
   border-top: 1px solid ${color("black10")};
-  width: 100%;
 `
+
+Separator.defaultProps = {
+  width: "100%",
+}


### PR DESCRIPTION
We have a case where we need to override the `width` in the new `<BorderedRadioGroup>`. This PR removes the hard-coded `width: 100%` and make it more flexible.