### PR TITLE
@l2succes => Display video bugs

### DIFF
--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -53,16 +53,17 @@ export class CanvasContainerComponent extends React.Component<
 
   // TODO: Ensure that full element can be clicked on video complete
   // Prevent links from blocking video playback.
-  @track(
-    (props, [e]) =>
-      !isVideoClickArea(e) && {
+  @track((props, [e]) => {
+    if (!isVideoClickArea(e)) {
+      return {
         action: "Click",
         label: "Display ad clickthrough",
         entity_type: "display_ad",
         campaign_name: props.campaign.name,
         unit_layout: unitLayout(props),
       }
-  )
+    }
+  })
   openLink(e) {
     e.preventDefault()
 
@@ -199,8 +200,13 @@ const isVideoClickArea = e => {
     "PlayButton",
     "PlayButton__PlayButtonCaret",
     "CanvasVideo__video",
+    "CanvasVideo__cover",
   ]
-  return videoClasses.some(c => e.target.className.includes(c))
+
+  const isVideo = videoClasses.some(c => {
+    return e.target.className.includes(c)
+  })
+  return isVideo
 }
 
 export const maxAssetSize = containerWidth => {

--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -241,6 +241,7 @@ export const CanvasLink = responsiveLink`
     padding: 0;
     width: 100%;
     height: 400px;
+    min-height: fit-content;
     flex-direction: column;
     justify-content: flex-start;
   `}

--- a/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasContainer.tsx
@@ -53,7 +53,7 @@ export class CanvasContainerComponent extends React.Component<
 
   // TODO: Ensure that full element can be clicked on video complete
   // Prevent links from blocking video playback.
-  @track((props, [e]) => {
+  @track((props, state, [e]) => {
     if (!isVideoClickArea(e)) {
       return {
         action: "Click",

--- a/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
@@ -1,7 +1,7 @@
 import { memoize, once } from "lodash"
 import React, { Component } from "react"
 import track from "react-tracking"
-import styled, { StyledFunction } from "styled-components"
+import styled from "styled-components"
 import { pMedia } from "../../../Helpers"
 import { VideoControls } from "../../Sections/VideoControls"
 
@@ -137,7 +137,7 @@ export class CanvasVideo extends Component<CanvasVideoProps, any> {
     return (
       <VideoContainer onClick={this.onPlayVideo}>
         {!isPlaying && (
-          <Cover coverUrl={this.props.coverUrl}>
+          <Cover coverUrl={this.props.coverUrl} className="CanvasVideo__cover">
             <VideoControls />
           </Cover>
         )}
@@ -177,12 +177,7 @@ const VideoContainer = styled.div`
   `};
 `
 
-const div: StyledFunction<{
-  coverUrl?: string
-}> =
-  styled.div
-
-const Cover = div`
+const Cover = styled.div.attrs<{ coverUrl?: string }>({})`
   background: url(${p => p.coverUrl || ""}) no-repeat center center;
   background-size: cover;
   position: absolute;
@@ -193,4 +188,5 @@ const Cover = div`
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 10;
 `

--- a/src/Components/Publishing/Display/__tests__/DisplayCanvas.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayCanvas.test.tsx
@@ -20,31 +20,31 @@ import {
 
 describe("snapshot", () => {
   it("renders the canvas in standard layout with image", () => {
-    const displayPanel = renderer
+    const component = renderer
       .create(<DisplayCanvas unit={UnitCanvasImage} campaign={Campaign} />)
       .toJSON()
-    expect(displayPanel).toMatchSnapshot()
+    expect(component).toMatchSnapshot()
   })
 
   it("renders the canvas in standard layout with video", () => {
-    const displayPanel = renderer
+    const component = renderer
       .create(<DisplayCanvas unit={UnitCanvasVideo} campaign={Campaign} />)
       .toJSON()
-    expect(displayPanel).toMatchSnapshot()
+    expect(component).toMatchSnapshot()
   })
 
   it("renders the canvas in overlay layout", () => {
-    const displayPanel = renderer
+    const component = renderer
       .create(<DisplayCanvas unit={UnitCanvasOverlay} campaign={Campaign} />)
       .toJSON()
-    expect(displayPanel).toMatchSnapshot()
+    expect(component).toMatchSnapshot()
   })
 
   it("renders the canvas in slideshow layout", () => {
-    const displayPanel = renderer
+    const component = renderer
       .create(<DisplayCanvas unit={UnitCanvasSlideshow} campaign={Campaign} />)
       .toJSON()
-    expect(displayPanel).toMatchSnapshot()
+    expect(component).toMatchSnapshot()
   })
 })
 

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -202,6 +202,9 @@ exports[`snapshot renders the canvas in overlay layout 1`] = `
     padding: 0;
     width: 100%;
     height: 400px;
+    min-height: -webkit-fit-content;
+    min-height: -moz-fit-content;
+    min-height: fit-content;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -583,6 +586,9 @@ exports[`snapshot renders the canvas in slideshow layout 1`] = `
     padding: 0;
     width: 100%;
     height: 400px;
+    min-height: -webkit-fit-content;
+    min-height: -moz-fit-content;
+    min-height: fit-content;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -949,6 +955,9 @@ exports[`snapshot renders the canvas in standard layout with image 1`] = `
     padding: 0;
     width: 100%;
     height: 400px;
+    min-height: -webkit-fit-content;
+    min-height: -moz-fit-content;
+    min-height: fit-content;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -1161,6 +1170,7 @@ exports[`snapshot renders the canvas in standard layout with video 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  z-index: 10;
 }
 
 .c2 {
@@ -1319,6 +1329,9 @@ exports[`snapshot renders the canvas in standard layout with video 1`] = `
     padding: 0;
     width: 100%;
     height: 400px;
+    min-height: -webkit-fit-content;
+    min-height: -moz-fit-content;
+    min-height: fit-content;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -1381,7 +1394,7 @@ exports[`snapshot renders the canvas in standard layout with video 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="CanvasVideo__cover c4"
       >
         <div
           className="PlayButton c5"


### PR DESCRIPTION
Addresses
https://artsyproduct.atlassian.net/browse/GROW-851
https://artsyproduct.atlassian.net/browse/GROW-841

I think this may have originated from our switch to typed analytics -- we now use the `react-tracking` library rather than a deprecated version that was in utils.  The tracking event was expecting an additional arg of state, which caused an error when clicking the video link.