### PR TITLE
Add phone number, refactor address form

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -4285,6 +4285,9 @@ type Order {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # Buyer phone number
+  buyerPhoneNumber: String
 }
 
 # A connection to a list of items.
@@ -5868,6 +5871,9 @@ input SetOrderShippingInput {
 
   # Fulfillment Type of this Order
   fulfillmentType: OrderFulfillmentType
+
+  # Shipping phone number
+  phoneNumber: String
 
   # Shipping information
   shipping: ShippingInputField

--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -47,6 +47,7 @@ export class AddressForm extends React.Component<
   changeEventHandler = (key: keyof Address) => (
     ev: React.FormEvent<HTMLInputElement>
   ) => {
+    console.log("FECK", ev.currentTarget.value)
     this.onChangeValue(key, ev.currentTarget.value)
   }
 
@@ -65,6 +66,7 @@ export class AddressForm extends React.Component<
       <Join separator={<Spacer mb={2} />}>
         <Flex flexDirection="column">
           <Input
+            id="AddressForm_name"
             placeholder="Add full name"
             title="Full name"
             defaultValue={this.props.defaultValue.name}
@@ -86,6 +88,7 @@ export class AddressForm extends React.Component<
 
           <Flex flexDirection="column">
             <Input
+              id="AddressForm_addressLine2"
               placeholder="Add postal code"
               title="Postal code"
               onChange={this.changeEventHandler("postalCode")}
@@ -96,6 +99,7 @@ export class AddressForm extends React.Component<
         <TwoColumnSplit>
           <Flex flexDirection="column">
             <Input
+              id="AddressForm_addressLine1"
               placeholder="Add street address"
               title="Address line 1"
               onChange={this.changeEventHandler("addressLine1")}
@@ -105,6 +109,7 @@ export class AddressForm extends React.Component<
 
           <Flex flexDirection="column">
             <Input
+              id="AddressForm_addressLine2"
               placeholder="Add apt, floor, suite, etc."
               title="Address line 2 (optional)"
               onChange={this.changeEventHandler("addressLine2")}
@@ -115,6 +120,7 @@ export class AddressForm extends React.Component<
         <TwoColumnSplit>
           <Flex flexDirection="column">
             <Input
+              id="AddressForm_city"
               placeholder="Add city"
               title="City"
               onChange={this.changeEventHandler("city")}
@@ -134,6 +140,7 @@ export class AddressForm extends React.Component<
         {!this.props.billing && (
           <Flex flexDirection="column">
             <Input
+              id="AddressForm_phoneNumber"
               title="Phone"
               description="For shipping purposes only"
               placeholder="Add phone"

--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -5,18 +5,61 @@ import { CountrySelect } from "Styleguide/Components"
 import { Flex, Join, Spacer } from "Styleguide/Elements"
 import { TwoColumnSplit } from "./TwoColumnLayout"
 
-interface AddressFormProps {
-  country?: string
-  onUpdateName?: (e: any) => void
-  onUpdateCountry?: (e: any) => void
-  onUpdatePostalCode?: (e: any) => void
-  onUpdateAddressLine1?: (e: any) => void
-  onUpdateAddressLine2?: (e: any) => void
-  onUpdateCity?: (e: any) => void
-  onUpdateRegion?: (e: any) => void
+export interface Address {
+  name: string
+  country: string
+  postalCode: string
+  addressLine1: string
+  addressLine2: string
+  city: string
+  region: string
+  phoneNumber: string
 }
 
-export class AddressForm extends React.Component<AddressFormProps> {
+export const emptyAddress: Address = Object.freeze({
+  name: "",
+  country: "",
+  postalCode: "",
+  addressLine1: "",
+  addressLine2: "",
+  city: "",
+  region: "",
+  phoneNumber: "",
+})
+export interface AddressFormProps {
+  onChange(address: Address): void
+  defaultValue?: Partial<Address>
+  billing?: boolean
+}
+
+interface AddressFormState {
+  address: Address
+}
+
+export class AddressForm extends React.Component<
+  AddressFormProps,
+  AddressFormState
+> {
+  state = {
+    address: { ...emptyAddress, ...this.props.defaultValue },
+  }
+
+  changeEventHandler = (key: keyof Address) => (
+    ev: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.onChangeValue(key, ev.currentTarget.value)
+  }
+
+  changeValueHandler = (key: keyof Address) => (value: string) => {
+    this.onChangeValue(key, value)
+  }
+
+  onChangeValue = (key: keyof Address, value: string) => {
+    this.setState({ address: { ...this.state.address, [key]: value } }, () => {
+      this.props.onChange({ ...this.state.address })
+    })
+  }
+
   render() {
     return (
       <Join separator={<Spacer mb={2} />}>
@@ -24,7 +67,8 @@ export class AddressForm extends React.Component<AddressFormProps> {
           <Input
             placeholder="Add full name"
             title="Full name"
-            onChange={this.props.onUpdateName}
+            defaultValue={this.props.defaultValue.name}
+            onChange={this.changeEventHandler("name")}
             block
           />
         </Flex>
@@ -35,8 +79,8 @@ export class AddressForm extends React.Component<AddressFormProps> {
               Country
             </Serif>
             <CountrySelect
-              selected={this.props.country}
-              onSelect={this.props.onUpdateCountry}
+              selected={this.state.address.country}
+              onSelect={this.changeValueHandler("country")}
             />
           </Flex>
 
@@ -44,7 +88,7 @@ export class AddressForm extends React.Component<AddressFormProps> {
             <Input
               placeholder="Add postal code"
               title="Postal code"
-              onChange={this.props.onUpdatePostalCode}
+              onChange={this.changeEventHandler("postalCode")}
               block
             />
           </Flex>
@@ -54,7 +98,7 @@ export class AddressForm extends React.Component<AddressFormProps> {
             <Input
               placeholder="Add street address"
               title="Address line 1"
-              onChange={this.props.onUpdateAddressLine1}
+              onChange={this.changeEventHandler("addressLine1")}
               block
             />
           </Flex>
@@ -63,7 +107,7 @@ export class AddressForm extends React.Component<AddressFormProps> {
             <Input
               placeholder="Add apt, floor, suite, etc."
               title="Address line 2 (optional)"
-              onChange={this.props.onUpdateAddressLine2}
+              onChange={this.changeEventHandler("addressLine2")}
               block
             />
           </Flex>
@@ -73,7 +117,7 @@ export class AddressForm extends React.Component<AddressFormProps> {
             <Input
               placeholder="Add city"
               title="City"
-              onChange={this.props.onUpdateCity}
+              onChange={this.changeEventHandler("city")}
               block
             />
           </Flex>
@@ -82,11 +126,22 @@ export class AddressForm extends React.Component<AddressFormProps> {
             <Input
               placeholder="Add State, province, or region"
               title="State, province, or region"
-              onChange={this.props.onUpdateRegion}
+              onChange={this.changeEventHandler("region")}
               block
             />
           </Flex>
         </TwoColumnSplit>
+        {!this.props.billing && (
+          <Flex flexDirection="column">
+            <Input
+              title="Phone"
+              description="For shipping purposes only"
+              placeholder="Add phone"
+              onChange={this.changeEventHandler("phoneNumber")}
+              block
+            />
+          </Flex>
+        )}
       </Join>
     )
   }

--- a/src/Apps/Order/Components/ShippingAddress.tsx
+++ b/src/Apps/Order/Components/ShippingAddress.tsx
@@ -11,6 +11,7 @@ export interface ShippingAddressProps {
   postalCode: string
   region: string
   country: string
+  phoneNumber: string
 }
 
 export const ShippingAddress = ({
@@ -21,6 +22,7 @@ export const ShippingAddress = ({
   postalCode,
   region,
   country,
+  phoneNumber,
 }: ShippingAddressProps) => {
   return (
     <>
@@ -34,6 +36,7 @@ export const ShippingAddress = ({
       <Serif size="3t">
         {COUNTRY_CODE_TO_COUNTRY_NAME[country] || country}
       </Serif>
+      {phoneNumber && <Serif size="3t">{phoneNumber}</Serif>}
     </>
   )
 }

--- a/src/Apps/Order/Components/ShippingAndPaymentReview.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentReview.tsx
@@ -12,6 +12,7 @@ export const ShippingAndPaymentReview = ({
     requestedFulfillment: { __typename, ...address },
     lineItems,
     creditCard,
+    buyerPhoneNumber,
   },
   onChangePayment,
   onChangeShipping,
@@ -24,7 +25,10 @@ export const ShippingAndPaymentReview = ({
   <Flex flexDirection="column" {...others}>
     {__typename === "Ship" ? (
       <StepSummaryItem onChange={onChangeShipping} title="Shipping address">
-        <ShippingAddress {...address as ShippingAddressProps} />
+        <ShippingAddress
+          {...address as ShippingAddressProps}
+          phoneNumber={buyerPhoneNumber}
+        />
       </StepSummaryItem>
     ) : (
       <StepSummaryItem
@@ -74,6 +78,7 @@ export const ShippingAndPaymentReviewFragmentContainer = createFragmentContainer
         expiration_year
         expiration_month
       }
+      buyerPhoneNumber
     }
   `
 )

--- a/src/Apps/Order/Components/ShippingAndPaymentSummary.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentSummary.tsx
@@ -12,6 +12,7 @@ export const ShippingAndPaymentSummary = ({
     requestedFulfillment: { __typename, ...address },
     lineItems,
     creditCard,
+    buyerPhoneNumber,
   },
   ...others
 }: {
@@ -20,7 +21,10 @@ export const ShippingAndPaymentSummary = ({
   <Flex flexDirection="column" {...others}>
     {__typename === "Ship" ? (
       <StepSummaryItem title="Ship to">
-        <ShippingAddress {...address as ShippingAddressProps} />
+        <ShippingAddress
+          {...address as ShippingAddressProps}
+          phoneNumber={buyerPhoneNumber}
+        />
       </StepSummaryItem>
     ) : (
       <StepSummaryItem
@@ -69,6 +73,7 @@ export const ShippingAndPaymentSummaryFragmentContainer = createFragmentContaine
         expiration_year
         expiration_month
       }
+      buyerPhoneNumber
     }
   `
 )

--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -30,6 +30,7 @@ const order: ShippingAndPaymentReview_order &
     expiration_month: 3,
     expiration_year: 21,
   },
+  buyerPhoneNumber: "555-8390344",
 }
 
 storiesOf("Apps/Order Page/Components", module).add(

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -14,17 +14,20 @@ import { Col, Row } from "Styleguide/Elements/Grid"
 import { Join } from "Styleguide/Elements/Join"
 import { Spacer } from "Styleguide/Elements/Spacer"
 import { Responsive } from "Utils/Responsive"
-import { AddressForm } from "../../Components/AddressForm"
+import {
+  Address,
+  AddressForm,
+  emptyAddress,
+} from "../../Components/AddressForm"
 import { Helper } from "../../Components/Helper"
 import { TransactionSummaryFragmentContainer as TransactionSummary } from "../../Components/TransactionSummary"
-import { Address } from "../Shipping"
 
 export interface PaymentProps {
   order: Payment_order
 }
 
 interface PaymentState {
-  country: string
+  address: Partial<Address>
   hideBillingAddress: boolean
 }
 
@@ -36,18 +39,14 @@ const ContinueButton = ({ order }) => (
   </Link>
 )
 
-export class PaymentRoute extends Component<
-  PaymentProps,
-  PaymentState & Address
-> {
-  state = { country: "US", hideBillingAddress: true }
-  onUpdateName = e => this.setState({ name: e.target.value })
-  onUpdateAddressLine1 = e => this.setState({ addressLine1: e.target.value })
-  onUpdateAddressLine2 = e => this.setState({ addressLine2: e.target.value })
-  onUpdateCity = e => this.setState({ city: e.target.value })
-  onUpdateRegion = e => this.setState({ region: e.target.value })
-  onUpdateCountry = country => this.setState({ country })
-  onUpdatePostalCode = e => this.setState({ postalCode: e.target.value })
+export class PaymentRoute extends Component<PaymentProps, PaymentState> {
+  state = {
+    address: {
+      ...emptyAddress,
+      country: "US",
+    },
+    hideBillingAddress: true,
+  }
 
   render() {
     const { order } = this.props
@@ -79,14 +78,9 @@ export class PaymentRoute extends Component<
                       </Checkbox>
                       <Collapse open={!this.state.hideBillingAddress}>
                         <AddressForm
-                          country={this.state.country}
-                          onUpdateName={this.onUpdateName}
-                          onUpdateAddressLine1={this.onUpdateAddressLine1}
-                          onUpdateAddressLine2={this.onUpdateAddressLine2}
-                          onUpdateCity={this.onUpdateCity}
-                          onUpdateRegion={this.onUpdateRegion}
-                          onUpdateCountry={this.onUpdateCountry}
-                          onUpdatePostalCode={this.onUpdatePostalCode}
+                          defaultValue={this.state.address}
+                          onChange={address => this.setState({ address })}
+                          billing
                         />
                       </Collapse>
                       {!xs && <ContinueButton order={order} />}

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { commitMutation, RelayProp } from "react-relay"
 
 import { UntouchedOrder } from "Apps/__test__/Fixtures/Order"
+import Input from "Components/Input"
 import { Button } from "Styleguide/Elements/Button"
 import { Radio } from "Styleguide/Elements/Radio"
 import { Provider } from "unstated"
@@ -45,10 +46,16 @@ describe("Shipping", () => {
 
   it("commits the mutation with shipping option", () => {
     const component = getWrapper(testProps)
-    component
+    const input = component
+      .find(Input)
+      .filterWhere(
+        wrapper => wrapper.props().title === "State, province, or region"
+      )
       .find("input")
-      .last()
-      .simulate("change", { target: { value: "New Brunswick" } })
+    // https://github.com/airbnb/enzyme/issues/218#issuecomment-388481390
+    input.getDOMNode().value = "New Brunswick"
+    input.simulate("change")
+
     const mockCommitMutation = commitMutation as jest.Mock<any>
     mockCommitMutation.mockImplementationOnce((_environment, config) => {
       expect(config.variables.input.shipping.region).toBe("New Brunswick")

--- a/src/Apps/__test__/Fixtures/Order.ts
+++ b/src/Apps/__test__/Fixtures/Order.ts
@@ -53,6 +53,7 @@ export const UntouchedOrder = {
 
 export const OrderWithShippingDetails = {
   ...UntouchedOrder,
+  buyerPhoneNumber: "120938120983",
   requestedFulfillment: {
     __typename: "Ship",
     name: "Joelle Van Dyne",

--- a/src/Components/Forms/support/Field.tsx
+++ b/src/Components/Forms/support/Field.tsx
@@ -1,12 +1,16 @@
 import { Field as FormikField } from "formik"
 import React from "react"
-import { default as Input } from "../../Input"
+import { default as Input, InputProps } from "../../Input"
 
+interface FieldProps extends InputProps {
+  name: string
+  type: string
+}
 /**
  * A text input with the standard FormimkProps added for rendering niceness
  */
-export const Field: (props: any) => any = props => {
-  const { name, type, placeholder, block, title } = props
+export const Field: (props: FieldProps) => any = props => {
+  const { name, type, placeholder, ref, ...inputProps } = props
   return (
     <FormikField
       name={name}
@@ -20,13 +24,12 @@ export const Field: (props: any) => any = props => {
         <div>
           <Input
             {...field}
-            title={title}
-            block={block}
             type={type}
             placeholder={placeholder}
             error={touched[name] && errors[name]}
             value={values[name]}
             {...restProps}
+            {...inputProps}
           />
         </div>
       )}

--- a/src/__generated__/ShippingAndPaymentReview_order.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentReview_order.graphql.ts
@@ -33,6 +33,7 @@ export type ShippingAndPaymentReview_order = {
         readonly expiration_year: number;
         readonly expiration_month: number;
     }) | null;
+    readonly buyerPhoneNumber: string | null;
     readonly " $refType": ShippingAndPaymentReview_order$ref;
 };
 
@@ -226,9 +227,16 @@ return {
         v0
       ]
     },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "buyerPhoneNumber",
+      "args": null,
+      "storageKey": null
+    },
     v1
   ]
 };
 })();
-(node as any).hash = 'e7d06d6951ef4d1722bd36d8beaa19f1';
+(node as any).hash = 'b01215b4751e102c732c6187f36fd283';
 export default node;

--- a/src/__generated__/ShippingAndPaymentSummary_order.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentSummary_order.graphql.ts
@@ -33,6 +33,7 @@ export type ShippingAndPaymentSummary_order = {
         readonly expiration_year: number;
         readonly expiration_month: number;
     }) | null;
+    readonly buyerPhoneNumber: string | null;
     readonly " $refType": ShippingAndPaymentSummary_order$ref;
 };
 
@@ -226,9 +227,16 @@ return {
         v0
       ]
     },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "buyerPhoneNumber",
+      "args": null,
+      "storageKey": null
+    },
     v1
   ]
 };
 })();
-(node as any).hash = 'ece160ca7fd755b9b805ffd2b741e3b2';
+(node as any).hash = '2dda3424744cd625f0d925f606ea5f40';
 export default node;

--- a/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
+++ b/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
@@ -5,6 +5,7 @@ export type OrderFulfillmentType = "PICKUP" | "SHIP" | "%future added value";
 export type SetOrderShippingInput = {
     readonly orderId?: string | null;
     readonly fulfillmentType?: OrderFulfillmentType | null;
+    readonly phoneNumber?: string | null;
     readonly shipping?: ShippingInputField | null;
     readonly clientMutationId?: string | null;
 };

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -136,6 +136,7 @@ fragment ShippingAndPaymentReview_order on Order {
     expiration_month
     __id
   }
+  buyerPhoneNumber
   __id: id
 }
 */
@@ -206,7 +207,7 @@ return {
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n      country\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n      country\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  buyerPhoneNumber\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -248,7 +249,35 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "buyerTotal",
+            "args": null,
+            "storageKey": null
+          },
           v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingTotal",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "taxTotal",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "itemsTotal",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -420,34 +449,6 @@ return {
             ]
           },
           {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "shippingTotal",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "taxTotal",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "itemsTotal",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "buyerTotal",
-            "args": null,
-            "storageKey": null
-          },
-          {
             "kind": "LinkedField",
             "alias": null,
             "name": "seller",
@@ -568,6 +569,13 @@ return {
               },
               v5
             ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "buyerPhoneNumber",
+            "args": null,
+            "storageKey": null
           }
         ]
       }

--- a/src/__generated__/routes_StatusQuery.graphql.ts
+++ b/src/__generated__/routes_StatusQuery.graphql.ts
@@ -117,6 +117,7 @@ fragment ShippingAndPaymentSummary_order on Order {
     expiration_month
     __id
   }
+  buyerPhoneNumber
   __id: id
 }
 
@@ -168,28 +169,28 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "__id",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__id",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
@@ -207,7 +208,7 @@ return {
   "operationKind": "query",
   "name": "routes_StatusQuery",
   "id": null,
-  "text": "query routes_StatusQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n      country\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
+  "text": "query routes_StatusQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      postalCode\n      region\n      country\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  buyerPhoneNumber\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -250,13 +251,26 @@ return {
         "plural": false,
         "selections": [
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "buyerTotal",
+            "name": "seller",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v3,
+              v4,
+              {
+                "kind": "InlineFragment",
+                "type": "Partner",
+                "selections": [
+                  v5
+                ]
+              }
+            ]
           },
-          v3,
+          v6,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -281,29 +295,16 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "code",
+            "name": "buyerTotal",
             "args": null,
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "seller",
-            "storageKey": null,
+            "name": "code",
             "args": null,
-            "concreteType": null,
-            "plural": false,
-            "selections": [
-              v4,
-              v5,
-              {
-                "kind": "InlineFragment",
-                "type": "Partner",
-                "selections": [
-                  v6
-                ]
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "LinkedField",
@@ -414,8 +415,8 @@ return {
                               }
                             ]
                           },
-                          v5,
-                          v3,
+                          v4,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -485,12 +486,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v4,
+              v3,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v6,
+                  v5,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -574,8 +575,15 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v5
+              v4
             ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "buyerPhoneNumber",
+            "args": null,
+            "storageKey": null
           }
         ]
       }


### PR DESCRIPTION
- bumped metaphysics to include changes from artsy/metaphysics#1265
- Added phone number field to AddressForm, while refactoring it to not have individual change handlers for each field, as discussed in https://github.com/artsy/reaction/pull/1152#pullrequestreview-147370701 and https://github.com/artsy/reaction/pull/1186#discussion_r213277528

https://artsyproduct.atlassian.net/browse/PURCHASE-422
https://artsyproduct.atlassian.net/browse/PURCHASE-397

force screenshots of phone number appearing in:
- review address
    ![image](https://user-images.githubusercontent.com/1242537/45160336-1e5d7780-b1e1-11e8-911a-031b011c5168.png)
- summary address
    ![image](https://user-images.githubusercontent.com/1242537/45160413-4e0c7f80-b1e1-11e8-82c1-9397abd95ef6.png)
- shipping address form
    ![image](https://user-images.githubusercontent.com/1242537/45160466-72685c00-b1e1-11e8-88a1-0cee8287d209.png)



