### PR TITLE
Removes extraneous fragment spreading

### DIFF
--- a/src/Apps/Order/Components/ShippingAndPaymentReview.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentReview.tsx
@@ -22,7 +22,11 @@ export const ShippingAndPaymentReview = ({
   onChangeShipping(): void
 } & FlexProps) => (
   <Flex flexDirection="column" {...others}>
-    {__typename === "Pickup" ? (
+    {__typename === "Ship" ? (
+      <StepSummaryItem onChange={onChangeShipping} title="Shipping address">
+        <ShippingAddress {...address as ShippingAddressProps} />
+      </StepSummaryItem>
+    ) : (
       <StepSummaryItem
         onChange={onChangeShipping}
         title={<>Pick up ({lineItems.edges[0].node.artwork.shippingOrigin})</>}
@@ -31,10 +35,6 @@ export const ShippingAndPaymentReview = ({
           After you place your order, you’ll be appointed an Artsy specialist
           within 2 business days to handle pickup logistics.
         </Sans>
-      </StepSummaryItem>
-    ) : (
-      <StepSummaryItem onChange={onChangeShipping} title="Shipping address">
-        <ShippingAddress {...address as ShippingAddressProps} />
       </StepSummaryItem>
     )}
     <StepSummaryItem onChange={onChangePayment} title="Payment method">
@@ -49,9 +49,6 @@ export const ShippingAndPaymentReviewFragmentContainer = createFragmentContainer
     fragment ShippingAndPaymentReview_order on Order {
       requestedFulfillment {
         __typename
-        ... on Pickup {
-          fulfillmentType
-        }
         ... on Ship {
           name
           addressLine1

--- a/src/Apps/Order/Components/ShippingAndPaymentSummary.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentSummary.tsx
@@ -18,7 +18,11 @@ export const ShippingAndPaymentSummary = ({
   order: ShippingAndPaymentSummary_order
 } & FlexProps) => (
   <Flex flexDirection="column" {...others}>
-    {__typename === "Pickup" ? (
+    {__typename === "Ship" ? (
+      <StepSummaryItem title="Ship to">
+        <ShippingAddress {...address as ShippingAddressProps} />
+      </StepSummaryItem>
+    ) : (
       <StepSummaryItem
         title={<>Pick up ({lineItems.edges[0].node.artwork.shippingOrigin})</>}
       >
@@ -26,10 +30,6 @@ export const ShippingAndPaymentSummary = ({
           You’ll be appointed an Artsy specialist within 2 business days to
           handle pickup logistics.
         </Serif>
-      </StepSummaryItem>
-    ) : (
-      <StepSummaryItem title="Ship to">
-        <ShippingAddress {...address as ShippingAddressProps} />
       </StepSummaryItem>
     )}
     <StepSummaryItem>
@@ -44,9 +44,6 @@ export const ShippingAndPaymentSummaryFragmentContainer = createFragmentContaine
     fragment ShippingAndPaymentSummary_order on Order {
       requestedFulfillment {
         __typename
-        ... on Pickup {
-          fulfillmentType
-        }
         ... on Ship {
           name
           addressLine1

--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -47,8 +47,7 @@ storiesOf("Apps/Order Page/Components", module).add(
               order={{
                 ...order,
                 requestedFulfillment: {
-                  __typename: "Pickup",
-                  fulfillmentType: "pickup",
+                  __typename: "%other",
                 },
               }}
             />
@@ -71,8 +70,7 @@ storiesOf("Apps/Order Page/Components", module).add(
               order={{
                 ...order,
                 requestedFulfillment: {
-                  __typename: "Pickup",
-                  fulfillmentType: "pickup",
+                  __typename: "%other",
                 },
               }}
             />

--- a/src/Apps/__test__/Fixtures/Order.ts
+++ b/src/Apps/__test__/Fixtures/Order.ts
@@ -6,8 +6,7 @@ export const UntouchedOrder = {
   taxTotal: null,
   buyerTotal: "$12,000",
   requestedFulfillment: {
-    __typename: "Pickup",
-    fulfillmentType: "pickup",
+    __typename: "%other",
   },
   lineItems: {
     edges: [

--- a/src/__generated__/ShippingAndPaymentReview_order.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentReview_order.graphql.ts
@@ -5,9 +5,6 @@ declare const _ShippingAndPaymentReview_order$ref: unique symbol;
 export type ShippingAndPaymentReview_order$ref = typeof _ShippingAndPaymentReview_order$ref;
 export type ShippingAndPaymentReview_order = {
     readonly requestedFulfillment: ({
-        readonly __typename: "Pickup";
-        readonly fulfillmentType: string | null;
-    } | {
         readonly __typename: "Ship";
         readonly name: string | null;
         readonly addressLine1: string | null;
@@ -125,19 +122,6 @@ return {
               "storageKey": null
             }
           ]
-        },
-        {
-          "kind": "InlineFragment",
-          "type": "Pickup",
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "fulfillmentType",
-              "args": null,
-              "storageKey": null
-            }
-          ]
         }
       ]
     },
@@ -238,5 +222,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'ff8b0587a4fd62eac9130a404316ab12';
+(node as any).hash = '5cedddcabb93383a1e506b265d4468b9';
 export default node;

--- a/src/__generated__/ShippingAndPaymentSummary_order.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentSummary_order.graphql.ts
@@ -5,9 +5,6 @@ declare const _ShippingAndPaymentSummary_order$ref: unique symbol;
 export type ShippingAndPaymentSummary_order$ref = typeof _ShippingAndPaymentSummary_order$ref;
 export type ShippingAndPaymentSummary_order = {
     readonly requestedFulfillment: ({
-        readonly __typename: "Pickup";
-        readonly fulfillmentType: string | null;
-    } | {
         readonly __typename: "Ship";
         readonly name: string | null;
         readonly addressLine1: string | null;
@@ -125,19 +122,6 @@ return {
               "storageKey": null
             }
           ]
-        },
-        {
-          "kind": "InlineFragment",
-          "type": "Pickup",
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "fulfillmentType",
-              "args": null,
-              "storageKey": null
-            }
-          ]
         }
       ]
     },
@@ -238,5 +222,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'f31550d4edde35f5f432b06b4ea29de1';
+(node as any).hash = '8aa1d8b313a6cb85a539e4d9453444ce';
 export default node;

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -108,9 +108,6 @@ fragment TransactionSummary_order on Order {
 fragment ShippingAndPaymentReview_order on Order {
   requestedFulfillment {
     __typename
-    ... on Pickup {
-      fulfillmentType
-    }
     ... on Ship {
       name
       addressLine1
@@ -208,7 +205,7 @@ return {
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Pickup {\n      fulfillmentType\n    }\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -517,19 +514,6 @@ return {
                     "kind": "ScalarField",
                     "alias": null,
                     "name": "region",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
-              {
-                "kind": "InlineFragment",
-                "type": "Pickup",
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "fulfillmentType",
                     "args": null,
                     "storageKey": null
                   }

--- a/src/__generated__/routes_StatusQuery.graphql.ts
+++ b/src/__generated__/routes_StatusQuery.graphql.ts
@@ -89,9 +89,6 @@ fragment TransactionSummary_order on Order {
 fragment ShippingAndPaymentSummary_order on Order {
   requestedFulfillment {
     __typename
-    ... on Pickup {
-      fulfillmentType
-    }
     ... on Ship {
       name
       addressLine1
@@ -209,7 +206,7 @@ return {
   "operationKind": "query",
   "name": "routes_StatusQuery",
   "id": null,
-  "text": "query routes_StatusQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Pickup {\n      fulfillmentType\n    }\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
+  "text": "query routes_StatusQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -525,19 +522,6 @@ return {
                     "kind": "ScalarField",
                     "alias": null,
                     "name": "region",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
-              {
-                "kind": "InlineFragment",
-                "type": "Pickup",
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "fulfillmentType",
                     "args": null,
                     "storageKey": null
                   }


### PR DESCRIPTION
As discussed in [this thread](
https://github.com/artsy/reaction/pull/1193#discussion_r213549330), we've hit kind of a weird edge of Relay/GraphQL schemas/tsc where we can only compare `__typename` to the names of types we spread over, even though the `Pickup` type has no useful information. That leads to two interesting tradeoffs:

- include the spread and transfer extra data from Metaphysics, but get type-checking working as expected, or
- not include it and only compare to `"Ship"` (or `"%other"`, which is a sentinel for non-spread-over value types). 

#1193 chose the first option, but this PR changes it to the second one. If you see weird type errors, let me know.