### PR TITLE
Shipping form commits mutation

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -66,27 +66,13 @@ export class ShippingRoute extends Component<
 
   // TODO: This can be handled with Formik.
   // See: https://artsyproduct.atlassian.net/browse/PURCHASE-375
-  onUpdateName = e => {
-    this.setState({ name: e.target.value })
-  }
-  onUpdateAddressLine1 = e => {
-    this.setState({ addressLine1: e.target.value })
-  }
-  onUpdateAddressLine2 = e => {
-    this.setState({ addressLine2: e.target.value })
-  }
-  onUpdateCity = e => {
-    this.setState({ city: e.target.value })
-  }
-  onUpdateRegion = e => {
-    this.setState({ region: e.target.value })
-  }
-  onUpdateCountry = country => {
-    this.setState({ country })
-  }
-  onUpdatePostalCode = e => {
-    this.setState({ postalCode: e.target.value })
-  }
+  onUpdateName = e => this.setState({ name: e.target.value })
+  onUpdateAddressLine1 = e => this.setState({ addressLine1: e.target.value })
+  onUpdateAddressLine2 = e => this.setState({ addressLine2: e.target.value })
+  onUpdateCity = e => this.setState({ city: e.target.value })
+  onUpdateRegion = e => this.setState({ region: e.target.value })
+  onUpdateCountry = country => this.setState({ country })
+  onUpdatePostalCode = e => this.setState({ postalCode: e.target.value })
 
   onContinueButtonPressed = () => {
     if (this.props.relay && this.props.relay.environment) {

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -1,0 +1,83 @@
+import { mount } from "enzyme"
+import React from "react"
+import { commitMutation, RelayProp } from "react-relay"
+
+import { Button } from "Styleguide/Elements/Button"
+import { Radio } from "Styleguide/Elements/Radio"
+import { Provider } from "unstated"
+import { ShippingProps, ShippingRoute } from "../Shipping"
+
+jest.mock("react-relay", () => ({
+  commitMutation: jest.fn(),
+  createFragmentContainer: component => component,
+}))
+
+describe("Shipping", () => {
+  const getWrapper = props => {
+    return mount(
+      <Provider>
+        <ShippingRoute {...props} />
+      </Provider>
+    )
+  }
+
+  let props: ShippingProps
+  beforeEach(() => {
+    props = {
+      order: {
+        id: "1234",
+      },
+      relay: {
+        environment: {},
+      } as RelayProp,
+    }
+  })
+
+  it("commits the mutation with the orderId", () => {
+    const component = getWrapper(props)
+    component
+      .find(Radio)
+      .last()
+      .simulate("click")
+    const mockCommitMutation = commitMutation as jest.Mock<any>
+    mockCommitMutation.mockImplementationOnce((_environment, config) => {
+      expect(config.variables.input.orderId).toBe("1234")
+    })
+
+    component.find(Button).simulate("click")
+
+    expect.assertions(1)
+  })
+
+  it("commits the mutation with shipping option", () => {
+    const component = getWrapper(props)
+    component
+      .find("input")
+      .last()
+      .simulate("change", { target: { value: "New Brunswick" } })
+    const mockCommitMutation = commitMutation as jest.Mock<any>
+    mockCommitMutation.mockImplementationOnce((_environment, config) => {
+      expect(config.variables.input.shippingRegion).toBe("New Brunswick")
+    })
+
+    component.find(Button).simulate("click")
+
+    expect.assertions(1)
+  })
+
+  it("commits the mutation with pickup option", () => {
+    const component = getWrapper(props)
+    component
+      .find(Radio)
+      .last()
+      .simulate("click")
+    const mockCommitMutation = commitMutation as jest.Mock<any>
+    mockCommitMutation.mockImplementationOnce((_environment, config) => {
+      expect(config.variables.input.fulfillmentType).toBe("PICKUP")
+    })
+
+    component.find(Button).simulate("click")
+
+    expect.assertions(1)
+  })
+})

--- a/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
+++ b/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
@@ -1,0 +1,135 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type OrderFulfillmentType = "PICKUP" | "SHIP" | "%future added value";
+export type SetOrderShippingInput = {
+    readonly orderId?: string | null;
+    readonly fulfillmentType?: OrderFulfillmentType | null;
+    readonly shippingAddressLine1?: string | null;
+    readonly shippingAddressLine2?: string | null;
+    readonly shippingCity?: string | null;
+    readonly shippingRegion?: string | null;
+    readonly shippingCountry?: string | null;
+    readonly shippingPostalCode?: string | null;
+    readonly clientMutationId?: string | null;
+};
+export type ShippingOrderAddressUpdateMutationVariables = {
+    readonly input: SetOrderShippingInput;
+};
+export type ShippingOrderAddressUpdateMutationResponse = {
+    readonly setOrderShipping: ({
+        readonly result: ({
+            readonly order: ({
+                readonly state: string | null;
+            }) | null;
+        }) | null;
+    }) | null;
+};
+
+
+
+/*
+mutation ShippingOrderAddressUpdateMutation(
+  $input: SetOrderShippingInput!
+) {
+  setOrderShipping(input: $input) {
+    result {
+      order {
+        state
+        __id: id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "SetOrderShippingInput!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "setOrderShipping",
+    "storageKey": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input",
+        "type": "SetOrderShippingInput!"
+      }
+    ],
+    "concreteType": "SetOrderShippingPayload",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "result",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "OrderReturnType",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "order",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Order",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "state",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": "__id",
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "mutation",
+  "name": "ShippingOrderAddressUpdateMutation",
+  "id": null,
+  "text": "mutation ShippingOrderAddressUpdateMutation(\n  $input: SetOrderShippingInput!\n) {\n  setOrderShipping(input: $input) {\n    result {\n      order {\n        state\n        __id: id\n      }\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ShippingOrderAddressUpdateMutation",
+    "type": "Mutation",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": v1
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ShippingOrderAddressUpdateMutation",
+    "argumentDefinitions": v0,
+    "selections": v1
+  }
+};
+})();
+(node as any).hash = 'a58cd0e6d450018a34b8ca4b546ba826';
+export default node;


### PR DESCRIPTION
This pull request adds the first mutation to the new order components (🎉) and address [PURCHASE-329](https://artsyproduct.atlassian.net/browse/PURCHASE-329). I've left a few TODOs with associated tickets to make sure they don't get dropped; the most immediate is moving the address entry fields into their own component so we can re-use it on the billing address screen. We'll almost certainly want to use Formik, as @damassi suggested, so I've included that in the note as well.

Since Relay will update its store with the new order state, we can tie into using that in our routing logic once this PR is merged. /cc @zephraph.

Here it is in action:

<img width="2433" alt="screen shot 2018-08-15 at 4 23 39 pm" src="https://user-images.githubusercontent.com/498212/44171202-a1d6ed80-a0a7-11e8-91af-26e3667065df.png">

