### PR TITLE
adds v1 of review page with dynamic components

### DIFF
--- a/src/Apps/Order/Components/ItemReview.tsx
+++ b/src/Apps/Order/Components/ItemReview.tsx
@@ -4,7 +4,7 @@ import { Serif } from "@artsy/palette"
 import { ItemReview_artwork } from "__generated__/ItemReview_artwork.graphql"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import { StackableBorderBox } from "Styleguide/Elements/Box"
+import { BorderBox } from "Styleguide/Elements/Box"
 import { Flex } from "Styleguide/Elements/Flex"
 
 interface ItemReviewProps {
@@ -34,7 +34,7 @@ export const ItemReview: React.SFC<ItemReviewProps> = ({
     },
   },
 }) => (
-  <StackableBorderBox>
+  <BorderBox>
     <Flex flexGrow={1} flexDirection="column">
       <Serif size="2" weight="semibold" color="black60">
         {artist_names}
@@ -62,7 +62,7 @@ export const ItemReview: React.SFC<ItemReviewProps> = ({
     <ImageBox>
       <img alt={`${title} by ${artist_names}`} src={url} />
     </ImageBox>
-  </StackableBorderBox>
+  </BorderBox>
 )
 
 export const ItemReviewFragmentContainer = createFragmentContainer(

--- a/src/Apps/Order/Components/ItemReview.tsx
+++ b/src/Apps/Order/Components/ItemReview.tsx
@@ -34,7 +34,7 @@ export const ItemReview: React.SFC<ItemReviewProps> = ({
     },
   },
 }) => (
-  <BorderBox>
+  <BorderBox p={[2, 3]}>
     <Flex flexGrow={1} flexDirection="column">
       <Serif size="2" weight="semibold" color="black60">
         {artist_names}

--- a/src/Apps/Order/Components/TermsOfServiceCheckbox.tsx
+++ b/src/Apps/Order/Components/TermsOfServiceCheckbox.tsx
@@ -1,0 +1,22 @@
+import { color, Serif } from "@artsy/palette"
+import React from "react"
+import styled from "styled-components"
+import { Checkbox } from "Styleguide/Elements/Checkbox"
+
+export const TermsOfServiceCheckbox = props => {
+  return (
+    <Checkbox {...props}>
+      <Serif size="3" color={color("black60")}>
+        {"Agree to "}
+        <A href="https://www.artsy.net/terms" target="_blank">
+          Terms & Conditions
+        </A>
+        {". All sales are final."}
+      </Serif>
+    </Checkbox>
+  )
+}
+
+const A = styled.a`
+  color: ${props => props.color};
+`

--- a/src/Apps/Order/Components/TermsOfServiceCheckbox.tsx
+++ b/src/Apps/Order/Components/TermsOfServiceCheckbox.tsx
@@ -1,22 +1,17 @@
-import { color, Serif } from "@artsy/palette"
+import { Serif } from "@artsy/palette"
 import React from "react"
-import styled from "styled-components"
 import { Checkbox } from "Styleguide/Elements/Checkbox"
 
 export const TermsOfServiceCheckbox = props => {
   return (
     <Checkbox {...props}>
-      <Serif size="3" color={color("black60")}>
+      <Serif size="3" color="black60">
         {"Agree to "}
-        <A href="https://www.artsy.net/terms" target="_blank">
+        <a href="https://www.artsy.net/terms" target="_blank">
           Terms & Conditions
-        </A>
+        </a>
         {". All sales are final."}
       </Serif>
     </Checkbox>
   )
 }
-
-const A = styled.a`
-  color: ${props => props.color};
-`

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -1,8 +1,10 @@
 import { Review_order } from "__generated__/Review_order.graphql"
 import { BuyNowStepper } from "Apps/Order/Components/BuyNowStepper"
+import { ItemReviewFragmentContainer as ItemReview } from "Apps/Order/Components/ItemReview"
+import { TermsOfServiceCheckbox } from "Apps/Order/Components/TermsOfServiceCheckbox"
+import { Router } from "found"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Link } from "Router"
 import { Button } from "Styleguide/Elements/Button"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
@@ -16,11 +18,34 @@ import { TwoColumnLayout } from "../../Components/TwoColumnLayout"
 
 export interface ReviewProps {
   order: Review_order
+  router: Router
 }
 
-export class ReviewRoute extends Component<ReviewProps> {
+interface ReviewState {
+  termsCheckboxSelected?: Boolean
+}
+
+export class ReviewRoute extends Component<ReviewProps, ReviewState> {
+  constructor(props) {
+    super(props)
+
+    this.state = { termsCheckboxSelected: false }
+  }
+
+  updateTermsCheckbox() {
+    const { termsCheckboxSelected } = this.state
+    this.setState({
+      termsCheckboxSelected: !termsCheckboxSelected,
+    })
+  }
+
+  onOrderSubmitted() {
+    this.props.router.push(`/order2/${this.props.order.id}/submission`)
+  }
+
   render() {
     const { order } = this.props
+    const { termsCheckboxSelected } = this.state
 
     return (
       <>
@@ -40,14 +65,29 @@ export class ReviewRoute extends Component<ReviewProps> {
                   <Join separator={<Spacer mb={3} />}>
                     <Placeholder height="68px" name="Step summary item" />
                     <Placeholder height="68px" name="Step summary item" />
-                    <Placeholder height="80px" name="Item review" />
-                    <Placeholder height="20px" name="Terms and conditions" />
+
+                    <ItemReview
+                      artwork={order.lineItems.edges[0].node.artwork}
+                    />
+
                     {!xs && (
-                      <Link to={`/order2/${order.id}/submission`}>
-                        <Button size="large" width="100%">
-                          Submit Order
-                        </Button>
-                      </Link>
+                      <Flex justifyContent="center">
+                        <TermsOfServiceCheckbox
+                          onSelect={() => this.updateTermsCheckbox()}
+                          selected={termsCheckboxSelected}
+                        />
+                      </Flex>
+                    )}
+
+                    {!xs && (
+                      <Button
+                        size="large"
+                        width="100%"
+                        disabled={!termsCheckboxSelected}
+                        onClick={() => this.onOrderSubmitted()}
+                      >
+                        Submit Order
+                      </Button>
                     )}
                   </Join>
                   <Spacer mb={3} />
@@ -62,13 +102,21 @@ export class ReviewRoute extends Component<ReviewProps> {
                   {xs && (
                     <>
                       <Spacer mb={3} />
-                      <Placeholder height="20px" name="Terms and conditions" />
+                      <Flex justifyContent="center">
+                        <TermsOfServiceCheckbox
+                          onSelect={() => this.updateTermsCheckbox()}
+                          selected={termsCheckboxSelected}
+                        />
+                      </Flex>
                       <Spacer mb={3} />
-                      <Link to={`/order2/${order.id}/submission`}>
-                        <Button size="large" width="100%">
-                          Continue
-                        </Button>
-                      </Link>
+                      <Button
+                        size="large"
+                        width="100%"
+                        disabled={!termsCheckboxSelected}
+                        onClick={() => this.onOrderSubmitted()}
+                      >
+                        Submit Order
+                      </Button>
                     </>
                   )}
                 </Flex>
@@ -91,6 +139,7 @@ export const ReviewFragmentContainer = createFragmentContainer(
           node {
             artwork {
               id
+              ...ItemReview_artwork
             }
           }
         }

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -66,9 +66,11 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                     <Placeholder height="68px" name="Step summary item" />
                     <Placeholder height="68px" name="Step summary item" />
 
-                    <ItemReview
-                      artwork={order.lineItems.edges[0].node.artwork}
-                    />
+                    {!xs && (
+                      <ItemReview
+                        artwork={order.lineItems.edges[0].node.artwork}
+                      />
+                    )}
 
                     {!xs && (
                       <Flex justifyContent="center">

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -67,29 +67,27 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                     <Placeholder height="68px" name="Step summary item" />
 
                     {!xs && (
-                      <ItemReview
-                        artwork={order.lineItems.edges[0].node.artwork}
-                      />
-                    )}
-
-                    {!xs && (
-                      <Flex justifyContent="center">
-                        <TermsOfServiceCheckbox
-                          onSelect={() => this.updateTermsCheckbox()}
-                          selected={termsCheckboxSelected}
+                      <>
+                        <ItemReview
+                          artwork={order.lineItems.edges[0].node.artwork}
                         />
-                      </Flex>
-                    )}
-
-                    {!xs && (
-                      <Button
-                        size="large"
-                        width="100%"
-                        disabled={!termsCheckboxSelected}
-                        onClick={() => this.onOrderSubmitted()}
-                      >
-                        Submit Order
-                      </Button>
+                        <Spacer mb={3} />
+                        <Flex justifyContent="center">
+                          <TermsOfServiceCheckbox
+                            onSelect={() => this.updateTermsCheckbox()}
+                            selected={termsCheckboxSelected}
+                          />
+                        </Flex>
+                        <Spacer mb={3} />
+                        <Button
+                          size="large"
+                          width="100%"
+                          disabled={!termsCheckboxSelected}
+                          onClick={() => this.onOrderSubmitted()}
+                        >
+                          Submit Order
+                        </Button>
+                      </>
                     )}
                   </Join>
                   <Spacer mb={3} />
@@ -98,19 +96,20 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               Sidebar={
                 <Flex flexDirection="column">
                   <TransactionSummary order={order} mb={xs ? 2 : 3} />
-                  <Helper
-                    artworkId={order.lineItems.edges[0].node.artwork.id}
-                  />
+                  {!xs && (
+                    <Helper
+                      artworkId={order.lineItems.edges[0].node.artwork.id}
+                    />
+                  )}
                   {xs && (
                     <>
-                      <Spacer mb={3} />
                       <Flex justifyContent="center">
                         <TermsOfServiceCheckbox
                           onSelect={() => this.updateTermsCheckbox()}
                           selected={termsCheckboxSelected}
                         />
                       </Flex>
-                      <Spacer mb={3} />
+                      <Spacer mb={2} />
                       <Button
                         size="large"
                         width="100%"
@@ -119,6 +118,10 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                       >
                         Submit Order
                       </Button>
+                      <Spacer mb={2} />
+                      <Helper
+                        artworkId={order.lineItems.edges[0].node.artwork.id}
+                      />
                     </>
                   )}
                 </Flex>

--- a/src/Apps/Order/Routes/__tests__/Review.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.test.tsx
@@ -1,0 +1,47 @@
+import { mount } from "enzyme"
+import React from "react"
+
+import { IncompleteOrder } from "Apps/__test__/Fixtures/Order"
+import { TermsOfServiceCheckbox } from "Apps/Order/Components/TermsOfServiceCheckbox"
+import { Button } from "Styleguide/Elements/Button"
+import { Provider } from "unstated"
+import { ReviewRoute } from "../Review"
+
+jest.mock("react-relay", () => ({
+  createFragmentContainer: component => component,
+}))
+
+const pushMock = jest.fn()
+const defaultProps = {
+  order: { ...IncompleteOrder, id: "1234" },
+  router: {
+    push: pushMock,
+  },
+}
+
+describe("Review", () => {
+  const getWrapper = props => {
+    return mount(
+      <Provider>
+        <ReviewRoute {...props} />
+      </Provider>
+    )
+  }
+
+  it("disables the button while the terms are unchecked", () => {
+    const component = getWrapper(defaultProps)
+    expect(component.find(Button).props().disabled).toBe(true)
+    expect(pushMock).not.toBeCalled
+  })
+
+  it("enables the button while the terms are checked and routes to the payoff page", () => {
+    const component = getWrapper(defaultProps)
+    expect(component.find(Button).props().disabled).toBe(true)
+    component
+      .find(TermsOfServiceCheckbox)
+      .props()
+      .onSelect()
+    component.find(Button).simulate("click")
+    expect(pushMock).toBeCalledWith("/order2/1234/submission")
+  })
+})

--- a/src/Apps/Order/Routes/__tests__/Review.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from "enzyme"
 import React from "react"
 
-import { IncompleteOrder } from "Apps/__test__/Fixtures/Order"
+import { UntouchedOrder } from "Apps/__test__/Fixtures/Order"
 import { TermsOfServiceCheckbox } from "Apps/Order/Components/TermsOfServiceCheckbox"
 import { Button } from "Styleguide/Elements/Button"
 import { Provider } from "unstated"
@@ -13,7 +13,7 @@ jest.mock("react-relay", () => ({
 
 const pushMock = jest.fn()
 const defaultProps = {
-  order: { ...IncompleteOrder, id: "1234" },
+  order: { ...UntouchedOrder, id: "1234" },
   router: {
     push: pushMock,
   },

--- a/src/Components/Forms/OrderForm/Forms/ShippingForm.tsx
+++ b/src/Components/Forms/OrderForm/Forms/ShippingForm.tsx
@@ -51,7 +51,7 @@ export const ShippingForm: React.SFC<WizardStepChildProps> = ({
   )
 }
 
-// Imported in `PaymentForm` if addresss is different than shipping
+// Imported in `PaymentForm` if address is different than shipping
 export const AddressFormInputs = ({ billing = false }) => {
   return (
     <Fragment>

--- a/src/__generated__/Review_order.graphql.ts
+++ b/src/__generated__/Review_order.graphql.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
+import { ItemReview_artwork$ref } from "./ItemReview_artwork.graphql";
 import { TransactionSummary_order$ref } from "./TransactionSummary_order.graphql";
 declare const _Review_order$ref: unique symbol;
 export type Review_order$ref = typeof _Review_order$ref;
@@ -11,6 +12,7 @@ export type Review_order = {
             readonly node: ({
                 readonly artwork: ({
                     readonly id: string;
+                    readonly " $fragmentRefs": ItemReview_artwork$ref;
                 }) | null;
             }) | null;
         }) | null> | null;
@@ -82,6 +84,11 @@ return {
                   "selections": [
                     v0,
                     {
+                      "kind": "FragmentSpread",
+                      "name": "ItemReview_artwork",
+                      "args": null
+                    },
+                    {
                       "kind": "ScalarField",
                       "alias": null,
                       "name": "__id",
@@ -106,5 +113,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'c1dc19ff02dce4160669a3b0dca53952';
+(node as any).hash = '36a2475f6277e9d21295f00eae5a74fa';
 export default node;

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -30,6 +30,7 @@ fragment Review_order on Order {
       node {
         artwork {
           id
+          ...ItemReview_artwork
           __id
         }
         __id: id
@@ -38,6 +39,26 @@ fragment Review_order on Order {
   }
   ...TransactionSummary_order
   __id: id
+}
+
+fragment ItemReview_artwork on Artwork {
+  artist_names
+  title
+  date
+  medium
+  dimensions {
+    in
+    cm
+  }
+  attribution_class {
+    short_description
+  }
+  image {
+    resized(width: 185) {
+      url
+    }
+  }
+  __id
 }
 
 fragment TransactionSummary_order on Order {
@@ -103,7 +124,16 @@ v3 = {
   "args": null,
   "storageKey": null
 },
-v4 = {
+v4 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+],
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
@@ -115,7 +145,7 @@ return {
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  partner {\n    name\n    __id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  partner {\n    name\n    __id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -195,7 +225,6 @@ return {
                         "plural": false,
                         "selections": [
                           v3,
-                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -220,9 +249,52 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "shippingOrigin",
+                            "name": "medium",
                             "args": null,
                             "storageKey": null
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "dimensions",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "dimensions",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "in",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "cm",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "attribution_class",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "AttributionClass",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "short_description",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
                           },
                           {
                             "kind": "LinkedField",
@@ -233,6 +305,23 @@ return {
                             "concreteType": "Image",
                             "plural": false,
                             "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "resized",
+                                "storageKey": "resized(width:185)",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 185,
+                                    "type": "Int"
+                                  }
+                                ],
+                                "concreteType": "ResizedImageUrl",
+                                "plural": false,
+                                "selections": v4
+                              },
                               {
                                 "kind": "LinkedField",
                                 "alias": "resized_transactionSummary",
@@ -248,17 +337,17 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": [
-                                  {
-                                    "kind": "ScalarField",
-                                    "alias": null,
-                                    "name": "url",
-                                    "args": null,
-                                    "storageKey": null
-                                  }
-                                ]
+                                "selections": v4
                               }
                             ]
+                          },
+                          v5,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "shippingOrigin",
+                            "args": null,
+                            "storageKey": null
                           }
                         ]
                       },
@@ -313,7 +402,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v4
+              v5
             ]
           },
           v2


### PR DESCRIPTION
This starts to add components to the "review" page.

No major changes except the addition of a `TermsOfServiceCheckbox` which is different enough from the current one that we use in the auth modal that I thought it deserved its own.

![image](https://user-images.githubusercontent.com/2081340/44355251-1e881400-a47a-11e8-8fe1-570744d94c55.png)

I left the `Step Summary Item` placeholders there until https://artsyproduct.atlassian.net/browse/PURCHASE-384 is done!