### PR TITLE
[WorksForYou] Create WorksForYou component to replace main grid

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2578,6 +2578,7 @@ type FollowedArtistsArtworksGroup implements Node {
 
   # List of artworks in this group.
   artworks: [Artwork]
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
   artists: String
   summary: String
   image: Image
@@ -4029,6 +4030,9 @@ type Order {
 
   # Fulfillment Type
   fulfillmentType: OrderFulfillmentType
+
+  # Name for shipping information
+  shippingName: String
 
   # Shipping address line 1
   shippingAddressLine1: String
@@ -5737,6 +5741,9 @@ input SetOrderShippingInput {
 
   # Fulfillment Type of this Order
   fulfillmentType: OrderFulfillmentType
+
+  # Name for the shipping information
+  shippingName: String
 
   # Shipping address line 1
   shippingAddressLine1: String

--- a/data/schema.json
+++ b/data/schema.json
@@ -33353,6 +33353,59 @@
               "deprecationReason": null
             },
             {
+              "name": "artworksConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ArtworkConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "artists",
               "description": null,
               "args": [],
@@ -33752,6 +33805,18 @@
               "type": {
                 "kind": "ENUM",
                 "name": "OrderFulfillmentType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingName",
+              "description": "Name for shipping information",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -45871,6 +45936,16 @@
               "type": {
                 "kind": "ENUM",
                 "name": "OrderFulfillmentType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingName",
+              "description": "Name for the shipping information",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null

--- a/src/Styleguide/Components/WorksForYou/WorksForYouContents.tsx
+++ b/src/Styleguide/Components/WorksForYou/WorksForYouContents.tsx
@@ -1,0 +1,157 @@
+import { WorksForYouContents_viewer } from "__generated__/WorksForYouContents_viewer.graphql"
+import ArtworkGrid from "Components/ArtworkGrid"
+import * as React from "react"
+import ReactDOM from "react-dom"
+import {
+  ConnectionData,
+  createPaginationContainer,
+  graphql,
+  RelayPaginationProp,
+} from "react-relay"
+
+interface Props {
+  relay?: RelayPaginationProp
+  viewer: WorksForYouContents_viewer
+}
+
+interface State {
+  loading: boolean
+  interval: any
+}
+
+const PageSize = 10
+
+export class WorksForYouContent extends React.Component<Props, State> {
+  state = { loading: false, interval: null }
+
+  componentDidMount() {
+    const interval = setInterval(() => {
+      this.maybeLoadMore()
+    }, 150)
+    this.setState({ interval })
+  }
+
+  componentWillUnmount() {
+    if (this.state.interval) {
+      clearInterval(this.state.interval)
+    }
+  }
+
+  maybeLoadMore() {
+    const threshold = window.innerHeight + window.scrollY
+    const el = ReactDOM.findDOMNode(this) as Element
+    if (threshold >= el.clientHeight + el.scrollTop) {
+      this.loadMoreArtworks()
+    }
+  }
+
+  loadMoreArtworks() {
+    const hasMore = this.props.viewer.me.followsAndSaves.notifications.pageInfo
+      .hasNextPage
+
+    if (!hasMore && this.state.interval) {
+      clearInterval(this.state.interval)
+    }
+    if (hasMore && !this.state.loading) {
+      this.setState({ loading: true }, () => {
+        this.props.relay.loadMore(PageSize, error => {
+          if (error) {
+            console.error(error)
+          }
+
+          this.setState({ loading: false })
+        })
+      })
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.viewer.me.followsAndSaves.notifications.edges.map(
+          ({ node }) => {
+            return (
+              <div>
+                <hr />
+                <div>{node.artists}</div>
+                <div>{node.summary}</div>
+                <ArtworkGrid
+                  artworks={node.artworksConnection}
+                  columnCount={4}
+                  itemMargin={40}
+                />
+              </div>
+            )
+          }
+        )}
+      </div>
+    )
+  }
+}
+
+export default createPaginationContainer(
+  WorksForYouContent,
+  {
+    viewer: graphql`
+      fragment WorksForYouContents_viewer on Viewer
+        @argumentDefinitions(
+          count: { type: "Int", defaultValue: 10 }
+          cursor: { type: "String" }
+        ) {
+        me {
+          followsAndSaves {
+            notifications: bundledArtworksByArtist(
+              sort: PUBLISHED_AT_DESC
+              first: $count
+              after: $cursor
+            ) @connection(key: "WorksForYou_notifications") {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              edges {
+                node {
+                  __id
+                  summary
+                  artists
+                  artworksConnection {
+                    ...ArtworkGrid_artworks
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    direction: "forward",
+    getConnectionFromProps(props) {
+      return props.viewer.me.followsAndSaves.notifications as ConnectionData
+    },
+    getFragmentVariables(prevVars, totalCount) {
+      return {
+        ...prevVars,
+        count: totalCount,
+      }
+    },
+    getVariables(_props, { count, cursor }, fragmentVariables) {
+      return {
+        // in most cases, for variables other than connection filters like
+        // `first`, `after`, etc. you may want to use the previous values.
+        ...fragmentVariables,
+        count,
+        cursor,
+      }
+    },
+    query: graphql`
+      query WorksForYouContentsPaginationQuery($count: Int!, $cursor: String) {
+        viewer {
+          ...WorksForYouContents_viewer
+            @arguments(count: $count, cursor: $cursor)
+        }
+      }
+    `,
+  }
+)

--- a/src/Styleguide/Components/WorksForYou/index.tsx
+++ b/src/Styleguide/Components/WorksForYou/index.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+
+import { ContextConsumer, ContextProps } from "Components/Artsy"
+import WorksForYouContent from "./WorksForYouContents"
+
+export interface Props extends ContextProps {}
+
+class WorksForYou extends React.Component<Props> {
+  render() {
+    const { relayEnvironment } = this.props
+    return (
+      <QueryRenderer
+        environment={relayEnvironment}
+        query={graphql`
+          query WorksForYouQuery {
+            viewer {
+              ...WorksForYouContents_viewer
+            }
+          }
+        `}
+        variables={{}}
+        render={({ props }) => {
+          if (props) {
+            return <WorksForYouContent viewer={props.viewer} />
+          } else {
+            return null
+          }
+        }}
+      />
+    )
+  }
+}
+
+export const Contents = ContextConsumer(WorksForYou)

--- a/src/Styleguide/Components/__stories__/WorksForYou.story.tsx
+++ b/src/Styleguide/Components/__stories__/WorksForYou.story.tsx
@@ -1,0 +1,15 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Contents as WorksForYouContent } from "Styleguide/Components/WorksForYou"
+
+import { ContextProvider } from "Components/Artsy"
+
+storiesOf("Components/WorksForYou/Contents", module).add("WorksForYou", () => {
+  return (
+    <div>
+      <ContextProvider>
+        <WorksForYouContent />
+      </ContextProvider>
+    </div>
+  )
+})

--- a/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
+++ b/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
@@ -5,6 +5,7 @@ export type OrderFulfillmentType = "PICKUP" | "SHIP" | "%future added value";
 export type SetOrderShippingInput = {
     readonly orderId?: string | null;
     readonly fulfillmentType?: OrderFulfillmentType | null;
+    readonly shippingName?: string | null;
     readonly shippingAddressLine1?: string | null;
     readonly shippingAddressLine2?: string | null;
     readonly shippingCity?: string | null;

--- a/src/__generated__/WorksForYouContentsPaginationQuery.graphql.ts
+++ b/src/__generated__/WorksForYouContentsPaginationQuery.graphql.ts
@@ -1,0 +1,722 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { WorksForYouContents_viewer$ref } from "./WorksForYouContents_viewer.graphql";
+export type WorksForYouContentsPaginationQueryVariables = {
+    readonly count: number;
+    readonly cursor?: string | null;
+};
+export type WorksForYouContentsPaginationQueryResponse = {
+    readonly viewer: ({
+        readonly " $fragmentRefs": WorksForYouContents_viewer$ref;
+    }) | null;
+};
+
+
+
+/*
+query WorksForYouContentsPaginationQuery(
+  $count: Int!
+  $cursor: String
+) {
+  viewer {
+    ...WorksForYouContents_viewer_1G22uz
+  }
+}
+
+fragment WorksForYouContents_viewer_1G22uz on Viewer {
+  me {
+    followsAndSaves {
+      notifications: bundledArtworksByArtist(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            __id
+            summary
+            artists
+            artworksConnection {
+              ...ArtworkGrid_artworks
+            }
+            __typename
+          }
+          cursor
+        }
+      }
+    }
+    __id
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnection {
+  edges {
+    node {
+      __id
+      image {
+        aspect_ratio
+      }
+      ...GridItem_artwork
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio
+  }
+  is_biddable
+  is_acquireable
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  __id
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  __id
+}
+
+fragment Save_artwork on Artwork {
+  __id
+  id
+  is_saved
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message
+  cultural_maker
+  artists(shallow: true) {
+    __id
+    href
+    name
+  }
+  collecting_institution
+  partner(shallow: true) {
+    name
+    href
+    __id
+  }
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  __id
+}
+
+fragment Contact_artwork on Artwork {
+  _id
+  href
+  is_inquireable
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  partner(shallow: true) {
+    type
+    __id
+  }
+  sale_artwork {
+    highest_bid {
+      display
+      __id: id
+    }
+    opening_bid {
+      display
+    }
+    counts {
+      bidder_positions
+    }
+    __id
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "count",
+    "type": "Int!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "cursor",
+    "type": "String",
+    "defaultValue": null
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "display",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "WorksForYouContentsPaginationQuery",
+  "id": null,
+  "text": "query WorksForYouContentsPaginationQuery(\n  $count: Int!\n  $cursor: String\n) {\n  viewer {\n    ...WorksForYouContents_viewer_1G22uz\n  }\n}\n\nfragment WorksForYouContents_viewer_1G22uz on Viewer {\n  me {\n    followsAndSaves {\n      notifications: bundledArtworksByArtist(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor) {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            __id\n            summary\n            artists\n            artworksConnection {\n              ...ArtworkGrid_artworks\n            }\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    __id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  is_acquireable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "WorksForYouContentsPaginationQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "viewer",
+        "name": "__viewer_viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "WorksForYouContents_viewer",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "count",
+                "variableName": "count",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "cursor",
+                "variableName": "cursor",
+                "type": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "WorksForYouContentsPaginationQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "me",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Me",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "followsAndSaves",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FollowsAndSaves",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": "notifications",
+                    "name": "bundledArtworksByArtist",
+                    "storageKey": null,
+                    "args": [
+                      {
+                        "kind": "Variable",
+                        "name": "after",
+                        "variableName": "cursor",
+                        "type": "String"
+                      },
+                      {
+                        "kind": "Variable",
+                        "name": "first",
+                        "variableName": "count",
+                        "type": "Int"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "sort",
+                        "value": "PUBLISHED_AT_DESC",
+                        "type": "ArtworkSorts"
+                      }
+                    ],
+                    "concreteType": "FollowedArtistsArtworksGroupConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "pageInfo",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "PageInfo",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "hasNextPage",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "endCursor",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "edges",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "FollowedArtistsArtworksGroupEdge",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "node",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "FollowedArtistsArtworksGroup",
+                            "plural": false,
+                            "selections": [
+                              v1,
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "summary",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "artists",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "artworksConnection",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "ArtworkConnection",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "edges",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "ArtworkEdge",
+                                    "plural": true,
+                                    "selections": [
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "node",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "Artwork",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "artists",
+                                            "storageKey": "artists(shallow:true)",
+                                            "args": v2,
+                                            "concreteType": "Artist",
+                                            "plural": true,
+                                            "selections": [
+                                              v1,
+                                              v3,
+                                              v4
+                                            ]
+                                          },
+                                          v1,
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "is_biddable",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "is_acquireable",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          v3,
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "title",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "date",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "sale_message",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "cultural_maker",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "image",
+                                            "storageKey": null,
+                                            "args": null,
+                                            "concreteType": "Image",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "aspect_ratio",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "placeholder",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "url",
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": "large",
+                                                    "type": "[String]"
+                                                  }
+                                                ],
+                                                "storageKey": "url(version:\"large\")"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "collecting_institution",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "partner",
+                                            "storageKey": "partner(shallow:true)",
+                                            "args": v2,
+                                            "concreteType": "Partner",
+                                            "plural": false,
+                                            "selections": [
+                                              v4,
+                                              v3,
+                                              v1,
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "type",
+                                                "args": null,
+                                                "storageKey": null
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "sale",
+                                            "storageKey": null,
+                                            "args": null,
+                                            "concreteType": "Sale",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "is_auction",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "is_live_open",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "is_open",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "is_closed",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              v1
+                                            ]
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "_id",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "is_inquireable",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "sale_artwork",
+                                            "storageKey": null,
+                                            "args": null,
+                                            "concreteType": "SaleArtwork",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "kind": "LinkedField",
+                                                "alias": null,
+                                                "name": "highest_bid",
+                                                "storageKey": null,
+                                                "args": null,
+                                                "concreteType": "SaleArtworkHighestBid",
+                                                "plural": false,
+                                                "selections": [
+                                                  v5,
+                                                  {
+                                                    "kind": "ScalarField",
+                                                    "alias": "__id",
+                                                    "name": "id",
+                                                    "args": null,
+                                                    "storageKey": null
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "LinkedField",
+                                                "alias": null,
+                                                "name": "opening_bid",
+                                                "storageKey": null,
+                                                "args": null,
+                                                "concreteType": "SaleArtworkOpeningBid",
+                                                "plural": false,
+                                                "selections": [
+                                                  v5
+                                                ]
+                                              },
+                                              {
+                                                "kind": "LinkedField",
+                                                "alias": null,
+                                                "name": "counts",
+                                                "storageKey": null,
+                                                "args": null,
+                                                "concreteType": "SaleArtworkCounts",
+                                                "plural": false,
+                                                "selections": [
+                                                  {
+                                                    "kind": "ScalarField",
+                                                    "alias": null,
+                                                    "name": "bidder_positions",
+                                                    "args": null,
+                                                    "storageKey": null
+                                                  }
+                                                ]
+                                              },
+                                              v1
+                                            ]
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "id",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "is_saved",
+                                            "args": null,
+                                            "storageKey": null
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "__typename",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "cursor",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "LinkedHandle",
+                    "alias": "notifications",
+                    "name": "bundledArtworksByArtist",
+                    "args": [
+                      {
+                        "kind": "Variable",
+                        "name": "after",
+                        "variableName": "cursor",
+                        "type": "String"
+                      },
+                      {
+                        "kind": "Variable",
+                        "name": "first",
+                        "variableName": "count",
+                        "type": "Int"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "sort",
+                        "value": "PUBLISHED_AT_DESC",
+                        "type": "ArtworkSorts"
+                      }
+                    ],
+                    "handle": "connection",
+                    "key": "WorksForYou_notifications",
+                    "filters": [
+                      "sort"
+                    ]
+                  }
+                ]
+              },
+              v1
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedHandle",
+        "alias": null,
+        "name": "viewer",
+        "args": null,
+        "handle": "viewer",
+        "key": "",
+        "filters": null
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '88d2c9fcb7aa6b2e80bcd338fef2fcf3';
+export default node;

--- a/src/__generated__/WorksForYouContents_viewer.graphql.ts
+++ b/src/__generated__/WorksForYouContents_viewer.graphql.ts
@@ -1,0 +1,211 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+import { ArtworkGrid_artworks$ref } from "./ArtworkGrid_artworks.graphql";
+declare const _WorksForYouContents_viewer$ref: unique symbol;
+export type WorksForYouContents_viewer$ref = typeof _WorksForYouContents_viewer$ref;
+export type WorksForYouContents_viewer = {
+    readonly me: ({
+        readonly followsAndSaves: ({
+            readonly notifications: ({
+                readonly pageInfo: {
+                    readonly hasNextPage: boolean;
+                    readonly endCursor: string | null;
+                };
+                readonly edges: ReadonlyArray<({
+                    readonly node: ({
+                        readonly __id: string;
+                        readonly summary: string | null;
+                        readonly artists: string | null;
+                        readonly artworksConnection: ({
+                            readonly " $fragmentRefs": ArtworkGrid_artworks$ref;
+                        }) | null;
+                    }) | null;
+                }) | null> | null;
+            }) | null;
+        }) | null;
+    }) | null;
+    readonly " $refType": WorksForYouContents_viewer$ref;
+};
+
+
+
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Fragment",
+  "name": "WorksForYouContents_viewer",
+  "type": "Viewer",
+  "metadata": {
+    "connection": [
+      {
+        "count": "count",
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": [
+          "me",
+          "followsAndSaves",
+          "notifications"
+        ]
+      }
+    ]
+  },
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "count",
+      "type": "Int",
+      "defaultValue": 10
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "cursor",
+      "type": "String",
+      "defaultValue": null
+    }
+  ],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "me",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Me",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "followsAndSaves",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "FollowsAndSaves",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": "notifications",
+              "name": "__WorksForYou_notifications_connection",
+              "storageKey": "__WorksForYou_notifications_connection(sort:\"PUBLISHED_AT_DESC\")",
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "sort",
+                  "value": "PUBLISHED_AT_DESC",
+                  "type": "ArtworkSorts"
+                }
+              ],
+              "concreteType": "FollowedArtistsArtworksGroupConnection",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "pageInfo",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "PageInfo",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "hasNextPage",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "endCursor",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "edges",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "FollowedArtistsArtworksGroupEdge",
+                  "plural": true,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "node",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "FollowedArtistsArtworksGroup",
+                      "plural": false,
+                      "selections": [
+                        v0,
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "summary",
+                          "args": null,
+                          "storageKey": null
+                        },
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "artists",
+                          "args": null,
+                          "storageKey": null
+                        },
+                        {
+                          "kind": "LinkedField",
+                          "alias": null,
+                          "name": "artworksConnection",
+                          "storageKey": null,
+                          "args": null,
+                          "concreteType": "ArtworkConnection",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "kind": "FragmentSpread",
+                              "name": "ArtworkGrid_artworks",
+                              "args": null
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "__typename",
+                          "args": null,
+                          "storageKey": null
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "cursor",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        v0
+      ]
+    }
+  ]
+};
+})();
+(node as any).hash = '70a43775f36bd66126320b6ded7bc13c';
+export default node;

--- a/src/__generated__/WorksForYouQuery.graphql.ts
+++ b/src/__generated__/WorksForYouQuery.graphql.ts
@@ -1,0 +1,677 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { WorksForYouContents_viewer$ref } from "./WorksForYouContents_viewer.graphql";
+export type WorksForYouQueryVariables = {};
+export type WorksForYouQueryResponse = {
+    readonly viewer: ({
+        readonly " $fragmentRefs": WorksForYouContents_viewer$ref;
+    }) | null;
+};
+
+
+
+/*
+query WorksForYouQuery {
+  viewer {
+    ...WorksForYouContents_viewer
+  }
+}
+
+fragment WorksForYouContents_viewer on Viewer {
+  me {
+    followsAndSaves {
+      notifications: bundledArtworksByArtist(sort: PUBLISHED_AT_DESC, first: 10) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            __id
+            summary
+            artists
+            artworksConnection {
+              ...ArtworkGrid_artworks
+            }
+            __typename
+          }
+          cursor
+        }
+      }
+    }
+    __id
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnection {
+  edges {
+    node {
+      __id
+      image {
+        aspect_ratio
+      }
+      ...GridItem_artwork
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio
+  }
+  is_biddable
+  is_acquireable
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  __id
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  __id
+}
+
+fragment Save_artwork on Artwork {
+  __id
+  id
+  is_saved
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message
+  cultural_maker
+  artists(shallow: true) {
+    __id
+    href
+    name
+  }
+  collecting_institution
+  partner(shallow: true) {
+    name
+    href
+    __id
+  }
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  __id
+}
+
+fragment Contact_artwork on Artwork {
+  _id
+  href
+  is_inquireable
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  partner(shallow: true) {
+    type
+    __id
+  }
+  sale_artwork {
+    highest_bid {
+      display
+      __id: id
+    }
+    opening_bid {
+      display
+    }
+    counts {
+      bidder_positions
+    }
+    __id
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "display",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "WorksForYouQuery",
+  "id": null,
+  "text": "query WorksForYouQuery {\n  viewer {\n    ...WorksForYouContents_viewer\n  }\n}\n\nfragment WorksForYouContents_viewer on Viewer {\n  me {\n    followsAndSaves {\n      notifications: bundledArtworksByArtist(sort: PUBLISHED_AT_DESC, first: 10) {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            __id\n            summary\n            artists\n            artworksConnection {\n              ...ArtworkGrid_artworks\n            }\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    __id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  is_acquireable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "WorksForYouQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "viewer",
+        "name": "__viewer_viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "WorksForYouContents_viewer",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "WorksForYouQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "me",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Me",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "followsAndSaves",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FollowsAndSaves",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": "notifications",
+                    "name": "bundledArtworksByArtist",
+                    "storageKey": "bundledArtworksByArtist(first:10,sort:\"PUBLISHED_AT_DESC\")",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 10,
+                        "type": "Int"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "sort",
+                        "value": "PUBLISHED_AT_DESC",
+                        "type": "ArtworkSorts"
+                      }
+                    ],
+                    "concreteType": "FollowedArtistsArtworksGroupConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "pageInfo",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "PageInfo",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "hasNextPage",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "endCursor",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "edges",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "FollowedArtistsArtworksGroupEdge",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "node",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "FollowedArtistsArtworksGroup",
+                            "plural": false,
+                            "selections": [
+                              v0,
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "summary",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "artists",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "artworksConnection",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "ArtworkConnection",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "edges",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "ArtworkEdge",
+                                    "plural": true,
+                                    "selections": [
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "node",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "Artwork",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "artists",
+                                            "storageKey": "artists(shallow:true)",
+                                            "args": v1,
+                                            "concreteType": "Artist",
+                                            "plural": true,
+                                            "selections": [
+                                              v0,
+                                              v2,
+                                              v3
+                                            ]
+                                          },
+                                          v0,
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "is_biddable",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "is_acquireable",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          v2,
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "title",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "date",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "sale_message",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "cultural_maker",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "image",
+                                            "storageKey": null,
+                                            "args": null,
+                                            "concreteType": "Image",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "aspect_ratio",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "placeholder",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "url",
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": "large",
+                                                    "type": "[String]"
+                                                  }
+                                                ],
+                                                "storageKey": "url(version:\"large\")"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "collecting_institution",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "partner",
+                                            "storageKey": "partner(shallow:true)",
+                                            "args": v1,
+                                            "concreteType": "Partner",
+                                            "plural": false,
+                                            "selections": [
+                                              v3,
+                                              v2,
+                                              v0,
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "type",
+                                                "args": null,
+                                                "storageKey": null
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "sale",
+                                            "storageKey": null,
+                                            "args": null,
+                                            "concreteType": "Sale",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "is_auction",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "is_live_open",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "is_open",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "is_closed",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              v0
+                                            ]
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "_id",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "is_inquireable",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "sale_artwork",
+                                            "storageKey": null,
+                                            "args": null,
+                                            "concreteType": "SaleArtwork",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "kind": "LinkedField",
+                                                "alias": null,
+                                                "name": "highest_bid",
+                                                "storageKey": null,
+                                                "args": null,
+                                                "concreteType": "SaleArtworkHighestBid",
+                                                "plural": false,
+                                                "selections": [
+                                                  v4,
+                                                  {
+                                                    "kind": "ScalarField",
+                                                    "alias": "__id",
+                                                    "name": "id",
+                                                    "args": null,
+                                                    "storageKey": null
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "LinkedField",
+                                                "alias": null,
+                                                "name": "opening_bid",
+                                                "storageKey": null,
+                                                "args": null,
+                                                "concreteType": "SaleArtworkOpeningBid",
+                                                "plural": false,
+                                                "selections": [
+                                                  v4
+                                                ]
+                                              },
+                                              {
+                                                "kind": "LinkedField",
+                                                "alias": null,
+                                                "name": "counts",
+                                                "storageKey": null,
+                                                "args": null,
+                                                "concreteType": "SaleArtworkCounts",
+                                                "plural": false,
+                                                "selections": [
+                                                  {
+                                                    "kind": "ScalarField",
+                                                    "alias": null,
+                                                    "name": "bidder_positions",
+                                                    "args": null,
+                                                    "storageKey": null
+                                                  }
+                                                ]
+                                              },
+                                              v0
+                                            ]
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "id",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "is_saved",
+                                            "args": null,
+                                            "storageKey": null
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "__typename",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "cursor",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "LinkedHandle",
+                    "alias": "notifications",
+                    "name": "bundledArtworksByArtist",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 10,
+                        "type": "Int"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "sort",
+                        "value": "PUBLISHED_AT_DESC",
+                        "type": "ArtworkSorts"
+                      }
+                    ],
+                    "handle": "connection",
+                    "key": "WorksForYou_notifications",
+                    "filters": [
+                      "sort"
+                    ]
+                  }
+                ]
+              },
+              v0
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedHandle",
+        "alias": null,
+        "name": "viewer",
+        "args": null,
+        "handle": "viewer",
+        "key": "",
+        "filters": null
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '588123f6411885aaa3448a59ec6fefa0';
+export default node;


### PR DESCRIPTION
Looks like:

![bp](https://user-images.githubusercontent.com/1457859/44288276-bbaa3900-a23d-11e8-80fc-933496713d11.gif)

This definitely needs an update layout-wise (just plain `<div>` and `<hr />`) for now. However, it's all functional w/ inf scroll working properly! There's a small MP PR with this as well.

Question- I wasn't sure if/how we would use the new router/app state for this, so I just kept it as a component with the Artsy context. Since we'll be keeping the Force-side server stuff and sidebar, etc. I was thinking we would just render this as `<ContextProvider><WorksForYou></ContextProvider>` in Force (similar to the storybook setup here). Does that seem reasonable to you? We can always pair or refactor that as well (Artsy context -> more modern approach).