### PR TITLE
Fixes safari icon direction

### DIFF
--- a/src/Assets/Icons/ChevronIcon.tsx
+++ b/src/Assets/Icons/ChevronIcon.tsx
@@ -1,11 +1,12 @@
 import { color } from "@artsy/palette"
 import React from "react"
+import styled from "styled-components"
 
 export enum Direction {
   LEFT = "rotate(0)",
-  RIGHT = "rotate(180)",
-  UP = "rotate(90)",
-  DOWN = "rotate(270)",
+  RIGHT = "rotate(180deg)",
+  UP = "rotate(90deg)",
+  DOWN = "rotate(270deg)",
 }
 
 interface IconProps {
@@ -18,18 +19,23 @@ interface IconProps {
   width?: number
 }
 
+const RotateIcon = styled.div<{ direction?: Direction }>`
+  transform: ${({ direction }) => direction || Direction.RIGHT};
+`
+
 export const ChevronIcon = ({ direction, fill, height, width }: IconProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 12 12"
-    width={`${width || 8}px`}
-    height={`${height || 8}px`}
-    transform={direction || Direction.RIGHT}
-  >
-    <path
-      fill={fill ? fill : color("black10")}
-      fillRule="evenodd"
-      d="M9.091 10.758l-.788.771-5.832-5.708L8.303.113l.788.771-5.044 4.937 5.044 4.937"
-    />
-  </svg>
+  <RotateIcon direction={direction}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 12 12"
+      width={`${width || 8}px`}
+      height={`${height || 8}px`}
+    >
+      <path
+        fill={fill ? fill : color("black10")}
+        fillRule="evenodd"
+        d="M9.091 10.758l-.788.771-5.832-5.708L8.303.113l.788.771-5.044 4.937 5.044 4.937"
+      />
+    </svg>
+  </RotateIcon>
 )


### PR DESCRIPTION
## Problem
Safari doesn't like `transform` attribute for `<svg>` element. Checkout [this](https://artsy-reaction.netlify.com/?selectedKind=Styleguide%2FComponents&selectedStory=Tabs%20%28Stepper%29&full=0&addons=1&stories=1&panelRight=0&addonPanel=PeterPanen%2Fstorybook-addon-scissors%2Fpanel) **in safari** and you can see chevron icons are facing backward.

## Solution
Instead added css `transform` tag to a container:

<img width="474" alt="screen shot 2018-09-14 at 6 11 59 pm" src="https://user-images.githubusercontent.com/687513/45577394-c3afc580-b849-11e8-97ab-320755a86cf8.png">


