### PR TITLE
Redirect to /order2/:id/shipping if you access /order2/:id

### DIFF
--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -1,4 +1,5 @@
-import { Location, RouteConfig, Router } from "found"
+import { Location, Redirect, RouteConfig, Router } from "found"
+import React from "react"
 import { graphql } from "react-relay"
 import { OrderApp } from "./OrderApp"
 
@@ -107,6 +108,18 @@ export const routes = [
             }
           }
         `,
+      },
+      // For now, redirect the empty route to the shipping page
+      new Redirect({
+        from: "/",
+        to: "/order2/:orderID/shipping",
+      }),
+      {
+        path: "*",
+        Component: props => {
+          console.warn("Route not found: ", props)
+          return <div>Page not found</div>
+        },
       },
     ],
   },


### PR DESCRIPTION
This addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-418. For now, when a user tries to access the blank `/order2/:id` route, we'll redirect them to the `/shipping` subroute.

I wasn't sure how to test the redirect, perhaps https://artsyproduct.atlassian.net/browse/PURCHASE-370 will unblock that?

I've also added another ticket: https://artsyproduct.atlassian.net/browse/PURCHASE-428 so we remember to follow-up on additional behavior that we may want around submitted orders.