### PR TITLE
[FEATURE BNMO] Disable input fields (including radio buttons) when the UpdateShipping mutation is underway

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -97,7 +97,10 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
           {({ xs }) => (
             <TwoColumnLayout
               Content={
-                <>
+                <Flex
+                  flexDirection="column"
+                  style={isComittingMutation ? { pointerEvents: "none" } : {}}
+                >
                   <Join separator={<Spacer mb={3} />}>
                     <Flex flexDirection="column">
                       <Serif mb={1} size="3t" color="black100" lineHeight={18}>
@@ -138,7 +141,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
                     )}
                   </Join>
                   <Spacer mb={3} />
-                </>
+                </Flex>
               }
               Sidebar={
                 <Flex flexDirection="column">

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -138,10 +138,12 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
 
   render() {
     const { order } = this.props
+    const { isComittingMutation } = this.state
     const isPickupAvailable = get(
       this.props,
       "order.lineItems.edges[0].node.artwork.pickup_available"
     )
+
     return (
       <>
         <Row>
@@ -154,7 +156,10 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
           {({ xs }) => (
             <TwoColumnLayout
               Content={
-                <>
+                <Flex
+                  flexDirection="column"
+                  style={isComittingMutation ? { pointerEvents: "none" } : {}}
+                >
                   {/* TODO: Make RadioGroup generic for the allowed values,
                   which could also ensure the children only use
                   allowed values. */}
@@ -197,14 +202,14 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                   {!xs && (
                     <Button
                       onClick={this.onContinueButtonPressed}
-                      loading={this.state.isComittingMutation}
+                      loading={isComittingMutation}
                       size="large"
                       width="100%"
                     >
                       Continue
                     </Button>
                   )}
-                </>
+                </Flex>
               }
               Sidebar={
                 <Flex flexDirection="column">
@@ -217,7 +222,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                       <Spacer mb={3} />
                       <Button
                         onClick={this.onContinueButtonPressed}
-                        loading={this.state.isComittingMutation}
+                        loading={isComittingMutation}
                         size="large"
                         width="100%"
                       >


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-436

I initially added `disabled` prop to the inputs but replaced them with a `pointer-events: none;` on the parent.