### PR TITLE
Fixes Articles re-rendering on scroll

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -2,9 +2,7 @@ import React from "react"
 import track from "react-tracking"
 import Events from "../../Utils/Events"
 
-import { debounce } from "lodash"
-import { MinimalCtaBanner } from "../MinimalCtaBanner"
-import { getArticleFullHref } from "./Constants"
+import { BannerWrapper } from "./Banner/Banner"
 import ArticleWithFullScreen from "./Layouts/ArticleWithFullScreen"
 import { ClassicLayout } from "./Layouts/ClassicLayout"
 import { NewsLayout } from "./Layouts/NewsLayout"
@@ -39,15 +37,6 @@ export interface ArticleProps {
   onExpand?: () => void
 }
 
-export interface State {
-  showCtaBanner: boolean
-}
-
-export enum CtaCopy {
-  news = "Sign up for the best in art world news",
-  default = "Sign up to get our best stories everyday",
-}
-
 @track(
   (props: ArticleProps) => {
     return {
@@ -60,40 +49,7 @@ export enum CtaCopy {
     dispatch: data => Events.postEvent(data),
   }
 )
-export class Article extends React.Component<ArticleProps, State> {
-  state = {
-    showCtaBanner: false,
-  }
-  lastScrollPosition: number = 0
-
-  handleScroll() {
-    const newScrollPosition = window.scrollY
-    let showCtaBanner = this.state.showCtaBanner
-
-    if (newScrollPosition <= this.lastScrollPosition) {
-      // scrolling up the page
-      if (this.state.showCtaBanner) {
-        showCtaBanner = false
-      }
-    } else {
-      // scrolling down the page
-      if (!this.state.showCtaBanner) {
-        showCtaBanner = true
-      }
-    }
-
-    if (this.state.showCtaBanner !== showCtaBanner) {
-      this.setState({ showCtaBanner })
-    }
-    this.lastScrollPosition = newScrollPosition
-  }
-
-  componentDidMount() {
-    if (window) {
-      window.addEventListener("scroll", debounce(() => this.handleScroll(), 10))
-    }
-  }
-
+export class Article extends React.Component<ArticleProps> {
   getArticleLayout = () => {
     const { article } = this.props
 
@@ -125,24 +81,11 @@ export class Article extends React.Component<ArticleProps, State> {
   }
 
   render() {
-    const { layout, slug } = this.props.article
-    const copy = layout === "news" ? CtaCopy.news : CtaCopy.default
-    const backgroundColor = layout === "video" ? "white" : "black"
-    const textColor = layout === "video" ? "black" : "white"
-
     return (
       <FullScreenProvider>
         {this.getArticleLayout()}
         {this.shouldRenderSignUpCta() && (
-          <MinimalCtaBanner
-            href={`/sign_up?redirect-to=${getArticleFullHref(slug)}`}
-            height="55px"
-            copy={copy}
-            position="bottom"
-            textColor={textColor}
-            backgroundColor={backgroundColor}
-            show={this.state.showCtaBanner}
-          />
+          <BannerWrapper article={this.props.article} />
         )}
       </FullScreenProvider>
     )

--- a/src/Components/Publishing/Banner/Banner.tsx
+++ b/src/Components/Publishing/Banner/Banner.tsx
@@ -1,0 +1,68 @@
+import { debounce } from "lodash"
+import React, { Component } from "react"
+import { MinimalCtaBanner } from "../../MinimalCtaBanner"
+import { getArticleFullHref } from "../Constants"
+import { ArticleData } from "../Typings"
+
+export interface State {
+  showCtaBanner: boolean
+}
+
+export enum CtaCopy {
+  news = "Sign up for the best in art world news",
+  default = "Sign up to get our best stories everyday",
+}
+
+export class BannerWrapper extends Component<{ article: ArticleData }, State> {
+  state = {
+    showCtaBanner: false,
+  }
+  lastScrollPosition: number = 0
+
+  handleScroll() {
+    const newScrollPosition = window.scrollY
+    let showCtaBanner = this.state.showCtaBanner
+
+    if (newScrollPosition <= this.lastScrollPosition) {
+      // scrolling up the page
+      if (this.state.showCtaBanner) {
+        showCtaBanner = false
+      }
+    } else {
+      // scrolling down the page
+      if (!this.state.showCtaBanner) {
+        showCtaBanner = true
+      }
+    }
+
+    if (this.state.showCtaBanner !== showCtaBanner) {
+      this.setState({ showCtaBanner })
+    }
+    this.lastScrollPosition = newScrollPosition
+  }
+
+  componentDidMount() {
+    if (window) {
+      window.addEventListener("scroll", debounce(() => this.handleScroll(), 10))
+    }
+  }
+
+  render() {
+    const { layout, slug } = this.props.article
+    const copy = layout === "news" ? CtaCopy.news : CtaCopy.default
+    const backgroundColor = layout === "video" ? "white" : "black"
+    const textColor = layout === "video" ? "black" : "white"
+
+    return (
+      <MinimalCtaBanner
+        href={`/sign_up?redirect-to=${getArticleFullHref(slug)}`}
+        height="55px"
+        copy={copy}
+        position="bottom"
+        textColor={textColor}
+        backgroundColor={backgroundColor}
+        show={this.state.showCtaBanner}
+      />
+    )
+  }
+}

--- a/src/Components/Publishing/Banner/__tests__/Banner.test.tsx
+++ b/src/Components/Publishing/Banner/__tests__/Banner.test.tsx
@@ -1,0 +1,25 @@
+import { shallow } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+
+import { BannerWrapper } from "../Banner"
+
+import { StandardArticle } from "../../Fixtures/Articles"
+
+describe("Banner", () => {
+  it("it sets state appropriately based on scroll direction", () => {
+    const aWindow: any = window
+
+    const wrapper = shallow(<BannerWrapper article={StandardArticle} />)
+    const article = wrapper.instance() as any
+
+    // User scrolls back up which should show the banner
+    article.handleScroll()
+    expect(article.state.showCtaBanner).toBe(false)
+
+    aWindow.scrollY = 500
+    article.handleScroll()
+    wrapper.update()
+    expect(article.state.showCtaBanner).toBe(true)
+  })
+})

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -5,7 +5,7 @@ import { getEditorialHref } from "Components/Publishing/Constants"
 import { get, omit } from "lodash"
 import React from "react"
 import styled from "styled-components"
-import { ResponsiveDeprecated } from "../../../Utils/ResponsiveDeprecated"
+import { Responsive } from "Utils/Responsive"
 import { pMedia } from "../../Helpers"
 import { ArticleProps } from "../Article"
 import { DisplayPanel } from "../Display/DisplayPanel"
@@ -67,6 +67,7 @@ export class StandardLayout extends React.Component<
       display,
       emailSignupUrl,
       infiniteScrollEntrySlug,
+      isMobile,
       relatedArticlesForCanvas,
       relatedArticlesForPanel,
       renderTime,
@@ -76,9 +77,8 @@ export class StandardLayout extends React.Component<
     const campaign = omit(display, "panel", "canvas")
 
     return (
-      // FIXME: Update with new version
-      <ResponsiveDeprecated initialState={{ isMobile: this.props.isMobile }}>
-        {({ isMobile, xs, sm, md }) => {
+      <Responsive>
+        {({ xs, sm, md }) => {
           const hasPanel = get(display, "panel", false)
           const isMobileAd = Boolean(isMobile || xs || sm || md)
 
@@ -138,7 +138,7 @@ export class StandardLayout extends React.Component<
             </ArticleWrapper>
           )
         }}
-      </ResponsiveDeprecated>
+      </Responsive>
     )
   }
 }

--- a/src/Components/Publishing/__tests__/Article.test.tsx
+++ b/src/Components/Publishing/__tests__/Article.test.tsx
@@ -10,7 +10,7 @@ import {
   VideoArticle,
 } from "../Fixtures/Articles"
 
-import { MinimalCtaBanner } from "../../MinimalCtaBanner"
+import { BannerWrapper } from "../Banner/Banner"
 import { ArticleWithFullScreen } from "../Layouts/ArticleWithFullScreen"
 import { NewsLayout } from "../Layouts/NewsLayout"
 import { SeriesLayout } from "../Layouts/SeriesLayout"
@@ -44,50 +44,28 @@ it("renders news articles in news layout", () => {
   const article = mount(<Article article={NewsArticle} />)
   expect(article.find(NewsLayout).length).toBe(1)
 })
-
-it("renders mobile MinimalCtaBanner for standard article layouts", () => {
-  const article = shallow(
-    <Article article={StandardArticle} isMobile isLoggedIn={false} />
-  )
-  expect(article.find(MinimalCtaBanner).length).toBe(1)
-})
-
-it("renders mobile MinimalCtaBanner for news article layouts", () => {
-  const article = shallow(
-    <Article article={NewsArticle} isMobile isLoggedIn={false} />
-  )
-  expect(article.find(MinimalCtaBanner).length).toBe(1)
-})
-
-it("renders mobile MinimalCtaBanner for video article layouts", () => {
-  const article = shallow(
-    <Article article={VideoArticle} isMobile isLoggedIn={false} />
-  )
-  expect(article.find(MinimalCtaBanner).length).toBe(1)
-})
-
-it("does not renders mobile MinimalCtaBanner for standard article layouts for desktop", () => {
+it("does not renders mobile BannerWrapper for standard article layouts for desktop", () => {
   const article = shallow(
     <Article article={StandardArticle} isMobile={false} isLoggedIn={false} />
   )
-  expect(article.find(MinimalCtaBanner).length).toBe(0)
+  expect(article.find(BannerWrapper).length).toBe(0)
 })
 
-it("does not renders mobile MinimalCtaBanner for standard article layouts for logged in users", () => {
+it("does not renders mobile BannerWrapper for standard article layouts for logged in users", () => {
   const article = shallow(
     <Article article={StandardArticle} isMobile isLoggedIn />
   )
-  expect(article.find(MinimalCtaBanner).length).toBe(0)
+  expect(article.find(BannerWrapper).length).toBe(0)
 })
 
-it("does not renders mobile MinimalCtaBanner for series article layouts for logged in users", () => {
+it("does not renders mobile BannerWrapper for series article layouts for logged in users", () => {
   const article = shallow(
     <Article article={SeriesArticle} isMobile isLoggedIn={false} />
   )
-  expect(article.find(MinimalCtaBanner).length).toBe(0)
+  expect(article.find(BannerWrapper).length).toBe(0)
 })
 
-it("does not render separate MinimalCtaBanner for articles after the initial article in infinite scroll", () => {
+it("does not render separate BannerWrapper for articles after the initial article in infinite scroll", () => {
   const article = shallow(
     <Article
       article={StandardArticle}
@@ -96,23 +74,5 @@ it("does not render separate MinimalCtaBanner for articles after the initial art
       isTruncated
     />
   )
-  expect(article.find(MinimalCtaBanner).length).toBe(0)
-})
-
-it("it sets state appropriately based on scroll direction", () => {
-  const aWindow: any = window
-
-  const wrapper = shallow(
-    <Article article={StandardArticle} isMobile isLoggedIn />
-  )
-  const article = wrapper.instance() as any
-
-  // User scrolls back up which should show the banner
-  article.handleScroll()
-  expect(article.state.showCtaBanner).toBe(false)
-
-  aWindow.scrollY = 500
-  article.handleScroll()
-  wrapper.update()
-  expect(article.state.showCtaBanner).toBe(true)
+  expect(article.find(BannerWrapper).length).toBe(0)
 })


### PR DESCRIPTION
This fixes an issue with the entire Article component and its children re-rendering entirely on scroll due to calling `setState` inside of a `handleScroll` high up in the render tree.

This also caused our ad impression tracking to fire at every scroll changes
Related: https://artsyproduct.atlassian.net/browse/GROW-872