### PR TITLE
Fixes /submission link and adds back continue button #superminor

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -44,7 +44,7 @@ export class ReviewRoute extends Component<ReviewProps> {
                     <Placeholder height="80px" name="Item review" />
                     <Placeholder height="20px" name="Terms and conditions" />
                     {!xs && (
-                      <Link to={`/order2/${order.id}/summary`}>
+                      <Link to={`/order2/${order.id}/submission`}>
                         <Button size="large" width="100%">
                           Submit Order
                         </Button>
@@ -61,7 +61,7 @@ export class ReviewRoute extends Component<ReviewProps> {
                       <Spacer mb={3} />
                       <Placeholder height="20px" name="Terms and conditions" />
                       <Spacer mb={3} />
-                      <Link to={`/order2/${order.id}/summary`}>
+                      <Link to={`/order2/${order.id}/submission`}>
                         <Button size="large" width="100%">
                           Continue
                         </Button>

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -118,6 +118,12 @@ export class ShippingRoute extends Component<ShippingProps> {
                   </Join>
 
                   <Spacer mb={3} />
+
+                  <Link to={`/order2/${order.id}/payment`}>
+                    <Button size="large" width="100%">
+                      Continue
+                    </Button>
+                  </Link>
                 </>
               }
               Sidebar={


### PR DESCRIPTION
Fixes a link that was going to `/summary` instead of `/submission` and adds back the "continue" button on the shipping page.