### PR TITLE
Update shipping mutation to show error modal when an error occurs

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -35,6 +35,7 @@ import {
   Spacer,
 } from "@artsy/palette"
 
+import { ErrorModal } from "Components/Modal/ErrorModal"
 import { Col, Row } from "Styleguide/Elements/Grid"
 
 export interface ShippingProps {
@@ -50,6 +51,7 @@ export interface ShippingState {
   address: Address
   shippingOption: OrderFulfillmentType
   isComittingMutation: boolean
+  isModalOpen: boolean
 }
 
 export class ShippingRoute extends Component<ShippingProps, ShippingState> {
@@ -66,6 +68,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
       ...pick(this.props.order.requestedFulfillment, Object.keys(emptyAddress)),
     },
     isComittingMutation: false,
+    isModalOpen: false,
   }
 
   onContinueButtonPressed = () => {
@@ -104,13 +107,33 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                 shipping: this.state.address,
               },
             },
-            onCompleted: () =>
-              // Note: We are only waiting for _a_ response and are not yet handling errors.
-              this.props.router.push(`/order2/${this.props.order.id}/payment`),
+            onCompleted: data => {
+              const {
+                setOrderShipping: { orderOrError },
+              } = data
+
+              if (orderOrError.error) {
+                this.onError(orderOrError.error)
+              } else {
+                this.props.router.push(`/order2/${this.props.order.id}/payment`)
+              }
+            },
+            onError: error => {
+              this.onError(error)
+            },
           }
         )
       })
     }
+  }
+
+  onError = error => {
+    console.error("Order/Shipping/index.tsx", error)
+    this.setState({ isComittingMutation: false, isModalOpen: true })
+  }
+
+  onCloseModal = () => {
+    this.setState({ isModalOpen: false })
   }
 
   render() {
@@ -199,6 +222,10 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
             />
           )}
         </Responsive>
+        <ErrorModal
+          onClose={this.onCloseModal.bind(this)}
+          show={this.state.isModalOpen}
+        />
       </>
     )
   }

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -51,7 +51,7 @@ export interface ShippingState {
   address: Address
   shippingOption: OrderFulfillmentType
   isComittingMutation: boolean
-  isModalOpen: boolean
+  isErrorModalOpen: boolean
 }
 
 export class ShippingRoute extends Component<ShippingProps, ShippingState> {
@@ -68,7 +68,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
       ...pick(this.props.order.requestedFulfillment, Object.keys(emptyAddress)),
     },
     isComittingMutation: false,
-    isModalOpen: false,
+    isErrorModalOpen: false,
   }
 
   onContinueButtonPressed = () => {
@@ -129,11 +129,11 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
 
   onError = error => {
     console.error("Order/Shipping/index.tsx", error)
-    this.setState({ isComittingMutation: false, isModalOpen: true })
+    this.setState({ isComittingMutation: false, isErrorModalOpen: true })
   }
 
   onCloseModal = () => {
-    this.setState({ isModalOpen: false })
+    this.setState({ isErrorModalOpen: false })
   }
 
   render() {
@@ -223,8 +223,8 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
           )}
         </Responsive>
         <ErrorModal
-          onClose={this.onCloseModal.bind(this)}
-          show={this.state.isModalOpen}
+          onClose={this.onCloseModal}
+          show={this.state.isErrorModalOpen}
         />
       </>
     )

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/index.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/index.ts
@@ -1,2 +1,3 @@
 export * from "./createCreditCard"
 export * from "./setOrderPayment"
+export * from "./setOrderShipping"

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/setOrderShipping.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/setOrderShipping.ts
@@ -1,0 +1,19 @@
+export const settingOrderShipmentFailure = {
+  setOrderShipping: {
+    orderOrError: {
+      error: {
+        code: "Not permitted",
+      },
+    },
+  },
+}
+
+export const settingOrderShipmentSuccess = {
+  setOrderShipping: {
+    orderOrError: {
+      order: {
+        id: "1234",
+      },
+    },
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@artsy/palette@^2.16.0":
+"@artsy/palette@^2.17.0":
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.17.0.tgz#0086c9134811c0ffc84f004968fec12248e8e7be"
   dependencies:


### PR DESCRIPTION
This addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-438

This uses our generic error modal (in this case not piping in any specific titles or messages).

![shipping-mutation](https://user-images.githubusercontent.com/2081340/45499325-320d5e80-b74a-11e8-84cc-215e6be9b5e8.gif)
