### PR TITLE
Show specific shipping error if there is an invalid address

### DIFF
--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/setOrderShipping.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/setOrderShipping.ts
@@ -8,6 +8,28 @@ export const settingOrderShipmentFailure = {
   },
 }
 
+export const settingOrderShipmentMissingRegionFailure = {
+  setOrderShipping: {
+    orderOrError: {
+      error: {
+        type: "validation",
+        code: "missing_region",
+      },
+    },
+  },
+}
+
+export const settingOrderShipmentMissingCountryFailure = {
+  setOrderShipping: {
+    orderOrError: {
+      error: {
+        type: "validation",
+        code: "missing_country",
+      },
+    },
+  },
+}
+
 export const settingOrderShipmentSuccess = {
   setOrderShipping: {
     orderOrError: {

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -12,6 +12,8 @@ import { ErrorModal } from "../../../../Components/Modal/ErrorModal"
 import { Address, AddressForm } from "../../Components/AddressForm"
 import {
   settingOrderShipmentFailure,
+  settingOrderShipmentMissingCountryFailure,
+  settingOrderShipmentMissingRegionFailure,
   settingOrderShipmentSuccess,
 } from "../__fixtures__/MutationResults"
 import { ShippingProps, ShippingRoute } from "../Shipping"
@@ -179,6 +181,44 @@ describe("Shipping", () => {
       )
       component.find("Button").simulate("click")
       expect(component.find(ErrorModal).props().show).toBe(true)
+
+      component.find(ModalButton).simulate("click")
+      expect(component.find(ErrorModal).props().show).toBe(false)
+    })
+
+    it("shows a validation error modal when there is a missing_country error from the server", () => {
+      const component = getWrapper(testProps)
+      expect(component.find(ErrorModal).props().show).toBe(false)
+      const mockCommitMutation = commitMutation as jest.Mock<any>
+      mockCommitMutation.mockImplementationOnce((_, { onCompleted }) =>
+        onCompleted(settingOrderShipmentMissingCountryFailure)
+      )
+      component.find("Button").simulate("click")
+      const errorComponent = component.find(ErrorModal)
+      expect(errorComponent.props().show).toBe(true)
+      expect(errorComponent.text()).toContain("Invalid address")
+      expect(errorComponent.text()).toContain(
+        "There was an error processing your address. Please review and try again."
+      )
+
+      component.find(ModalButton).simulate("click")
+      expect(component.find(ErrorModal).props().show).toBe(false)
+    })
+
+    it("shows a validation error modal when there is a missing_region error from the server", () => {
+      const component = getWrapper(testProps)
+      expect(component.find(ErrorModal).props().show).toBe(false)
+      const mockCommitMutation = commitMutation as jest.Mock<any>
+      mockCommitMutation.mockImplementationOnce((_, { onCompleted }) =>
+        onCompleted(settingOrderShipmentMissingRegionFailure)
+      )
+      component.find("Button").simulate("click")
+      const errorComponent = component.find(ErrorModal)
+      expect(errorComponent.props().show).toBe(true)
+      expect(errorComponent.text()).toContain("Invalid address")
+      expect(errorComponent.text()).toContain(
+        "There was an error processing your address. Please review and try again."
+      )
 
       component.find(ModalButton).simulate("click")
       expect(component.find(ErrorModal).props().show).toBe(false)


### PR DESCRIPTION
This PR addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-442

It's unlikely that we would _ever_ get these errors in this current iteration, since we have strong client-side validation on this form. However, if we change those requirements (especially around things like zip code), that could change. Additionally, this adds the ability to customize the header and detail message for the error modal on the shipping page, which we'll need for subsequent tickets.

![image](https://user-images.githubusercontent.com/2081340/46048141-e9fd1d00-c0f5-11e8-9a1c-1905aafa488b.png)
