### PR TITLE
[FIX ClientRouter] Fix .env user auth

### DIFF
--- a/src/Artsy/Router/Components/ClientRouter.tsx
+++ b/src/Artsy/Router/Components/ClientRouter.tsx
@@ -1,8 +1,10 @@
 import { createMockNetworkLayer } from "Artsy/Relay/createMockNetworkLayer"
 import { buildClientApp } from "Artsy/Router/buildClientApp"
+import { ContextProps } from "Artsy/SystemContext"
 import { HistoryOptions } from "farce"
 import { IMocks } from "graphql-tools/dist/Interfaces"
 import React from "react"
+import { getUser } from "Utils/getUser"
 import { MatchingMediaQueries } from "Utils/Responsive"
 
 interface Props {
@@ -12,7 +14,7 @@ interface Props {
   initialState?: object
   historyOptions?: HistoryOptions
   mockResolvers?: IMocks
-  context?: object
+  context?: ContextProps
 }
 
 export class ClientRouter extends React.Component<Props> {
@@ -35,6 +37,8 @@ export class ClientRouter extends React.Component<Props> {
     } = this.props
 
     try {
+      const user = getUser(context && context.user)
+
       const { ClientApp } = await buildClientApp({
         routes,
         initialRoute,
@@ -44,6 +48,7 @@ export class ClientRouter extends React.Component<Props> {
         },
         context: {
           ...context,
+          user,
           initialMatchingMediaQueries,
           relayNetwork: mockResolvers && createMockNetworkLayer(mockResolvers),
         },

--- a/src/Artsy/Router/__stories__/Router.story.tsx
+++ b/src/Artsy/Router/__stories__/Router.story.tsx
@@ -80,7 +80,9 @@ storiesOf("SSR Router/Example", module).add("Example Router App", () => {
     <ClientRouter
       routes={routes}
       context={{
-        mediator: x => x,
+        mediator: {
+          trigger: x => x,
+        },
       }}
     />
   )

--- a/src/__stories__/storiesOf.js
+++ b/src/__stories__/storiesOf.js
@@ -6,7 +6,6 @@ import Events from "../Utils/Events"
 
 const bootProps = {
   mediator: x => x,
-  user: {},
 }
 
 export function storiesOf(desc, mod) {


### PR DESCRIPTION
Fixes an issue where the default user isn't retrieved from `.env` file if not explicitly passed to context. Noticed this when clicking the follow button in the artist storybooks app. 