### PR TITLE
@damassi => Dont request the header fragment in the overview query

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -158,7 +158,6 @@ export const OverviewRouteFragmentContainer = createFragmentContainer(
           defaultValue: ["blue-chip", "top-established", "top-emerging"]
         }
       ) {
-      ...ArtistHeader_artist
       ...ArtistBio_bio
       ...CurrentEvent_artist
       ...MarketInsightsArtistPage_artist

--- a/src/__generated__/Overview_artist.graphql.ts
+++ b/src/__generated__/Overview_artist.graphql.ts
@@ -126,12 +126,7 @@ return {
     },
     {
       "kind": "FragmentSpread",
-      "name": "ArtistHeader_artist",
-      "args": null
-    },
-    {
-      "kind": "FragmentSpread",
-      "name": "CurrentEvent_artist",
+      "name": "ArtistBio_bio",
       "args": null
     },
     {
@@ -225,7 +220,7 @@ return {
     },
     {
       "kind": "FragmentSpread",
-      "name": "ArtistBio_bio",
+      "name": "CurrentEvent_artist",
       "args": null
     },
     {
@@ -438,5 +433,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '38af5f5aa7a18abd8fd70255eb280acb';
+(node as any).hash = '9c5f82d04f60217de3f7c2d50798a349';
 export default node;

--- a/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
@@ -33,7 +33,6 @@ query routes_OverviewQueryRendererQuery(
 }
 
 fragment Overview_artist_461vLz on Artist {
-  ...ArtistHeader_artist
   ...ArtistBio_bio
   ...CurrentEvent_artist
   ...MarketInsightsArtistPage_artist
@@ -81,29 +80,6 @@ fragment Overview_artist_461vLz on Artist {
       }
     }
   }
-  __id
-}
-
-fragment ArtistHeader_artist on Artist {
-  _id
-  id
-  name
-  nationality
-  years
-  counts {
-    follows
-  }
-  carousel {
-    images {
-      href
-      resized(height: 300) {
-        url
-        width
-        height
-      }
-    }
-  }
-  ...FollowArtistButton_artist
   __id
 }
 
@@ -370,15 +346,6 @@ fragment Contact_artwork on Artwork {
   }
   __id
 }
-
-fragment FollowArtistButton_artist on Artist {
-  __id
-  id
-  is_followed
-  counts {
-    follows
-  }
-}
 */
 
 const node: ConcreteRequest = (function(){
@@ -450,34 +417,40 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "href",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "url",
-  "args": null,
-  "storageKey": null
-},
-v5 = [
-  v4
-],
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v7 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+],
 v8 = {
   "kind": "ScalarField",
   "alias": null,
@@ -486,19 +459,12 @@ v8 = {
   "storageKey": null
 },
 v9 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v10 = {
   "kind": "Literal",
   "name": "first",
   "value": 10,
   "type": "Int"
 },
-v11 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "format",
@@ -506,29 +472,29 @@ v11 = [
     "type": "String"
   }
 ],
