### PR TITLE
[BREAKING] Don’t mix build server and client app

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 Circle CI is set up to publish releases to NPM automatically via [semantic-release](https://github.com/semantic-release/semantic-release) following every successful merge to master.
 
-Release versions (major, minor, patch) are triggered [by commit messages](https://github.com/semantic-release/semantic-release#commit-message-format), when they adhere to [Ember conventions](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-ember/readme.md):
+Release versions (major, minor, patch) are triggered [by commit messages](https://github.com/semantic-release/semantic-release#commit-message-format), when they adhere to [Ember conventions](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-ember/README.md):
 
 ```
 [TAG context] commit message

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/react"
-import { StorybooksRouter } from "Artsy/Router"
+import { ClientRouter } from "Artsy/Router/client"
 import React from "react"
 import { routes as artistRoutes } from "../Artist/routes"
 import { routes as artworkRoutes } from "../Artwork/routes"
@@ -8,7 +8,7 @@ import { routes as collectRoutes } from "../Collect/routes"
 storiesOf("Apps", module)
   .add("Artwork Page", () => {
     return (
-      <StorybooksRouter
+      <ClientRouter
         routes={artworkRoutes}
         initialRoute="/artwork2/pablo-picasso-david-et-bethsabee"
       />
@@ -16,7 +16,7 @@ storiesOf("Apps", module)
   })
   .add("Artist Page", () => {
     return (
-      <StorybooksRouter
+      <ClientRouter
         routes={artistRoutes}
         initialRoute="/artist/pablo-picasso"
         context={{
@@ -29,7 +29,7 @@ storiesOf("Apps", module)
   })
   .add("Collect Page", () => {
     return (
-      <StorybooksRouter
+      <ClientRouter
         routes={collectRoutes}
         initialRoute="/collect2"
         context={{

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/react"
-import { ClientRouter } from "Artsy/Router/client"
+import { ClientRouter } from "Artsy/Router/Components/ClientRouter"
 import React from "react"
 import { routes as artistRoutes } from "../Artist/routes"
 import { routes as artworkRoutes } from "../Artwork/routes"

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -2,7 +2,7 @@ import {
   OrderWithShippingDetails,
   PickupOrder,
 } from "Apps/__test__/Fixtures/Order"
-import { StorybooksRouter } from "Artsy/Router"
+import { ClientRouter } from "Artsy/Router/client"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { routes as orderRoutes } from "../Order/routes"
@@ -24,7 +24,7 @@ const mock = {
 }
 
 const Router = props => (
-  <StorybooksRouter
+  <ClientRouter
     routes={orderRoutes}
     mockResolvers={mock}
     historyOptions={{ useBeforeUnload: true }}

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -2,7 +2,7 @@ import {
   OrderWithShippingDetails,
   PickupOrder,
 } from "Apps/__test__/Fixtures/Order"
-import { ClientRouter } from "Artsy/Router/client"
+import { ClientRouter } from "Artsy/Router/Components/ClientRouter"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { routes as orderRoutes } from "../Order/routes"

--- a/src/Artsy/Router/Components/ClientRouter.tsx
+++ b/src/Artsy/Router/Components/ClientRouter.tsx
@@ -15,7 +15,7 @@ interface Props {
   context?: object
 }
 
-export class StorybooksRouter extends React.Component<Props> {
+export class ClientRouter extends React.Component<Props> {
   state = {
     ClientApp: null,
   }
@@ -53,7 +53,7 @@ export class StorybooksRouter extends React.Component<Props> {
         ClientApp,
       })
     } catch (error) {
-      console.error("StorybooksRouter.story", error)
+      console.error("ClientRouter", error)
     }
   }
 

--- a/src/Artsy/Router/Components/StorybooksRouter.tsx
+++ b/src/Artsy/Router/Components/StorybooksRouter.tsx
@@ -1,5 +1,5 @@
 import { createMockNetworkLayer } from "Artsy/Relay/createMockNetworkLayer"
-import { buildClientApp } from "Artsy/Router"
+import { buildClientApp } from "Artsy/Router/buildClientApp"
 import { HistoryOptions } from "farce"
 import { IMocks } from "graphql-tools/dist/Interfaces"
 import React from "react"

--- a/src/Artsy/Router/__stories__/Router.story.tsx
+++ b/src/Artsy/Router/__stories__/Router.story.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from "@storybook/react"
-import { ClientRouter, PreloadLink } from "Artsy/Router/client"
+import { PreloadLink } from "Artsy/Router"
+import { ClientRouter } from "Artsy/Router/Components/ClientRouter"
 import { ContextConsumer } from "Artsy/SystemContext"
 import React from "react"
 import { graphql } from "react-relay"

--- a/src/Artsy/Router/__stories__/Router.story.tsx
+++ b/src/Artsy/Router/__stories__/Router.story.tsx
@@ -1,6 +1,5 @@
 import { storiesOf } from "@storybook/react"
-import { StorybooksRouter } from "Artsy/Router"
-import { PreloadLink } from "Artsy/Router"
+import { ClientRouter, PreloadLink } from "Artsy/Router/client"
 import { ContextConsumer } from "Artsy/SystemContext"
 import React from "react"
 import { graphql } from "react-relay"
@@ -77,7 +76,7 @@ const routes = [
 
 storiesOf("SSR Router/Example", module).add("Example Router App", () => {
   return (
-    <StorybooksRouter
+    <ClientRouter
       routes={routes}
       context={{
         mediator: x => x,

--- a/src/Artsy/Router/client.ts
+++ b/src/Artsy/Router/client.ts
@@ -1,0 +1,3 @@
+export * from "./index"
+export { buildClientApp } from "./buildClientApp"
+export { StorybooksRouter } from "./Components/StorybooksRouter"

--- a/src/Artsy/Router/client.ts
+++ b/src/Artsy/Router/client.ts
@@ -1,3 +1,2 @@
 export * from "./index"
 export { buildClientApp } from "./buildClientApp"
-export { ClientRouter } from "./Components/ClientRouter"

--- a/src/Artsy/Router/client.ts
+++ b/src/Artsy/Router/client.ts
@@ -1,3 +1,3 @@
 export * from "./index"
 export { buildClientApp } from "./buildClientApp"
-export { StorybooksRouter } from "./Components/StorybooksRouter"
+export { ClientRouter } from "./Components/ClientRouter"

--- a/src/Artsy/Router/index.ts
+++ b/src/Artsy/Router/index.ts
@@ -2,12 +2,9 @@ import { HistoryOptions, HistoryProtocol } from "farce"
 import { RouteConfig } from "found"
 import { ContextProps } from "../SystemContext"
 
-// API Exports
-export { buildServerApp } from "./buildServerApp"
-export { buildClientApp } from "./buildClientApp"
+// API Exports for either client or server
 export { PreloadLink, PreloadLinkProps } from "./Components/PreloadLink"
 export { Link } from "found"
-export { StorybooksRouter } from "./Components/StorybooksRouter"
 export { Boot } from "./Components/Boot"
 export { ContextProvider, ContextConsumer } from "Artsy/SystemContext"
 

--- a/src/Artsy/Router/server.ts
+++ b/src/Artsy/Router/server.ts
@@ -1,0 +1,2 @@
+export * from "./index"
+export { buildServerApp } from "./buildServerApp"

--- a/src/Artsy/index.tsx
+++ b/src/Artsy/index.tsx
@@ -1,3 +1,2 @@
 export * from "./Analytics"
-export * from "./Router"
 export { ContextProvider, ContextConsumer, ContextProps } from "./SystemContext"

--- a/src/Styleguide/Components/__stories__/SelectedExhibitions.story.tsx
+++ b/src/Styleguide/Components/__stories__/SelectedExhibitions.story.tsx
@@ -1,5 +1,5 @@
 import { exhibitions } from "Apps/__test__/Fixtures/SelectedExhibitions"
-import { ClientRouter } from "Artsy/Router/client"
+import { ClientRouter } from "Artsy/Router/Components/ClientRouter"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"

--- a/src/Styleguide/Components/__stories__/SelectedExhibitions.story.tsx
+++ b/src/Styleguide/Components/__stories__/SelectedExhibitions.story.tsx
@@ -1,5 +1,5 @@
 import { exhibitions } from "Apps/__test__/Fixtures/SelectedExhibitions"
-import { StorybooksRouter } from "Artsy/Router"
+import { ClientRouter } from "Artsy/Router/client"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
@@ -16,7 +16,7 @@ const props = {
 
 storiesOf("Styleguide/Components", module).add("SelectedExhibitions", () => {
   return (
-    <StorybooksRouter
+    <ClientRouter
       routes={[
         {
           path: "*",

--- a/src/Styleguide/Components/__stories__/Tabs.Router.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.Router.story.tsx
@@ -1,4 +1,4 @@
-import { StorybooksRouter } from "Artsy/Router"
+import { ClientRouter } from "Artsy/Router/client"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { RouteTab, RouteTabs } from "Styleguide/Components"
@@ -8,7 +8,7 @@ storiesOf("Styleguide/Components", module).add("Tabs (Router)", () => {
   return (
     <React.Fragment>
       <Section title="Route Tabs">
-        <StorybooksRouter
+        <ClientRouter
           initialRoute="/cv"
           routes={[
             {

--- a/src/Styleguide/Components/__stories__/Tabs.Router.story.tsx
+++ b/src/Styleguide/Components/__stories__/Tabs.Router.story.tsx
@@ -1,4 +1,4 @@
-import { ClientRouter } from "Artsy/Router/client"
+import { ClientRouter } from "Artsy/Router/Components/ClientRouter"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { RouteTab, RouteTabs } from "Styleguide/Components"

--- a/src/Styleguide/Components/__tests__/RouteTabs.test.tsx
+++ b/src/Styleguide/Components/__tests__/RouteTabs.test.tsx
@@ -1,4 +1,4 @@
-import { StorybooksRouter } from "Artsy/Router"
+import { StorybooksRouter } from "Artsy/Router/client"
 import { mount } from "enzyme"
 import React from "react"
 import { MockBoot } from "Utils/MockBoot"

--- a/src/Styleguide/Components/__tests__/RouteTabs.test.tsx
+++ b/src/Styleguide/Components/__tests__/RouteTabs.test.tsx
@@ -1,4 +1,4 @@
-import { StorybooksRouter } from "Artsy/Router/client"
+import { ClientRouter } from "Artsy/Router/client"
 import { mount } from "enzyme"
 import React from "react"
 import { MockBoot } from "Utils/MockBoot"
@@ -8,7 +8,7 @@ describe("RouteTabs", () => {
   const getWrapper = () => {
     return mount(
       <MockBoot>
-        <StorybooksRouter
+        <ClientRouter
           initialRoute="/cv"
           routes={[
             {
@@ -44,7 +44,7 @@ describe("RouteTabs", () => {
     const wrapper = getWrapper()
 
     await wrapper
-      .find("StorybooksRouter")
+      .find("ClientRouter")
       .instance()
       .componentDidMount()
 

--- a/src/Styleguide/Components/__tests__/RouteTabs.test.tsx
+++ b/src/Styleguide/Components/__tests__/RouteTabs.test.tsx
@@ -1,4 +1,4 @@
-import { ClientRouter } from "Artsy/Router/client"
+import { ClientRouter } from "Artsy/Router/Components/ClientRouter"
 import { mount } from "enzyme"
 import React from "react"
 import { MockBoot } from "Utils/MockBoot"

--- a/tslint/relayOperationGenericsRule.js
+++ b/tslint/relayOperationGenericsRule.js
@@ -183,13 +183,14 @@ class RelayOperationGenericsWalker extends Lint.RuleWalker {
    * @param {number} width
    * @param {string} replacement
    * @param {string} operationName
+   * @returns {Lint.Replacement[]}
    */
   createFixes(start, width, replacement, operationName) {
     const fixes = [new Lint.Replacement(start, width, replacement)]
     if (!this.hasImportForOperation(operationName)) {
       fixes.push(this.importDeclarationFixForOperation(operationName))
     }
-    return new Lint.Fix("fix-relay-type-parameter", fixes)
+    return fixes
   }
 
   /**


### PR DESCRIPTION
* `Artsy/Router/index` still exists, but it no longer exports server or client specific code, that has to be imported from either `Artsy/Router/client` or `Artsy/Router/server`.
* Renames `StorybooksRouter` to `ClientRouter`.
* Fixes custom Relay linter rule and makes lint green again.