### PR TITLE
[FEATURE BNMO] disable country field when work is continental shipping only

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1032,7 +1032,7 @@ type ArtworkContextFair {
     section: String
 
     # Sorts for shows in a fair
-    sort: ShowSort = null
+    sort: ShowSort
     after: String
     first: Int
     before: String
@@ -1964,7 +1964,7 @@ type Collection implements Node {
     before: String
     last: Int
     private: Boolean = false
-    sort: CollectionSorts = null
+    sort: CollectionSorts
   ): ArtworkConnection
   description: String!
   default: Boolean!
@@ -2705,7 +2705,7 @@ type Fair {
     section: String
 
     # Sorts for shows in a fair
-    sort: ShowSort = null
+    sort: ShowSort
     after: String
     first: Int
     before: String
@@ -3661,7 +3661,7 @@ type HomePageModuleContextFair {
     section: String
 
     # Sorts for shows in a fair
-    sort: ShowSort = null
+    sort: ShowSort
     after: String
     first: Int
     before: String

--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -1,4 +1,4 @@
-import { Flex, Join, Serif, Spacer } from "@artsy/palette"
+import { Flex, Join, Sans, Serif, Spacer } from "@artsy/palette"
 import Input from "Components/Input"
 import React from "react"
 import { CountrySelect } from "Styleguide/Components"
@@ -35,6 +35,7 @@ export interface AddressFormProps {
   onChange: AddressChangeHandler
   defaultValue?: Partial<Address>
   billing?: boolean
+  continentalUsOnly?: boolean
   errors?: AddressErrors
 }
 
@@ -70,6 +71,7 @@ export class AddressForm extends React.Component<
   }
 
   render() {
+    const lockCountryToUS = !this.props.billing && this.props.continentalUsOnly
     return (
       <Join separator={<Spacer mb={2} />}>
         <Flex flexDirection="column">
@@ -92,9 +94,18 @@ export class AddressForm extends React.Component<
               Country
             </Serif>
             <CountrySelect
-              selected={this.state.address.country}
+              selected={lockCountryToUS ? "US" : this.state.address.country}
               onSelect={this.changeValueHandler("country")}
+              disabled={lockCountryToUS}
             />
+            {lockCountryToUS && (
+              <>
+                <Spacer m={0.5} />
+                <Sans size="2" color="black60">
+                  Ships to continental US only
+                </Sans>
+              </>
+            )}
           </Flex>
 
           <Flex flexDirection="column">

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -26,7 +26,7 @@ import { validatePresence } from "Apps/Order/Components/Validators"
 import { Mediator } from "Artsy/SystemContext"
 import { ErrorModal } from "Components/Modal/ErrorModal"
 import { Router } from "found"
-import { get, pick } from "lodash"
+import { pick } from "lodash"
 import React, { Component } from "react"
 import {
   commitMutation,
@@ -36,6 +36,7 @@ import {
 } from "react-relay"
 import { Collapse } from "Styleguide/Components"
 import { Col, Row } from "Styleguide/Elements/Grid"
+import { get } from "Utils/get"
 import { Responsive } from "Utils/Responsive"
 
 export interface ShippingProps {
@@ -208,9 +209,9 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
   render() {
     const { order } = this.props
     const { address, addressErrors, isCommittingMutation } = this.state
-    const isPickupAvailable = get(
+    const artwork = get(
       this.props,
-      "order.lineItems.edges[0].node.artwork.pickup_available"
+      props => order.lineItems.edges[0].node.artwork
     )
 
     return (
@@ -232,7 +233,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                   {/* TODO: Make RadioGroup generic for the allowed values,
                   which could also ensure the children only use
                   allowed values. */}
-                  {isPickupAvailable && (
+                  {artwork.pickup_available && (
                     <>
                       <RadioGroup
                         onSelect={(shippingOption: OrderFulfillmentType) =>
@@ -263,13 +264,15 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
 
                   <Collapse
                     open={
-                      !isPickupAvailable || this.state.shippingOption === "SHIP"
+                      !artwork.pickup_available ||
+                      this.state.shippingOption === "SHIP"
                     }
                   >
                     <AddressForm
                       defaultValue={address}
                       errors={addressErrors}
                       onChange={this.onAddressChange}
+                      continentalUsOnly={artwork.shipsToContinentalUSOnly}
                     />
                   </Collapse>
 
@@ -288,9 +291,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
               Sidebar={
                 <Flex flexDirection="column">
                   <TransactionSummary order={order} mb={xs ? 2 : 3} />
-                  <Helper
-                    artworkId={order.lineItems.edges[0].node.artwork.id}
-                  />
+                  <Helper artworkId={artwork.id} />
                   {xs && (
                     <>
                       <Spacer mb={3} />
@@ -345,6 +346,7 @@ export const ShippingFragmentContainer = createFragmentContainer(
             artwork {
               id
               pickup_available
+              shipsToContinentalUSOnly
             }
           }
         }

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -8,6 +8,7 @@ import { UntouchedOrder } from "Apps/__test__/Fixtures/Order"
 import Input, { InputProps } from "Components/Input"
 import { ModalButton } from "Components/Modal/ErrorModal"
 import { commitMutation, RelayProp } from "react-relay"
+import { CountrySelect } from "Styleguide/Components"
 import { ErrorModal } from "../../../../Components/Modal/ErrorModal"
 import { Address, AddressForm } from "../../Components/AddressForm"
 import {
@@ -68,6 +69,13 @@ describe("Shipping", () => {
     testPropWithShipOnlyOrder.order.lineItems.edges[0].node.artwork.pickup_available = false
     const component = getWrapper(testPropWithShipOnlyOrder)
     expect(component.find(RadioGroup).length).toEqual(0)
+  })
+
+  it("disables country select when shipsToContinentalUSOnly is true", () => {
+    const testPropWithContinentalUSOnlyOrder = cloneDeep(testProps)
+    testPropWithContinentalUSOnlyOrder.order.lineItems.edges[0].node.artwork.shipsToContinentalUSOnly = true
+    const component = getWrapper(testPropWithContinentalUSOnlyOrder)
+    expect(component.find(CountrySelect).props().disabled).toBe(true)
   })
 
   it("commits the mutation with the orderId", () => {

--- a/src/Apps/__test__/Fixtures/Order.ts
+++ b/src/Apps/__test__/Fixtures/Order.ts
@@ -36,6 +36,7 @@ export const UntouchedOrder = {
             date: "2016",
             shippingOrigin: "New York, NY",
             medium: "Oil and pencil on panel",
+            shipsToContinentalUSOnly: false,
             dimensions: {
               in: "36 × 36 in",
               cm: "91.4 × 91.4 cm",

--- a/src/Styleguide/Components/CountrySelect.tsx
+++ b/src/Styleguide/Components/CountrySelect.tsx
@@ -4,6 +4,7 @@ import { PositionProps, SpaceProps } from "styled-system"
 
 export interface CountrySelectProps extends PositionProps, SpaceProps {
   selected?: string
+  disabled?: boolean
   onSelect?: (value) => void
 }
 

--- a/src/__generated__/Shipping_order.graphql.ts
+++ b/src/__generated__/Shipping_order.graphql.ts
@@ -27,6 +27,7 @@ export type Shipping_order = {
                 readonly artwork: ({
                     readonly id: string;
                     readonly pickup_available: boolean | null;
+                    readonly shipsToContinentalUSOnly: boolean | null;
                 }) | null;
             }) | null;
         }) | null> | null;
@@ -187,6 +188,13 @@ return {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "shipsToContinentalUSOnly",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "__id",
                       "args": null,
                       "storageKey": null
@@ -209,5 +217,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '2ea5766b77c168a536520eed217a7c3f';
+(node as any).hash = '4f33217ba6f66907afd60846e143003a';
 export default node;

--- a/src/__generated__/routes_ShippingQuery.graphql.ts
+++ b/src/__generated__/routes_ShippingQuery.graphql.ts
@@ -48,6 +48,7 @@ fragment Shipping_order on Order {
         artwork {
           id
           pickup_available
+          shipsToContinentalUSOnly
           __id
         }
         __id: id
@@ -155,7 +156,7 @@ return {
   "operationKind": "query",
   "name": "routes_ShippingQuery",
   "id": null,
-  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          shipsToContinentalUSOnly\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -307,6 +308,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "pickup_available",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "shipsToContinentalUSOnly",
                             "args": null,
                             "storageKey": null
                           },


### PR DESCRIPTION
Implements [PURCHASE-477](https://artsyproduct.atlassian.net/browse/PURCHASE-477) by disabling the country field on the Shipping panel when a work is continental US shipping only. A non-US billing address can still be selected.