### PR TITLE
Make order story names consistent

### DIFF
--- a/src/Apps/Order/Components/__stories__/ItemReview.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ItemReview.story.tsx
@@ -4,7 +4,7 @@ import { Flex } from "Styleguide/Elements/Flex"
 import { Section } from "Styleguide/Utils/Section"
 import { ItemReview } from "../ItemReview"
 
-storiesOf("Apps/Order/Components", module).add("ItemReview", () => {
+storiesOf("Apps/Order Page/Components", module).add("ItemReview", () => {
   return (
     <>
       <Section title="Item Review">

--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -9,7 +9,7 @@ const address = `Brian Watterson
 Brooklyn, NY 10011
 United States`
 
-storiesOf("Apps/Order/Components", module).add(
+storiesOf("Apps/Order Page/Components", module).add(
   "ShippingAndPaymentDetails",
   () => {
     return (

--- a/src/Apps/Order/Components/__stories__/TransactionSummary.story.tsx
+++ b/src/Apps/Order/Components/__stories__/TransactionSummary.story.tsx
@@ -4,22 +4,25 @@ import { storiesOf } from "storybook/storiesOf"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Section } from "Styleguide/Utils/Section"
 
-storiesOf("Apps/Order/Components", module).add("TransactionSummary", () => {
-  return (
-    <Section title="Price Summary">
-      <Flex width={280} flexDirection="column">
-        <TransactionSummary
-          price="£3,024.89"
-          shipping="£132.32"
-          tax="£232.23"
-          total="£1,200,823.33"
-          artistName="Francesca DiMattio"
-          artworkName="The Fox and the Hound, 2018"
-          artworkLocation="New York, NY"
-          imageURL="https://d32dm0rphc51dk.cloudfront.net/SCShf97jlpFZpDBJUBqntg/small.jpg"
-          sellerName="Salon 94"
-        />
-      </Flex>
-    </Section>
-  )
-})
+storiesOf("Apps/Order Page/Components", module).add(
+  "TransactionSummary",
+  () => {
+    return (
+      <Section title="Price Summary">
+        <Flex width={280} flexDirection="column">
+          <TransactionSummary
+            price="£3,024.89"
+            shipping="£132.32"
+            tax="£232.23"
+            total="£1,200,823.33"
+            artistName="Francesca DiMattio"
+            artworkName="The Fox and the Hound, 2018"
+            artworkLocation="New York, NY"
+            imageURL="https://d32dm0rphc51dk.cloudfront.net/SCShf97jlpFZpDBJUBqntg/small.jpg"
+            sellerName="Salon 94"
+          />
+        </Flex>
+      </Section>
+    )
+  }
+)


### PR DESCRIPTION
There was an inconsistency in some of the story names that caused two order sections to show up. This PR cleans that up.

![image](https://user-images.githubusercontent.com/3087225/44232375-deb9e780-a16e-11e8-87b3-e474b44fed3f.png)
