### PR TITLE
Adds a tslint rule for unmocking when doing tests with tracking

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
   "rules": {
+    "no-import-un-mocked": true,
     "curly": false,
     "interface-name": [true, "never-prefix"],
     "jsx-boolean-value": [true, "never"],
@@ -16,5 +17,6 @@
     "no-namespace": [true, "allow-declarations"],
     "trailing-comma": false,
     "variable-name": [true, "ban-keywords", "allow-leading-underscore"]
-  }
+  },
+  "rulesDirectory": ["tslint"]
 }

--- a/tslint/README.md
+++ b/tslint/README.md
@@ -1,0 +1,19 @@
+## Steps to adding a custom TSLint rule
+
+1.  Make a new file, the name is important, it must be camel-case and not a `.ts` file.
+1.  You will need to convert your camelCase name to kebab-case and add it to the [`tslint.json`](../tslint.json)
+
+    E.g. `noDoingAnythingRule.js` -> `no-doing-anything` and:
+
+    ```diff
+    {
+      "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
+      "rules": {
+        "no-import-un-mocked": true,
+    +    "no-doing-anything": true,
+        "curly": false,
+        ...
+    ```
+
+1.  You want to export a class called `Rule` that lints your file, this is what it used on the file.
+1.  Ideally you can do simple string matching like in [`noImportUnMockedRule.js`](./noImportUnMockedRule.js) - but if not, study how to make an [AST walker here](https://palantir.github.io/tslint/develop/custom-rules/)

--- a/tslint/noImportUnMockedRule.js
+++ b/tslint/noImportUnMockedRule.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+const Lint = require("tslint")
+const ts = require("typescript")
+
+class Rule extends Lint.Rules.AbstractRule {
+  /**
+   * @param {ts.SourceFile} sourceFile
+   */
+  apply(sourceFile) {
+    // Test files only
+    if (!sourceFile.fileName.includes(".test")) {
+      return []
+    }
+    // Does it include mockTracking but not un-mock react-tracking?
+    if (
+      sourceFile.text.includes("mockTracking") &&
+      !sourceFile.text.includes(`jest.unmock("react-tracking")`)
+    ) {
+      // Offer a fix-it, and show a message.
+      const message =
+        "You need to un-mock react-tracking if you are using mockTracking in this file."
+      const fix = new Lint.Fix("fix-tracking", [
+        new Lint.Replacement(0, 0, `jest.unmock("react-tracking")\n`),
+      ])
+
+      return [new Lint.RuleFailure(sourceFile, 0, 0, message, "tracking", fix)]
+    }
+
+    return []
+  }
+}
+
+module.exports = { Rule: Rule }


### PR DESCRIPTION
We've talked about doing these before, but me and @ansor4 wasted a bunch of time on something we can easily make a linter rule for - so this fixes #1172 and now we have at least one custom lint rule, so the next ones are much easier to write.

Making the rules is simple, and I added docs so it's easy for the next person.

![akjsbndfak 2018-08-22 20_04_55](https://user-images.githubusercontent.com/49038/44497323-aa4e9b80-a646-11e8-9407-adfe944c4a53.gif)

🎉 