### PR TITLE
@damassi => Adds basic error page

### DIFF
--- a/src/Components/ErrorPage.tsx
+++ b/src/Components/ErrorPage.tsx
@@ -1,0 +1,101 @@
+import { color, Serif } from "@artsy/palette"
+import { garamond } from "Assets/Fonts"
+import React from "react"
+import styled from "styled-components"
+import { Button } from "Styleguide/Elements/Button"
+import { Spacer } from "Styleguide/Elements/Spacer"
+
+interface ErrorPageProps {
+  code: number
+  message?: string
+  detail?: string
+}
+
+interface ErrorCodeBackgroundProps extends React.HTMLProps<HTMLDivElement> {
+  code: Number
+}
+
+export class ErrorPage extends React.Component<ErrorPageProps, null> {
+  render() {
+    const { code, message, detail } = this.props
+    const defaultMessage =
+      code === 404
+        ? "Sorry, the page you were looking for doesn’t exist at this URL."
+        : "Internal Error"
+
+    const detailMessage = message ? `Error Message: ${message}` : detail
+
+    return (
+      <>
+        <StyledErrorCodeBackground code={code}>
+          <StyledErrorDefaultMessage>
+            {defaultMessage}
+          </StyledErrorDefaultMessage>
+          {code !== 404 && <StyledErrorInner>{detailMessage}</StyledErrorInner>}
+          <Serif size="4" color="black60">
+            Please contact{" "}
+            <Link href="mailto:support@artsy.net">support@artsy.net</Link> with
+            any questions.
+          </Serif>
+          <Spacer mb={4} />
+          <Link href="/">
+            <Button size="large">Go to Artsy homepage</Button>
+          </Link>
+        </StyledErrorCodeBackground>
+      </>
+    )
+  }
+}
+
+const Link = styled.a`
+  color: ${color("black100")};
+`
+
+const StyledErrorDefaultMessage = styled.div`
+  max-width: 60%;
+  margin: 40px auto;
+  ${garamond("s40")};
+`
+
+const StyledErrorInner = styled.div`
+  background: ${color("white100")};
+  border: 0;
+  border: 3px solid ${color("black10")};
+  color: ${color("black60")};
+  font-size: 13px;
+  line-height: 1.6em;
+  margin: 20px auto;
+  max-height: 115px;
+  max-width: 75%;
+  font-family: "Menlo", "Monaco", "Andale Mono", "lucida console", "Courier New",
+    "monospace";
+  overflow-x: auto;
+  padding: 5px 9px;
+  text-align: left;
+  word-break: break-word;
+`
+
+const StyledErrorCodeBackground = styled<ErrorCodeBackgroundProps, any>("div")`
+  position: absolute;
+  text-align: center;
+  width: 100%;
+  margin: 0;
+  padding: 0 20px;
+  top: calc(50% \- 70px);
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  &:before {
+    content: "${(props: ErrorCodeBackgroundProps) => `${props.code}`}";
+    display: block;
+    position: absolute;
+    top: calc(50% \+ 30px);
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    font-size: 535px;
+    line-height: 1;
+    z-index: -1;
+    color: ${color("black5")};
+  }
+`

