### PR TITLE
[FIX display] don't call gemini with empty urls

### DIFF
--- a/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
@@ -134,11 +134,14 @@ export class CanvasVideo extends Component<CanvasVideoProps, any> {
 
   render() {
     const { isPlaying } = this.state
+    const { coverUrl, src } = this.props
 
-    const resized_cover = resize(this.props.coverUrl, {
-      width: 760,
-      isDisplayAd: true,
-    })
+    const resized_cover =
+      coverUrl &&
+      resize(coverUrl, {
+        width: 760,
+        isDisplayAd: true,
+      })
 
     return (
       <VideoContainer onClick={this.onPlayVideo}>
@@ -150,7 +153,7 @@ export class CanvasVideo extends Component<CanvasVideoProps, any> {
 
         <video
           playsInline
-          src={this.props.src}
+          src={src}
           className="CanvasVideo__video"
           controls={false}
           ref={video => (this.video = video)}

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -366,13 +366,13 @@ export class DisplayPanel extends Component<
     const { unit, campaign, isMobile, renderTime } = this.props
     const url = get(unit.assets, "0.url", "")
     const isVideo = this.isVideo()
-    const cover = unit.cover_image_url || ""
-
     const imageUrl = isVideo
       ? url
       : crop(url, { width: 680, height: 284, isDisplayAd: true })
     const hoverImageUrl = resize(unit.logo, { width: 680, isDisplayAd: true })
-    const coverUrl = crop(cover, { width: 680, height: 284, isDisplayAd: true })
+    const coverUrl =
+      unit.cover_image_url &&
+      crop(unit.cover_image_url, { width: 680, height: 284, isDisplayAd: true })
 
     return (
       <ErrorBoundary>

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayPanel.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`snapshots renders the display panel with an image 1`] = `
 }
 
 .c1 .DisplayPanel__VideoCover-s1e0gfmg-2 {
-  background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
+  background: url() no-repeat center center;
   background-size: cover;
 }
 
@@ -181,13 +181,13 @@ exports[`snapshots renders the display panel with video 1`] = `
   justify-content: center;
 }
 
-.fjpYNi .c3 {
+.bVVUfh .c3 {
   background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FYqTtwB7AWqKD95NGItwjJg%252FRachel_Rossin_portrait_2.jpg&width=680&height=284&quality=95) no-repeat center center;
   background-size: cover;
 }
 
-.fjpYNi .c5 {
-  background: url(https://de5y2r7wr8mpb.cloudfront.net?resize_to=fill&src=&width=680&height=284&quality=95) no-repeat center center;
+.bVVUfh .c5 {
+  background: url() no-repeat center center;
   background-size: cover;
 }
 

--- a/src/Utils/resizer.ts
+++ b/src/Utils/resizer.ts
@@ -19,6 +19,9 @@ export const crop = (
 ) => {
   const { width, height, quality, isDisplayAd } = options
 
+  // dont call gemini with empty src
+  if (!src) return null
+
   if (!width && !height) {
     warn("requires width and height")
     return src
@@ -54,6 +57,9 @@ export const resize = (
   }
 ) => {
   const { width, height, quality, isDisplayAd } = options
+
+  // dont call gemini with empty src
+  if (!src) return null
 
   let resizeTo
   if (width && !height) {


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-889

Fixes a bug where gemini resize was called with empty strings, causing long timeouts and impacting article load performance. 