### PR TITLE
DISCO 286: Expanded width of artist name container to prevent text wrapping

### DIFF
--- a/src/Apps/WorksForYou/WorksForYouContents.tsx
+++ b/src/Apps/WorksForYou/WorksForYouContents.tsx
@@ -109,11 +109,12 @@ export class WorksForYouContent extends React.Component<Props, State> {
                         </a>
                       </Avatar>
                     )}
-                    <Box ml={2}>
+                    <Box ml={2} width="100%">
                       <Serif
                         style={{
                           textDecoration: "none",
                           display: "inline-block",
+                          width: "100%",
                         }}
                         weight="semibold"
                         size={"3"}


### PR DESCRIPTION

Previous version:
![screen shot 2018-09-12 at 9 49 13 am](https://user-images.githubusercontent.com/10385964/46095189-e5824400-c189-11e8-9ab4-31198c502b70.png)

Fix:
<img width="1034" alt="screen shot 2018-09-26 at 12 41 53 pm" src="https://user-images.githubusercontent.com/10385964/46095109-ba97f000-c189-11e8-9642-133f8e842872.png">

[Also see DISCO-286](https://artsyproduct.atlassian.net/browse/DISCO-286)