### PR TITLE
Refactors existing modal and adds new error modal

### DIFF
--- a/src/Components/Modal/ErrorModal.tsx
+++ b/src/Components/Modal/ErrorModal.tsx
@@ -3,7 +3,7 @@ import { ModalWrapper } from "Components/Modal/ModalWrapper"
 import React from "react"
 import styled from "styled-components"
 
-interface ModalErrorProps extends React.HTMLProps<HTMLDivElement> {
+interface ErrorModalProps extends React.HTMLProps<HTMLDivElement> {
   show?: boolean
   headerText?: string
   detailText?: string
@@ -11,14 +11,14 @@ interface ModalErrorProps extends React.HTMLProps<HTMLDivElement> {
   onClose?: () => void
 }
 
-export class ModalError extends React.Component<ModalErrorProps> {
+export class ErrorModal extends React.Component<ErrorModalProps> {
   static defaultProps = {
     headerText: "An error occurred",
     closeText: "Continue",
   }
 
   close = () => {
-    this.props.onClose()
+    this.props.onClose && this.props.onClose()
   }
 
   render() {
@@ -26,7 +26,7 @@ export class ModalError extends React.Component<ModalErrorProps> {
 
     return (
       <ModalWrapper show={show} onClose={onClose}>
-        <ModalErrorInner>
+        <ErrorModalInner>
           <Sans size="4" weight="medium" mb={10}>
             {headerText}
           </Sans>
@@ -46,7 +46,7 @@ export class ModalError extends React.Component<ModalErrorProps> {
               {closeText}
             </Sans>
           </Dismiss>
-        </ModalErrorInner>
+        </ErrorModalInner>
       </ModalWrapper>
     )
   }
@@ -56,11 +56,11 @@ const Link = styled.a`
   color: ${color("black60")};
 `
 
-const ModalErrorInner = styled.div`
+const ErrorModalInner = styled.div`
   padding: 20px;
 `
 
-const Dismiss = styled.div`
+export const Dismiss = styled.div`
   text-align: right;
   &:hover {
     cursor: pointer;

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -1,8 +1,9 @@
 import { color } from "@artsy/palette"
 import Icon from "Components/Icon"
 import React from "react"
-import styled, { injectGlobal, keyframes } from "styled-components"
-import FadeTransition from "../Animation/FadeTransition"
+import styled from "styled-components"
+
+import ModalWrapper from "Components/Modal/ModalWrapper"
 import { media } from "../Helpers"
 import { CtaProps, ModalCta } from "./ModalCta"
 import { ModalHeader } from "./ModalHeader"
@@ -12,25 +13,13 @@ export interface ModalProps extends React.HTMLProps<Modal> {
   cta?: CtaProps
   onClose?: () => void
   hasLogo?: boolean
-  image?: string
   isWide?: boolean
+  image?: string
   show?: boolean
   title?: string
 }
 
-export interface ModalState {
-  isAnimating: boolean
-  isShown: boolean
-  blurContainers: Element[]
-}
-
-injectGlobal`
-  .blurred {
-    filter: blur(50px);
-  }
-`
-
-export class Modal extends React.Component<ModalProps, ModalState> {
+export class Modal extends React.Component<ModalProps> {
   static defaultProps = {
     show: false,
     blurContainerSelector: "",
@@ -53,104 +42,54 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     }
   }
 
-  componentWillUnmount() {
-    this.removeBlurToContainers()
-  }
-
   close = () => {
     this.props.onClose()
-    this.removeBlurToContainers()
-  }
-
-  addBlurToContainers = () => {
-    for (const container of this.state.blurContainers) {
-      container.classList.add("blurred")
-    }
-  }
-
-  removeBlurToContainers = () => {
-    for (const container of this.state.blurContainers) {
-      container.classList.remove("blurred")
-    }
   }
 
   render(): JSX.Element {
-    const { children, cta, hasLogo, image, isWide, title } = this.props
-    const { isShown, isAnimating } = this.state
-
-    if (isShown) {
-      this.addBlurToContainers()
-    } else {
-      this.removeBlurToContainers()
-    }
+    const {
+      children,
+      cta,
+      hasLogo,
+      image,
+      isWide,
+      onClose,
+      show,
+      title,
+    } = this.props
 
     return (
-      <ModalWrapper isShown={isShown || isAnimating}>
-        {isShown && <ModalOverlay onClick={this.close} />}
-        <FadeTransition
-          in={isShown}
-          mountOnEnter
-          onExited={() => {
-            this.setState({ isAnimating: false })
-          }}
-          unmountOnExit
-          timeout={{ enter: 10, exit: 200 }}
-        >
-          <ModalContainer isWide={isWide} image={image}>
-            <ModalInner>
-              <CloseButton name="close" onClick={this.close} />
+      <ModalWrapper
+        cta={cta}
+        onClose={onClose}
+        show={show}
+        isWide={isWide}
+        image={image}
+      >
+        <CloseButton name="close" onClick={this.close} />
 
-              {image && <Image image={image} />}
+        {image && <Image image={image} />}
 
-              <ModalContent cta={cta}>
-                {(hasLogo || title) && (
-                  <ModalHeader title={title} hasLogo={hasLogo} />
-                )}
+        <ModalContent cta={cta} hasImage={image && true}>
+          {(hasLogo || title) && (
+            <ModalHeader title={title} hasLogo={hasLogo} />
+          )}
 
-                <div>{children}</div>
+          <div>{children}</div>
 
-                {cta && (
-                  <ModalCta
-                    cta={cta}
-                    hasImage={image && true}
-                    onClose={this.close}
-                  />
-                )}
-              </ModalContent>
-            </ModalInner>
-          </ModalContainer>
-        </FadeTransition>
+          {cta && (
+            <ModalCta cta={cta} hasImage={image && true} onClose={this.close} />
+          )}
+        </ModalContent>
       </ModalWrapper>
     )
   }
 }
 
-const slideUp = keyframes`
-  from {
-    transform: translate(-50%,-40%);
-    opacity: 0;
-  },
-
-  to {
-    transform: translate(-50%,-50%);
-    opacity: 1;
-  }
-`
-
-const ModalWrapper = styled.div.attrs<{ isShown?: boolean }>({})`
-  ${props =>
-    props.isShown &&
-    `
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 9999
-  `};
-`
-
-const ModalContent = styled.div.attrs<{ cta: CtaProps }>({})`
+export const ModalContent = styled.div.attrs<{
+  cta: CtaProps
+  hasImage: boolean
+}>({})`
   padding: ${props =>
     props.cta
       ? props.cta.isFixed
@@ -158,48 +97,12 @@ const ModalContent = styled.div.attrs<{ cta: CtaProps }>({})`
         : "20px 40px 0"
       : "20px 40px 40px"};
   width: 100%;
+
+  width: ${props => (props.cta && props.hasImage ? "50%" : "100%")};
+  margin-left: ${props => props.cta && props.hasImage && "50%"};
   ${media.sm`
     padding: ${props =>
       props.cta && props.cta.isFixed ? "20px 20px 110px" : "20px"};
-  `};
-`
-
-export const ModalContainer = styled.div.attrs<{
-  isWide?: boolean
-  image?: string
-}>({})`
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: #fff;
-  width: ${props => (props.isWide || props.image ? "900px" : "440px")};
-  height: min-content;
-  border-radius: 5px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
-  animation: ${slideUp} 250ms linear;
-
-  ${ModalContent} {
-    ${props =>
-      props.image &&
-      `
-      width: 50%;
-      margin-left: 50%;
-    `};
-  }
-  ${media.sm`
-    width: 100%;
-    border-radius: 0;
-  `};
-`
-
-const ModalInner = styled.div`
-  /* disabling scrolling until custom scrollbars are implemented */
-  /* overflow-y: scroll; */
-  max-height: calc(100vh - 80px);
-  ${media.sm`
-    max-height: 100vh;
-    height: 100vh
   `};
 `
 

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -3,7 +3,7 @@ import Icon from "Components/Icon"
 import React from "react"
 import styled from "styled-components"
 
-import ModalWrapper from "Components/Modal/ModalWrapper"
+import { ModalWrapper } from "Components/Modal/ModalWrapper"
 import { media } from "../Helpers"
 import { CtaProps, ModalCta } from "./ModalCta"
 import { ModalHeader } from "./ModalHeader"

--- a/src/Components/Modal/ModalError.tsx
+++ b/src/Components/Modal/ModalError.tsx
@@ -1,0 +1,68 @@
+import { color, Sans } from "@artsy/palette"
+import { ModalWrapper } from "Components/Modal/ModalWrapper"
+import React from "react"
+import styled from "styled-components"
+
+interface ModalErrorProps extends React.HTMLProps<HTMLDivElement> {
+  show?: boolean
+  headerText?: string
+  detailText?: string
+  closeText?: string
+  onClose?: () => void
+}
+
+export class ModalError extends React.Component<ModalErrorProps> {
+  static defaultProps = {
+    headerText: "An error occurred",
+    closeText: "Continue",
+  }
+
+  close = () => {
+    this.props.onClose()
+  }
+
+  render() {
+    const { show, onClose, headerText, detailText, closeText } = this.props
+
+    return (
+      <ModalWrapper show={show} onClose={onClose}>
+        <ModalErrorInner>
+          <Sans size="4" weight="medium" mb={10}>
+            {headerText}
+          </Sans>
+          {detailText ? (
+            <Sans size="3" color="black60" mb={30}>
+              {detailText}
+            </Sans>
+          ) : (
+            <Sans size="3" color="black60" mb={30}>
+              Something went wrong. Please try again or contact{" "}
+              <Link href="mailto:support@artsy.net">support@artsy.net</Link>.
+            </Sans>
+          )}
+
+          <Dismiss onClick={this.close}>
+            <Sans size="3" color="purple100" weight="medium">
+              {closeText}
+            </Sans>
+          </Dismiss>
+        </ModalErrorInner>
+      </ModalWrapper>
+    )
+  }
+}
+
+const Link = styled.a`
+  color: ${color("black60")};
+`
+
+const ModalErrorInner = styled.div`
+  padding: 20px;
+`
+
+const Dismiss = styled.div`
+  text-align: right;
+  &:hover {
+    cursor: pointer;
+  }
+`

--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -1,0 +1,171 @@
+import React from "react"
+import styled, { injectGlobal, keyframes } from "styled-components"
+import FadeTransition from "../Animation/FadeTransition"
+import { media } from "../Helpers"
+import { CtaProps } from "./ModalCta"
+
+export interface ModalWrapperProps extends React.HTMLProps<ModalWrapper> {
+  blurContainerSelector?: string
+  cta?: CtaProps
+  onClose?: () => void
+  isWide?: boolean
+  image?: string
+  show?: boolean
+}
+
+export interface ModalWrapperState {
+  isAnimating: boolean
+  isShown: boolean
+  blurContainers: Element[]
+}
+
+injectGlobal`
+  .blurred {
+    filter: blur(50px);
+  }
+`
+
+export class ModalWrapper extends React.Component<
+  ModalWrapperProps,
+  ModalWrapperState
+> {
+  static defaultProps = {
+    show: false,
+    blurContainerSelector: "",
+  }
+
+  state = {
+    isAnimating: this.props.show || false,
+    isShown: this.props.show || false,
+    blurContainers: this.props.blurContainerSelector
+      ? Array.from(document.querySelectorAll(this.props.blurContainerSelector))
+      : [],
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.show !== nextProps.show) {
+      this.setState({
+        isAnimating: true,
+        isShown: nextProps.show,
+      })
+    }
+  }
+
+  componentWillUnmount() {
+    this.removeBlurToContainers()
+  }
+
+  close = () => {
+    this.props.onClose()
+    this.removeBlurToContainers()
+  }
+
+  addBlurToContainers = () => {
+    for (const container of this.state.blurContainers) {
+      container.classList.add("blurred")
+    }
+  }
+
+  removeBlurToContainers = () => {
+    for (const container of this.state.blurContainers) {
+      container.classList.remove("blurred")
+    }
+  }
+
+  render(): JSX.Element {
+    const { children, isWide, image } = this.props
+    const { isShown, isAnimating } = this.state
+
+    if (isShown) {
+      this.addBlurToContainers()
+    } else {
+      this.removeBlurToContainers()
+    }
+
+    return (
+      <Wrapper isShown={isShown || isAnimating}>
+        {isShown && <ModalOverlay onClick={this.close} />}
+        <FadeTransition
+          in={isShown}
+          mountOnEnter
+          onExited={() => {
+            this.setState({ isAnimating: false })
+          }}
+          unmountOnExit
+          timeout={{ enter: 10, exit: 200 }}
+        >
+          <ModalContainer isWide={isWide} image={image}>
+            <ModalInner>{children}</ModalInner>
+          </ModalContainer>
+        </FadeTransition>
+      </Wrapper>
+    )
+  }
+}
+
+const Wrapper = styled.div.attrs<{ isShown?: boolean }>({})`
+  ${props =>
+    props.isShown &&
+    `
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999
+  `};
+`
+
+const slideUp = keyframes`
+  from {
+    transform: translate(-50%,-40%);
+    opacity: 0;
+  },
+
+  to {
+    transform: translate(-50%,-50%);
+    opacity: 1;
+  }
+`
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background: rgba(200, 200, 200, 0.5);
+`
+
+export const ModalContainer = styled.div.attrs<{
+  isWide?: boolean
+  image?: string
+}>({})`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #fff;
+  width: ${props => (props.isWide || props.image ? "900px" : "440px")};
+  height: min-content;
+  border-radius: 5px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+  animation: ${slideUp} 250ms linear;
+
+  ${media.sm`
+    width: 100%;
+    border-radius: 0;
+  `};
+`
+
+const ModalInner = styled.div`
+  /* disabling scrolling until custom scrollbars are implemented */
+  /* overflow-y: scroll; */
+  max-height: calc(100vh - 80px);
+  ${media.sm`
+    max-height: 100vh;
+    height: 100vh
+  `};
+`
+
+export default ModalWrapper

--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -1,3 +1,4 @@
+import { Theme } from "@artsy/palette"
 import React from "react"
 import styled, { injectGlobal, keyframes } from "styled-components"
 import FadeTransition from "../Animation/FadeTransition"
@@ -83,22 +84,24 @@ export class ModalWrapper extends React.Component<
     }
 
     return (
-      <Wrapper isShown={isShown || isAnimating}>
-        {isShown && <ModalOverlay onClick={this.close} />}
-        <FadeTransition
-          in={isShown}
-          mountOnEnter
-          onExited={() => {
-            this.setState({ isAnimating: false })
-          }}
-          unmountOnExit
-          timeout={{ enter: 10, exit: 200 }}
-        >
-          <ModalContainer isWide={isWide} image={image}>
-            <ModalInner>{children}</ModalInner>
-          </ModalContainer>
-        </FadeTransition>
-      </Wrapper>
+      <Theme>
+        <Wrapper isShown={isShown || isAnimating}>
+          {isShown && <ModalOverlay onClick={this.close} />}
+          <FadeTransition
+            in={isShown}
+            mountOnEnter
+            onExited={() => {
+              this.setState({ isAnimating: false })
+            }}
+            unmountOnExit
+            timeout={{ enter: 10, exit: 200 }}
+          >
+            <ModalContainer isWide={isWide} image={image}>
+              <ModalInner>{children}</ModalInner>
+            </ModalContainer>
+          </FadeTransition>
+        </Wrapper>
+      </Theme>
     )
   }
 }

--- a/src/Components/Modal/__tests__/ErrorModal.test.tsx
+++ b/src/Components/Modal/__tests__/ErrorModal.test.tsx
@@ -1,0 +1,61 @@
+import { mount } from "enzyme"
+import React from "react"
+import { Dismiss, ErrorModal } from "../ErrorModal"
+
+describe("ErrorModal", () => {
+  const getWrapper = inputs => {
+    return mount(<ErrorModal {...inputs} />)
+  }
+
+  let props
+  beforeEach(() => {
+    props = {
+      onClose: jest.fn(),
+      blurContainerSelector: "",
+    }
+  })
+
+  describe("ErrorModal content", () => {
+    beforeEach(() => {
+      props.show = true
+    })
+
+    it("Renders with default text if no props are specified", () => {
+      const component = getWrapper(props)
+      const text = component.text()
+      expect(text).toContain("An error occurred")
+      expect(text).toContain(
+        "Something went wrong. Please try again or contact support@artsy.net."
+      )
+      expect(text).toContain("Continue")
+    })
+
+    it("Renders with a specified detailText", () => {
+      props.detailText = "A custom error detail."
+      const component = getWrapper(props)
+      const text = component.text()
+      expect(text).toContain("A custom error detail.")
+      expect(text).not.toContain(
+        "Something went wrong. Please try again or contact support@artsy.net."
+      )
+    })
+
+    it("Renders with a specified props for header, detail, and the close button", () => {
+      props.headerText = "Custom header"
+      props.detailText = "A custom error detail."
+      props.closeText = "OK"
+      const component = getWrapper(props)
+      const text = component.text()
+      expect(text).toContain("Custom header")
+      expect(text).toContain("A custom error detail.")
+      expect(text).toContain("OK")
+    })
+
+    it("Clicking on the continue button closes the modal", () => {
+      props.onClose = jest.fn()
+      const component = getWrapper(props)
+      component.find(Dismiss).simulate("click")
+      expect(props.onClose).toBeCalled()
+    })
+  })
+})

--- a/src/Components/Modal/__tests__/Modal.test.tsx
+++ b/src/Components/Modal/__tests__/Modal.test.tsx
@@ -1,14 +1,14 @@
 import Icon from "Components/Icon"
 import { mount } from "enzyme"
 import React from "react"
-import { Modal, ModalContainer, ModalOverlay } from "../Modal"
+import { Modal, ModalOverlay } from "../Modal"
 import { ModalCta } from "../ModalCta"
 import { ModalHeader } from "../ModalHeader"
 
 describe("Modal", () => {
-  const getWrapper = props => {
+  const getWrapper = inputs => {
     return mount(
-      <Modal {...props}>
+      <Modal {...inputs}>
         <div>Modal Contents</div>
       </Modal>
     )
@@ -20,46 +20,6 @@ describe("Modal", () => {
       onClose: jest.fn(),
       blurContainerSelector: "",
     }
-  })
-
-  it("does not render children by default", () => {
-    const component = getWrapper(props)
-    expect(component.html()).not.toMatch("Modal Contents")
-  })
-
-  it("Renders children if props.show", () => {
-    props.show = true
-    const component = getWrapper(props)
-
-    expect(component.find(ModalContainer)).toHaveLength(1)
-    expect(component.find(ModalOverlay)).toHaveLength(1)
-    expect(component.html()).toMatch("Modal Contents")
-  })
-
-  it("Closes on background click", () => {
-    props.show = true
-    const component = getWrapper(props)
-    component.instance().removeBlurToContainers = jest.fn()
-    component
-      .find(ModalOverlay)
-      .at(0)
-      .simulate("click")
-
-    expect(component.instance().removeBlurToContainers).toHaveBeenCalled()
-    expect(props.onClose).toHaveBeenCalled()
-  })
-
-  it("Closes on x-button click", () => {
-    props.show = true
-    const component = getWrapper(props)
-    component.instance().removeBlurToContainers = jest.fn()
-    component
-      .find(Icon)
-      .at(0)
-      .simulate("click")
-
-    expect(component.instance().removeBlurToContainers).toHaveBeenCalled()
-    expect(props.onClose).toHaveBeenCalled()
   })
 
   describe("Modal content", () => {

--- a/src/Components/Modal/__tests__/ModalWrapper.test.tsx
+++ b/src/Components/Modal/__tests__/ModalWrapper.test.tsx
@@ -1,0 +1,47 @@
+import { mount } from "enzyme"
+import React from "react"
+import { ModalContainer, ModalOverlay, ModalWrapper } from "../ModalWrapper"
+
+describe("Modal", () => {
+  const getWrapper = inputs => {
+    return mount(
+      <ModalWrapper {...inputs}>
+        <div>Modal Contents</div>
+      </ModalWrapper>
+    )
+  }
+
+  let props
+  beforeEach(() => {
+    props = {
+      onClose: jest.fn(),
+      blurContainerSelector: "",
+    }
+  })
+
+  it("does not render children by default", () => {
+    const component = getWrapper(props)
+    expect(component.html()).not.toMatch("Modal Contents")
+  })
+
+  it("Renders children if props.show", () => {
+    props.show = true
+    const component = getWrapper(props)
+
+    expect(component.find(ModalContainer)).toHaveLength(1)
+    expect(component.find(ModalOverlay)).toHaveLength(1)
+    expect(component.html()).toMatch("Modal Contents")
+  })
+  it("Closes on background click", () => {
+    props.show = true
+    const component = getWrapper(props)
+    component.instance().removeBlurToContainers = jest.fn()
+    component
+      .find(ModalOverlay)
+      .at(0)
+      .simulate("click")
+
+    expect(component.instance().removeBlurToContainers).toHaveBeenCalled()
+    expect(props.onClose).toHaveBeenCalled()
+  })
+})

--- a/src/Components/__stories__/Modal.story.tsx
+++ b/src/Components/__stories__/Modal.story.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
 
+import { ModalError } from "Components/Modal/ModalError"
 import { Images } from "Components/Publishing/Fixtures/Components"
 import Button from "../Buttons/Default"
 import Modal from "../Modal/Modal"
@@ -48,6 +49,38 @@ class ModalDemo extends React.Component<any, any> {
             <div>Even more contents</div>
           </div>
         </Modal>
+      </div>
+    )
+  }
+}
+
+class ModalErrorDemo extends React.Component<any, any> {
+  constructor(props) {
+    super(props)
+    this.state = { isModalOpen: true }
+    this.openModal = this.openModal.bind(this)
+    this.closeModal = this.closeModal.bind(this)
+  }
+
+  openModal() {
+    this.setState({ isModalOpen: true })
+  }
+
+  closeModal() {
+    this.setState({ isModalOpen: false })
+  }
+
+  render(): JSX.Element {
+    return (
+      <div>
+        <Button onClick={this.openModal}>Open Modal</Button>
+        <ModalError
+          onClose={this.closeModal}
+          show={this.state.isModalOpen}
+          headerText={this.props.headerText}
+          detailText={this.props.detailText}
+          closeText={this.props.closeText}
+        />
       </div>
     )
   }
@@ -123,6 +156,14 @@ storiesOf("Components/Modal/Demo", module)
         onClick: () => alert("clicked"),
       }}
       isWide
+    />
+  ))
+  .add("Error Modal (Default)", () => <ModalErrorDemo />)
+  .add("Error Modal (Custom)", () => (
+    <ModalErrorDemo
+      closeText="OK"
+      headerText="Price changed"
+      detailText="The price of the work changed since you started checkout. Please review pricing details before submitting."
     />
   ))
 

--- a/src/Components/__stories__/Modal.story.tsx
+++ b/src/Components/__stories__/Modal.story.tsx
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
 
-import { ModalError } from "Components/Modal/ModalError"
+import { ErrorModal } from "Components/Modal/ErrorModal"
 import { Images } from "Components/Publishing/Fixtures/Components"
 import Button from "../Buttons/Default"
 import Modal from "../Modal/Modal"
@@ -54,7 +54,7 @@ class ModalDemo extends React.Component<any, any> {
   }
 }
 
-class ModalErrorDemo extends React.Component<any, any> {
+class ErrorModalDemo extends React.Component<any, any> {
   constructor(props) {
     super(props)
     this.state = { isModalOpen: true }
@@ -74,7 +74,7 @@ class ModalErrorDemo extends React.Component<any, any> {
     return (
       <div>
         <Button onClick={this.openModal}>Open Modal</Button>
-        <ModalError
+        <ErrorModal
           onClose={this.closeModal}
           show={this.state.isModalOpen}
           headerText={this.props.headerText}
@@ -158,9 +158,9 @@ storiesOf("Components/Modal/Demo", module)
       isWide
     />
   ))
-  .add("Error Modal (Default)", () => <ModalErrorDemo />)
+  .add("Error Modal (Default)", () => <ErrorModalDemo />)
   .add("Error Modal (Custom)", () => (
-    <ModalErrorDemo
+    <ErrorModalDemo
       closeText="OK"
       headerText="Price changed"
       detailText="The price of the work changed since you started checkout. Please review pricing details before submitting."


### PR DESCRIPTION
This PR:
- Extracts the "meaty" bits of our existing `Modal` component into a `ModalWrapper` so that it can be re-used for a `ModalError` (named to keep it consistent, but open to change).
- Updates `Modal` to consume the new `ModalWrapper`
- Adds a new `ModalError` which looks like:
![image](https://user-images.githubusercontent.com/2081340/45173435-34196f80-b1d6-11e8-8575-750005022303.png)

I spent a while faffing around trying to extend the existing `Modal` component for this error case, but there was a lot that was coupled in there. The error modal is much simpler and has different styling rules, but it still needs to handle the animations, blur behavior, etc.

If people find that this abstraction doesn't make sense, I am happy to update!

Also... if anyone knows why the `color` isn't being picked up on my `Sans` elements, please let me know. It's coming through in the css as:
![image](https://user-images.githubusercontent.com/2081340/45173579-9f634180-b1d6-11e8-9405-ca03bd46ec4d.png)
which suggests that it's not being interpreted correctly but I'm not sure what I'm doing wrong.