### PR TITLE
Fixed an issue where the height of <Collapse> is always fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "react-router": "^4.2.0",
     "react-sizeme": "^2.4.4",
     "react-slick": "^0.23.1",
+    "react-spring": "^5.7.2",
     "react-stripe-elements": "^2.0.1",
     "react-styled-flexboxgrid": "^2.2.0",
     "react-tracking": "^5.3.0",

--- a/src/Styleguide/Components/Collapse.tsx
+++ b/src/Styleguide/Components/Collapse.tsx
@@ -1,50 +1,33 @@
 import React from "react"
-import styled from "styled-components"
+import { animated, Spring } from "react-spring"
 
 export interface CollapseProps {
   open: boolean
 }
 
-export interface CollapseState {
-  computedHeight: string
-}
-
-export class Collapse extends React.Component<CollapseProps, CollapseState> {
+export class Collapse extends React.Component<CollapseProps> {
   state = {
-    computedHeight: null,
-  }
-
-  private element: HTMLElement
-
-  handleRef = element => {
-    this.element = element
+    mounted: false,
   }
 
   componentDidMount() {
-    if (this.state.computedHeight === null) {
-      const prevHeight = this.element.style.height
-      this.element.style.height = "auto"
-      const computedHeight = getComputedStyle(this.element).height
-      this.element.style.height = prevHeight
-
-      this.setState({ computedHeight })
-    }
+    this.setState({ mounted: true })
   }
 
   render() {
-    const height = this.props.open ? this.state.computedHeight || "auto" : "0"
-
     return (
-      <Collapseable
-        innerRef={this.handleRef}
-        {...this.props}
-        style={{ height }}
-      />
+      <Spring
+        native
+        immediate={!this.state.mounted}
+        from={{ height: 0 }}
+        to={{ height: this.props.open ? "auto" : 0 }}
+      >
+        {props => (
+          <animated.div style={{ ...props, overflow: "hidden" }}>
+            {this.props.children}
+          </animated.div>
+        )}
+      </Spring>
     )
   }
 }
-
-const Collapseable = styled.div`
-  overflow: hidden;
-  transition: height 0.25s ease-in-out;
-`

--- a/src/Styleguide/Components/__tests__/Collapse.test.tsx
+++ b/src/Styleguide/Components/__tests__/Collapse.test.tsx
@@ -16,6 +16,6 @@ describe("Collapse", () => {
       <Collapse open={false}>The elegant spiral of the Nautilus ...</Collapse>
     )
 
-    expect(component.find("div").prop("style")).toHaveProperty("height", "0")
+    expect(component.find("div").prop("style")).toHaveProperty("height", 0)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,6 +800,12 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.49":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.49.tgz#e38abe8217cb9793f461a5306d7ad745d83e1d27"
@@ -12409,6 +12415,12 @@ react-split-pane@^0.1.77:
     inline-style-prefixer "^3.0.6"
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
+
+react-spring@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-5.7.2.tgz#5c0fb7c726305f11bfae6fbb5dfaf08fe0ea113f"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
 
 react-static-container@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-501

The issue is that the `<Collapse>` component always holds a fixed height and it doesn't change the height when the elements inside of it stretches vertically. I just replaced the implementation with `react-spring` that doesn't have this issue.

## Screenshot

![kapture 2018-09-25 at 15 18 05](https://user-images.githubusercontent.com/386234/46037523-5f58f580-c0d6-11e8-94b6-0d2ca258d5b1.gif)
