### PR TITLE
 [Collect] add support for collect/<medium> urls

### DIFF
--- a/src/Apps/Collect/CollectApp.tsx
+++ b/src/Apps/Collect/CollectApp.tsx
@@ -29,8 +29,34 @@ export class CollectApp extends Component<CollectAppProps> {
 export const CollectAppFragmentContainer = createFragmentContainer(
   CollectApp,
   graphql`
-    fragment CollectApp_viewer on Viewer {
+    fragment CollectApp_viewer on Viewer
+      @argumentDefinitions(
+        medium: { type: "String", defaultValue: "*" }
+        major_periods: { type: "[String]" }
+        partner_id: { type: "ID" }
+        for_sale: { type: "Boolean" }
+        at_auction: { type: "Boolean" }
+        acquireable: { type: "Boolean" }
+        inquireable_only: { type: "Boolean" }
+        aggregations: {
+          type: "[ArtworkAggregation]"
+          defaultValue: [MAJOR_PERIOD, MEDIUM, TOTAL]
+        }
+        sort: { type: "String", defaultValue: "-partner_updated_at" }
+        price_range: { type: "String" }
+      ) {
       ...ArtworkGrid_viewer
+        @arguments(
+          medium: $medium
+          major_periods: $major_periods
+          partner_id: $partner_id
+          for_sale: $for_sale
+          sort: $sort
+          acquireable: $acquireable
+          at_auction: $at_auction
+          inquireable_only: $inquireable_only
+          price_range: $price_range
+        )
     }
   `
 )

--- a/src/Apps/Collect/Components/ArtworkGrid/CollectArtworkGrid.tsx
+++ b/src/Apps/Collect/Components/ArtworkGrid/CollectArtworkGrid.tsx
@@ -1,5 +1,5 @@
 import { ArtworkFilterArtworkGrid_filtered_artworks } from "__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql"
-import { FilterState } from "Apps/Artist/Routes/Overview/state"
+import { FilterState } from "Apps/Collect/FilterState"
 import { ContextConsumer } from "Artsy/Router"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React, { Component } from "react"
@@ -106,7 +106,6 @@ class Artworks extends Component<Props, LoadingAreaState> {
                         onNext={() => {
                           this.loadNext(filters, mediator)
                         }}
-                        scrollTo="#jump--artistArtworkGrid"
                       />
                     </Box>
                   </LoadingArea>

--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -25,7 +25,7 @@ const initialState = {
   page: 1,
   major_periods: [],
   partner_id: null,
-  sort: "-partner_updated_at",
+  sort: "-decayed_merch",
   acquireable: null,
   at_auction: null,
   inquireable_only: null,
@@ -63,19 +63,19 @@ export class FilterState extends Container<State> {
 
   setPage(page, mediator) {
     this.setState({ page }, () => {
-      mediator.trigger("artist:filter:changed", this.state)
+      mediator.trigger("collect:filter:changed", this.state)
     })
   }
 
   setSort = (sort, mediator) => {
     this.setState({ sort }, () => {
-      mediator.trigger("artist:filter:changed", this.state)
+      mediator.trigger("collect:filter:changed", this.state)
     })
   }
 
   setPriceRange = (price_range, mediator) => {
     this.setState({ price_range }, () => {
-      mediator.trigger("artist:filter:changed", this.state)
+      mediator.trigger("collect:filter:changed", this.state)
     })
   }
 
@@ -125,7 +125,7 @@ export class FilterState extends Container<State> {
         "selectedFilterCount",
         "showActionSheet",
       ])
-      mediator.trigger("artist:filter:changed", filterState)
+      mediator.trigger("collect:filter:changed", filterState)
     })
   }
 
@@ -170,7 +170,7 @@ export class FilterState extends Container<State> {
       ])
       filterState = omitBy(filterState, isNil)
 
-      mediator.trigger("artist:filter:changed", filterState)
+      mediator.trigger("collect:filter:changed", filterState)
     })
   }
 }

