### PR TITLE
User sees error modal if there is an error submitting the mutation to submit the payment form

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -36,6 +36,7 @@ interface PaymentState {
   error: stripe.Error
   isComittingMutation: boolean
   isErrorModalOpen: boolean
+  errorModalMessage: string
 }
 
 export const ContinueButton = props => (
@@ -54,6 +55,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     error: null,
     isComittingMutation: false,
     isErrorModalOpen: false,
+    errorModalMessage: null,
   }
 
   onContinueButtonPressed = () => {
@@ -162,6 +164,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
         <ErrorModal
           onClose={this.onCloseModal}
           show={this.state.isErrorModalOpen}
+          detailText={this.state.errorModalMessage}
         />
       </>
     )
@@ -203,7 +206,11 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
             creditCardId: creditCardOrError.creditCard.id,
           })
         } else {
-          this.onMutationError(errors || creditCardOrError.mutationError)
+          this.onMutationError(
+            errors || creditCardOrError.mutationError,
+            creditCardOrError.mutationError &&
+              creditCardOrError.mutationError.message
+          )
         }
       },
       onError: this.onMutationError.bind(this),
@@ -282,9 +289,13 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     })
   }
 
-  private onMutationError(errors) {
+  private onMutationError(errors, errorModalMessage?) {
     console.error("Order/Routes/Payment/index.tsx", errors)
-    this.setState({ isComittingMutation: false, isErrorModalOpen: true })
+    this.setState({
+      isComittingMutation: false,
+      isErrorModalOpen: true,
+      errorModalMessage,
+    })
   }
 
   private isPickup() {

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/createCreditCard.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/createCreditCard.ts
@@ -7,3 +7,16 @@ export const creatingCreditCardSuccess = {
     },
   },
 }
+
+export const creatingCreditCardFailed = {
+  createCreditCard: {
+    creditCardOrError: {
+      mutationError: {
+        type: "other_error",
+        message: "No such token: fake-token",
+        detail: null,
+        error: null,
+      },
+    },
+  },
+}

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/setOrderPayment.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/setOrderPayment.ts
@@ -7,3 +7,15 @@ export const settingOrderPaymentSuccess = {
     },
   },
 }
+
+export const settingOrderPaymentFailed = {
+  setOrderPayment: {
+    orderOrError: {
+      error: {
+        type: "validation",
+        code: "invalid_state",
+        data: '{"state":"canceled"}',
+      },
+    },
+  },
+}

--- a/src/Apps/Order/Routes/__tests__/Payment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.test.tsx
@@ -266,6 +266,9 @@ describe("Payment", () => {
     component.find(ContinueButton).simulate("click")
 
     expect(component.find(ErrorModal).props().show).toBe(true)
+    expect(component.find(ErrorModal).props().detailText).toBe(
+      "No such token: fake-token"
+    )
 
     component.find(ModalButton).simulate("click")
 

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -5,7 +5,7 @@ import { commitMutation, RelayProp } from "react-relay"
 import { Button } from "@artsy/palette"
 import { UntouchedOrder } from "Apps/__test__/Fixtures/Order"
 import Input, { InputProps } from "Components/Input"
-import { Dismiss } from "Components/Modal/ErrorModal"
+import { ModalButton } from "Components/Modal/ErrorModal"
 import { Provider } from "unstated"
 import {
   settingOrderShipmentFailure,
@@ -134,7 +134,7 @@ describe("Shipping", () => {
       component.find("Button").simulate("click")
       expect(component.find("ErrorModal").props().show).toBe(true)
 
-      component.find(Dismiss).simulate("click")
+      component.find(ModalButton).simulate("click")
       expect(component.find("ErrorModal").props().show).toBe(false)
     })
 
@@ -148,7 +148,7 @@ describe("Shipping", () => {
       component.find("Button").simulate("click")
       expect(component.find("ErrorModal").props().show).toBe(true)
 
-      component.find(Dismiss).simulate("click")
+      component.find(ModalButton).simulate("click")
       expect(component.find("ErrorModal").props().show).toBe(false)
     })
   })

--- a/src/Components/Modal/ErrorModal.tsx
+++ b/src/Components/Modal/ErrorModal.tsx
@@ -1,4 +1,4 @@
-import { color, Sans } from "@artsy/palette"
+import { color, Flex, Sans } from "@artsy/palette"
 import { ModalWrapper } from "Components/Modal/ModalWrapper"
 import React from "react"
 import styled from "styled-components"
@@ -26,43 +26,41 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
 
     return (
       <ModalWrapper show={show} onClose={onClose}>
-        <ErrorModalInner>
+        <Flex flexDirection="column" pt={2} px={2}>
           <Sans size="4" weight="medium" mb={10}>
             {headerText}
           </Sans>
-          {detailText ? (
-            <Sans size="3" color="black60" mb={30}>
-              {detailText}
-            </Sans>
-          ) : (
-            <Sans size="3" color="black60" mb={30}>
-              Something went wrong. Please try again or contact{" "}
-              <Link href="mailto:support@artsy.net">support@artsy.net</Link>.
-            </Sans>
-          )}
+          <Sans size="3" color="black60">
+            {detailText || (
+              <>
+                Something went wrong. Please try again or contact{" "}
+                <Link href="mailto:support@artsy.net">support@artsy.net</Link>.
+              </>
+            )}
+          </Sans>
+        </Flex>
 
-          <Dismiss onClick={this.close}>
-            <Sans size="3" color="purple100" weight="medium">
-              {closeText}
-            </Sans>
-          </Dismiss>
-        </ErrorModalInner>
+        <Flex mt={1} justifyContent="flex-end" onClick={this.close}>
+          <ModalButton>{closeText}</ModalButton>
+        </Flex>
       </ModalWrapper>
     )
   }
 }
 
+// TODO: Generalize this button and move it to @artsy/palette
+export const ModalButton = props => (
+  <Sans
+    p={2}
+    size="3"
+    color="purple100"
+    weight="medium"
+    style={{ cursor: "pointer" }}
+    {...props}
+  />
+)
+
+// TODO: Generalize this link and move it to @artsy/palette
 const Link = styled.a`
   color: ${color("black60")};
-`
-
-const ErrorModalInner = styled.div`
-  padding: 20px;
-`
-
-export const Dismiss = styled.div`
-  text-align: right;
-  &:hover {
-    cursor: pointer;
-  }
 `

--- a/src/Components/Modal/__tests__/ErrorModal.test.tsx
+++ b/src/Components/Modal/__tests__/ErrorModal.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { Dismiss, ErrorModal } from "../ErrorModal"
+import { Dismiss, ErrorModal, ModalButton } from "../ErrorModal"
 
 describe("ErrorModal", () => {
   const getWrapper = inputs => {
@@ -54,7 +54,7 @@ describe("ErrorModal", () => {
     it("Clicking on the continue button closes the modal", () => {
       props.onClose = jest.fn()
       const component = getWrapper(props)
-      component.find(Dismiss).simulate("click")
+      component.find(ModalButton).simulate("click")
       expect(props.onClose).toBeCalled()
     })
   })


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-404

This is pretty much the same as https://github.com/artsy/reaction/pull/1240 but for the `<PaymentStep>`.

## Screenshot

![kapture 2018-09-17 at 13 53 36](https://user-images.githubusercontent.com/386234/45640591-1b844180-ba81-11e8-98d0-0d433d712044.gif)
