### PR TITLE
[package] Make relay-mock-network-layer a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-router": "^4.2.0",
+    "relay-mock-network-layer": "^1.2.0",
     "styled-components": "^2 || ^3"
   },
   "scripts": {
@@ -128,6 +129,7 @@
     "react-test-renderer": "^16.2.0",
     "relay-compiler": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-compiler-1.5.0-artsy.3.tgz",
     "relay-compiler-language-typescript": "^1.1.0",
+    "relay-mock-network-layer": "^1.2.0",
     "semantic-release": "^12.4.1",
     "storybook-addon-scissors": "^4.0.1",
     "styled-components": "^3.4.5",
@@ -182,7 +184,6 @@
     "react-transition-group": "^2.3.0",
     "react-url-query": "^1.1.4",
     "react-waypoint": "^7.3.3",
-    "relay-mock-network-layer": "^1.2.0",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.3/relay-runtime-1.5.0-artsy.3.tgz",
     "serialize-javascript": "^1.5.0",
     "sharify": "^0.1.6",


### PR DESCRIPTION
Reverts the change in #1182 for this to be a hard dep.

This dep is useful for dev when projects want to make use of `StorybookRouter`, but that doesn’t (yet) apply to all consumers, hence it should be a peer dep.