### PR TITLE
RadioGroup fixes

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -12,8 +12,8 @@ import { Collapse } from "Styleguide/Components/Collapse"
 import { Button } from "Styleguide/Elements/Button"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
-import { Radio } from "Styleguide/Elements/Radio"
-import { BorderedRadioGroup } from "Styleguide/Elements/RadioGroup"
+import { BorderedRadio } from "Styleguide/Elements/Radio"
+import { RadioGroup } from "Styleguide/Elements/RadioGroup"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Responsive } from "Utils/Responsive"
 
@@ -115,15 +115,17 @@ export class ShippingRoute extends Component<
             <TwoColumnLayout
               Content={
                 <>
-                  <BorderedRadioGroup
+                  <RadioGroup
                     onSelect={shippingOption =>
                       this.setState({ shippingOption })
                     }
                     defaultValue="SHIP"
                   >
-                    <Radio value="SHIP">Provide shipping address</Radio>
+                    <BorderedRadio value="SHIP">
+                      Provide shipping address
+                    </BorderedRadio>
 
-                    <Radio value="PICKUP">
+                    <BorderedRadio value="PICKUP">
                       Arrange for pickup
                       <Collapse open={this.state.shippingOption === "PICKUP"}>
                         <Sans size="2" color="black60">
@@ -132,8 +134,8 @@ export class ShippingRoute extends Component<
                           pickup logistics.
                         </Sans>
                       </Collapse>
-                    </Radio>
-                  </BorderedRadioGroup>
+                    </BorderedRadio>
+                  </RadioGroup>
 
                   <Spacer mb={3} />
 

--- a/src/Styleguide/Elements/Radio.tsx
+++ b/src/Styleguide/Elements/Radio.tsx
@@ -56,6 +56,8 @@ export const Radio = styled(
             role="presentation"
             border={1}
             mr={1}
+            mt="2px"
+            mb="-2px"
             selected={selected}
             disabled={disabled}
           >
@@ -78,6 +80,29 @@ export const Radio = styled(
     }
   }
 ).attrs<RadioProps>({})``
+
+export const BorderedRadio = styled(Radio).attrs<RadioProps>({
+  p: 2,
+})`
+  border-radius: 2px;
+  border: 1px solid ${color("black10")};
+  transition: background-color 0.14s ease-in-out;
+
+  :hover:not(:disabled) {
+    background-color: ${color("black5")};
+  }
+
+  :not(:first-child) {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  :not(:last-child) {
+    border-bottom: 0;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+`
 
 const hoverStyles = ({ selected, hover }) => {
   const styles = `background-color: ${color("black10")};`

--- a/src/Styleguide/Elements/RadioGroup.tsx
+++ b/src/Styleguide/Elements/RadioGroup.tsx
@@ -1,11 +1,8 @@
 import React from "react"
 import { BorderProps, SizeProps, SpaceProps } from "styled-system"
 
-import { BorderBox } from "Styleguide/Elements/Box"
 import { Flex } from "Styleguide/Elements/Flex"
-import { Join } from "Styleguide/Elements/Join"
 import { RadioProps } from "Styleguide/Elements/Radio"
-import { Separator } from "Styleguide/Elements/Separator"
 
 export interface RadioGroupProps {
   disabled?: boolean
@@ -67,18 +64,6 @@ export class RadioGroup extends React.Component<
       <Flex flexDirection="column" p={2}>
         {this.renderRadioButtons()}
       </Flex>
-    )
-  }
-}
-
-export class BorderedRadioGroup extends RadioGroup {
-  render() {
-    return (
-      <BorderBox flexDirection="column" p={2}>
-        <Join separator={<Separator mx={-2} my={2} width="inherit" />}>
-          {this.renderRadioButtons()}
-        </Join>
-      </BorderBox>
     )
   }
 }

--- a/src/Styleguide/Elements/RadioGroup.tsx
+++ b/src/Styleguide/Elements/RadioGroup.tsx
@@ -1,21 +1,14 @@
 import React from "react"