--- a/src/Components/ErrorPage.tsx
+++ b/src/Components/ErrorPage.tsx
@@ -27,11 +27,9 @@ export class ErrorPage extends React.Component<ErrorPageProps, null> {
 
     return (
       <>
-        <StyledErrorCodeBackground code={code}>
-          <StyledErrorDefaultMessage>
-            {defaultMessage}
-          </StyledErrorDefaultMessage>
-          {code !== 404 && <StyledErrorInner>{detailMessage}</StyledErrorInner>}
+        <ErrorCodeBackground code={code}>
+          <ErrorDefaultMessage>{defaultMessage}</ErrorDefaultMessage>
+          {code !== 404 && <ErrorInner>{detailMessage}</ErrorInner>}
           <Serif size="4" color="black60">
             Please contact{" "}
             <Link href="mailto:support@artsy.net">support@artsy.net</Link> with
@@ -41,7 +39,7 @@ export class ErrorPage extends React.Component<ErrorPageProps, null> {
           <Link href="/">
             <Button size="large">Go to Artsy homepage</Button>
           </Link>
-        </StyledErrorCodeBackground>
+        </ErrorCodeBackground>
       </>
     )
   }
@@ -51,13 +49,13 @@ const Link = styled.a`
   color: ${color("black100")};
 `
 
-const StyledErrorDefaultMessage = styled.div`
+const ErrorDefaultMessage = styled.div`
   max-width: 60%;
   margin: 40px auto;
   ${garamond("s40")};
 `
 
-const StyledErrorInner = styled.div`
+const ErrorInner = styled.div`
   background: ${color("white100")};
   border: 0;
   border: 3px solid ${color("black10")};
@@ -75,7 +73,7 @@ const StyledErrorInner = styled.div`
   word-break: break-word;
 `
 
-const StyledErrorCodeBackground = styled<ErrorCodeBackgroundProps, any>("div")`
+const ErrorCodeBackground = styled<ErrorCodeBackgroundProps, any>("div")`
   position: absolute;
   text-align: center;
   width: 100%;

--- a/src/Components/__stories__/ErrorPage.story.tsx
+++ b/src/Components/__stories__/ErrorPage.story.tsx
@@ -1,0 +1,12 @@
+import { storiesOf } from "@storybook/react"
+import { ErrorPage } from "Components/ErrorPage"
+import React from "react"
+
+storiesOf("Components/Error Page", module)
+  .add("Basic 404", () => <ErrorPage code={404} />)
+  .add("503 with custom message", () => (
+    <ErrorPage code={503} message="custom error message" />
+  ))
+  .add("500 with stack trace", () => (
+    <ErrorPage code={503} detail="Lots of detail here, maybe a stack trace" />
+  ))

--- a/src/Components/__tests__/ErrorPage.test.tsx
+++ b/src/Components/__tests__/ErrorPage.test.tsx
@@ -1,0 +1,30 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import renderer from "react-test-renderer"
+import { ErrorPage } from "../ErrorPage"
+
+describe("ErrorPage", () => {
+  describe("snapshots", () => {
+    it("renders correctly", () => {
+      const errorPage = renderer.create(<ErrorPage code={404} />).toJSON()
+      expect(errorPage).toMatchSnapshot()
+    })
+  })
+
+  describe("unit", () => {
+    it("renders an error page with no stack trace if it's a 404", () => {
+      const component = mount(
+        <ErrorPage code={404} message="Custom error message" />
+      )
+      expect(component.text()).not.toMatch("Custom error message")
+    })
+
+    it("renders an error page with a stack trace if it's not a 404", () => {
+      const component = mount(
+        <ErrorPage code={500} message="Custom error message" />
+      )
+      expect(component.text()).toMatch("Custom error message")
+    })
+  })
+})

--- a/src/Components/__tests__/__snapshots__/ErrorPage.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/ErrorPage.test.tsx.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorPage snapshots renders correctly 1`] = `
+.c2 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  color: black60;
+}
+
+.c6 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  padding-top: 1px;
+}
+
+.c5 {
+  position: relative;
+  border: 2px solid;
+  border-radius: 3px;
+  padding-left: 30px;
+  padding-right: 30px;
+  height: 50px;
+  cursor: pointer;
+  -webkit-transition: 0.25s ease;
+  transition: 0.25s ease;
+  background-color: #000;
+  border-color: #000;
+  color: #FFF;
+}
+
+.c5.loading {
+  -webkit-transition: none;
+  transition: none;
+  background-color: transparent;
+  color: transparent;
+  border: 0;
+}
+
+.c5.disabled {
+  background-color: #E5E5E5;
+  border-color: #E5E5E5;
+  color: #FFF;
+  pointer-events: none;
+}
+
+.c4 {
+  margin-bottom: 32px;
+}
+
+.c3 {
+  color: #000000;
+}
+
+.c1 {
+  max-width: 60%;
+  margin: 40px auto;
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 40px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 {
+  position: absolute;
+  text-align: center;
+  width: 100%;
+  margin: 0;
+  padding: 0 20px;
+  top: calc(50% - 70px);
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c0:before {
+  content: "404";
+  display: block;
+  position: absolute;
+  top: calc(50% + 30px);
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  text-align: center;
+  font-size: 535px;
+  line-height: 1;
+  z-index: -1;
+  color: #f8f8f8;
+}
+
+@media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
+  .c5:hover {
+    background-color: #6E1EFF;
+    border-color: #6E1EFF;
+    color: #FFF;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    Sorry, the page you were looking for doesn’t exist at this URL.
+  </div>
+  <div
+    className="c2"
+    color="black60"
+    fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+    fontSize={18}
+  >
+    Please contact
+     
+    <a
+      className="c3"
+      href="mailto:support@artsy.net"
+    >
+      support@artsy.net
+    </a>
+     with any questions.
+  </div>
+  <div
+    className="c4"
+  />
+  <a
+    className="c3"
+    href="/"
+  >
+    <button
+      className="  c5"
+      height="50px"
+    >
+      <div
+        className="c6"
+        fontFamily={
+          Object {
+            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+            "fontWeight": 500,
+          }
+        }
+        fontSize={14}
+      >
+        Go to Artsy homepage
+      </div>
+    </button>
+  </a>
+</div>
+`;

--- a/src/Components/__tests__/__snapshots__/ErrorPage.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/ErrorPage.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`ErrorPage snapshots renders correctly 1`] = `
 }
 
 .c3 {
-  color: #000000;
+  color: #000;
 }
 
 .c1 {
@@ -89,7 +89,7 @@ exports[`ErrorPage snapshots renders correctly 1`] = `
   font-size: 535px;
   line-height: 1;
   z-index: -1;
-  color: #f8f8f8;
+  color: #F8F8F8;
 }
 
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {


### PR DESCRIPTION
This PR adds a basic error page to reaction.

Some notes:
- It's just the error page _content_ right now (since it seems that the header is still rendered right now from force? I wasn't totally sure about this. If we need to render a custom header here, hopefully we can do something minimal with just the logo)
- This doesn't hook up the page rendering to anything, it's just the component which accepts `code`, `message`, and `detail`.
- I copied this verbatim from force, but tried to alter the styles within reason to match our design system

![image](https://user-images.githubusercontent.com/2081340/44119306-deee1142-9fe6-11e8-8a25-f2e0f53c42fb.png)

![image](https://user-images.githubusercontent.com/2081340/44119320-e6e9797c-9fe6-11e8-8bea-1a88902f3c5a.png)
