### PR TITLE
Summary formatting issues

### DIFF
--- a/src/Apps/Order/Components/TransactionSummary.tsx
+++ b/src/Apps/Order/Components/TransactionSummary.tsx
@@ -1,4 +1,4 @@
-import { Serif } from "@artsy/palette"
+import { Serif, space } from "@artsy/palette"
 import { TransactionSummary_order } from "__generated__/TransactionSummary_order.graphql"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -31,6 +31,12 @@ export const TransactionSummary: React.SFC<TransactionSummaryProps> = ({
       resized_transactionSummary: { url: imageURL },
     },
   } = lineItems.edges[0].node.artwork
+  const truncateTextStyle = {
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    width: "100%",
+  } as any
 
   return (
     <Flex flexDirection="column" {...others}>
@@ -38,11 +44,24 @@ export const TransactionSummary: React.SFC<TransactionSummaryProps> = ({
         <Box height="auto">
           <Image src={imageURL} width="55px" mr={1} />
         </Box>
-        <Flex flexDirection="column">
-          <Serif size="2" weight="semibold" color="black60">
+        <Flex
+          flexDirection="column"
+          style={{ width: `calc(100% - 55px - ${space(1)}px)` }} // 55px for Image above, plus 1 for its mr.
+        >
+          <Serif
+            size="2"
+            weight="semibold"
+            color="black60"
+            style={truncateTextStyle}
+          >
             {artist_names}
           </Serif>
-          <div style={{ lineHeight: "1" }}>
+          <div
+            style={{
+              lineHeight: "1",
+              ...truncateTextStyle,
+            }}
+          >
             <Serif italic size="2" color="black60" display="inline">
               {title}
             </Serif>
@@ -50,7 +69,7 @@ export const TransactionSummary: React.SFC<TransactionSummaryProps> = ({
               {date && `, ${date}`}
             </Serif>
           </div>
-          <Serif size="2" color="black60">
+          <Serif size="2" color="black60" style={truncateTextStyle}>
             {name}
           </Serif>
           <Serif size="2" color="black60">

--- a/src/Apps/Order/Components/TransactionSummary.tsx
+++ b/src/Apps/Order/Components/TransactionSummary.tsx
@@ -1,4 +1,4 @@
-import { Serif, space } from "@artsy/palette"
+import { Serif } from "@artsy/palette"
 import { TransactionSummary_order } from "__generated__/TransactionSummary_order.graphql"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -35,7 +35,6 @@ export const TransactionSummary: React.SFC<TransactionSummaryProps> = ({
     whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis",
-    width: "100%",
   } as any
 
   return (
@@ -44,10 +43,7 @@ export const TransactionSummary: React.SFC<TransactionSummaryProps> = ({
         <Box height="auto">
           <Image src={imageURL} width="55px" mr={1} />
         </Box>
-        <Flex
-          flexDirection="column"
-          style={{ width: `calc(100% - 55px - ${space(1)}px)` }} // 55px for Image above, plus 1 for its mr.
-        >
+        <Flex flexDirection="column" style={{ overflow: "hidden" }}>
           <Serif
             size="2"
             weight="semibold"

--- a/src/Apps/Order/Components/__stories__/TransactionSummary.story.tsx
+++ b/src/Apps/Order/Components/__stories__/TransactionSummary.story.tsx
@@ -4,9 +4,29 @@ import { storiesOf } from "storybook/storiesOf"
 import { Flex } from "Styleguide/Elements/Flex"
 import { Section } from "Styleguide/Utils/Section"
 
-storiesOf("Apps/Order Page/Components", module).add(
-  "TransactionSummary",
-  () => {
+const makeLineItem = ({ artistName, artworkTitle }) => ({
+  edges: [
+    {
+      node: {
+        artwork: {
+          artist_names: artistName,
+          title: artworkTitle,
+          date: "2018",
+          shippingOrigin: "New York, NY",
+          image: {
+            resized_transactionSummary: {
+              url:
+                "https://d32dm0rphc51dk.cloudfront.net/SCShf97jlpFZpDBJUBqntg/small.jpg",
+            },
+          },
+        },
+      },
+    },
+  ],
+})
+
+storiesOf("Apps/Order Page/Components", module)
+  .add("TransactionSummary", () => {
     return (
       <Section title="Transaction Summary">
         <Flex width={280} flexDirection="column">
@@ -17,26 +37,10 @@ storiesOf("Apps/Order Page/Components", module).add(
               shippingTotal: "£132.32",
               taxTotal: "£232.23",
               buyerTotal: "£1,200,823.33",
-              lineItems: {
-                edges: [
-                  {
-                    node: {
-                      artwork: {
-                        artist_names: "Francesca DiMattio",
-                        title: "The Fox and the Hound",
-                        date: "2018",
-                        shippingOrigin: "New York, NY",
-                        image: {
-                          resized_transactionSummary: {
-                            url:
-                              "https://d32dm0rphc51dk.cloudfront.net/SCShf97jlpFZpDBJUBqntg/small.jpg",
-                          },
-                        },
-                      },
-                    },
-                  },
-                ],
-              },
+              lineItems: makeLineItem({
+                artistName: "Francesca DiMattio",
+                artworkTitle: "The Fox",
+              }) as any,
               partner: {
                 name: "Salon 94",
               },
@@ -45,5 +49,26 @@ storiesOf("Apps/Order Page/Components", module).add(
         </Flex>
       </Section>
     )
-  }
-)
+  })
+  .add("TransactionSummary (with long titles)", () => (
+    <Section title="Transaction Summary">
+      <Flex width={280} flexDirection="column">
+        <TransactionSummary
+          order={{
+            " $refType": null,
+            itemsTotal: "£3,024.89",
+            shippingTotal: "£132.32",
+            taxTotal: "£232.23",
+            buyerTotal: "£1,200,823.33",
+            lineItems: makeLineItem({
+              artistName: "Francesca DiMattio and Orta Theroxicus",
+              artworkTitle: "Some quite long title you know how artists can be",
+            }) as any,
+            partner: {
+              name: "Salon Nineteen Eighty Four and Three Quarters",
+            },
+          }}
+        />
+      </Flex>
+    </Section>
+  ))


### PR DESCRIPTION
Fixes [PURCHASE-372](
https://artsyproduct.atlassian.net/browse/PURCHASE-372), which had the following requirements:

- Artist name should be displayed, truncated if longer than one line with …
- Title should be italicized, year should not be, whole title should be truncated if longer than one line with …
- Seller/partner should be displayed, truncated if longer than one line with …

I [clarified with Brian on Slack](https://artsy.slack.com/archives/C9YNS4X32/p1534788907000100) about how truncation works. Here's the what it looks like:

| Mobile  | Desktop |
|---|---|
|  <img width="309" alt="screen shot 2018-08-20 at 3 01 48 pm" src="https://user-images.githubusercontent.com/498212/44361116-e9d08880-a48a-11e8-9bdc-e1563c0b8f79.png"> | <img width="306" alt="screen shot 2018-08-20 at 3 02 03 pm" src="https://user-images.githubusercontent.com/498212/44361126-f1902d00-a48a-11e8-8523-624bd8a79c27.png">  |


And in context:

<img width="1095" alt="screen shot 2018-08-20 at 3 11 20 pm" src="https://user-images.githubusercontent.com/498212/44361270-56e41e00-a48b-11e8-9e67-51a9ab9cccbb.png">

I wasn't sure quite the best way to do this, please let me know if there's a better way. I added a storybook entry for long-titles to test.