### PR TITLE
@l2succes: [FIX onboarding] explicitly pass in a number value to onNextButtonPressed

### DIFF
--- a/src/Components/Onboarding/Steps/Genes/index.tsx
+++ b/src/Components/Onboarding/Steps/Genes/index.tsx
@@ -60,12 +60,17 @@ export default class Genes extends React.Component<StepProps, State> {
     })
   }
 
+  handleNextButtonClick() {
+    const increaseBy = 1
+    this.props.onNextButtonPressed(increaseBy)
+  }
+
   render() {
     return (
       <Layout
         title="What categories most interest you?"
         subtitle="Follow one or more"
-        onNextButtonPressed={this.props.onNextButtonPressed}
+        onNextButtonPressed={this.handleNextButtonClick.bind(this)}
         buttonState={
           this.state.followCount > 0
             ? MultiButtonState.Highlighted

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -37,7 +37,7 @@ export class Wizard extends React.Component<Props, State> {
     }
   }
 
-  onNextButtonPressed = (increaseBy, history) => {
+  onNextButtonPressed = (increaseBy: number, history) => {
     history.push(STEPS[STEPS.indexOf(location.pathname) + increaseBy])
   }
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-603

In the [Layout Component](https://github.com/artsy/reaction/blob/master/src/Components/Onboarding/Steps/Layout.tsx#L106), the `onClick` prop executes the `onNextButtonPressed` function. When we don't explicitly pass a number value, the `event` gets passed as `increaseBy` in the [Wizard](https://github.com/artsy/reaction/blob/master/src/Components/Onboarding/Wizard.tsx#L40-L42) and fails to increment to the next index (step) correctly.