### PR TITLE
Navigates to payment after shipment step

### DIFF
--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -32,7 +32,8 @@ describe("Shipping", () => {
       relay: {
         environment: {},
       } as RelayProp,
-    }
+      router: { push: jest.fn() },
+    } as any
   })
 
   it("commits the mutation with the orderId", () => {
@@ -77,5 +78,37 @@ describe("Shipping", () => {
     component.find(Button).simulate("click")
 
     expect.hasAssertions()
+  })
+
+  describe("mutation", () => {
+    it("routes to payment screen after mutation completes", () => {
+      const component = getWrapper(props)
+      const mockCommitMutation = commitMutation as jest.Mock<any>
+      mockCommitMutation.mockImplementationOnce(
+        (_environment, { onCompleted }) => {
+          onCompleted()
+        }
+      )
+
+      component.find(Button).simulate("click")
+
+      expect(props.router.push).toHaveBeenCalledWith("/order2/1234/payment")
+    })
+
+    it("shows the button spinner while loading the mutation", () => {
+      const component = getWrapper(props)
+      const mockCommitMutation = commitMutation as jest.Mock<any>
+      mockCommitMutation.mockImplementationOnce(() => {
+        const buttonProps = component
+          .update() // We need to wait for the component to re-render
+          .find(Button)
+          .props() as any
+        expect(buttonProps.loading).toBeTruthy()
+      })
+
+      component.find(Button).simulate("click")
+
+      expect.hasAssertions()
+    })
   })
 })


### PR DESCRIPTION
This PR moves the user to the payment step after the mutation for setting the payment has returned. I made the button show a spinner while the mutation was happening as well, and left a note about error-handling that we can tackle later on.

![2018-08-20 15_54_56](https://user-images.githubusercontent.com/498212/44364316-a2e79080-a494-11e8-8fc2-1433e84220a3.gif)

I ran into an interesting problem with Enzyme and found this comment really helpful: https://github.com/airbnb/enzyme/issues/1153#issuecomment-394951184 I have a better understanding of how Enzyme works with the React component lifecycle now.

Fixes [PURCHASE-383](
https://artsyproduct.atlassian.net/browse/PURCHASE-383).