-v12 = {
+v11 = {
   "kind": "Literal",
   "name": "size",
   "value": 0,
   "type": "Int"
 },
-v13 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v15 = [
+v14 = [
+  v12,
   v13,
-  v14,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -537,7 +503,7 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -545,22 +511,22 @@ v16 = [
     "type": "Boolean"
   }
 ],
-v17 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
   "args": null,
   "storageKey": null
 },
-v18 = [
-  v6
+v17 = [
+  v4
 ];
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_OverviewQueryRendererQuery",
   "id": null,
-  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_461vLz\n    __id\n  }\n}\n\nfragment Overview_artist_461vLz on Artist {\n  ...ArtistHeader_artist\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsightsArtistPage_artist\n  ...Genes_artist\n  ...ArtworkFilter_artist_3vi6l5\n  id\n  exhibition_highlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  counts {\n    partner_shows\n  }\n  href\n  is_consignable\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  currentEvent {\n    name\n  }\n  related {\n    genes {\n      edges {\n        node {\n          id\n          __id\n        }\n      }\n    }\n  }\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  _id\n  id\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 300) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        __id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n  __id\n}\n\nfragment MarketInsightsArtistPage_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilter_artist_3vi6l5 on Artist {\n  id\n  counts {\n    for_sale_artworks\n  }\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_1eWdEF\n  __id\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_1eWdEF on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_461vLz\n    __id\n  }\n}\n\nfragment Overview_artist_461vLz on Artist {\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsightsArtistPage_artist\n  ...Genes_artist\n  ...ArtworkFilter_artist_3vi6l5\n  id\n  exhibition_highlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  counts {\n    partner_shows\n  }\n  href\n  is_consignable\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  currentEvent {\n    name\n  }\n  related {\n    genes {\n      edges {\n        node {\n          id\n          __id\n        }\n      }\n    }\n  }\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        __id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n  __id\n}\n\nfragment MarketInsightsArtistPage_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilter_artist_3vi6l5 on Artist {\n  id\n  counts {\n    for_sale_artworks\n  }\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_1eWdEF\n  __id\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_1eWdEF on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -648,189 +614,50 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "currentEvent",
+            "name": "related",
             "storageKey": null,
             "args": null,
-            "concreteType": "CurrentEvent",
+            "concreteType": "ArtistRelatedData",
             "plural": false,
             "selections": [
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "event",
+                "name": "genes",
                 "storageKey": null,
                 "args": null,
-                "concreteType": null,
-                "plural": false,
-                "selections": [
-                  v3,
-                  v2
-                ]
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "image",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Image",
+                "concreteType": "GeneConnection",
                 "plural": false,
                 "selections": [
                   {
                     "kind": "LinkedField",
                     "alias": null,
-                    "name": "resized",
-                    "storageKey": "resized(width:300)",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 300,
-                        "type": "Int"
-                      }
-                    ],
-                    "concreteType": "ResizedImageUrl",
-                    "plural": false,
-                    "selections": v5
-                  }
-                ]
-              },
-              v6,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "status",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "details",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "partner",
-                "args": null,
-                "storageKey": null
-              },
-              v7
-            ]
-          },
-          v8,
-          v6,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "nationality",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "years",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "counts",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "ArtistCounts",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "follows",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "for_sale_artworks",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "partner_shows",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "carousel",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "ArtistCarousel",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "images",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Image",
-                "plural": true,
-                "selections": [
-                  v7,
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "resized",
-                    "storageKey": "resized(height:300)",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 300,
-                        "type": "Int"
-                      }
-                    ],
-                    "concreteType": "ResizedImageUrl",
-                    "plural": false,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "GeneEdge",
+                    "plural": true,
                     "selections": [
-                      v4,
                       {
-                        "kind": "ScalarField",
+                        "kind": "LinkedField",
                         "alias": null,
-                        "name": "width",
+                        "name": "node",
+                        "storageKey": null,
                         "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "height",
-                        "args": null,
-                        "storageKey": null
+                        "concreteType": "Gene",
+                        "plural": false,
+                        "selections": [
+                          v3,
+                          v4,
+                          v2,
+                          v5
+                        ]
                       }
                     ]
                   }
                 ]
               }
             ]
-          },
-          v2,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "is_followed",
-            "args": null,
-            "storageKey": null
           },
           {
             "kind": "LinkedField",
@@ -870,7 +697,82 @@ return {
               }
             ]
           },
-          v9,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "currentEvent",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CurrentEvent",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "event",
+                "storageKey": null,
+                "args": null,
+                "concreteType": null,
+                "plural": false,
+                "selections": [
+                  v6,
+                  v2
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "resized",
+                    "storageKey": "resized(width:300)",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 300,
+                        "type": "Int"
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
+                    "plural": false,
+                    "selections": v7
+                  }
+                ]
+              },
+              v4,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "status",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "details",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "partner",
+                "args": null,
+                "storageKey": null
+              },
+              v3
+            ]
+          },
+          v8,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -899,7 +801,7 @@ return {
                     "value": true,
                     "type": "Boolean"
                   },
-                  v10,
+                  v9,
                   {
                     "kind": "Literal",
                     "name": "partner_category",
@@ -947,7 +849,7 @@ return {
                             "concreteType": "Category",
                             "plural": true,
                             "selections": [
-                              v9
+                              v5
                             ]
                           },
                           v2
@@ -1042,7 +944,7 @@ return {
                         "kind": "ScalarField",
                         "alias": null,
                         "name": "sale_date",
-                        "args": v11,
+                        "args": v10,
                         "storageKey": "sale_date(format:\"YYYY\")"
                       },
                       v2
@@ -1052,51 +954,30 @@ return {
               }
             ]
           },
+          v2,
+          v5,
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "related",
+            "name": "counts",
             "storageKey": null,
             "args": null,
