### PR TITLE
hook up ShippingAndPaymentDetails

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -4030,6 +4030,9 @@ type Order {
   # Fulfillment Type
   fulfillmentType: OrderFulfillmentType
 
+  # Name for shipping information
+  shippingName: String
+
   # Shipping address line 1
   shippingAddressLine1: String
 
@@ -5737,6 +5740,9 @@ input SetOrderShippingInput {
 
   # Fulfillment Type of this Order
   fulfillmentType: OrderFulfillmentType
+
+  # Name for the shipping information
+  shippingName: String
 
   # Shipping address line 1
   shippingAddressLine1: String

--- a/data/schema.json
+++ b/data/schema.json
@@ -33758,6 +33758,18 @@
               "deprecationReason": null
             },
             {
+              "name": "shippingName",
+              "description": "Name for shipping information",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "shippingAddressLine1",
               "description": "Shipping address line 1",
               "args": [],
@@ -45871,6 +45883,16 @@
               "type": {
                 "kind": "ENUM",
                 "name": "OrderFulfillmentType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingName",
+              "description": "Name for the shipping information",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null

--- a/src/Apps/Order/Components/ShippingAndPaymentDetails.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentDetails.tsx
@@ -56,7 +56,7 @@ export const ShippingAndPaymentDetails: React.SFC<
           <Serif size="3" weight="semibold" color="black100">
             Pick up
           </Serif>
-          <Serif size="3" color="black100">
+          <Serif size="3t" color="black100">
             You’ll be appointed an Artsy specialist within 2 business days to
             handle pickup logistics.
           </Serif>
@@ -66,7 +66,7 @@ export const ShippingAndPaymentDetails: React.SFC<
           <Serif size="3" weight="semibold" color="black100">
             Ship to
           </Serif>
-          <Serif size="3" color="black100" style={{ whiteSpace: "pre-wrap" }}>
+          <Serif size="3t" color="black100" style={{ whiteSpace: "pre-wrap" }}>
             {renderAddress(addressProps)}
           </Serif>
         </>

--- a/src/Apps/Order/Components/ShippingAndPaymentDetails.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentDetails.tsx
@@ -35,7 +35,7 @@ const renderAddress = ({
     cityLine,
     shippingRegion,
   ]
-    .filter(x => x)
+    .filter(Boolean)
     .join("\n")
 }
 

--- a/src/Apps/Order/Components/ShippingAndPaymentDetails.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentDetails.tsx
@@ -45,6 +45,7 @@ export const ShippingAndPaymentDetails: React.SFC<
   order: {
     fulfillmentType,
     creditCard: { brand, last_digits, expiration_year, expiration_month },
+    lineItems,
     ...addressProps
   },
   ...others
@@ -54,7 +55,7 @@ export const ShippingAndPaymentDetails: React.SFC<
       {fulfillmentType === "PICKUP" ? (
         <>
           <Serif size="3" weight="semibold" color="black100">
-            Pick up
+            Pick up ({lineItems.edges[0].node.artwork.shippingOrigin})
           </Serif>
           <Serif size="3t" color="black100">
             You’ll be appointed an Artsy specialist within 2 business days to
@@ -96,6 +97,15 @@ export const ShippingAndPaymentDetailsFragmentContainer = createFragmentContaine
       shippingCity
       shippingPostalCode
       shippingRegion
+      lineItems {
+        edges {
+          node {
+            artwork {
+              shippingOrigin
+            }
+          }
+        }
+      }
       creditCard {
         brand
         last_digits

--- a/src/Apps/Order/Components/ShippingAndPaymentDetails.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentDetails.tsx
@@ -1,38 +1,107 @@
 import React from "react"
 
 import { Serif, space } from "@artsy/palette"
+import { ShippingAndPaymentDetails_order } from "__generated__/ShippingAndPaymentDetails_order.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
 import { StackableBorderBox } from "Styleguide/Elements/Box"
-import { Flex } from "Styleguide/Elements/Flex"
-import {
-  CreditCardIcon,
-  CreditCardType,
-} from "Styleguide/Elements/icons/CreditCardIcon"
+import { Flex, FlexProps } from "Styleguide/Elements/Flex"
+import { CreditCardIcon } from "Styleguide/Elements/icons/CreditCardIcon"
 
-interface ShippingAndPaymentDetailsProps {
-  address: string
-  creditCardLast4digits: string
-  creditCardtype: CreditCardType
-  creditCardExpiry: string
+interface ShippingAndPaymentDetailsProps extends FlexProps {
+  order: ShippingAndPaymentDetails_order
+}
+
+const renderAddress = ({
+  shippingName,
+  shippingAddressLine1,
+  shippingAddressLine2,
+  shippingCity,
+  shippingPostalCode,
+  shippingRegion,
+}: {
+  shippingName: string
+  shippingAddressLine1: string
+  shippingAddressLine2: string | null
+  shippingCity: string
+  shippingPostalCode: string | null
+  shippingRegion: string | null
+}) => {
+  const cityLine =
+    shippingCity + (shippingPostalCode ? ` ${shippingPostalCode}` : "")
+  return [
+    shippingName,
+    shippingAddressLine1,
+    shippingAddressLine2,
+    cityLine,
+    shippingRegion,
+  ]
+    .filter(x => x)
+    .join("\n")
 }
 
 export const ShippingAndPaymentDetails: React.SFC<
   ShippingAndPaymentDetailsProps
-> = ({ address, creditCardLast4digits, creditCardtype, creditCardExpiry }) => (
-  <Flex flexDirection="column">
-    <StackableBorderBox>
-      <Serif size="3" color="black100" style={{ whiteSpace: "pre-wrap" }}>
-        {address}
-      </Serif>
+> = ({
+  order: {
+    fulfillmentType,
+    creditCard: { brand, last_digits, expiration_year, expiration_month },
+    ...addressProps
+  },
+  ...others
+}) => (
+  <Flex flexDirection="column" {...others}>
+    <StackableBorderBox flexDirection="column">
+      {fulfillmentType === "PICKUP" ? (
+        <>
+          <Serif size="3" weight="semibold" color="black100">
+            Pick up
+          </Serif>
+          <Serif size="3" color="black100">
+            You’ll be appointed an Artsy specialist within 2 business days to
+            handle pickup logistics.
+          </Serif>
+        </>
+      ) : (
+        <>
+          <Serif size="3" weight="semibold" color="black100">
+            Ship to
+          </Serif>
+          <Serif size="3" color="black100" style={{ whiteSpace: "pre-wrap" }}>
+            {renderAddress(addressProps)}
+          </Serif>
+        </>
+      )}
     </StackableBorderBox>
     <StackableBorderBox alignItems="center">
       <CreditCardIcon
-        type={creditCardtype}
+        type={brand}
         style={{ marginRight: space(1), position: "relative", top: "-2px" }}
       />
       <Serif size="3" color="black100">
-        •••• {creditCardLast4digits}
-        &nbsp; Exp {creditCardExpiry}
+        •••• {last_digits}
+        &nbsp; Exp {expiration_month}/{expiration_year}
       </Serif>
     </StackableBorderBox>
   </Flex>
+)
+
+export const ShippingAndPaymentDetailsFragmentContainer = createFragmentContainer(
+  ShippingAndPaymentDetails,
+  graphql`
+    fragment ShippingAndPaymentDetails_order on Order {
+      fulfillmentType
+      shippingName
+      shippingAddressLine1
+      shippingAddressLine2
+      shippingCity
+      shippingPostalCode
+      shippingRegion
+      creditCard {
+        brand
+        last_digits
+        expiration_year
+        expiration_month
+      }
+    }
+  `
 )

--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -14,6 +14,9 @@ const order: ShippingAndPaymentDetails_order = {
   shippingCity: "New York",
   shippingPostalCode: "90210",
   shippingRegion: "US",
+  lineItems: {
+    edges: [{ node: { artwork: { shippingOrigin: "Jersey City, NJ" } } }],
+  },
   creditCard: {
     brand: "Visa",
     last_digits: "4444",

--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -1,13 +1,26 @@
+import { ShippingAndPaymentDetails_order } from "__generated__/ShippingAndPaymentDetails_order.graphql"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Section } from "Styleguide/Utils/Section"
 import { ShippingAndPaymentDetails } from "../ShippingAndPaymentDetails"
 
-const address = `Brian Watterson
-401 Broadway, Suite 25
-Brooklyn, NY 10011
-United States`
+const order: ShippingAndPaymentDetails_order = {
+  " $refType": null,
+  fulfillmentType: "SHIP",
+  shippingName: "Joelle Van Dyne",
+  shippingAddressLine1: "23 41st st",
+  shippingAddressLine2: null,
+  shippingCity: "New York",
+  shippingPostalCode: "90210",
+  shippingRegion: "US",
+  creditCard: {
+    brand: "Visa",
+    last_digits: "4444",
+    expiration_month: 3,
+    expiration_year: 21,
+  },
+}
 
 storiesOf("Apps/Order Page/Components", module).add(
   "ShippingAndPaymentDetails",
@@ -17,50 +30,65 @@ storiesOf("Apps/Order Page/Components", module).add(
         <Section title="Shipping and Payment details (mastercard)">
           <Flex flexDirection="column" width={300}>
             <ShippingAndPaymentDetails
-              address={address}
-              creditCardLast4digits="4444"
-              creditCardExpiry="04/34"
-              creditCardtype="mastercard"
+              order={{
+                ...order,
+                creditCard: { ...order.creditCard, brand: "Mastercard" },
+              }}
             />
           </Flex>
         </Section>
         <Section title="Shipping and Payment details (visa)">
           <Flex flexDirection="column" width={300}>
-            <ShippingAndPaymentDetails
-              address={address}
-              creditCardLast4digits="4444"
-              creditCardExpiry="04/34"
-              creditCardtype="visa"
-            />
+            <ShippingAndPaymentDetails order={order} />
           </Flex>
         </Section>
         <Section title="Shipping and Payment details (discover)">
           <Flex flexDirection="column" width={300}>
             <ShippingAndPaymentDetails
-              address={address}
-              creditCardLast4digits="4444"
-              creditCardExpiry="04/34"
-              creditCardtype="discover"
+              order={{
+                ...order,
+                creditCard: { ...order.creditCard, brand: "Discover" },
+              }}
             />
           </Flex>
         </Section>
         <Section title="Shipping and Payment details (amex)">
           <Flex flexDirection="column" width={300}>
             <ShippingAndPaymentDetails
-              address={address}
-              creditCardLast4digits="4444"
-              creditCardExpiry="04/34"
-              creditCardtype="amex"
+              order={{
+                ...order,
+                creditCard: { ...order.creditCard, brand: "American Express" },
+              }}
             />
           </Flex>
         </Section>
-        <Section title="Shipping and Payment details (generic)">
+        <Section title="Shipping and Payment details (Unknown)">
           <Flex flexDirection="column" width={300}>
             <ShippingAndPaymentDetails
-              address={address}
-              creditCardLast4digits="4444"
-              creditCardExpiry="04/34"
-              creditCardtype="other"
+              order={{
+                ...order,
+                creditCard: { ...order.creditCard, brand: "Unknown" },
+              }}
+            />
+          </Flex>
+        </Section>
+        <Section title="Shipping and Payment details (Anything else)">
+          <Flex flexDirection="column" width={300}>
+            <ShippingAndPaymentDetails
+              order={{
+                ...order,
+                creditCard: { ...order.creditCard, brand: "blasdijf22023" },
+              }}
+            />
+          </Flex>
+        </Section>
+        <Section title="Shipping and Payment details (pickup, visa)">
+          <Flex flexDirection="column" width={300}>
+            <ShippingAndPaymentDetails
+              order={{
+                ...order,
+                fulfillmentType: "PICKUP",
+              }}
             />
           </Flex>
         </Section>

--- a/src/Apps/Order/Routes/Submission/index.tsx
+++ b/src/Apps/Order/Routes/Submission/index.tsx
@@ -7,9 +7,9 @@ import { Flex } from "Styleguide/Elements/Flex"
 import { Join } from "Styleguide/Elements/Join"
 import { Message } from "Styleguide/Elements/Message"
 import { Spacer } from "Styleguide/Elements/Spacer"
-import { Placeholder } from "Styleguide/Utils/Placeholder"
 import { Responsive } from "Utils/Responsive"
 import { Helper } from "../../Components/Helper"
+import { ShippingAndPaymentDetailsFragmentContainer as ShippingAndPaymentDetails } from "../../Components/ShippingAndPaymentDetails"
 import { TransactionSummaryFragmentContainer as TransactionSummary } from "../../Components/TransactionSummary"
 
 export interface SubmissionProps {
@@ -50,11 +50,7 @@ export class SubmissionRoute extends Component<SubmissionProps> {
             }
             Sidebar={
               <Flex flexDirection="column">
-                <Placeholder
-                  height="180px"
-                  name="Shipping and payment details"
-                  mb={xs ? 2 : 3}
-                />
+                <ShippingAndPaymentDetails order={order} mb={xs ? 2 : 3} />
                 <Helper artworkId={order.lineItems.edges[0].node.artwork.id} />
               </Flex>
             }
@@ -72,6 +68,7 @@ export const SubmissionFragmentContainer = createFragmentContainer(
       id
       code
       ...TransactionSummary_order
+      ...ShippingAndPaymentDetails_order
       lineItems {
         edges {
           node {

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -2,7 +2,7 @@ import { mount } from "enzyme"
 import React from "react"
 import { commitMutation, RelayProp } from "react-relay"
 
-import { IncompleteOrder } from "Apps/__test__/Fixtures/Order"
+import { UntouchedOrder } from "Apps/__test__/Fixtures/Order"
 import { Button } from "Styleguide/Elements/Button"
 import { Radio } from "Styleguide/Elements/Radio"
 import { Provider } from "unstated"
@@ -26,7 +26,7 @@ describe("Shipping", () => {
   beforeEach(() => {
     props = {
       order: {
-        ...IncompleteOrder,
+        ...UntouchedOrder,
         id: "1234",
       },
       relay: {

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -1,4 +1,4 @@
-import { IncompleteOrder } from "Apps/__test__/Fixtures/Order"
+import { OrderWithShippingDetails } from "Apps/__test__/Fixtures/Order"
 import React from "react"
 import { StorybooksRouter } from "Router/StorybooksRouter"
 import { storiesOf } from "storybook/storiesOf"
@@ -12,7 +12,7 @@ const mock = {
   }),
   Order: (_, { id, ...others }) => {
     return {
-      ...IncompleteOrder,
+      ...OrderWithShippingDetails,
       id,
       ...others,
     }

--- a/src/Apps/__test__/Fixtures/Order.ts
+++ b/src/Apps/__test__/Fixtures/Order.ts
@@ -1,4 +1,4 @@
-export const IncompleteOrder = {
+export const UntouchedOrder = {
   id: "2939023",
   code: "abcdefg",
   itemsTotal: "$12,000",
@@ -44,5 +44,22 @@ export const IncompleteOrder = {
         country: "US",
       },
     ],
+  },
+}
+
+export const OrderWithShippingDetails = {
+  ...UntouchedOrder,
+  fulfillmentType: "SHIP",
+  shippingName: "Joelle Van Dyne",
+  shippingAddressLine1: "23 41st st",
+  shippingAddressLine2: null,
+  shippingCity: "New York",
+  shippingPostalCode: "90210",
+  shippingRegion: "US",
+  creditCard: {
+    brand: "Visa",
+    last_digits: "4444",
+    expiration_month: 3,
+    expiration_year: 21,
   },
 }

--- a/src/Styleguide/Elements/icons/CreditCardIcon.tsx
+++ b/src/Styleguide/Elements/icons/CreditCardIcon.tsx
@@ -1,28 +1,29 @@
 import React from "react"
 
+// https://stripe.com/docs/api#card_object-brand
 export type CreditCardType =
-  | "mastercard"
-  | "visa"
-  | "discover"
-  | "amex"
-  | "other"
+  | "Mastercard"
+  | "Visa"
+  | "Discover"
+  | "American Express"
+  | "Unknown"
 
 export const CreditCardIcon = ({
   type,
   ...others
 }: React.SVGProps<SVGSVGElement> & {
-  type?: CreditCardType
+  type?: CreditCardType | string
 }) => {
   switch (type) {
-    case "mastercard":
+    case "Mastercard":
       return <MastercardIcon {...others} />
-    case "visa":
+    case "Visa":
       return <VisaIcon {...others} />
-    case "discover":
+    case "Discover":
       return <DiscoverIcon {...others} />
-    case "amex":
+    case "American Express":
       return <AmexIcon {...others} />
-    case "other":
+    case "Unknown":
     default:
       return <FallbackIcon {...others} />
   }

--- a/src/__generated__/ShippingAndPaymentDetails_order.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentDetails_order.graphql.ts
@@ -12,6 +12,15 @@ export type ShippingAndPaymentDetails_order = {
     readonly shippingCity: string | null;
     readonly shippingPostalCode: string | null;
     readonly shippingRegion: string | null;
+    readonly lineItems: ({
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly artwork: ({
+                    readonly shippingOrigin: string | null;
+                }) | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
     readonly creditCard: ({
         readonly brand: string;
         readonly last_digits: string;
@@ -23,7 +32,22 @@ export type ShippingAndPaymentDetails_order = {
 
 
 
-const node: ConcreteFragment = {
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
   "kind": "Fragment",
   "name": "ShippingAndPaymentDetails_order",
   "type": "Order",
@@ -82,6 +106,59 @@ const node: ConcreteFragment = {
     {
       "kind": "LinkedField",
       "alias": null,
+      "name": "lineItems",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "OrderLineItemConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "OrderLineItemEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "OrderLineItem",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "artwork",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Artwork",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "shippingOrigin",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    v0
+                  ]
+                },
+                v1
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
       "name": "creditCard",
       "storageKey": null,
       "args": null,
@@ -116,23 +193,12 @@ const node: ConcreteFragment = {
           "args": null,
           "storageKey": null
         },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "__id",
-          "args": null,
-          "storageKey": null
-        }
+        v0
       ]
     },
-    {
-      "kind": "ScalarField",
-      "alias": "__id",
-      "name": "id",
-      "args": null,
-      "storageKey": null
-    }
+    v1
   ]
 };
-(node as any).hash = '244c767cb9600a1f938ccddda84018f1';
+})();
+(node as any).hash = '868ebbbec1e0bda85945e5794a51b160';
 export default node;

--- a/src/__generated__/ShippingAndPaymentDetails_order.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentDetails_order.graphql.ts
@@ -1,0 +1,138 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type OrderFulfillmentType = "PICKUP" | "SHIP" | "%future added value";
+declare const _ShippingAndPaymentDetails_order$ref: unique symbol;
+export type ShippingAndPaymentDetails_order$ref = typeof _ShippingAndPaymentDetails_order$ref;
+export type ShippingAndPaymentDetails_order = {
+    readonly fulfillmentType: OrderFulfillmentType | null;
+    readonly shippingName: string | null;
+    readonly shippingAddressLine1: string | null;
+    readonly shippingAddressLine2: string | null;
+    readonly shippingCity: string | null;
+    readonly shippingPostalCode: string | null;
+    readonly shippingRegion: string | null;
+    readonly creditCard: ({
+        readonly brand: string;
+        readonly last_digits: string;
+        readonly expiration_year: number;
+        readonly expiration_month: number;
+    }) | null;
+    readonly " $refType": ShippingAndPaymentDetails_order$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "ShippingAndPaymentDetails_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "fulfillmentType",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "shippingName",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "shippingAddressLine1",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "shippingAddressLine2",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "shippingCity",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "shippingPostalCode",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "shippingRegion",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "creditCard",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CreditCard",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "brand",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "last_digits",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "expiration_year",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "expiration_month",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "__id",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "__id",
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '244c767cb9600a1f938ccddda84018f1';
+export default node;

--- a/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
+++ b/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
@@ -5,6 +5,7 @@ export type OrderFulfillmentType = "PICKUP" | "SHIP" | "%future added value";
 export type SetOrderShippingInput = {
     readonly orderId?: string | null;
     readonly fulfillmentType?: OrderFulfillmentType | null;
+    readonly shippingName?: string | null;
     readonly shippingAddressLine1?: string | null;
     readonly shippingAddressLine2?: string | null;
     readonly shippingCity?: string | null;

--- a/src/__generated__/Submission_order.graphql.ts
+++ b/src/__generated__/Submission_order.graphql.ts
@@ -2,6 +2,7 @@
 
 import { ConcreteFragment } from "relay-runtime";
 import { ItemReview_artwork$ref } from "./ItemReview_artwork.graphql";
+import { ShippingAndPaymentDetails_order$ref } from "./ShippingAndPaymentDetails_order.graphql";
 import { TransactionSummary_order$ref } from "./TransactionSummary_order.graphql";
 declare const _Submission_order$ref: unique symbol;
 export type Submission_order$ref = typeof _Submission_order$ref;
@@ -18,7 +19,7 @@ export type Submission_order = {
             }) | null;
         }) | null> | null;
     }) | null;
-    readonly " $fragmentRefs": TransactionSummary_order$ref;
+    readonly " $fragmentRefs": TransactionSummary_order$ref & ShippingAndPaymentDetails_order$ref;
     readonly " $refType": Submission_order$ref;
 };
 
@@ -57,6 +58,11 @@ return {
     {
       "kind": "FragmentSpread",
       "name": "TransactionSummary_order",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ShippingAndPaymentDetails_order",
       "args": null
     },
     {
@@ -121,5 +127,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '8413fd35bda3cbb8ad69db290e1d6bb4';
+(node as any).hash = 'bd0e2493065931b528bb30c049e387e7';
 export default node;

--- a/src/__generated__/routes_SubmissionQuery.graphql.ts
+++ b/src/__generated__/routes_SubmissionQuery.graphql.ts
@@ -27,6 +27,7 @@ fragment Submission_order on Order {
   id
   code
   ...TransactionSummary_order
+  ...ShippingAndPaymentDetails_order
   lineItems {
     edges {
       node {
@@ -69,6 +70,24 @@ fragment TransactionSummary_order on Order {
         __id: id
       }
     }
+  }
+  __id: id
+}
+
+fragment ShippingAndPaymentDetails_order on Order {
+  fulfillmentType
+  shippingName
+  shippingAddressLine1
+  shippingAddressLine2
+  shippingCity
+  shippingPostalCode
+  shippingRegion
+  creditCard {
+    brand
+    last_digits
+    expiration_year
+    expiration_month
+    __id
   }
   __id: id
 }
@@ -146,7 +165,7 @@ return {
   "operationKind": "query",
   "name": "routes_SubmissionQuery",
   "id": null,
-  "text": "query routes_SubmissionQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Submission_order\n    __id: id\n  }\n}\n\nfragment Submission_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  partner {\n    name\n    __id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
+  "text": "query routes_SubmissionQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Submission_order\n    __id: id\n  }\n}\n\nfragment Submission_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentDetails_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  partner {\n    name\n    __id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentDetails_order on Order {\n  fulfillmentType\n  shippingName\n  shippingAddressLine1\n  shippingAddressLine2\n  shippingCity\n  shippingPostalCode\n  shippingRegion\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -188,14 +207,8 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
+          v2,
           v3,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "code",
-            "args": null,
-            "storageKey": null
-          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -413,7 +426,102 @@ return {
               }
             ]
           },
-          v2
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "code",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "fulfillmentType",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingName",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingAddressLine1",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingAddressLine2",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingCity",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingPostalCode",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingRegion",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCard",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CreditCard",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "brand",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "last_digits",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_year",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_month",
+                "args": null,
+                "storageKey": null
+              },
+              v4
+            ]
+          }
         ]
       }
     ]

--- a/src/__generated__/routes_SubmissionQuery.graphql.ts
+++ b/src/__generated__/routes_SubmissionQuery.graphql.ts
@@ -82,6 +82,17 @@ fragment ShippingAndPaymentDetails_order on Order {
   shippingCity
   shippingPostalCode
   shippingRegion
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          __id
+        }
+        __id: id
+      }
+    }
+  }
   creditCard {
     brand
     last_digits
@@ -165,7 +176,7 @@ return {
   "operationKind": "query",
   "name": "routes_SubmissionQuery",
   "id": null,
-  "text": "query routes_SubmissionQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Submission_order\n    __id: id\n  }\n}\n\nfragment Submission_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentDetails_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  partner {\n    name\n    __id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentDetails_order on Order {\n  fulfillmentType\n  shippingName\n  shippingAddressLine1\n  shippingAddressLine2\n  shippingCity\n  shippingPostalCode\n  shippingRegion\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
+  "text": "query routes_SubmissionQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Submission_order\n    __id: id\n  }\n}\n\nfragment Submission_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentDetails_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  partner {\n    name\n    __id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentDetails_order on Order {\n  fulfillmentType\n  shippingName\n  shippingAddressLine1\n  shippingAddressLine2\n  shippingCity\n  shippingPostalCode\n  shippingRegion\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",


### PR DESCRIPTION
I bumped metaphysics to the latest version and synced the schema because I needed the `Order#shippingName` field introduced in https://github.com/artsy/metaphysics/pull/1227

I also added a missing state for the Shipping details component. The 'pick up' state:
![image](https://user-images.githubusercontent.com/1242537/44278277-683be900-a245-11e8-869b-d3fec4739f74.png)

We should get Brian to do a copy review on Monday.