-import { BorderProps, SizeProps, SpaceProps } from "styled-system"
 
-import { Flex } from "Styleguide/Elements/Flex"
+import { Flex, FlexProps } from "Styleguide/Elements/Flex"
 import { RadioProps } from "Styleguide/Elements/Radio"
 
-export interface RadioGroupProps {
+export interface RadioGroupProps extends FlexProps {
   disabled?: boolean
   onSelect?: (selectedOption: string) => void
   defaultValue?: string
   children: Array<React.ReactElement<RadioProps>>
 }
-
-export interface RadioGroupToggleProps
-  extends RadioGroupProps,
-    BorderProps,
-    SizeProps,
-    SpaceProps {}
 
 interface RadioGroupState {
   selectedOption: string | null
@@ -60,8 +53,9 @@ export class RadioGroup extends React.Component<
   }
 
   render() {
+    const { disabled, onSelect, defaultValue, children, ...others } = this.props
     return (
-      <Flex flexDirection="column" p={2}>
+      <Flex flexDirection="column" {...others}>
         {this.renderRadioButtons()}
       </Flex>
     )

--- a/src/Styleguide/Elements/RadioGroup.tsx
+++ b/src/Styleguide/Elements/RadioGroup.tsx
@@ -22,7 +22,7 @@ export class RadioGroup extends React.Component<
     selectedOption: this.props.defaultValue || null,
   }
 
-  onSelect = ({ selected, value }) => {
+  onSelect = ({ value }) => {
     if (this.props.onSelect) {
       this.props.onSelect(value)
     }

--- a/src/Styleguide/Elements/__stories__/RadioGroup.story.tsx
+++ b/src/Styleguide/Elements/__stories__/RadioGroup.story.tsx
@@ -1,8 +1,8 @@
 import { Sans } from "@artsy/palette"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
-import { Radio } from "Styleguide/Elements/Radio"
-import { BorderedRadioGroup, RadioGroup } from "Styleguide/Elements/RadioGroup"
+import { BorderedRadio, Radio } from "Styleguide/Elements/Radio"
+import { RadioGroup } from "Styleguide/Elements/RadioGroup"
 import { Section } from "Styleguide/Utils/Section"
 
 storiesOf("Styleguide/Elements", module).add("RadioGroup", () => {
@@ -27,17 +27,17 @@ storiesOf("Styleguide/Elements", module).add("RadioGroup", () => {
         </RadioGroup>
       </Section>
       <Section title="Bordered RadioGroup">
-        <BorderedRadioGroup defaultValue="SHIP">
-          <Radio value="SHIP">Provide shipping address</Radio>
+        <RadioGroup defaultValue="SHIP">
+          <BorderedRadio value="SHIP">Provide shipping address</BorderedRadio>
 
-          <Radio value="PICKUP">
+          <BorderedRadio value="PICKUP">
             Arrange for pickup
             <Sans size="2" color="black60">
               After you place your order, you’ll be appointed an Artsy
               Specialist within 2 business days to handle pickup logistics.
             </Sans>
-          </Radio>
-        </BorderedRadioGroup>
+          </BorderedRadio>
+        </RadioGroup>
       </Section>
     </>
   )


### PR DESCRIPTION
We refactored the RadioGroup last week and accidentally broke some stuff. Here's what I did:

1. Fixed button–text alignment 

![image](https://user-images.githubusercontent.com/1242537/44336179-8b95ac80-a46e-11e8-9cae-5746217449f0.png)

2. Removed outer padding, which should be provided by parents in most cases.

2. Fixed hit area for bordered radio
3. Added back the hover state for bordered radio

Before:
![bad](https://user-images.githubusercontent.com/1242537/44336382-2f7f5800-a46f-11e8-923e-3c657db2ad77.gif)

After:
![good](https://user-images.githubusercontent.com/1242537/44337245-e7ae0000-a471-11e8-8f58-f94abcf40641.gif)
