### PR TITLE
Adds viewport meta tag for Eigen to disable zoom

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -1,7 +1,8 @@
 import { routes_OrderQueryResponse } from "__generated__/routes_OrderQuery.graphql"
+import { ContextConsumer } from "Artsy/SystemContext"
 import { Location, RouteConfig, Router } from "found"
 import React from "react"
-import { Title } from "react-head"
+import { Meta, Title } from "react-head"
 import { Elements, StripeProvider } from "react-stripe-elements"
 
 declare global {
@@ -79,6 +80,7 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
 
   render() {
     const { children, location, router, order, params } = this.props
+
     if (
       order &&
       order.state !== "PENDING" &&
@@ -87,12 +89,22 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
       router.replace(`/order2/${params.orderID}/status`)
     }
     return (
-      <>
-        <Title>Checkout | Artsy</Title>
-        <StripeProvider stripe={this.state.stripe}>
-          <Elements>{children}</Elements>
-        </StripeProvider>
-      </>
+      <ContextConsumer>
+        {({ isEigen }) => (
+          <>
+            <Title>Checkout | Artsy</Title>
+            {isEigen ? (
+              <Meta
+                name="viewport"
+                content="width=device-width, user-scalable=no"
+              />
+            ) : null}
+            <StripeProvider stripe={this.state.stripe}>
+              <Elements>{children}</Elements>
+            </StripeProvider>
+          </>
+        )}
+      </ContextConsumer>
     )
   }
 }

--- a/src/Artsy/SystemContext.tsx
+++ b/src/Artsy/SystemContext.tsx
@@ -35,6 +35,8 @@ interface SystemProps {
    * the `user` if available.
    */
   relayNetwork?: RelayNetwork
+
+  isEigen?: boolean
 }
 
 /**


### PR DESCRIPTION
This PR, for [PURCHASE-464](
https://artsyproduct.atlassian.net/browse/PURCHASE-464), follows up on [this Force PR](https://github.com/artsy/force/pull/2931) to consume the new `isEigen` context variable and emit a `<meta>` tag that will disable zoom in Eigen's web view (but not for mobile users more generally). I moved some stuff around in the `OrderApp` tests, let me know what you think. 