### PR TITLE
[FEATURE BNMO] Payment form should pre-populate with available details when returning to the payment route

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2396,6 +2396,24 @@ type CreditCard {
 
   # Credit card's expiration year
   expiration_year: Int!
+
+  # Billing address street1
+  street1: String
+
+  # Billing address street2
+  street2: String
+
+  # Billing address city
+  city: String
+
+  # Billing address state
+  state: String
+
+  # Billing address country code
+  country: String
+
+  # Billing address postal code
+  postal_code: String
 }
 
 input CreditCardInput {

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -59,14 +59,29 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     isCommittingMutation: false,
     isErrorModalOpen: false,
     errorModalMessage: null,
-    address: this.startingAddress,
+    address: this.startingAddress(),
     addressErrors: {},
   }
 
-  get startingAddress(): Address {
-    return {
-      ...emptyAddress,
-      country: "US",
+  startingAddress(): Address {
+    const { creditCard } = this.props.order
+
+    if (creditCard) {
+      return {
+        ...emptyAddress,
+        name: creditCard.name,
+        country: creditCard.country,
+        postalCode: creditCard.postal_code,
+        addressLine1: creditCard.street1,
+        addressLine2: creditCard.street2,
+        city: creditCard.city,
+        region: creditCard.state,
+      }
+    } else {
+      return {
+        ...emptyAddress,
+        country: "US",
+      }
     }
   }
 
@@ -370,6 +385,15 @@ export const PaymentFragmentContainer = createFragmentContainer(
   graphql`
     fragment Payment_order on Order {
       id
+      creditCard {
+        name
+        street1
+        street2
+        city
+        state
+        country
+        postal_code
+      }
       requestedFulfillment {
         __typename
         ... on Ship {

--- a/src/Apps/Order/Routes/__tests__/Payment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.test.tsx
@@ -86,6 +86,38 @@ describe("Payment", () => {
     expect(paymentRoute.find(Collapse).props().open).toBe(true)
   })
 
+  it("pre-populates with available details when returning to the payment route", () => {
+    const paymentRoute = mount(
+      <PaymentRoute
+        {...testProps}
+        order={{
+          ...PickupOrder,
+          id: "1234",
+          creditCard: {
+            name: "Artsy UK Ltd",
+            street1: "14 Gower's Walk",
+            street2: "Suite 2.5, The Loom",
+            city: "London",
+            state: "Whitechapel",
+            country: "UK",
+            postal_code: "E1 8PY",
+          },
+        }}
+      />
+    )
+
+    expect(paymentRoute.find(AddressForm).props().defaultValue).toEqual({
+      name: "Artsy UK Ltd",
+      addressLine1: "14 Gower's Walk",
+      addressLine2: "Suite 2.5, The Loom",
+      city: "London",
+      region: "Whitechapel",
+      postalCode: "E1 8PY",
+      country: "UK",
+      phoneNumber: "",
+    })
+  })
+
   it("always uses the billing address for stripe tokenization when the user selected 'pick' shipping option", () => {
     const thenMock = jest.fn()
     stripeMock.createToken.mockReturnValue({ then: thenMock })

--- a/src/__generated__/Payment_order.graphql.ts
+++ b/src/__generated__/Payment_order.graphql.ts
@@ -6,6 +6,15 @@ declare const _Payment_order$ref: unique symbol;
 export type Payment_order$ref = typeof _Payment_order$ref;
 export type Payment_order = {
     readonly id: string | null;
+    readonly creditCard: ({
+        readonly name: string | null;
+        readonly street1: string | null;
+        readonly street2: string | null;
+        readonly city: string | null;
+        readonly state: string | null;
+        readonly country: string | null;
+        readonly postal_code: string | null;
+    }) | null;
     readonly requestedFulfillment: ({
         readonly __typename: "Ship";
         readonly name: string | null;
@@ -48,6 +57,34 @@ var v0 = {
 },
 v1 = {
   "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "city",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "country",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
@@ -61,6 +98,49 @@ return {
   "argumentDefinitions": [],
   "selections": [
     v0,
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "creditCard",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CreditCard",
+      "plural": false,
+      "selections": [
+        v1,
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "street1",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "street2",
+          "args": null,
+          "storageKey": null
+        },
+        v2,
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "state",
+          "args": null,
+          "storageKey": null
+        },
+        v3,
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "postal_code",
+          "args": null,
+          "storageKey": null
+        },
+        v4
+      ]
+    },
     {
       "kind": "LinkedField",
       "alias": null,
@@ -94,13 +174,7 @@ return {
           "kind": "InlineFragment",
           "type": "Ship",
           "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "name",
-              "args": null,
-              "storageKey": null
-            },
+            v1,
             {
               "kind": "ScalarField",
               "alias": null,
@@ -115,13 +189,7 @@ return {
               "args": null,
               "storageKey": null
             },
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "city",
-              "args": null,
-              "storageKey": null
-            },
+            v2,
             {
               "kind": "ScalarField",
               "alias": null,
@@ -129,13 +197,7 @@ return {
               "args": null,
               "storageKey": null
             },
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "country",
-              "args": null,
-              "storageKey": null
-            },
+            v3,
             {
               "kind": "ScalarField",
               "alias": null,
@@ -184,16 +246,10 @@ return {
                   "plural": false,
                   "selections": [
                     v0,
-                    {
-                      "kind": "ScalarField",
-                      "alias": null,
-                      "name": "__id",
-                      "args": null,
-                      "storageKey": null
-                    }
+                    v4
                   ]
                 },
-                v1
+                v5
               ]
             }
           ]
@@ -205,9 +261,9 @@ return {
       "name": "TransactionSummary_order",
       "args": null
     },
-    v1
+    v5
   ]
 };
 })();
-(node as any).hash = '3cdee803a766cd0d71a9daeb6caba12a';
+(node as any).hash = 'd04e90e3364e639fb25aa49292a041d2';
 export default node;

--- a/src/__generated__/routes_PaymentQuery.graphql.ts
+++ b/src/__generated__/routes_PaymentQuery.graphql.ts
@@ -29,6 +29,16 @@ query routes_PaymentQuery(
 
 fragment Payment_order on Order {
   id
+  creditCard {
+    name
+    street1
+    street2
+    city
+    state
+    country
+    postal_code
+    __id
+  }
   requestedFulfillment {
     __typename
     ... on Ship {
@@ -133,21 +143,35 @@ v3 = {
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "city",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "country",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
   "args": null,
   "storageKey": null
 };
@@ -156,7 +180,7 @@ return {
   "operationKind": "query",
   "name": "routes_PaymentQuery",
   "id": null,
-  "text": "query routes_PaymentQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Payment_order\n    __id: id\n  }\n}\n\nfragment Payment_order on Order {\n  id\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on Pickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_PaymentQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Payment_order\n    __id: id\n  }\n}\n\nfragment Payment_order on Order {\n  id\n  creditCard {\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postal_code\n    __id\n  }\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on Pickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -202,13 +226,56 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "creditCard",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CreditCard",
+            "plural": false,
+            "selections": [
+              v4,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "street1",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "street2",
+                "args": null,
+                "storageKey": null
+              },
+              v5,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "state",
+                "args": null,
+                "storageKey": null
+              },
+              v6,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "postal_code",
+                "args": null,
+                "storageKey": null
+              },
+              v7
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "requestedFulfillment",
             "storageKey": null,
             "args": null,
             "concreteType": null,
             "plural": false,
             "selections": [
-              v4,
+              v8,
               {
                 "kind": "InlineFragment",
                 "type": "Pickup",
@@ -226,7 +293,7 @@ return {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v5,
+                  v4,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -241,13 +308,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "city",
-                    "args": null,
-                    "storageKey": null
-                  },
+                  v5,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -255,13 +316,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "country",
-                    "args": null,
-                    "storageKey": null
-                  },
+                  v6,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -310,7 +365,7 @@ return {
                         "plural": false,
                         "selections": [
                           v3,
-                          v6,
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -421,13 +476,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v4,
-              v6,
+              v8,
+              v7,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v5
+                  v4
                 ]
               }
             ]


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-495

 * Updates the `<PaymentRoute>` component to pull in the billing address in the order if any
 * I looked into pre-populating the credit card input as well, but it's prohibited by Stripe

## Screenshot

![payment-form](https://user-images.githubusercontent.com/386234/46106454-b3330f80-c1a6-11e8-8e1b-905d4ceade19.gif)
