### PR TITLE
@cavvia => Make WFY avatar a link, and enable analytics tracking

### DIFF
--- a/src/Apps/WorksForYou/WorksForYouArtist.tsx
+++ b/src/Apps/WorksForYou/WorksForYouArtist.tsx
@@ -75,12 +75,14 @@ export class WorksForYouArtist extends React.Component<Props, State> {
           <Flex>
             {artist.image && (
               <Avatar>
-                <Image
-                  src={artist.image.resized.url}
-                  width={40}
-                  height={40}
-                  style={{ borderRadius: "20px" }}
-                />
+                <a href={artist.href}>
+                  <Image
+                    src={artist.image.resized.url}
+                    width={40}
+                    height={40}
+                    style={{ borderRadius: "20px" }}
+                  />
+                </a>
               </Avatar>
             )}
             <Box ml={2}>

--- a/src/Apps/WorksForYou/WorksForYouContents.tsx
+++ b/src/Apps/WorksForYou/WorksForYouContents.tsx
@@ -106,12 +106,14 @@ export class WorksForYouContent extends React.Component<Props, State> {
                   <Flex>
                     {node.image && (
                       <Avatar>
-                        <Image
-                          src={node.image.resized.url}
-                          width={40}
-                          height={40}
-                          style={{ borderRadius: "20px" }}
-                        />
+                        <a href={node.href}>
+                          <Image
+                            src={node.image.resized.url}
+                            width={40}
+                            height={40}
+                            style={{ borderRadius: "20px" }}
+                          />
+                        </a>
                       </Avatar>
                     )}
                     <Box ml={2}>

--- a/src/Apps/WorksForYou/index.tsx
+++ b/src/Apps/WorksForYou/index.tsx
@@ -61,10 +61,14 @@ export class WorksForYou extends Component<Props> {
               `}
               variables={{ artistID, includeSelectedArtist, forSale, filter }}
               render={({ props }) => {
+                const hasBuyNowLabFeature =
+                  user &&
+                  user.lab_features &&
+                  user.lab_features.includes("New Buy Now Flow")
                 if (props) {
                   return (
                     <>
-                      <MarketingHeader />
+                      {hasBuyNowLabFeature && <MarketingHeader />}
 
                       {includeSelectedArtist ? (
                         <WorksForYouArtist

--- a/src/Apps/WorksForYou/index.tsx
+++ b/src/Apps/WorksForYou/index.tsx
@@ -2,10 +2,12 @@ import { ArtistArtworksFilters } from "__generated__/WorksForYouQuery.graphql"
 import { WorksForYouQuery } from "__generated__/WorksForYouQuery.graphql"
 import { MarketingHeader } from "Apps/WorksForYou/Components/MarketingHeader"
 import { ContextConsumer, ContextProps } from "Artsy"
+import { track } from "Artsy/Analytics"
 import Spinner from "Components/Spinner"
 import React, { Component } from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import styled from "styled-components"
+import Events from "Utils/Events"
 import WorksForYouArtist from "./WorksForYouArtist"
 import WorksForYouContent from "./WorksForYouContents"
 
@@ -20,6 +22,9 @@ const SpinnerContainer = styled.div`
   position: relative;
 `
 
+@track(null, {
+  dispatch: data => Events.postEvent(data),
+})
 export class WorksForYou extends Component<Props> {
   static defaultProps = {
     forSale: true,


### PR DESCRIPTION
I think this does it:
  - protect the marketing banner behind the BNMO lab
  - make avatar images clickable to the artist page
  - enable tracking, which then 'just works' on the save button