### PR TITLE
Execute submit_order mutation from Review page

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -34,7 +34,7 @@ input ApproveOrderInput {
 }
 
 type ApproveOrderPayload {
-  result: OrderReturnType
+  orderOrError: OrderOrFailureUnionType
   clientMutationId: String
 }
 
@@ -2750,7 +2750,7 @@ input FulfillOrderAtOnceInput {
 }
 
 type FulfillOrderAtOncePayload {
-  result: OrderReturnType
+  orderOrError: OrderOrFailureUnionType
   clientMutationId: String
 }
 
@@ -4414,14 +4414,6 @@ union OrderOrFailureUnionType = OrderWithMutationSuccess | OrderWithMutationFail
 
 union OrderParty = Partner | User
 
-type OrderReturnType {
-  # Returned order object
-  order: Order
-
-  # Errors
-  errors: [String]
-}
-
 enum OrdersSortMethodType {
   # Sort by latest timestamp order was updated in ascending order
   UPDATED_AT_ASC
@@ -5346,7 +5338,7 @@ input RejectOrderInput {
 }
 
 type RejectOrderPayload {
-  result: OrderReturnType
+  orderOrError: OrderOrFailureUnionType
   clientMutationId: String
 }
 
@@ -5849,7 +5841,7 @@ input SetOrderPaymentInput {
 }
 
 type SetOrderPaymentPayload {
-  result: OrderReturnType
+  orderOrError: OrderOrFailureUnionType
   clientMutationId: String
 }
 
@@ -5866,7 +5858,7 @@ input SetOrderShippingInput {
 }
 
 type SetOrderShippingPayload {
-  result: OrderReturnType
+  orderOrError: OrderOrFailureUnionType
   clientMutationId: String
 }
 
@@ -6117,7 +6109,7 @@ input SubmitOrderInput {
 }
 
 type SubmitOrderPayload {
-  result: OrderReturnType
+  orderOrError: OrderOrFailureUnionType
   clientMutationId: String
 }
 

--- a/data/schema.json
+++ b/data/schema.json
@@ -46577,12 +46577,12 @@
           "description": null,
           "fields": [
             {
-              "name": "result",
+              "name": "orderOrError",
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "OrderReturnType",
+                "kind": "UNION",
+                "name": "OrderOrFailureUnionType",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -46596,45 +46596,6 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "OrderReturnType",
-          "description": null,
-          "fields": [
-            {
-              "name": "order",
-              "description": "Returned order object",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Order",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "errors",
-              "description": "Errors",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -46700,12 +46661,12 @@
           "description": null,
           "fields": [
             {
-              "name": "result",
+              "name": "orderOrError",
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "OrderReturnType",
+                "kind": "UNION",
+                "name": "OrderOrFailureUnionType",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -46770,12 +46731,12 @@
           "description": null,
           "fields": [
             {
-              "name": "result",
+              "name": "orderOrError",
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "OrderReturnType",
+                "kind": "UNION",
+                "name": "OrderOrFailureUnionType",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -46899,12 +46860,12 @@
           "description": null,
           "fields": [
             {
-              "name": "result",
+              "name": "orderOrError",
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "OrderReturnType",
+                "kind": "UNION",
+                "name": "OrderOrFailureUnionType",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -46969,12 +46930,12 @@
           "description": null,
           "fields": [
             {
-              "name": "result",
+              "name": "orderOrError",
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "OrderReturnType",
+                "kind": "UNION",
+                "name": "OrderOrFailureUnionType",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -47039,12 +47000,12 @@
           "description": null,
           "fields": [
             {
-              "name": "result",
+              "name": "orderOrError",
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "OrderReturnType",
+                "kind": "UNION",
+                "name": "OrderOrFailureUnionType",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -57,6 +57,11 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                 submitOrder(input: $input) {
                   orderOrError {
                     __typename
+                    ... on OrderWithMutationFailure {
+                      error {
+                        description
+                      }
+                    }
                   }
                 }
               }
@@ -66,9 +71,14 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                 orderId: this.props.order.id,
               },
             },
-            onCompleted: () =>
-              // TODO: handle failure
-              this.props.router.push(`/order2/${this.props.order.id}/status`),
+            onCompleted(result) {
+              if (result.submitOrder.orderOrError.error) {
+                // TODO: handle failure properly
+                console.error(result.submitOrder.orderOrError.error.description)
+                return
+              }
+              this.props.router.push(`/order2/${this.props.order.id}/status`)
+            },
           }
         )
       )

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -91,11 +91,17 @@ export class ShippingRoute extends Component<
                 $input: SetOrderShippingInput!
               ) {
                 setOrderShipping(input: $input) {
-                  result {
-                    order {
-                      state
+                  orderOrError {
+                    ... on OrderWithMutationSuccess {
+                      order {
+                        state
+                      }
                     }
-                    errors
+                    ... on OrderWithMutationFailure {
+                      error {
+                        description
+                      }
+                    }
                   }
                 }
               }

--- a/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
+++ b/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
@@ -1,0 +1,140 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type SubmitOrderInput = {
+    readonly orderId: string;
+    readonly clientMutationId?: string | null;
+};
+export type ReviewSubmitOrderMutationVariables = {
+    readonly input: SubmitOrderInput;
+};
+export type ReviewSubmitOrderMutationResponse = {
+    readonly submitOrder: ({
+        readonly result: ({
+            readonly order: ({
+                readonly state: string | null;
+            }) | null;
+            readonly errors: ReadonlyArray<string | null> | null;
+        }) | null;
+    }) | null;
+};
+export type ReviewSubmitOrderMutation = {
+    readonly response: ReviewSubmitOrderMutationResponse;
+    readonly variables: ReviewSubmitOrderMutationVariables;
+};
+
+
+
+/*
+mutation ReviewSubmitOrderMutation(
+  $input: SubmitOrderInput!
+) {
+  submitOrder(input: $input) {
+    result {
+      order {
+        state
+        __id: id
+      }
+      errors
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "SubmitOrderInput!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "submitOrder",
+    "storageKey": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input",
+        "type": "SubmitOrderInput!"
+      }
+    ],
+    "concreteType": "SubmitOrderPayload",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "result",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "OrderReturnType",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "order",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Order",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "state",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": "__id",
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "errors",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "mutation",
+  "name": "ReviewSubmitOrderMutation",
+  "id": null,
+  "text": "mutation ReviewSubmitOrderMutation(\n  $input: SubmitOrderInput!\n) {\n  submitOrder(input: $input) {\n    result {\n      order {\n        state\n        __id: id\n      }\n      errors\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ReviewSubmitOrderMutation",
+    "type": "Mutation",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": v1
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ReviewSubmitOrderMutation",
+    "argumentDefinitions": v0,
+    "selections": v1
+  }
+};
+})();
+(node as any).hash = 'c9ec99b36a2ceb273923f323b4c2ed4d';
+export default node;

--- a/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
+++ b/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
@@ -10,11 +10,10 @@ export type ReviewSubmitOrderMutationVariables = {
 };
 export type ReviewSubmitOrderMutationResponse = {
     readonly submitOrder: ({
-        readonly result: ({
-            readonly order: ({
-                readonly state: string | null;
+        readonly orderOrError: ({
+            readonly error?: ({
+                readonly description: string;
             }) | null;
-            readonly errors: ReadonlyArray<string | null> | null;
         }) | null;
     }) | null;
 };
@@ -30,12 +29,13 @@ mutation ReviewSubmitOrderMutation(
   $input: SubmitOrderInput!
 ) {
   submitOrder(input: $input) {
-    result {
-      order {
-        state
-        __id: id
+    orderOrError {
+      __typename
+      ... on OrderWithMutationFailure {
+        error {
+          description
+        }
       }
-      errors
     }
   }
 }
@@ -52,73 +52,42 @@ var v0 = [
 ],
 v1 = [
   {
-    "kind": "LinkedField",
-    "alias": null,
-    "name": "submitOrder",
-    "storageKey": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input",
-        "type": "SubmitOrderInput!"
-      }
-    ],
-    "concreteType": "SubmitOrderPayload",
-    "plural": false,
-    "selections": [
-      {
-        "kind": "LinkedField",
-        "alias": null,
-        "name": "result",
-        "storageKey": null,
-        "args": null,
-        "concreteType": "OrderReturnType",
-        "plural": false,
-        "selections": [
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "order",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Order",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "state",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": "__id",
-                "name": "id",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "errors",
-            "args": null,
-            "storageKey": null
-          }
-        ]
-      }
-    ]
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input",
+    "type": "SubmitOrderInput!"
   }
-];
+],
+v2 = {
+  "kind": "InlineFragment",
+  "type": "OrderWithMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "error",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "EcommerceError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "description",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+};
 return {
   "kind": "Request",
   "operationKind": "mutation",
   "name": "ReviewSubmitOrderMutation",
   "id": null,
-  "text": "mutation ReviewSubmitOrderMutation(\n  $input: SubmitOrderInput!\n) {\n  submitOrder(input: $input) {\n    result {\n      order {\n        state\n        __id: id\n      }\n      errors\n    }\n  }\n}\n",
+  "text": "mutation ReviewSubmitOrderMutation(\n  $input: SubmitOrderInput!\n) {\n  submitOrder(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationFailure {\n        error {\n          description\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -126,15 +95,70 @@ return {
     "type": "Mutation",
     "metadata": null,
     "argumentDefinitions": v0,
-    "selections": v1
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "submitOrder",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SubmitOrderPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "orderOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v2
+            ]
+          }
+        ]
+      }
+    ]
   },
   "operation": {
     "kind": "Operation",
     "name": "ReviewSubmitOrderMutation",
     "argumentDefinitions": v0,
-    "selections": v1
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "submitOrder",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SubmitOrderPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "orderOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "__typename",
+                "args": null,
+                "storageKey": null
+              },
+              v2
+            ]
+          }
+        ]
+      }
+    ]
   }
 };
 })();
-(node as any).hash = 'c9ec99b36a2ceb273923f323b4c2ed4d';
+(node as any).hash = '0e81fed46f5998cbc84f51387e0e71a9';
 export default node;

--- a/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
+++ b/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
@@ -22,11 +22,13 @@ export type ShippingOrderAddressUpdateMutationVariables = {
 };
 export type ShippingOrderAddressUpdateMutationResponse = {
     readonly setOrderShipping: ({
-        readonly result: ({
-            readonly order: ({
+        readonly orderOrError: ({
+            readonly order?: ({
                 readonly state: string | null;
             }) | null;
-            readonly errors: ReadonlyArray<string | null> | null;
+            readonly error?: ({
+                readonly description: string;
+            }) | null;
         }) | null;
     }) | null;
 };
@@ -42,12 +44,19 @@ mutation ShippingOrderAddressUpdateMutation(
   $input: SetOrderShippingInput!
 ) {
   setOrderShipping(input: $input) {
-    result {
-      order {
-        state
-        __id: id
+    orderOrError {
+      __typename
+      ... on OrderWithMutationSuccess {
+        order {
+          state
+          __id: id
+        }
       }
-      errors
+      ... on OrderWithMutationFailure {
+        error {
+          description
+        }
+      }
     }
   }
 }
@@ -64,73 +73,73 @@ var v0 = [
 ],
 v1 = [
   {
-    "kind": "LinkedField",
-    "alias": null,
-    "name": "setOrderShipping",
-    "storageKey": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input",
-        "type": "SetOrderShippingInput!"
-      }
-    ],
-    "concreteType": "SetOrderShippingPayload",
-    "plural": false,
-    "selections": [
-      {
-        "kind": "LinkedField",
-        "alias": null,
-        "name": "result",
-        "storageKey": null,
-        "args": null,
-        "concreteType": "OrderReturnType",
-        "plural": false,
-        "selections": [
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "order",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Order",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "state",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": "__id",
-                "name": "id",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "errors",
-            "args": null,
-            "storageKey": null
-          }
-        ]
-      }
-    ]
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input",
+    "type": "SetOrderShippingInput!"
   }
-];
+],
+v2 = {
+  "kind": "InlineFragment",
+  "type": "OrderWithMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "error",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "EcommerceError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "description",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+},
+v3 = {
+  "kind": "InlineFragment",
+  "type": "OrderWithMutationSuccess",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "order",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Order",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "state",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": "__id",
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+};
 return {
   "kind": "Request",
   "operationKind": "mutation",
   "name": "ShippingOrderAddressUpdateMutation",
   "id": null,
-  "text": "mutation ShippingOrderAddressUpdateMutation(\n  $input: SetOrderShippingInput!\n) {\n  setOrderShipping(input: $input) {\n    result {\n      order {\n        state\n        __id: id\n      }\n      errors\n    }\n  }\n}\n",
+  "text": "mutation ShippingOrderAddressUpdateMutation(\n  $input: SetOrderShippingInput!\n) {\n  setOrderShipping(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          state\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          description\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -138,15 +147,72 @@ return {
     "type": "Mutation",
     "metadata": null,
     "argumentDefinitions": v0,
-    "selections": v1
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "setOrderShipping",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SetOrderShippingPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "orderOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v2,
+              v3
+            ]
+          }
+        ]
+      }
+    ]
   },
   "operation": {
     "kind": "Operation",
     "name": "ShippingOrderAddressUpdateMutation",
     "argumentDefinitions": v0,
-    "selections": v1
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "setOrderShipping",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SetOrderShippingPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "orderOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "__typename",
+                "args": null,
+                "storageKey": null
+              },
+              v2,
+              v3
+            ]
+          }
+        ]
+      }
+    ]
   }
 };
 })();
-(node as any).hash = '8c15f3b0558274117be3712f4a6a3afb';
+(node as any).hash = 'a60f684961592e31c2bcd74fc872d32c';
 export default node;


### PR DESCRIPTION
- bumped metaphysics to include schema changes from artsy/metaphysics#1247
- execute submitOrder mutation when clicking the submit button on the review page