### PR TITLE
User sees a full country name in shipping details views

### DIFF
--- a/src/Apps/Order/Components/ShippingAddress.tsx
+++ b/src/Apps/Order/Components/ShippingAddress.tsx
@@ -1,14 +1,16 @@
+import { Serif } from "@artsy/palette"
 import React from "react"
 
-import { Serif } from "@artsy/palette"
+import { COUNTRY_CODE_TO_COUNTRY_NAME } from "Styleguide/Components"
 
 export interface ShippingAddressProps {
   name: string
   addressLine1: string
-  addressLine2: string | null
+  addressLine2?: string | null
   city: string
   postalCode: string
   region: string
+  country: string
 }
 
 export const ShippingAddress = ({
@@ -18,13 +20,20 @@ export const ShippingAddress = ({
   city,
   postalCode,
   region,
+  country,
 }: ShippingAddressProps) => {
-  const cityLine = city + (postalCode ? ` ${postalCode}` : "")
   return (
-    <Serif size="3t" style={{ whiteSpace: "pre-wrap" }}>
-      {[name, addressLine1, addressLine2, cityLine, region]
-        .filter(Boolean)
-        .join("\n")}
-    </Serif>
+    <>
+      <Serif size="3t">{name}</Serif>
+      <Serif size="3t">
+        {[addressLine1, (addressLine2 || "").trim()].filter(Boolean).join(", ")}
+      </Serif>
+      <Serif size="3t">
+        {city}, {region} {postalCode}
+      </Serif>
+      <Serif size="3t">
+        {COUNTRY_CODE_TO_COUNTRY_NAME[country] || country}
+      </Serif>
+    </>
   )
 }

--- a/src/Apps/Order/Components/ShippingAndPaymentReview.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentReview.tsx
@@ -56,6 +56,7 @@ export const ShippingAndPaymentReviewFragmentContainer = createFragmentContainer
           city
           postalCode
           region
+          country
         }
       }
       lineItems {

--- a/src/Apps/Order/Components/ShippingAndPaymentSummary.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentSummary.tsx
@@ -51,6 +51,7 @@ export const ShippingAndPaymentSummaryFragmentContainer = createFragmentContaine
           city
           postalCode
           region
+          country
         }
       }
       lineItems {

--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -14,11 +14,12 @@ const order: ShippingAndPaymentReview_order &
   requestedFulfillment: {
     __typename: "Ship",
     name: "Joelle Van Dyne",
-    addressLine1: "23 41st st",
-    addressLine2: null,
+    addressLine1: "401 Broadway",
+    addressLine2: "Suite 25",
     city: "New York",
-    postalCode: "90210",
-    region: "US",
+    postalCode: "10013",
+    region: "NY",
+    country: "US",
   },
   lineItems: {
     edges: [{ node: { artwork: { shippingOrigin: "Jersey City, NJ" } } }],

--- a/src/Apps/Order/Components/__tests__/ShippingAddress.test.tsx
+++ b/src/Apps/Order/Components/__tests__/ShippingAddress.test.tsx
@@ -1,0 +1,62 @@
+import { render } from "enzyme"
+import React from "react"
+import { ShippingAddress } from "../ShippingAddress"
+
+describe("ShippingAddress", () => {
+  it("shows the given shipping address", () => {
+    const shippingAddress = render(
+      <ShippingAddress
+        name="Yuki Nishijima"
+        addressLine1="401 Broadway"
+        addressLine2="Suite 25"
+        city="New York"
+        postalCode="10013"
+        region="NY"
+        country="US"
+      />
+    )
+
+    const text = shippingAddress.text()
+
+    expect(text).toMatch("Yuki Nishijima")
+    expect(text).toMatch("401 Broadway, Suite 25")
+    expect(text).toMatch("New York, NY 10013")
+    expect(text).toMatch("United States")
+  })
+
+  it("ignores addressLine2if it is blank or null", () => {
+    const shippingAddressWithBlankAddressLine2 = render(
+      <ShippingAddress
+        name="Yuki Nishijima"
+        addressLine1="401 Broadway"
+        addressLine2=" "
+        city="New York"
+        postalCode="10013"
+        region="NY"
+        country="US"
+      />
+    )
+
+    expect(shippingAddressWithBlankAddressLine2.text()).toMatch("401 Broadway")
+    expect(shippingAddressWithBlankAddressLine2.text()).not.toMatch(
+      "401 Broadway, "
+    )
+
+    const shippingAddressWithoutAddressLine2 = render(
+      <ShippingAddress
+        name="Yuki Nishijima"
+        addressLine1="401 Broadway"
+        addressLine2={null}
+        city="New York"
+        postalCode="10013"
+        region="NY"
+        country="US"
+      />
+    )
+
+    expect(shippingAddressWithoutAddressLine2.text()).toMatch("401 Broadway")
+    expect(shippingAddressWithoutAddressLine2.text()).not.toMatch(
+      "401 Broadway, "
+    )
+  })
+})

--- a/src/Apps/__test__/Fixtures/Order.ts
+++ b/src/Apps/__test__/Fixtures/Order.ts
@@ -56,11 +56,12 @@ export const OrderWithShippingDetails = {
   requestedFulfillment: {
     __typename: "Ship",
     name: "Joelle Van Dyne",
-    addressLine1: "23 41st st",
-    addressLine2: null,
+    addressLine1: "401 Broadway",
+    addressLine2: "Suite 25",
     city: "New York",
-    postalCode: "90210",
-    region: "US",
+    postalCode: "10013",
+    region: "NY",
+    country: "US",
   },
   creditCard: {
     brand: "Visa",

--- a/src/Styleguide/Components/CountrySelect.tsx
+++ b/src/Styleguide/Components/CountrySelect.tsx
@@ -256,3 +256,8 @@ const COUNTRY_SELECT_OPTIONS = [
   { text: "Zambia", value: "ZM" },
   { text: "Zimbabwe", value: "ZW" },
 ]
+
+export const COUNTRY_CODE_TO_COUNTRY_NAME = COUNTRY_SELECT_OPTIONS.reduce(
+  (acc, option) => Object.assign(acc, { [option.value]: option.text }),
+  {}
+)

--- a/src/__generated__/ShippingAndPaymentReview_order.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentReview_order.graphql.ts
@@ -12,6 +12,7 @@ export type ShippingAndPaymentReview_order = {
         readonly city: string | null;
         readonly postalCode: string | null;
         readonly region: string | null;
+        readonly country: string;
     } | {
         /*This will never be '% other', but we need some
         value in case none of the concrete values match.*/
@@ -120,6 +121,13 @@ return {
               "name": "region",
               "args": null,
               "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "country",
+              "args": null,
+              "storageKey": null
             }
           ]
         }
@@ -222,5 +230,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '5cedddcabb93383a1e506b265d4468b9';
+(node as any).hash = 'e7d06d6951ef4d1722bd36d8beaa19f1';
 export default node;

--- a/src/__generated__/ShippingAndPaymentSummary_order.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentSummary_order.graphql.ts
@@ -12,6 +12,7 @@ export type ShippingAndPaymentSummary_order = {
         readonly city: string | null;
         readonly postalCode: string | null;
         readonly region: string | null;
+        readonly country: string;
     } | {
         /*This will never be '% other', but we need some
         value in case none of the concrete values match.*/
@@ -120,6 +121,13 @@ return {
               "name": "region",
               "args": null,
               "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "country",
+              "args": null,
+              "storageKey": null
             }
           ]
         }
@@ -222,5 +230,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '8aa1d8b313a6cb85a539e4d9453444ce';
+(node as any).hash = 'ece160ca7fd755b9b805ffd2b741e3b2';
 export default node;

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -115,6 +115,7 @@ fragment ShippingAndPaymentReview_order on Order {
       city
       postalCode
       region
+      country
     }
   }
   lineItems {
@@ -205,7 +206,7 @@ return {
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n      country\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -514,6 +515,13 @@ return {
                     "kind": "ScalarField",
                     "alias": null,
                     "name": "region",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "country",
                     "args": null,
                     "storageKey": null
                   }

--- a/src/__generated__/routes_StatusQuery.graphql.ts
+++ b/src/__generated__/routes_StatusQuery.graphql.ts
@@ -96,6 +96,7 @@ fragment ShippingAndPaymentSummary_order on Order {
       city
       postalCode
       region
+      country
     }
   }
   lineItems {
@@ -206,7 +207,7 @@ return {
   "operationKind": "query",
   "name": "routes_StatusQuery",
   "id": null,
-  "text": "query routes_StatusQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
+  "text": "query routes_StatusQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n      country\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -522,6 +523,13 @@ return {
                     "kind": "ScalarField",
                     "alias": null,
                     "name": "region",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "country",
                     "args": null,
                     "storageKey": null
                   }


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-421

This PR adds a new constant called `COUNTRY_CODE_TO_COUNTRY_NAME` , which is a country-code-to-full-name map based on the same data used in the `<CountrySelect>` component. The name sounds ok but a bit too long, so open to suggestions.

I also noticed that in the storybook we had `US` in the `region` property, which has been fixed as part of this PR.

## Screenshot

![screen_shot_2018-08-31_at_9_34_53_am](https://user-images.githubusercontent.com/386234/44915567-40e32280-ad01-11e8-9f18-51feb0450127.png)

