### PR TITLE
@xtina-starr => [FIX display] do not resize video assets

### DIFF
--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -367,7 +367,10 @@ export class DisplayPanel extends Component<
     const url = get(unit.assets, "0.url", "")
     const isVideo = this.isVideo()
     const cover = unit.cover_image_url || ""
-    const imageUrl = crop(url, { width: 680, height: 284, isDisplayAd: true })
+
+    const imageUrl = isVideo
+      ? url
+      : crop(url, { width: 680, height: 284, isDisplayAd: true })
     const hoverImageUrl = resize(unit.logo, { width: 680, isDisplayAd: true })
     const coverUrl = crop(cover, { width: 680, height: 284, isDisplayAd: true })
 

--- a/src/Components/Publishing/Display/__tests__/DisplayPanel.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayPanel.test.tsx
@@ -34,7 +34,7 @@ describe("units", () => {
     let unit = props.unit || UnitPanel
 
     if (isVideo) {
-      unit = cloneDeep(UnitPanel)
+      unit = cloneDeep(UnitPanelVideo)
       unit.assets[0].url = "foo.mp4"
     }
 
@@ -468,10 +468,22 @@ describe("units", () => {
       const wrapper = getWrapper({ isVideo: true })
       expect(wrapper.find("video").length).toEqual(1)
     })
+
+    it("Returns original URL if video asset", () => {
+      const wrapper = getWrapper({ isVideo: true })
+      expect(wrapper.find("video").props().src).toBe("foo.mp4")
+    })
   })
 
   it("renders an image", () => {
     const wrapper = getWrapper()
     expect(wrapper.find("Image").length).toEqual(1)
+  })
+
+  it("Returns resized cloudfront URL if image asset", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.find("DisplayPanelContainer").props().imageUrl).toMatch(
+      "cloudfront"
+    )
   })
 })

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayPanel.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`snapshots renders the display panel with video 1`] = `
 }
 
 .c1 .c3 {
-  background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlHEsRROMLasYi9yZtgTR7A%252Fbombay_artsy_panel_640_28_480.mp4&width=680&height=284&quality=95) no-repeat center center;
+  background: url(https://artsy-media-uploads.s3.amazonaws.com/lHEsRROMLasYi9yZtgTR7A%2Fbombay_artsy_panel_640_28_480.mp4) no-repeat center center;
   background-size: cover;
 }
 


### PR DESCRIPTION
Pair sesh with @l2succes 
Checks if asset url is a video before calling gemini, should return original url for video and resized url for image. 

Fixes:
https://artsyproduct.atlassian.net/browse/GROW-859