-            "concreteType": "ArtistRelatedData",
+            "concreteType": "ArtistCounts",
             "plural": false,
             "selections": [
               {
-                "kind": "LinkedField",
+                "kind": "ScalarField",
                 "alias": null,
-                "name": "genes",
-                "storageKey": null,
+                "name": "for_sale_artworks",
                 "args": null,
-                "concreteType": "GeneConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "edges",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "GeneEdge",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "node",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": "Gene",
-                        "plural": false,
-                        "selections": [
-                          v7,
-                          v6,
-                          v2,
-                          v9
-                        ]
-                      }
-                    ]
-                  }
-                ]
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "partner_shows",
+                "args": null,
+                "storageKey": null
               }
             ]
           },
@@ -1118,7 +999,7 @@ return {
                 ],
                 "type": "[ArtworkAggregation]"
               },
-              v12
+              v11
             ],
             "concreteType": "FilterArtworks",
             "plural": false,
@@ -1148,8 +1029,8 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      v6,
-                      v9,
+                      v4,
+                      v5,
                       v2
                     ]
                   }
@@ -1196,7 +1077,7 @@ return {
                 "variableName": "partner_id",
                 "type": "ID"
               },
-              v12,
+              v11,
               {
                 "kind": "Variable",
                 "name": "sort",
@@ -1220,7 +1101,7 @@ return {
                     "value": "",
                     "type": "String"
                   },
-                  v10
+                  v9
                 ],
                 "concreteType": "ArtworkConnection",
                 "plural": false,
@@ -1267,7 +1148,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": true,
-                        "selections": v15
+                        "selections": v14
                       },
                       {
                         "kind": "LinkedField",
@@ -1277,7 +1158,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v15
+                        "selections": v14
                       },
                       {
                         "kind": "LinkedField",
@@ -1287,7 +1168,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v15
+                        "selections": v14
                       },
                       {
                         "kind": "LinkedField",
@@ -1298,8 +1179,8 @@ return {
                         "concreteType": "PageCursor",
                         "plural": false,
                         "selections": [
-                          v13,
-                          v14
+                          v12,
+                          v13
                         ]
                       }
                     ]
@@ -1330,7 +1211,7 @@ return {
                             "storageKey": null
                           },
                           v2,
-                          v7,
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1364,13 +1245,13 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v16,
+                            "args": v15,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
                               v2,
-                              v7,
-                              v6
+                              v3,
+                              v4
                             ]
                           },
                           {
@@ -1417,12 +1298,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v16,
+                            "args": v15,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v6,
-                              v7,
+                              v4,
+                              v3,
                               v2,
                               {
                                 "kind": "ScalarField",
@@ -1499,7 +1380,7 @@ return {
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
                                 "selections": [
-                                  v17,
+                                  v16,
                                   {
                                     "kind": "ScalarField",
                                     "alias": "__id",
@@ -1518,7 +1399,7 @@ return {
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
                                 "selections": [
-                                  v17
+                                  v16
                                 ]
                               },
                               {
@@ -1542,7 +1423,7 @@ return {
                               v2
                             ]
                           },
-                          v9,
+                          v5,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1583,26 +1464,26 @@ return {
                 "concreteType": null,
                 "plural": false,
                 "selections": [
-                  v3,
+                  v6,
                   v2,
                   {
                     "kind": "InlineFragment",
                     "type": "Partner",
-                    "selections": v18
+                    "selections": v17
                   },
                   {
                     "kind": "InlineFragment",
                     "type": "ExternalPartner",
-                    "selections": v18
+                    "selections": v17
                   }
                 ]
               },
-              v6,
+              v4,
               {
                 "kind": "ScalarField",
                 "alias": null,
                 "name": "start_at",
-                "args": v11,
+                "args": v10,
                 "storageKey": "start_at(format:\"YYYY\")"
               },
               {
@@ -1635,7 +1516,7 @@ return {
                     ],
                     "concreteType": "CroppedImageUrl",
                     "plural": false,
-                    "selections": v5
+                    "selections": v7
                   }
                 ]
               },
@@ -1649,7 +1530,7 @@ return {
               v2
             ]
           },
-          v7,
+          v3,
           {
             "kind": "ScalarField",
             "alias": null,


### PR DESCRIPTION
When rationalizing our 3 ES calls for `/related/shows` (once for carousel, once for exhib highlights, and once for current event), there was a fourth...the carousel again!

Realizing that we have it in https://github.com/artsy/reaction/blob/2c856446c4356c910daf958fe1366a2a98deefe2/src/Apps/Artist/ArtistApp.tsx#L93 , so don't need it in the Overview query.