### PR TITLE
Only use transition hook on client, check for order before accessing

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -39,15 +39,13 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
   state = { stripe: null }
   removeTransitionHook: () => void
 
-  constructor(props) {
-    super(props)
-
-    this.removeTransitionHook = props.router.addTransitionHook(
-      this.onTransition
-    )
-  }
-
   componentDidMount() {
+    if (!this.removeTransitionHook) {
+      this.removeTransitionHook = this.props.router.addTransitionHook(
+        this.onTransition
+      )
+    }
+
     if (window.Stripe) {
       this.setState({
         stripe: window.Stripe(window.sd.STRIPE_PUBLISHABLE_KEY),
@@ -63,7 +61,9 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
   }
 
   componentWillUnmount() {
-    this.removeTransitionHook()
+    if (this.removeTransitionHook) {
+      this.removeTransitionHook()
+    }
   }
 
   onTransition = newLocation => {
@@ -79,7 +79,11 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
 
   render() {
     const { children, location, router, order, params } = this.props
-    if (order.state !== "pending" && !location.pathname.includes("status")) {
+    if (
+      order &&
+      order.state !== "pending" &&
+      !location.pathname.includes("status")
+    ) {
       router.replace(`/order2/${params.orderID}/status`)
     }
     return (

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -81,7 +81,7 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
     const { children, location, router, order, params } = this.props
     if (
       order &&
-      order.state !== "pending" &&
+      order.state !== "PENDING" &&
       !location.pathname.includes("status")
     ) {
       router.replace(`/order2/${params.orderID}/status`)

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -18,7 +18,7 @@ const mock = {
       ...OrderWithShippingDetails,
       id,
       ...others,
-      state: "pending",
+      state: "PENDING",
     }
   },
 }


### PR DESCRIPTION
@yuki24 reported the below error, which seems to be due to to the transition hook firing on the server. It's not needed there, so I moved it to only be registered on the client. 

Also, I noticed an error on pages where the user didn't have access to the order (i.e. it 401s) are throwing an error about `order.state` not being defined. I updated the logic to check for the existence of `order` before accessing `state`. 

```
(apps/order2) Error:  TypeError: protocol.transition is not a function
    at /Users/yuki/GitHub/force/node_modules/farce/lib/createHistoryMiddleware.js:35:49
    at /Users/yuki/GitHub/force/node_modules/farce/lib/createLocationMiddleware.js:26:20
    at /Users/yuki/GitHub/force/node_modules/farce/lib/createTransitionHookMiddleware.js:154:22
    at /Users/yuki/GitHub/force/node_modules/farce/lib/createTransitionHookMiddleware.js:75:12
    at /Users/yuki/GitHub/force/node_modules/farce/lib/createTransitionHookMiddleware.js:61:29
    at runHook (/Users/yuki/GitHub/force/node_modules/farce/lib/createTransitionHookMiddleware.js:43:12)
    at runHooks (/Users/yuki/GitHub/force/node_modules/farce/lib/createTransitionHookMiddleware.js:60:10)
    at runAllowTransition (/Users/yuki/GitHub/force/node_modules/farce/lib/createTransitionHookMiddleware.js:74:10)
    at /Users/yuki/GitHub/force/node_modules/farce/lib/createTransitionHookMiddleware.js:144:20
    at /Users/yuki/GitHub/force/node_modules/farce/lib/ensureLocationMiddleware.js:33:18
    at Object.replace (/Users/yuki/GitHub/force/node_modules/found/node_modules/redux/lib/redux.js:455:12)
    at OrderApp.replace [as render] (/Users/yuki/GitHub/force/node_modules/@artsy/reaction/src/Apps/Order/OrderApp.tsx:83:14)
    at processChild (/Users/yuki/GitHub/force/node_modules/react-dom/cjs/react-dom-server.node.development.js:2478:18)
    at resolve (/Users/yuki/GitHub/force/node_modules/react-dom/cjs/react-dom-server.node.development.js:2335:5)
    at ReactDOMServerRenderer.render (/Users/yuki/GitHub/force/node_modules/react-dom/cjs/react-dom-server.node.development.js:2657:22)
    at ReactDOMServerRenderer.read (/Users/yuki/GitHub/force/node_modules/react-dom/cjs/react-dom-server.node.development.js:2631:23)
    at Object.renderToString (/Users/yuki/GitHub/force/node_modules/react-dom/cjs/react-dom-server.node.development.js:3022:25)
    at renderToString (/Users/yuki/GitHub/force/node_modules/@artsy/reaction/src/Artsy/Router/buildServerApp.tsx:72:22)
    at tryCatch (/Users/yuki/GitHub/force/node_modules/regenerator-runtime/runtime.js:62:40)
    at Generator.invoke [as _invoke] (/Users/yuki/GitHub/force/node_modules/regenerator-runtime/runtime.js:296:22)
    at Generator.prototype.(anonymous function) [as next] (/Users/yuki/GitHub/force/node_modules/regenerator-runtime/runtime.js:114:21)
    at asyncGeneratorStep (/Users/yuki/GitHub/force/node_modules/@artsy/reaction/dist/Artsy/Router/buildServerApp.js:34:103)
    at _next (/Users/yuki/GitHub/force/node_modules/@artsy/reaction/dist/Artsy/Router/buildServerApp.js:36:194)
    at run (/Users/yuki/GitHub/force/node_modules/core-js/modules/es6.promise.js:75:22)
    at /Users/yuki/GitHub/force/node_modules/core-js/modules/es6.promise.js:92:30
    at flush (/Users/yuki/GitHub/force/node_modules/core-js/modules/_microtask.js:18:9)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
```