### PR TITLE
Always use upcase state names

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -79,7 +79,7 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
 
   render() {
     const { children, location, router, order, params } = this.props
-    if (order.state !== "pending" && !location.pathname.includes("status")) {
+    if (order.state !== "PENDING" && !location.pathname.includes("status")) {
       router.replace(`/order2/${params.orderID}/status`)
     }
     return (

--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -41,7 +41,7 @@ describe("OrderApp", () => {
   it("does not redirect to the Status route when the order is pending", () => {
     const replace = jest.fn()
     const props = getProps({
-      state: "pending",
+      state: "PENDING",
       location: "/order/123/shipping",
       replace,
     })
@@ -53,7 +53,7 @@ describe("OrderApp", () => {
   it("redirects to the Status route when the order is not pending", () => {
     const replace = jest.fn()
     const props = getProps({
-      state: "submitted",
+      state: "SUBMITTED",
       location: "/order/123/review",
       replace,
     })

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -18,7 +18,7 @@ const mock = {
       ...OrderWithShippingDetails,
       id,
       ...others,
-      state: "pending",
+      state: "PENDING",
     }
   },
 }


### PR DESCRIPTION
We were using lower-case state names [when they should be upper-case](https://github.com/artsy/exchange/blob/190b297fd3dc72c7433230523f12e970deb0a46e/app/graphql/types/order_state_enum.rb#L2-L7)...