### PR TITLE
[FIX collect] ensure paginated links scrolls user back to the top of the page

### DIFF
--- a/src/Apps/Collect/Components/ArtworkGrid/CollectArtworkGrid.tsx
+++ b/src/Apps/Collect/Components/ArtworkGrid/CollectArtworkGrid.tsx
@@ -105,6 +105,7 @@ class Artworks extends Component<Props, LoadingAreaState> {
                         onNext={() => {
                           this.loadNext(filters, mediator)
                         }}
+                        scrollTo="#jump--collectArtworkGrid"
                       />
                     </Box>
                   </LoadingArea>

--- a/src/Apps/Collect/Components/ArtworkGrid/index.tsx
+++ b/src/Apps/Collect/Components/ArtworkGrid/index.tsx
@@ -192,6 +192,8 @@ class Filter extends Component<Props> {
                             Main Artwork Grid
                           */}
 
+                            <span id="jump--collectArtworkGrid" />
+
                             <Box width={xs ? "100%" : "75%"}>
                               {!hideTopBorder && <Separator mb={2} mt={-1} />}
 

--- a/src/Styleguide/Components/Pagination.tsx
+++ b/src/Styleguide/Components/Pagination.tsx
@@ -27,6 +27,7 @@ export class Pagination extends React.Component<Props> {
     if (this.props.pageCursors.around.length === 1) {
       return null
     }
+
     return (
       <ScrollIntoView selector={this.props.scrollTo}>
         <Responsive>
@@ -207,7 +208,7 @@ const activeButton = css`
 
 const Button = styled.button.attrs<{ active?: boolean }>({})`
   cursor: pointer;
-  width: 23px;
+  width: min-content;
   height: 25px;
   background: transparent;
   border: 0;


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-909.

- This makes sure the hover state of the pagination link isn't a fixed width and covers the larger numbers.
- This adds the `scrollTo` prop to make sure that page links scroll back tot he top of the page.