### PR TITLE
@l2succes: adds analytics for mobile auth cta

### DIFF
--- a/src/Artsy/Analytics/Schema/Interaction.ts
+++ b/src/Artsy/Analytics/Schema/Interaction.ts
@@ -8,7 +8,7 @@ import { ActionName, ActionType } from "./Values"
  * Some actions lead to results, such as following an artist, in which case the
  * action name is used to tie the interaction and result events together.
  */
-export interface BaseInteraction {
+export interface Interaction {
   /**
    * The type of interaction that this event represents. E.g. `Click`.
    *
@@ -36,7 +36,7 @@ export interface BaseInteraction {
   destination_path?: string
 }
 
-export interface AuthInteraction {
+export interface AuthenticationInteraction extends Interaction {
   /*
   * The action taken that prompted user to signup or login.
   */
@@ -52,5 +52,3 @@ export interface AuthInteraction {
   */
   trigger?: string
 }
-
-export type Interaction = BaseInteraction & AuthInteraction

--- a/src/Artsy/Analytics/Schema/Interaction.ts
+++ b/src/Artsy/Analytics/Schema/Interaction.ts
@@ -8,7 +8,7 @@ import { ActionName, ActionType } from "./Values"
  * Some actions lead to results, such as following an artist, in which case the
  * action name is used to tie the interaction and result events together.
  */
-export interface Interaction {
+export interface BaseInteraction {
   /**
    * The type of interaction that this event represents. E.g. `Click`.
    *
@@ -35,3 +35,22 @@ export interface Interaction {
    */
   destination_path?: string
 }
+
+export interface AuthInteraction {
+  /*
+  * The action taken that prompted user to signup or login.
+  */
+  intent?: string
+
+  /*
+  * Flow
+  */
+  flow?: string
+
+  /*
+  *  The type of action that triggered the modal (eg: click, timed)
+  */
+  trigger?: string
+}
+
+export type Interaction = BaseInteraction & AuthInteraction

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -56,6 +56,7 @@ export enum ActionType {
   /**
    * A UI element was rendered in the viewport
    */
+  AuthImpression = "Auth impression",
   Impression = "Impression",
 
   /**
@@ -73,6 +74,12 @@ export enum ActionName {
    */
   ArtistFollow = "artistFollow",
   ArtistUnfollow = "artistUnfollow",
+
+  /**
+   * Authentication
+   */
+  ViewEditorial = "viewed editorial",
+  Dismiss = "dismiss",
 
   /**
    * Gene Page
@@ -156,4 +163,9 @@ export enum Context {
   FurtherReading = "Further reading",
   ReadMore = "Read more",
   RelatedArticles = "Related articles",
+
+  /**
+   * Authentication modal
+   */
+  MinimalCtaBanner = "MinimalCtaBanner",
 }

--- a/src/Artsy/Analytics/Schema/index.ts
+++ b/src/Artsy/Analytics/Schema/index.ts
@@ -15,10 +15,11 @@ export * from "./Values"
 
 import { ContextModule } from "./ContextModule"
 import { ContextPage } from "./ContextPage"
-import { Interaction } from "./Interaction"
+import { AuthenticationInteraction, Interaction } from "./Interaction"
 import { Failure, Success } from "./Result"
 
 export type Trackables =
+  | AuthenticationInteraction
   | ContextModule
   | ContextPage
   | Interaction

--- a/src/Components/MinimalCtaBanner.tsx
+++ b/src/Components/MinimalCtaBanner.tsx
@@ -12,7 +12,6 @@ export interface MinimalCtaBannerProps extends React.Props<HTMLDivElement> {
   height?: string
   href?: string
   position: "top" | "bottom"
-  tracking?: any
   textColor?: string
   show?: boolean
 }
@@ -44,7 +43,7 @@ export class MinimalCtaBanner extends React.Component<
     action_name: Schema.ActionName.Dismiss,
     subject: "dismiss auth banner for editorial cta on mobile",
     intent: Schema.ActionName.ViewEditorial,
-    flow: "auth",
+    flow: "authentication",
   })
   dismissCta() {
     this.setState({ dismissed: true })

--- a/src/Components/MinimalCtaBanner.tsx
+++ b/src/Components/MinimalCtaBanner.tsx
@@ -1,6 +1,8 @@
 import { Sans } from "@artsy/palette"
 import React from "react"
+import track from "react-tracking"
 import styled from "styled-components"
+import Events from "Utils/Events"
 import SlideTransition from "./Animation/SlideTransition"
 import Icon from "./Icon"
 
@@ -10,6 +12,7 @@ export interface MinimalCtaBannerProps extends React.Props<HTMLDivElement> {
   height?: string
   href?: string
   position: "top" | "bottom"
+  tracking?: any
   textColor?: string
   show?: boolean
 }
@@ -18,6 +21,7 @@ export interface State {
   dismissed: boolean
 }
 
+@track({}, { dispatch: data => Events.postEvent(data) })
 export class MinimalCtaBanner extends React.Component<
   MinimalCtaBannerProps,
   State
@@ -26,7 +30,27 @@ export class MinimalCtaBanner extends React.Component<
     dismissed: false,
   }
 
+  componentDidMount() {
+    if (this.props.tracking) {
+      this.props.tracking.trackEvent({
+        action: "Auth impression",
+        trigger: "click",
+        context_module: "auth minimal cta banner",
+      })
+    }
+  }
+
   dismissCta = () => {
+    if (this.props.tracking) {
+      this.props.tracking.trackEvent({
+        action: "Click",
+        type: "dismiss",
+        intent: "viewed editorial",
+        label: "dismiss auth banner",
+        flow: "auth",
+      })
+    }
+
     this.setState({ dismissed: true })
   }
 

--- a/src/Components/MinimalCtaBanner.tsx
+++ b/src/Components/MinimalCtaBanner.tsx
@@ -32,7 +32,8 @@ export class MinimalCtaBanner extends React.Component<
 
   @track({
     action_type: Schema.ActionType.AuthImpression,
-    action_name: Schema.ActionName.ViewEditorial,
+    intent: Schema.ActionName.ViewEditorial,
+    trigger: "click",
   })
   componentDidMount() {
     // no op
@@ -41,7 +42,9 @@ export class MinimalCtaBanner extends React.Component<
   @track({
     action_type: Schema.ActionType.Click,
     action_name: Schema.ActionName.Dismiss,
-    subject: "dismiss auth banner",
+    subject: "dismiss auth banner for editorial cta on mobile",
+    intent: Schema.ActionName.ViewEditorial,
+    flow: "auth",
   })
   dismissCta() {
     this.setState({ dismissed: true })

--- a/src/Components/MinimalCtaBanner.tsx
+++ b/src/Components/MinimalCtaBanner.tsx
@@ -1,8 +1,8 @@
 import { Sans } from "@artsy/palette"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import React from "react"
-import track from "react-tracking"
 import styled from "styled-components"
-import Events from "Utils/Events"
 import SlideTransition from "./Animation/SlideTransition"
 import Icon from "./Icon"
 
@@ -21,7 +21,7 @@ export interface State {
   dismissed: boolean
 }
 
-@track({}, { dispatch: data => Events.postEvent(data) })
+@track({ context_module: Schema.Context.MinimalCtaBanner })
 export class MinimalCtaBanner extends React.Component<
   MinimalCtaBannerProps,
   State
@@ -30,27 +30,20 @@ export class MinimalCtaBanner extends React.Component<
     dismissed: false,
   }
 
+  @track({
+    action_type: Schema.ActionType.AuthImpression,
+    action_name: Schema.ActionName.ViewEditorial,
+  })
   componentDidMount() {
-    if (this.props.tracking) {
-      this.props.tracking.trackEvent({
-        action: "Auth impression",
-        trigger: "click",
-        context_module: "auth minimal cta banner",
-      })
-    }
+    // no op
   }
 
-  dismissCta = () => {
-    if (this.props.tracking) {
-      this.props.tracking.trackEvent({
-        action: "Click",
-        type: "dismiss",
-        intent: "viewed editorial",
-        label: "dismiss auth banner",
-        flow: "auth",
-      })
-    }
-
+  @track({
+    action_type: Schema.ActionType.Click,
+    action_name: Schema.ActionName.Dismiss,
+    subject: "dismiss auth banner",
+  })
+  dismissCta() {
     this.setState({ dismissed: true })
   }
 
@@ -71,7 +64,7 @@ export class MinimalCtaBanner extends React.Component<
                 <p>{this.props.copy}</p>
               </Sans>
             </a>
-            <IconContainer onClick={this.dismissCta as any}>
+            <IconContainer onClick={this.dismissCta.bind(this) as any}>
               <Icon name="close" color={this.props.textColor} fontSize="16px" />
             </IconContainer>
           </Banner>

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -135,7 +135,9 @@ export class Article extends React.Component<ArticleProps, State> {
         {this.getArticleLayout()}
         {this.shouldRenderSignUpCta() && (
           <MinimalCtaBanner
-            href={`/sign_up?redirect-to=${getArticleFullHref(slug)}`}
+            href={`/sign_up?intent=viewed+editorial&trigger=click&contextModule=auth+minimal+cta+banner&redirect-to=${getArticleFullHref(
+              slug
+            )}`}
             height="55px"
             copy={copy}
             position="bottom"

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -1,3 +1,4 @@
+import qs from "querystring"
 import React from "react"
 import track from "react-tracking"
 import Events from "../../Utils/Events"
@@ -135,9 +136,12 @@ export class Article extends React.Component<ArticleProps, State> {
         {this.getArticleLayout()}
         {this.shouldRenderSignUpCta() && (
           <MinimalCtaBanner
-            href={`/sign_up?intent=viewed+editorial&trigger=click&contextModule=auth+minimal+cta+banner&redirect-to=${getArticleFullHref(
-              slug
-            )}`}
+            href={`/sign_up?${qs.stringify({
+              intent: "viewed editorial",
+              trigger: "click",
+              contextModule: "auth minimal cta banner",
+              "redirect-to": getArticleFullHref(slug),
+            })}`}
             height="55px"
             copy={copy}
             position="bottom"


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-880.

Adds analytics events:
- Auth impression when the cta banner is displayed
- Click event for when the user dismiss the cta banner
- Passes analytic properties to auth sign up modal
