### PR TITLE
@damassi => [ArtworkBrick] Display a sentence cased version of contact for price

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -139,6 +139,11 @@ export class Details extends React.Component<Props, null> {
       return sa.highest_bid.display || sa.opening_bid.display
     }
 
+    // TODO: Extract this sentence-cased version and apply everywhere.
+    if (artwork.sale_message === "Contact For Price") {
+      return "Contact for price"
+    }
+
     return artwork.sale_message
   }
 


### PR DESCRIPTION
We want to display `Contact For Price` as `Contact for price` in the new artwork brick.

This reeks of something we should handle in the most upstream place, namely, https://github.com/artsy/gravity/blob/354c3f12cbe1f1562501193a2efc9e3f99fb9431/app/models/domain/availability_display.rb#L5 . Or, possibly Metaphysics: https://github.com/artsy/metaphysics/blob/1a4f8c30fd68b425c0831410abf5fab8e0a920e8/src/schema/artwork/index.ts#L609

However, unfortunately a grep in Reaction and Force for `Contact For Price` reveals a whole bunch of places like: https://github.com/artsy/force/blob/33ece666e9df1cf32f9c6cbe7914811815a860cc/src/desktop/models/artwork.coffee#L67 . It's possible there are other apps (Pulse, Impulse) that refer to this also.

So, given this is a purely cosmetic change (not functional), but has the potential to cause annoying bugs everywhere, I've scoped it to _just_ the new artwork bricks for now (which we're cool with).