### PR TITLE
Add a new <BorderedRadioGroup> component

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -1,4 +1,4 @@
-import { Serif } from "@artsy/palette"
+import { Sans, Serif } from "@artsy/palette"
 import { Shipping_order } from "__generated__/Shipping_order.graphql"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -9,7 +9,8 @@ import { CountrySelect } from "Styleguide/Components/CountrySelect"
 import { Button } from "Styleguide/Elements/Button"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Join } from "Styleguide/Elements/Join"
-import { RadioGroup } from "Styleguide/Elements/RadioGroup"
+import { Radio } from "Styleguide/Elements/Radio"
+import { BorderedRadioGroup } from "Styleguide/Elements/RadioGroup"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Responsive } from "Utils/Responsive"
 
@@ -29,7 +30,15 @@ export interface ShippingProps {
   }
 }
 
-export class ShippingRoute extends Component<ShippingProps> {
+export interface ShippingState {
+  shippingOption: string
+}
+
+export class ShippingRoute extends Component<ShippingProps, ShippingState> {
+  state = {
+    shippingOption: "SHIP",
+  }
+
   render() {
     const { order } = this.props
     return (
@@ -39,20 +48,30 @@ export class ShippingRoute extends Component<ShippingProps> {
             <BuyNowStepper currentStep={"shipping"} />
           </Col>
         </Row>
-
         <Spacer mb={3} />
         <Responsive>
           {({ xs }) => (
             <TwoColumnLayout
               Content={
                 <>
-                  <RadioGroup
-                    onSelect={id => id}
-                    options={[
-                      { label: "Provide shipping address", id: "SHIP" },
-                      { label: "Arrange for pickup", id: "PICKUP" },
-                    ]}
-                  />
+                  <BorderedRadioGroup
+                    onSelect={shippingOption =>
+                      this.setState({ shippingOption })
+                    }
+                    defaultValue="SHIP"
+                  >
+                    <Radio value="SHIP">Provide shipping address</Radio>
+
+                    <Radio value="PICKUP">
+                      Arrange for pickup
+                      <Sans size="2" color="black60">
+                        After you place your order, you’ll be appointed an Artsy
+                        Specialist within 2 business days to handle pickup
+                        logistics.
+                      </Sans>
+                    </Radio>
+                  </BorderedRadioGroup>
+
                   <Spacer mb={3} />
 
                   <Join separator={<Spacer mb={2} />}>

--- a/src/Styleguide/Elements/Radio.tsx
+++ b/src/Styleguide/Elements/Radio.tsx
@@ -102,7 +102,9 @@ interface ContainerProps extends FlexProps {
   hover: boolean
   selected: boolean
 }
+
 const Container = styled(Flex).attrs<ContainerProps>({})`
+  align-items: flex-start;
   cursor: ${({ disabled }) => !disabled && "pointer"};
   user-select: none;
   ${hoverStyles};
@@ -159,6 +161,8 @@ const RadioButton = styled.div.attrs<RadioToggleProps>({})`
   border-color: ${radioBorderColor};
   width: ${space(2)}px;
   height: ${space(2)}px;
+  min-width: ${space(2)}px;
+  min-height: ${space(2)}px;
   border-radius: 50%;
   transition: background-color 0.25s, border-color 0.25s;
   ${InnerCircle} {

--- a/src/Styleguide/Elements/RadioGroup.tsx
+++ b/src/Styleguide/Elements/RadioGroup.tsx
@@ -1,25 +1,21 @@
-import { color, space } from "@artsy/palette"
 import React from "react"
 import { BorderProps, SizeProps, SpaceProps } from "styled-system"
 
-import { css } from "styled-components"
+import { BorderBox } from "Styleguide/Elements/Box"
 import { Flex } from "Styleguide/Elements/Flex"
-import { Radio } from "Styleguide/Elements/Radio"
+import { Join } from "Styleguide/Elements/Join"
+import { RadioProps } from "Styleguide/Elements/Radio"
+import { Separator } from "Styleguide/Elements/Separator"
+
+export interface RadioGroupElementProps {
+  value?: string
+}
 
 export interface RadioGroupProps {
   disabled?: boolean
-  onSelect: (selectedOption: string) => void
+  onSelect?: (selectedOption: string) => void
   defaultValue?: string
-  options: Array<{ label: React.ReactNode | null; id: string }>
-  renderRadio?: (
-    props: {
-      id: string
-      label: React.ReactNode
-      selected: boolean
-      onSelect: () => void
-      disabled: boolean
-    }
-  ) => React.ReactNode | null
+  children: Array<React.ReactElement<RadioProps>>
 }
 
 export interface RadioGroupToggleProps
@@ -40,60 +36,53 @@ export class RadioGroup extends React.Component<
     selectedOption: this.props.defaultValue || null,
   }
 
-  static defaultProps = {
-    renderRadio: ({ id, label, selected, onSelect, disabled }) => (
-      <StyledRadio
-        key={id}
-        selected={selected}
-        onSelect={onSelect}
-        disabled={disabled}
-      >
-        {label}
-      </StyledRadio>
-    ),
+  onSelect = ({ selected, value }) => {
+    if (this.props.onSelect) {
+      this.props.onSelect(value)
+    }
+
+    this.setState({ selectedOption: value })
   }
 
-  onSelectionChange = (id: string) => {
-    if (id !== this.state.selectedOption) {
-      this.setState({ selectedOption: id }, () => {
-        this.props.onSelect(id)
-      })
-    }
+  renderRadioButtons() {
+    return React.Children.map(
+      this.props.children,
+      (child: React.ReactElement<RadioProps>) => {
+        return React.cloneElement(child, {
+          disabled:
+            child.props.disabled !== undefined
+              ? child.props.disabled
+              : this.props.disabled,
+          onSelect: child.props.onSelect
+            ? selected => {
+                this.onSelect(selected)
+                child.props.onSelect(selected)
+              }
+            : this.onSelect,
+          // FIXME: Throw an error `child.props.selected' is set once we enable the dev code elimination.
+          selected: this.state.selectedOption === child.props.value,
+        })
+      }
+    )
   }
 
   render() {
-    const { disabled, options, renderRadio } = this.props
-
     return (
-      <Flex flexDirection="column">
-        {options.map(({ id, label }) =>
-          renderRadio({
-            id,
-            label,
-            onSelect: () => this.onSelectionChange(id),
-            selected: this.state.selectedOption === id,
-            disabled,
-          })
-        )}
+      <Flex flexDirection="column" p={2}>
+        {this.renderRadioButtons()}
       </Flex>
     )
   }
 }
 
-const StyledRadio = Radio.extend`
-  border: 1px solid #eee;
-  /* offset the vertical padding to account for label line-height */
-  padding: calc(${space(2)}px - 3px) ${space(2)}px;
-  :not(:first-child) {
-    border-top: 0;
+export class BorderedRadioGroup extends RadioGroup {
+  render() {
+    return (
+      <BorderBox flexDirection="column" p={2}>
+        <Join separator={<Separator mx={-2} my={2} width="inherit" />}>
+          {this.renderRadioButtons()}
+        </Join>
+      </BorderBox>
+    )
   }
-  ${({ disabled }) =>
-    !disabled &&
-    css`
-      :hover {
-        background-color: ${color("black5")};
-      }
-    `};
-`
-
-StyledRadio.displayName = "StyledRadio"
+}

--- a/src/Styleguide/Elements/RadioGroup.tsx
+++ b/src/Styleguide/Elements/RadioGroup.tsx
@@ -7,10 +7,6 @@ import { Join } from "Styleguide/Elements/Join"
 import { RadioProps } from "Styleguide/Elements/Radio"
 import { Separator } from "Styleguide/Elements/Separator"
 
-export interface RadioGroupElementProps {
-  value?: string
-}
-
 export interface RadioGroupProps {
   disabled?: boolean
   onSelect?: (selectedOption: string) => void

--- a/src/Styleguide/Elements/__stories__/RadioGroup.story.tsx
+++ b/src/Styleguide/Elements/__stories__/RadioGroup.story.tsx
@@ -1,40 +1,30 @@
+import { Sans } from "@artsy/palette"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
-import { RadioGroup } from "Styleguide/Elements/RadioGroup"
+import { Radio } from "Styleguide/Elements/Radio"
+import { BorderedRadioGroup, RadioGroup } from "Styleguide/Elements/RadioGroup"
 import { Section } from "Styleguide/Utils/Section"
 
 storiesOf("Styleguide/Elements", module).add("RadioGroup", () => {
   return (
     <>
       <Section title="RadioGroup">
-        <RadioGroup
-          onSelect={id => id}
-          options={[
-            { label: "Provide shipping address", id: "SHIP" },
-            { label: "Arrange for pickup", id: "PICKUP" },
-          ]}
-        />
+        <RadioGroup>
+          <Radio value="SHIP">Provide shipping address</Radio>
+          <Radio value="PICKUP">Arrange for pickup</Radio>
+        </RadioGroup>
       </Section>
       <Section title="RadioGroup with default value">
-        <RadioGroup
-          onSelect={id => id}
-          defaultValue="PICKUP"
-          options={[
-            { label: "Provide shipping address", id: "SHIP" },
-            { label: "Arrange for pickup", id: "PICKUP" },
-          ]}
-        />
+        <RadioGroup defaultValue="SHIP">
+          <Radio value="SHIP">Provide shipping address</Radio>
+          <Radio value="PICKUP">Arrange for pickup</Radio>
+        </RadioGroup>
       </Section>
       <Section title="RadioGroup disabled with default value">
-        <RadioGroup
-          disabled
-          onSelect={id => id}
-          defaultValue="PICKUP"
-          options={[
-            { label: "Provide shipping address", id: "SHIP" },
-            { label: "Arrange for pickup", id: "PICKUP" },
-          ]}
-        />
+        <RadioGroup defaultValue="SHIP" disabled>
+          <Radio value="SHIP">Provide shipping address</Radio>
+          <Radio value="PICKUP">Arrange for pickup</Radio>
+        </RadioGroup>
       </Section>
     </>
   )

--- a/src/Styleguide/Elements/__stories__/RadioGroup.story.tsx
+++ b/src/Styleguide/Elements/__stories__/RadioGroup.story.tsx
@@ -26,6 +26,19 @@ storiesOf("Styleguide/Elements", module).add("RadioGroup", () => {
           <Radio value="PICKUP">Arrange for pickup</Radio>
         </RadioGroup>
       </Section>
+      <Section title="Bordered RadioGroup">
+        <BorderedRadioGroup defaultValue="SHIP">
+          <Radio value="SHIP">Provide shipping address</Radio>
+
+          <Radio value="PICKUP">
+            Arrange for pickup
+            <Sans size="2" color="black60">
+              After you place your order, you’ll be appointed an Artsy
+              Specialist within 2 business days to handle pickup logistics.
+            </Sans>
+          </Radio>
+        </BorderedRadioGroup>
+      </Section>
     </>
   )
 })

--- a/src/Styleguide/Elements/__tests__/RadioGroup.test.tsx
+++ b/src/Styleguide/Elements/__tests__/RadioGroup.test.tsx
@@ -1,64 +1,144 @@
 import { mount } from "enzyme"
 import React from "react"
+import { Radio } from "../Radio"
 import { RadioGroup } from "../RadioGroup"
 
 describe("RadioGroup", () => {
-  const options = [
-    { label: "Provide shipping address", id: "SHIP" },
-    { label: "Arrange for pickup", id: "PICKUP" },
-  ]
-
   it("renders a radio group", () => {
     const spy = jest.fn()
-    const wrapper = mount(<RadioGroup onSelect={spy} options={options} />)
+    const wrapper = mount(
+      <RadioGroup onSelect={spy}>
+        <Radio value="SHIP">Provide shipping address</Radio>
+        <Radio value="PICKUP">Arrange for pickup</Radio>
+      </RadioGroup>
+    )
+
     expect(wrapper.text()).toContain("Provide shipping address")
     expect(wrapper.text()).toContain("Arrange for pickup")
-    expect(wrapper.find("StyledRadio").length).toBe(2)
+
     wrapper
-      .find("StyledRadio")
+      .find("Radio")
       .first()
       .simulate("click")
+
     expect(spy).toHaveBeenCalled()
   })
 
   it("renders default value on mount", () => {
     const wrapper = mount(
-      <RadioGroup options={options} onSelect={x => x} defaultValue="PICKUP" />
+      <RadioGroup defaultValue="PICKUP">
+        <Radio value="SHIP">Provide shipping address</Radio>
+        <Radio value="PICKUP">Arrange for pickup</Radio>
+      </RadioGroup>
     )
+
     expect(
       wrapper
-        .find("StyledRadio")
+        .find("Radio")
+        .first()
+        .props().selected
+    ).toBe(false)
+    expect(
+      wrapper
+        .find("Radio")
         .last()
         .props().selected
     ).toBe(true)
   })
 
-  it("renders custom radio button", () => {
+  it("selects the radio that gets clicked", () => {
     const wrapper = mount(
-      <RadioGroup
-        options={options}
-        onSelect={x => x}
-        renderRadio={() => (
-          <div key={Math.random()} className="customRadio">
-            found
-          </div>
-        )}
-      />
+      <RadioGroup defaultValue="PICKUP">
+        <Radio value="SHIP">Provide shipping address</Radio>
+        <Radio value="PICKUP">Arrange for pickup</Radio>
+      </RadioGroup>
     )
-    expect(wrapper.find(".customRadio").length).toBe(2)
+
+    wrapper
+      .find("Radio")
+      .first()
+      .simulate("click")
+
     expect(
       wrapper
-        .find(".customRadio")
-        .at(1)
-        .text()
-    ).toBe("found")
+        .find("Radio")
+        .first()
+        .props().selected
+    ).toBe(true)
+    expect(
+      wrapper
+        .find("Radio")
+        .last()
+        .props().selected
+    ).toBe(false)
   })
 
-  it("disables radio group", () => {
+  it("allows the 'disabled' prop on the Radio component to take the precedence", () => {
+    const wrapper = mount(
+      <RadioGroup disabled>
+        <Radio value="SHIP" disabled={false}>
+          Provide shipping address
+        </Radio>
+        <Radio value="PICKUP">Arrange for pickup</Radio>
+      </RadioGroup>
+    )
+
+    const radio = wrapper.find("Radio").first()
+
+    expect(
+      wrapper
+        .find("Radio")
+        .first()
+        .props().disabled
+    ).toBe(false)
+    expect(
+      wrapper
+        .find("Radio")
+        .last()
+        .props().disabled
+    ).toBe(true)
+  })
+
+  it("ignores the 'selected' prop on the Radio component", () => {
     const spy = jest.fn()
-    const wrapper = mount(<RadioGroup onSelect={spy} options={options} />)
-    const radio = wrapper.find("StyledRadio").at(1)
-    radio.simulate("click")
-    expect(radio.props().selected).toBe(false)
+
+    const wrapper = mount(
+      <RadioGroup defaultValue="PICKUP">
+        <Radio value="SHIP" selected>
+          Provide shipping address
+        </Radio>
+        <Radio value="PICKUP">Arrange for pickup</Radio>
+      </RadioGroup>
+    )
+
+    const ship = wrapper.find("Radio").first()
+
+    expect(ship.props().selected).toBe(false)
+
+    const pickup = wrapper.find("Radio").last()
+
+    expect(pickup.props().selected).toBe(true)
+  })
+
+  it("allows for using the onSelect callback both on RadioGroup and Radio", () => {
+    const spyOnRadioGroup = jest.fn()
+    const spyOnRadio = jest.fn()
+
+    const wrapper = mount(
+      <RadioGroup onSelect={spyOnRadioGroup}>
+        <Radio value="SHIP" onSelect={spyOnRadio}>
+          Provide shipping address
+        </Radio>
+        <Radio value="PICKUP">Arrange for pickup</Radio>
+      </RadioGroup>
+    )
+
+    wrapper
+      .find("Radio")
+      .first()
+      .simulate("click")
+
+    expect(spyOnRadioGroup).toHaveBeenCalled()
+    expect(spyOnRadio).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
This PR basically changes three things:

 * Update the existing `<RadioGroup>` component to not render borders
 * Break down the monolith `<RadioGroup>` interface into a composable API
 * Add a new `<BorderedRadioGroup>` component

At this point, we don't use the `<RadioGroup>` component outside of Reaction, so this should be ok to change the interface. We may be able to use this component on the new Artist page (e.g. https://www.artsy.net/artist/andy-warhol) in the future.

 * [x] Add new tests
 * [x] Fix failing tests

## Screenshot

![screen shot 2018-08-10 at 3 37 36 pm](https://user-images.githubusercontent.com/386234/43977858-55a54f76-9cb3-11e8-8524-1d26ff30e11d.png)