--- a/src/Apps/Collect/routes.tsx
+++ b/src/Apps/Collect/routes.tsx
@@ -6,7 +6,7 @@ import { CollectAppFragmentContainer as CollectApp } from "./CollectApp"
 
 export const routes = [
   {
-    path: "/collect2",
+    path: "/collect2/:medium?",
     Component: CollectApp,
     query: graphql`
       query routes_CollectAppQuery(
@@ -43,15 +43,23 @@ export const routes = [
 
       const { __fragments, __id, ...remainingProps } = props
       return (
-        <Provider inject={[new FilterState(props.location.query)]}>
+        <Provider
+          inject={[
+            new FilterState({ ...props.params, ...props.location.query }),
+          ]}
+        >
           <Component {...remainingProps} query={{ __id, __fragments }} />
         </Provider>
       )
     },
     prepareVariables: (params, props) => {
-      // FIXME: The initial render includes `location` in props, but subsequent
-      // renders (such as tabbing back to this route in your browser) will not.
       const initialFilterState = props.location ? props.location.query : {}
+      if (params.medium) {
+        initialFilterState.medium = params.medium
+        if (props.location.query) {
+          props.location.query.medium = params.medium
+        }
+      }
       return { ...initialFilterState, ...params }
     },
   },

--- a/src/__generated__/CollectApp_viewer.graphql.ts
+++ b/src/__generated__/CollectApp_viewer.graphql.ts
@@ -16,14 +16,134 @@ const node: ConcreteFragment = {
   "name": "CollectApp_viewer",
   "type": "Viewer",
   "metadata": null,
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "medium",
+      "type": "String",
+      "defaultValue": "*"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "major_periods",
+      "type": "[String]",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "partner_id",
+      "type": "ID",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "for_sale",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "at_auction",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "acquireable",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "inquireable_only",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "aggregations",
+      "type": "[ArtworkAggregation]",
+      "defaultValue": [
+        "MAJOR_PERIOD",
+        "MEDIUM",
+        "TOTAL"
+      ]
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "sort",
+      "type": "String",
+      "defaultValue": "-partner_updated_at"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "price_range",
+      "type": "String",
+      "defaultValue": null
+    }
+  ],
   "selections": [
     {
       "kind": "FragmentSpread",
       "name": "ArtworkGrid_viewer",
-      "args": null
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "acquireable",
+          "variableName": "acquireable",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "at_auction",
+          "variableName": "at_auction",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "for_sale",
+          "variableName": "for_sale",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "inquireable_only",
+          "variableName": "inquireable_only",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "major_periods",
+          "variableName": "major_periods",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "medium",
+          "variableName": "medium",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "partner_id",
+          "variableName": "partner_id",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "price_range",
+          "variableName": "price_range",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "sort",
+          "variableName": "sort",
+          "type": null
+        }
+      ]
     }
   ]
 };
-(node as any).hash = '4c99c398ca24361f4061d49d8e94568a';
+(node as any).hash = '713d7615e649accdd8ec08518e3d2700';
 export default node;

--- a/src/__generated__/routes_CollectAppQuery.graphql.ts
+++ b/src/__generated__/routes_CollectAppQuery.graphql.ts
@@ -26,17 +26,26 @@ export type routes_CollectAppQuery = {
 
 
 /*
-query routes_CollectAppQuery {
+query routes_CollectAppQuery(
+  $medium: String
+  $major_periods: [String]
+  $partner_id: ID
+  $for_sale: Boolean
+  $sort: String
+  $at_auction: Boolean
+  $inquireable_only: Boolean
+  $price_range: String
+) {
   viewer {
     ...CollectApp_viewer_48m6Qi
   }
 }
 
 fragment CollectApp_viewer_48m6Qi on Viewer {
-  ...ArtworkGrid_viewer
+  ...ArtworkGrid_viewer_11qwCU
 }
 
-fragment ArtworkGrid_viewer on Viewer {
+fragment ArtworkGrid_viewer_11qwCU on Viewer {
   filter_artworks(aggregations: [MAJOR_PERIOD, MEDIUM, TOTAL], size: 0) {
     aggregations {
       slice
@@ -48,11 +57,11 @@ fragment ArtworkGrid_viewer on Viewer {
     }
     __id
   }
-  ...CollectArtworkFilterRefetch_viewer_3cMrV3
+  ...CollectArtworkFilterRefetch_viewer_11qwCU
 }
 
-fragment CollectArtworkFilterRefetch_viewer_3cMrV3 on Viewer {
-  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: "*", size: 0, sort: "-partner_updated_at") {
+fragment CollectArtworkFilterRefetch_viewer_11qwCU on Viewer {
+  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range) {
     ...CollectArtworkGrid_filtered_artworks
     __id
   }
@@ -332,7 +341,7 @@ return {
   "operationKind": "query",
   "name": "routes_CollectAppQuery",
   "id": null,
-  "text": "query routes_CollectAppQuery {\n  viewer {\n    ...CollectApp_viewer_48m6Qi\n  }\n}\n\nfragment CollectApp_viewer_48m6Qi on Viewer {\n  ...ArtworkGrid_viewer\n}\n\nfragment ArtworkGrid_viewer on Viewer {\n  filter_artworks(aggregations: [MAJOR_PERIOD, MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectArtworkFilterRefetch_viewer_3cMrV3\n}\n\nfragment CollectArtworkFilterRefetch_viewer_3cMrV3 on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  is_acquireable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_CollectAppQuery(\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n) {\n  viewer {\n    ...CollectApp_viewer_48m6Qi\n  }\n}\n\nfragment CollectApp_viewer_48m6Qi on Viewer {\n  ...ArtworkGrid_viewer_11qwCU\n}\n\nfragment ArtworkGrid_viewer_11qwCU on Viewer {\n  filter_artworks(aggregations: [MAJOR_PERIOD, MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectArtworkFilterRefetch_viewer_11qwCU\n}\n\nfragment CollectArtworkFilterRefetch_viewer_11qwCU on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  is_acquireable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -488,7 +497,7 @@ return {
             "kind": "LinkedField",
             "alias": "filtered_artworks",
             "name": "filter_artworks",
-            "storageKey": "filter_artworks(aggregations:[\"TOTAL\"],medium:\"*\",size:0,sort:\"-partner_updated_at\")",
+            "storageKey": null,
             "args": [
               {
                 "kind": "Literal",
@@ -499,16 +508,52 @@ return {
                 "type": "[ArtworkAggregation]"
               },
               {
-                "kind": "Literal",
+                "kind": "Variable",
+                "name": "at_auction",
+                "variableName": "at_auction",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "for_sale",
+                "variableName": "for_sale",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "inquireable_only",
+                "variableName": "inquireable_only",
+                "type": "Boolean"
+              },
+              {
+                "kind": "Variable",
+                "name": "major_periods",
+                "variableName": "major_periods",
+                "type": "[String]"
+              },
+              {
+                "kind": "Variable",
                 "name": "medium",
-                "value": "*",
+                "variableName": "medium",
+                "type": "String"
+              },
+              {
+                "kind": "Variable",
+                "name": "partner_id",
+                "variableName": "partner_id",
+                "type": "ID"
+              },
+              {
+                "kind": "Variable",
+                "name": "price_range",
+                "variableName": "price_range",
                 "type": "String"
               },
               v1,
               {
-                "kind": "Literal",
+                "kind": "Variable",
                 "name": "sort",
-                "value": "-partner_updated_at",
+                "variableName": "sort",
                 "type": "String"
               }
             ],


### PR DESCRIPTION
This PR 
- implements pretty URLs for medium filter
- changes default sort to prioritize merchandisable artworks
- fixes some filtering bugs

Closes:

- https://artsyproduct.atlassian.net/browse/GROW-896
- https://artsyproduct.atlassian.net/browse/GROW-871