### PR TITLE
Use correct chevron color for stepper

### DIFF
--- a/src/Styleguide/Components/Stepper.tsx
+++ b/src/Styleguide/Components/Stepper.tsx
@@ -24,7 +24,7 @@ export const Stepper = (props: StepperProps) => {
       key={props.currentStepIndex}
       separator={
         <ChevronWrapper>
-          <ChevronIcon />
+          <ChevronIcon fill={color("black60")} />
         </ChevronWrapper>
       }
       transformTabBtn={transformTabBtn}


### PR DESCRIPTION
While going through QA feedback on the orders pages, I hit this one from @nicoleyeo. Here's the before/after:

<img width="1310" alt="screen shot 2018-09-25 at 11 18 25 am" src="https://user-images.githubusercontent.com/79799/46028138-64f21380-c0b5-11e8-8117-62937b08e748.png">
<img width="1310" alt="screen shot 2018-09-25 at 11 18 07 am" src="https://user-images.githubusercontent.com/79799/46028141-67546d80-c0b5-11e8-9a9f-f990921575df.png">
