### PR TITLE
Replace shipping review with actual component

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -1,6 +1,7 @@
 import { Review_order } from "__generated__/Review_order.graphql"
 import { BuyNowStepper } from "Apps/Order/Components/BuyNowStepper"
 import { ItemReviewFragmentContainer as ItemReview } from "Apps/Order/Components/ItemReview"
+import { ShippingAndPaymentReviewFragmentContainer as ShippingAndPaymentReview } from "Apps/Order/Components/ShippingAndPaymentReview"
 import { TermsOfServiceCheckbox } from "Apps/Order/Components/TermsOfServiceCheckbox"
 import { Router } from "found"
 import React, { Component } from "react"
@@ -10,7 +11,6 @@ import { Flex } from "Styleguide/Elements/Flex"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { Join } from "Styleguide/Elements/Join"
 import { Spacer } from "Styleguide/Elements/Spacer"
-import { Placeholder } from "Styleguide/Utils/Placeholder"
 import { Responsive } from "Utils/Responsive"
 import { Helper } from "../../Components/Helper"
 import { TransactionSummaryFragmentContainer as TransactionSummary } from "../../Components/TransactionSummary"
@@ -43,6 +43,14 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
     this.props.router.push(`/order2/${this.props.order.id}/status`)
   }
 
+  onChangePayment() {
+    console.log("Clicked to change payment")
+  }
+
+  onChangeShipping() {
+    console.log("Clicked to change shipping")
+  }
+
   render() {
     const { order } = this.props
     const { termsCheckboxSelected } = this.state
@@ -63,8 +71,12 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               Content={
                 <>
                   <Join separator={<Spacer mb={3} />}>
-                    <Placeholder height="68px" name="Step summary item" />
-                    <Placeholder height="68px" name="Step summary item" />
+                    <ShippingAndPaymentReview
+                      order={order}
+                      onChangePayment={this.onChangePayment}
+                      onChangeShipping={this.onChangeShipping}
+                      mb={xs ? 2 : 3}
+                    />
 
                     {!xs && (
                       <>
@@ -150,6 +162,7 @@ export const ReviewFragmentContainer = createFragmentContainer(
         }
       }
       ...TransactionSummary_order
+      ...ShippingAndPaymentReview_order
     }
   `
 )

--- a/src/__generated__/Review_order.graphql.ts
+++ b/src/__generated__/Review_order.graphql.ts
@@ -2,6 +2,7 @@
 
 import { ConcreteFragment } from "relay-runtime";
 import { ItemReview_artwork$ref } from "./ItemReview_artwork.graphql";
+import { ShippingAndPaymentReview_order$ref } from "./ShippingAndPaymentReview_order.graphql";
 import { TransactionSummary_order$ref } from "./TransactionSummary_order.graphql";
 declare const _Review_order$ref: unique symbol;
 export type Review_order$ref = typeof _Review_order$ref;
@@ -17,7 +18,7 @@ export type Review_order = {
             }) | null;
         }) | null> | null;
     }) | null;
-    readonly " $fragmentRefs": TransactionSummary_order$ref;
+    readonly " $fragmentRefs": TransactionSummary_order$ref & ShippingAndPaymentReview_order$ref;
     readonly " $refType": Review_order$ref;
 };
 
@@ -109,9 +110,14 @@ return {
       "name": "TransactionSummary_order",
       "args": null
     },
+    {
+      "kind": "FragmentSpread",
+      "name": "ShippingAndPaymentReview_order",
+      "args": null
+    },
     v1
   ]
 };
 })();
-(node as any).hash = '36a2475f6277e9d21295f00eae5a74fa';
+(node as any).hash = 'df52d5788d78942fe9c4ff41f50c9192';
 export default node;

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -42,6 +42,7 @@ fragment Review_order on Order {
     }
   }
   ...TransactionSummary_order
+  ...ShippingAndPaymentReview_order
   __id: id
 }
 
@@ -95,6 +96,35 @@ fragment TransactionSummary_order on Order {
   }
   __id: id
 }
+
+fragment ShippingAndPaymentReview_order on Order {
+  fulfillmentType
+  shippingName
+  shippingAddressLine1
+  shippingAddressLine2
+  shippingCity
+  shippingPostalCode
+  shippingRegion
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          __id
+        }
+        __id: id
+      }
+    }
+  }
+  creditCard {
+    brand
+    last_digits
+    expiration_year
+    expiration_month
+    __id
+  }
+  __id: id
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -128,7 +158,14 @@ v3 = {
   "args": null,
   "storageKey": null
 },
-v4 = [
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -136,20 +173,13 @@ v4 = [
     "args": null,
     "storageKey": null
   }
-],
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-};
+];
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  partner {\n    name\n    __id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  partner {\n    name\n    __id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  fulfillmentType\n  shippingName\n  shippingAddressLine1\n  shippingAddressLine2\n  shippingCity\n  shippingPostalCode\n  shippingRegion\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -191,7 +221,62 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "fulfillmentType",
+            "args": null,
+            "storageKey": null
+          },
           v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingTotal",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "taxTotal",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "itemsTotal",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "buyerTotal",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "name",
+                "args": null,
+                "storageKey": null
+              },
+              v4
+            ]
+          },
+          v2,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -324,7 +409,7 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v4
+                                "selections": v5
                               },
                               {
                                 "kind": "LinkedField",
@@ -341,11 +426,11 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v4
+                                "selections": v5
                               }
                             ]
                           },
-                          v5,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -365,51 +450,85 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "shippingTotal",
+            "name": "shippingName",
             "args": null,
             "storageKey": null
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "taxTotal",
+            "name": "shippingAddressLine1",
             "args": null,
             "storageKey": null
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "itemsTotal",
+            "name": "shippingAddressLine2",
             "args": null,
             "storageKey": null
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "buyerTotal",
+            "name": "shippingCity",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingPostalCode",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingRegion",
             "args": null,
             "storageKey": null
           },
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "partner",
+            "name": "creditCard",
             "storageKey": null,
             "args": null,
-            "concreteType": "Partner",
+            "concreteType": "CreditCard",
             "plural": false,
             "selections": [
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "name",
+                "name": "brand",
                 "args": null,
                 "storageKey": null
               },
-              v5
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "last_digits",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_year",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_month",
+                "args": null,
+                "storageKey": null
+              },
+              v4
             ]
-          },
-          v2
+          }
         ]
       }
     ]


### PR DESCRIPTION
This is minor but finishes up: https://artsyproduct.atlassian.net/browse/PURCHASE-386

I made a follow-up ticket to replace the region code (i.e. "US") with the actual country name ("United States"), but it seems like that should wait until we've finished updating the schema. (That's here: https://artsyproduct.atlassian.net/browse/PURCHASE-421)