### PR TITLE
User sees an error message for credit card input immediately

### DIFF
--- a/src/Apps/Order/Components/CreditCardInput.tsx
+++ b/src/Apps/Order/Components/CreditCardInput.tsx
@@ -1,4 +1,4 @@
-import { color } from "@artsy/palette"
+import { color, Sans } from "@artsy/palette"
 import { fontFamily } from "@artsy/palette/dist/platform/fonts"
 import {
   border as inputBorder,
@@ -9,7 +9,7 @@ import { CardElement } from "react-stripe-elements"
 import styled from "styled-components"
 import { BorderBox } from "Styleguide/Elements/Box"
 
-const StyledCardElement = styled(CardElement)`
+export const StyledCardElement = styled(CardElement)`
   width: 100%;
 `
 
@@ -18,37 +18,62 @@ const StyledBorderBox = styled(BorderBox).attrs<InputBorderProps>({})`
   ${inputBorder};
 `
 
-export class CreditCardInput extends React.Component {
-  state = {
-    focused: false,
-    error: false,
+interface CreditCardInputProps {
+  error?: stripe.Error
+}
+
+interface CreditCardInputState {
+  focused: boolean
+  error: stripe.Error
+}
+
+export class CreditCardInput extends React.Component<
+  CreditCardInputProps,
+  CreditCardInputState
+> {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      focused: false,
+      error: props.error || {},
+    }
   }
 
   render() {
+    const { message } = this.state.error || { message: null }
+
     return (
-      <StyledBorderBox
-        className={`${this.state.focused ? "focused" : ""}`}
-        hasError={this.state.error}
-        p={1}
-      >
-        <StyledCardElement
-          onChange={res => {
-            this.setState({ error: res.error })
-          }}
-          onFocus={() => this.setState({ focused: true })}
-          onBlur={() => this.setState({ focused: false })}
-          style={{
-            base: {
-              "::placeholder": {
-                color: color("black30"),
+      <>
+        <StyledBorderBox
+          className={`${this.state.focused ? "focused" : ""}`}
+          hasError={!!message}
+          p={1}
+        >
+          <StyledCardElement
+            onChange={res => {
+              this.setState({ error: res.error })
+            }}
+            onFocus={() => this.setState({ focused: true })}
+            onBlur={() => this.setState({ focused: false })}
+            style={{
+              base: {
+                "::placeholder": {
+                  color: color("black30"),
+                },
+                fontFamily: fontFamily.serif.regular as string,
+                fontSmoothing: "antialiased",
+                lineHeight: "20px",
               },
-              fontFamily: fontFamily.serif.regular as string,
-              fontSmoothing: "antialiased",
-              lineHeight: "20px",
-            },
-          }}
-        />
-      </StyledBorderBox>
+            }}
+          />
+        </StyledBorderBox>
+        {message && (
+          <Sans pt={1} size="2" color="red100">
+            {message}
+          </Sans>
+        )}
+      </>
     )
   }
 }

--- a/src/Apps/Order/Components/__tests__/CreditCardInput.test.tsx
+++ b/src/Apps/Order/Components/__tests__/CreditCardInput.test.tsx
@@ -1,0 +1,49 @@
+import { Sans } from "@artsy/palette"
+import { shallow } from "enzyme"
+import React from "react"
+import { CreditCardInput, StyledCardElement } from "../CreditCardInput"
+
+describe("CreditCardInput", () => {
+  it("does not show an error message when onChange is fired with undefined response", () => {
+    const creditCardInput = shallow(<CreditCardInput />)
+
+    // We test this because the <CardElement> component invokes the onChange()
+    // callback with no error when there is no validation error in the CC info
+    // and this case is very easy to forget to test.
+    creditCardInput
+      .find(StyledCardElement)
+      .simulate("change", { complete: false, empty: false, error: undefined })
+
+    expect(creditCardInput.find(Sans).length).toEqual(0)
+  })
+
+  it("shows an error message when error.message prop is present", () => {
+    const creditCardInput = shallow(
+      <CreditCardInput error={{ message: "Card number is invalid" } as any} />
+    )
+
+    expect(creditCardInput.find(Sans).html()).toMatch("Card number is invalid")
+  })
+
+  it("shows an error message from state", () => {
+    const creditCardInput = shallow(
+      <CreditCardInput error={{ message: "Card number is invalid" }} />
+    )
+
+    creditCardInput
+      .find(StyledCardElement)
+      .simulate("change", { error: { message: "Service unavailable" } })
+
+    expect(creditCardInput.find(Sans).html()).toMatch("Service unavailable")
+  })
+
+  it("shows an error message from state even when error.message prop is present", () => {
+    const creditCardInput = shallow(<CreditCardInput />)
+
+    creditCardInput
+      .find(StyledCardElement)
+      .simulate("change", { error: { message: "Service unavailable" } })
+
+    expect(creditCardInput.find(Sans).html()).toMatch("Service unavailable")
+  })
+})

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -1,4 +1,3 @@
-import { Sans } from "@artsy/palette"
 import { Payment_order } from "__generated__/Payment_order.graphql"
 import { BuyNowStepper } from "Apps/Order/Components/BuyNowStepper"
 import { CreditCardInput } from "Apps/Order/Components/CreditCardInput"
@@ -37,7 +36,7 @@ export interface PaymentProps extends ReactStripeElements.InjectedStripeProps {
 interface PaymentState {
   address: Address
   hideBillingAddress: boolean
-  errorMessage: string
+  error: stripe.Error
   isComittingMutation: boolean
 }
 
@@ -54,7 +53,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
       country: "US",
     },
     hideBillingAddress: true,
-    errorMessage: null,
+    error: null,
     isComittingMutation: false,
   }
 
@@ -65,7 +64,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
       this.props.stripe.createToken(billingAddress).then(({ error, token }) => {
         if (error) {
           this.setState({
-            errorMessage: error.message,
+            error,
             isComittingMutation: false,
           })
         } else {
@@ -77,7 +76,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
 
   render() {
     const { order } = this.props
-    const { errorMessage, isComittingMutation } = this.state
+    const { error, isComittingMutation } = this.state
 
     return (
       <>
@@ -95,14 +94,8 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
               Content={
                 <>
                   <Join separator={<Spacer mb={3} />}>
-                    <Flex flexDirection="column">
-                      <CreditCardInput />
-                      {errorMessage && (
-                        <Sans pt={1} size="2" color="red100">
-                          {errorMessage}
-                        </Sans>
-                      )}
-                    </Flex>
+                    <CreditCardInput error={error} />
+
                     <Checkbox
                       selected={this.state.hideBillingAddress}
                       onSelect={hideBillingAddress =>


### PR DESCRIPTION
Right now users don't see an error message for the `<CreditCardInput>` as soon as they type, but this PR updates that so users will get immediate feedback. This also moves the message from the `<PaymentRoute>` to the `<CreditCardInput>` so it'll help implement the same, consistent behaviour across the site.

# Screenshot

![kapture 2018-09-07 at 15 53 30](https://user-images.githubusercontent.com/386234/45240319-32bf7400-b2b6-11e8-9766-783c03fe4863.gif)
