### PR TITLE
[FIX authentication] restore auth signup modal on articles

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -52,7 +52,7 @@ export interface ArticleProps {
 )
 export class Article extends React.Component<ArticleProps> {
   componentDidMount() {
-    if (!this.props.isLoggedIn && window) {
+    if (!this.props.isLoggedIn) {
       window.addEventListener(
         "scroll",
         debounce(() => {

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -1,3 +1,4 @@
+import { debounce } from "lodash"
 import React from "react"
 import track from "react-tracking"
 import Events from "../../Utils/Events"
@@ -50,6 +51,28 @@ export interface ArticleProps {
   }
 )
 export class Article extends React.Component<ArticleProps> {
+  componentDidMount() {
+    if (!this.props.isLoggedIn && window) {
+      window.addEventListener(
+        "scroll",
+        debounce(() => {
+          setTimeout(
+            this.props.onOpenAuthModal("register", {
+              mode: "signup",
+              intent: "Viewed editorial",
+              signupIntent: "signup",
+              trigger: "timed",
+              triggerSeconds: 2,
+              copy: "Sign up for the Best Stories in Art and Visual Culture",
+              destination: location.href,
+            }),
+            2000
+          )
+        }, 250)
+      )
+    }
+  }
+
   getArticleLayout = () => {
     const { article } = this.props
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-887. We lost the auth modal trigger when we removed the old [editorial sign up view](https://github.com/artsy/force/commit/31130073685a018bce2b5e90fce8c40f865284b7). This restores the auth modal by moving the modal trigger to the `componentDidMount` function of the `<Article>` component.