### PR TITLE
Fixes an issue where shipping country does not default to US

### DIFF
--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -35,7 +35,7 @@ export class AddressForm extends React.Component<AddressFormProps> {
               Country
             </Serif>
             <CountrySelect
-              selected={this.props.country || "US"}
+              selected={this.props.country}
               onSelect={this.props.onUpdateCountry}
             />
           </Flex>

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -65,6 +65,7 @@ export class ShippingRoute extends Component<
   // See: https://artsyproduct.atlassian.net/browse/PURCHASE-376
   state = {
     shippingOption: "SHIP",
+    country: "US",
     isComittingMutation: false,
   } as ShippingState & Address
 
@@ -109,7 +110,7 @@ export class ShippingRoute extends Component<
                   addressLine2: this.state.addressLine2,
                   city: this.state.city,
                   region: this.state.region,
-                  country: this.state.country || "", // Required, kind of, for now. See: https://artsyproduct.atlassian.net/browse/PURCHASE-408
+                  country: this.state.country,
                   postalCode: this.state.postalCode,
                 },
               },

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -57,6 +57,7 @@ describe("Shipping", () => {
     const mockCommitMutation = commitMutation as jest.Mock<any>
     mockCommitMutation.mockImplementationOnce((_environment, config) => {
       expect(config.variables.input.shipping.region).toBe("New Brunswick")
+      expect(config.variables.input.shipping.country).toBe("US") // It defaults to "US" when not selected
     })
 
     component.find(Button).simulate("click")


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-408

This PR removes the hard-coded "US" and expciltly sets it to the state. This may be a naive solution, but for now this is a working solution that reduces confusing behaviour. In the future we may want to make this UX slightly better by automatically detecting the country with IP.
