### PR TITLE
@damassi => [ArtworkBrick] BugFix: Remove all a tags in tombstone

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -56,14 +56,19 @@ export class Details extends React.Component<Props, null> {
   }
 
   titleLine() {
-    return (
-      <TruncatedLine>
-        <TextLink href={this.props.artwork.href}>
-          <em>{this.props.artwork.title}</em>
-          {this.props.artwork.date && `, ${this.props.artwork.date}`}
-        </TextLink>
-      </TruncatedLine>
+    const { includeLinks } = this.props
+    const artworkText = (
+      <>
+        <em>{this.props.artwork.title}</em>
+        {this.props.artwork.date && `, ${this.props.artwork.date}`}
+      </>
     )
+    const artworkTextWithLink = includeLinks ? (
+      <TextLink href={this.props.artwork.href}>{artworkText}</TextLink>
+    ) : (
+      artworkText
+    )
+    return <TruncatedLine>{artworkTextWithLink}</TruncatedLine>
   }
 
   line(text) {


### PR DESCRIPTION
Thanks, didn't notice that warning during storybooks.

B/c one of the lines in this section _already_ linked to the artwork page, I didn't remove it when making the whole area be linkable. This removes it.