### PR TITLE
Auth mobile analytics qa

### DIFF
--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -165,6 +165,7 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
 
     return (
       <Form
+        contextModule={options.contextModule}
         error={error}
         values={defaultValues}
         handleTypeChange={this.handleTypeChange}

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -29,7 +29,7 @@ export const currentStepActionName = {
   1: Schema.ActionName.PasswordNextButton,
 }
 
-@track({ context_module: Schema.Context.Header })
+@track()
 export class MobileSignUpForm extends Component<
   FormProps,
   MobileSignUpFormState
@@ -38,14 +38,15 @@ export class MobileSignUpForm extends Component<
     isSocialSignUp: false,
   }
 
-  @track((props: { intent: string }, state, args) => ({
+  @track((props: { contextModule: string; intent: string }, state, args) => ({
     action_type: Schema.ActionType.Click,
     action_name: currentStepActionName[args[0]],
+    contextModule: args[1],
     flow: "auth",
     subject: "clicked next button",
     intent: props.intent,
   }))
-  trackNextClick(currentStepIndex) {
+  trackNextClick(currentStepIndex, contextModule) {
     // no op
   }
 
@@ -178,8 +179,11 @@ export class MobileSignUpForm extends Component<
                 {this.showError(status)}
                 <SubmitButton
                   onClick={e => {
-                    if (wizard.shouldAllowNext) {
-                      this.trackNextClick(wizard.currentStepIndex)
+                    if (wizard.shouldAllowNext && this.props.contextModule) {
+                      this.trackNextClick(
+                        wizard.currentStepIndex,
+                        this.props.contextModule
+                      )
                     }
 
                     this.setState(

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -23,6 +23,7 @@ export interface FormProps {
    * any global error that comes from an external data source
    * (e.g. server)
    */
+  contextModule?: string
   error?: string
   values?: InputValues
   handleSubmit?: SubmitHandler

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -52,7 +52,7 @@ export interface ArticleProps {
 )
 export class Article extends React.Component<ArticleProps> {
   componentDidMount() {
-    if (!this.props.isLoggedIn) {
+    if (!this.props.isLoggedIn && !this.props.isMobile) {
       window.addEventListener(
         "scroll",
         debounce(() => {

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -1,4 +1,3 @@
-import { debounce } from "lodash"
 import React from "react"
 import track from "react-tracking"
 import Events from "../../Utils/Events"
@@ -51,28 +50,6 @@ export interface ArticleProps {
   }
 )
 export class Article extends React.Component<ArticleProps> {
-  componentDidMount() {
-    if (!this.props.isLoggedIn && !this.props.isMobile) {
-      window.addEventListener(
-        "scroll",
-        debounce(() => {
-          setTimeout(
-            this.props.onOpenAuthModal("register", {
-              mode: "signup",
-              intent: "Viewed editorial",
-              signupIntent: "signup",
-              trigger: "timed",
-              triggerSeconds: 2,
-              copy: "Sign up for the Best Stories in Art and Visual Culture",
-              destination: location.href,
-            }),
-            2000
-          )
-        }, 250)
-      )
-    }
-  }
-
   getArticleLayout = () => {
     const { article } = this.props
 


### PR DESCRIPTION
While QA'ing https://artsyproduct.atlassian.net/browse/GROW-887 and https://artsyproduct.atlassian.net/browse/GROW-684 I noticed that we should be dynamically passing in the `contextModule` for the steps in the mobile auth modal flow and that the desktop auth mobile displays on mobile when it shouldn't. This PR address those items.