### PR TITLE
Adds bottom space to Helper component #trivial

### DIFF
--- a/src/Apps/Order/Components/Summary.tsx
+++ b/src/Apps/Order/Components/Summary.tsx
@@ -78,6 +78,7 @@ const Helper: React.SFC<HelperProps> = ({ mediator, artworkId }) => (
         ask an Artsy Specialist
       </Link>.
     </Sans>
+    <Spacer mb={2} />
   </>
 )
 

--- a/src/Apps/Order/Components/__tests__/__snapshots__/Summary.test.tsx.snap
+++ b/src/Apps/Order/Components/__tests__/__snapshots__/Summary.test.tsx.snap
@@ -49,5 +49,8 @@ Array [
     </a>
     .
   </div>,
+  <div
+    className="Box-s8jehsh-2 fDdqfP"
+  />,
 ]
 `;


### PR DESCRIPTION
I noticed that the Helper component was butting up against the bottom of the screen in xs. [The designs](https://zpl.io/bzWDR54) specify a space of 2. I didn't feel it was necessary to add a check for `xs` since space underneath the sidebar on desktop won't affect layout, but let me know.

| Before  | After  |
|---|---|
| <img width="503" alt="screen shot 2018-08-14 at 10 36 49 am" src="https://user-images.githubusercontent.com/498212/44098423-33bc11bc-9fae-11e8-8a70-ed6e445fc320.png">  | <img width="484" alt="screen shot 2018-08-14 at 10 36 52 am" src="https://user-images.githubusercontent.com/498212/44098433-38dd0160-9fae-11e8-9ed1-a7347383c033.png">  |

