### PR TITLE
Handle known errors while submitting an order

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -277,7 +277,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
             this.onMutationError(
               errors || creditCardOrError.mutationError,
               creditCardOrError.mutationError &&
-                creditCardOrError.mutationError.message
+                creditCardOrError.mutationError.detail
             )
           }
         },

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -5,7 +5,7 @@ import { BuyNowStepper } from "Apps/Order/Components/BuyNowStepper"
 import { ItemReviewFragmentContainer as ItemReview } from "Apps/Order/Components/ItemReview"
 import { ShippingAndPaymentReviewFragmentContainer as ShippingAndPaymentReview } from "Apps/Order/Components/ShippingAndPaymentReview"
 import { ErrorModal } from "Components/Modal/ErrorModal"
-import { Router } from "found"
+import { RouteConfig, Router } from "found"
 import React, { Component } from "react"
 import {
   commitMutation,
@@ -14,6 +14,7 @@ import {
   RelayProp,
 } from "react-relay"
 import { Col, Row } from "Styleguide/Elements/Grid"
+import { get } from "Utils/get"
 import { Responsive } from "Utils/Responsive"
 import { Helper } from "../../Components/Helper"
 import { TransactionSummaryFragmentContainer as TransactionSummary } from "../../Components/TransactionSummary"
@@ -23,12 +24,15 @@ export interface ReviewProps {
   order: Review_order
   relay?: RelayProp
   router: Router
+  route: RouteConfig
 }
 
 interface ReviewState {
   isSubmitting: boolean
   isErrorModalOpen: boolean
   errorModalMessage: string
+  errorModalTitle: string
+  errorModalCtaAction: () => null
 }
 
 export class ReviewRoute extends Component<ReviewProps, ReviewState> {
@@ -36,6 +40,8 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
     isSubmitting: false,
     isErrorModalOpen: false,
     errorModalMessage: null,
+    errorModalTitle: null,
+    errorModalCtaAction: null,
   }
 
   onOrderSubmitted() {
@@ -48,7 +54,6 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               mutation ReviewSubmitOrderMutation($input: SubmitOrderInput!) {
                 submitOrder(input: $input) {
                   orderOrError {
-                    __typename
                     ... on OrderWithMutationFailure {
                       error {
                         type
@@ -66,12 +71,49 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               },
             },
             onCompleted: result => {
-              if ("error" in result.submitOrder.orderOrError) {
-                this.onMutationError(result.submitOrder.orderOrError.error)
-                return
-              }
+              const {
+                submitOrder: { orderOrError },
+              } = result
 
-              this.props.router.push(`/order2/${this.props.order.id}/status`)
+              const error = orderOrError.error
+              if (error) {
+                switch (error.code) {
+                  case "insufficient_inventory":
+                    const artistId = get(
+                      this.props.order,
+                      o => o.lineItems.edges[0].node.artwork.artist.id
+                    )
+
+                    this.onMutationError(
+                      error,
+                      "Not available",
+                      "Sorry, the work is no longer available.",
+                      artistId ? this.routeToArtistPage.bind(this) : null
+                    )
+                    break
+                  case "failed_charge_authorize":
+                    const parsedData = JSON.parse(error.data)
+                    this.onMutationError(
+                      error,
+                      "An error occurred",
+                      parsedData.failure_message
+                    )
+                    break
+                  case "artwork_version_mismatch":
+                    this.onMutationError(
+                      error,
+                      "Work has been updated",
+                      "Something about the work changed since you started checkout. Please review the work before submitting your order.",
+                      this.routeToArtworkPage.bind(this)
+                    )
+                    break
+                  default:
+                    this.onMutationError(error)
+                    break
+                }
+              } else {
+                this.props.router.push(`/order2/${this.props.order.id}/status`)
+              }
             },
             onError: this.onMutationError.bind(this),
           }
@@ -80,12 +122,39 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
     }
   }
 
-  private onMutationError(errors, errorModalMessage?) {
+  private routeToArtworkPage() {
+    const artworkId = get(
+      this.props.order,
+      o => o.lineItems.edges[0].node.artwork.id
+    )
+    // Don't confirm whether or not you want to leave the page
+    this.props.route.onTransition = () => null
+    window.location.assign(`/artwork/${artworkId}`)
+  }
+
+  private routeToArtistPage() {
+    const artistId = get(
+      this.props.order,
+      o => o.lineItems.edges[0].node.artwork.artist.id
+    )
+    // Don't confirm whether or not you want to leave the page
+    this.props.route.onTransition = () => null
+    window.location.assign(`/artist/${artistId}`)
+  }
+
+  private onMutationError(
+    errors,
+    errorModalTitle?,
+    errorModalMessage?,
+    errorModalCtaAction?
+  ) {
     console.error("Order/Routes/Review/index.tsx", errors)
     this.setState({
       isSubmitting: false,
       isErrorModalOpen: true,
+      errorModalTitle,
       errorModalMessage,
+      errorModalCtaAction,
     })
   }
 
@@ -202,6 +271,8 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
           onClose={this.onCloseModal}
           show={this.state.isErrorModalOpen}
           detailText={this.state.errorModalMessage}
+          headerText={this.state.errorModalTitle}
+          ctaAction={this.state.errorModalCtaAction}
         />
       </>
     )
@@ -218,6 +289,9 @@ export const ReviewFragmentContainer = createFragmentContainer(
           node {
             artwork {
               id
+              artist {
+                id
+              }
               ...ItemReview_artwork
             }
           }

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -78,12 +78,8 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               const error = orderOrError.error
               if (error) {
                 switch (error.code) {
-                  case "insufficient_inventory":
-                    const artistId = get(
-                      this.props.order,
-                      o => o.lineItems.edges[0].node.artwork.artist.id
-                    )
-
+                  case "insufficient_inventory": {
+                    const artistId = this.artistId()
                     this.onMutationError(
                       error,
                       "Not available",
@@ -91,7 +87,8 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                       artistId ? this.routeToArtistPage.bind(this) : null
                     )
                     break
-                  case "failed_charge_authorize":
+                  }
+                  case "failed_charge_authorize": {
                     const parsedData = JSON.parse(error.data)
                     this.onMutationError(
                       error,
@@ -99,7 +96,8 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                       parsedData.failure_message
                     )
                     break
-                  case "artwork_version_mismatch":
+                  }
+                  case "artwork_version_mismatch": {
                     this.onMutationError(
                       error,
                       "Work has been updated",
@@ -107,9 +105,11 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                       this.routeToArtworkPage.bind(this)
                     )
                     break
-                  default:
+                  }
+                  default: {
                     this.onMutationError(error)
                     break
+                  }
                 }
               } else {
                 this.props.router.push(`/order2/${this.props.order.id}/status`)
@@ -120,6 +120,13 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
         )
       )
     }
+  }
+
+  private artistId() {
+    return get(
+      this.props.order,
+      o => o.lineItems.edges[0].node.artwork.artists[0].id
+    )
   }
 
   private routeToArtworkPage() {
@@ -133,10 +140,8 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
   }
 
   private routeToArtistPage() {
-    const artistId = get(
-      this.props.order,
-      o => o.lineItems.edges[0].node.artwork.artist.id
-    )
+    const artistId = this.artistId()
+
     // Don't confirm whether or not you want to leave the page
     this.props.route.onTransition = () => null
     window.location.assign(`/artist/${artistId}`)
@@ -289,7 +294,7 @@ export const ReviewFragmentContainer = createFragmentContainer(
           node {
             artwork {
               id
-              artist {
+              artists {
                 id
               }
               ...ItemReview_artwork

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/createCreditCard.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/createCreditCard.ts
@@ -12,9 +12,9 @@ export const creatingCreditCardFailed = {
   createCreditCard: {
     creditCardOrError: {
       mutationError: {
-        type: "other_error",
-        message: "No such token: fake-token",
-        detail: null,
+        type: "payment_error",
+        message: "Payment error",
+        detail: "No such token: fake-token",
         error: null,
       },
     },

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/index.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/index.ts
@@ -1,3 +1,4 @@
 export * from "./createCreditCard"
 export * from "./setOrderPayment"
 export * from "./setOrderShipping"
+export * from "./submitOrder"

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/submitOrder.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/submitOrder.ts
@@ -1,0 +1,32 @@
+export const submitOrderWithFailure = {
+  submitOrder: {
+    orderOrError: {
+      __typename: "OrderWithMutationFailure",
+      error: {
+        type: "validation",
+        code: "credit_card_not_found",
+        data: '{"credit_card_id":"5b9987f72957190026d0ff54"}',
+      },
+    },
+  },
+}
+
+export const submitOrderWithVersionMismatchFailure = {
+  submitOrder: {
+    orderOrError: {
+      __typename: "OrderWithMutationFailure",
+      error: { type: "processing", code: "artwork_version_mismatch" },
+    },
+  },
+}
+
+export const submitOrderWithNoInventoryFailure = {
+  submitOrder: {
+    orderOrError: {
+      error: {
+        type: "processing",
+        code: "insufficient_inventory",
+      },
+    },
+  },
+}

--- a/src/Apps/__test__/Fixtures/Order.ts
+++ b/src/Apps/__test__/Fixtures/Order.ts
@@ -40,9 +40,11 @@ export const UntouchedOrder = {
               in: "36 × 36 in",
               cm: "91.4 × 91.4 cm",
             },
-            artist: {
-              id: "artistId",
-            },
+            artists: [
+              {
+                id: "artistId",
+              },
+            ],
             attribution_class: null,
             image: {
               resized: {

--- a/src/Apps/__test__/Fixtures/Order.ts
+++ b/src/Apps/__test__/Fixtures/Order.ts
@@ -29,6 +29,7 @@ export const UntouchedOrder = {
       {
         node: {
           artwork: {
+            id: "artworkId",
             pickup_available: true,
             artist_names: "Lisa Breslow",
             title: "Gramercy Park South",
@@ -38,6 +39,9 @@ export const UntouchedOrder = {
             dimensions: {
               in: "36 × 36 in",
               cm: "91.4 × 91.4 cm",
+            },
+            artist: {
+              id: "artistId",
             },
             attribution_class: null,
             image: {

--- a/src/Components/Modal/ErrorModal.tsx
+++ b/src/Components/Modal/ErrorModal.tsx
@@ -9,6 +9,7 @@ interface ErrorModalProps extends React.HTMLProps<HTMLDivElement> {
   detailText?: string
   closeText?: string
   onClose?: () => void
+  ctaAction?: () => void
 }
 
 export class ErrorModal extends React.Component<ErrorModalProps> {
@@ -22,7 +23,14 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
   }
 
   render() {
-    const { show, onClose, headerText, detailText, closeText } = this.props
+    const {
+      show,
+      onClose,
+      headerText,
+      detailText,
+      closeText,
+      ctaAction,
+    } = this.props
 
     return (
       <ModalWrapper show={show} onClose={onClose}>
@@ -40,7 +48,11 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
           </Sans>
         </Flex>
 
-        <Flex mt={1} justifyContent="flex-end" onClick={this.close}>
+        <Flex
+          mt={1}
+          justifyContent="flex-end"
+          onClick={ctaAction ? ctaAction : this.close}
+        >
           <ModalButton>{closeText}</ModalButton>
         </Flex>
       </ModalWrapper>

--- a/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
+++ b/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
@@ -11,16 +11,11 @@ export type ReviewSubmitOrderMutationVariables = {
 export type ReviewSubmitOrderMutationResponse = {
     readonly submitOrder: ({
         readonly orderOrError: ({
-            readonly __typename: "OrderWithMutationFailure";
-            readonly error: ({
+            readonly error?: ({
                 readonly type: string;
                 readonly code: string;
                 readonly data: string | null;
             }) | null;
-        } | {
-            /*This will never be '% other', but we need some
-            value in case none of the concrete values match.*/
-            readonly __typename: "%other";
         }) | null;
     }) | null;
 };
@@ -61,80 +56,50 @@ var v0 = [
 ],
 v1 = [
   {
-    "kind": "LinkedField",
-    "alias": null,
-    "name": "submitOrder",
-    "storageKey": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input",
-        "type": "SubmitOrderInput!"
-      }
-    ],
-    "concreteType": "SubmitOrderPayload",
-    "plural": false,
-    "selections": [
-      {
-        "kind": "LinkedField",
-        "alias": null,
-        "name": "orderOrError",
-        "storageKey": null,
-        "args": null,
-        "concreteType": null,
-        "plural": false,
-        "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "__typename",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "InlineFragment",
-            "type": "OrderWithMutationFailure",
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "error",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "EcommerceError",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "type",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "code",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "data",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input",
+    "type": "SubmitOrderInput!"
   }
-];
+],
+v2 = {
+  "kind": "InlineFragment",
+  "type": "OrderWithMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "error",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "EcommerceError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "type",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "code",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "data",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+};
 return {
   "kind": "Request",
   "operationKind": "mutation",
@@ -148,15 +113,70 @@ return {
     "type": "Mutation",
     "metadata": null,
     "argumentDefinitions": v0,
-    "selections": v1
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "submitOrder",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SubmitOrderPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "orderOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v2
+            ]
+          }
+        ]
+      }
+    ]
   },
   "operation": {
     "kind": "Operation",
     "name": "ReviewSubmitOrderMutation",
     "argumentDefinitions": v0,
-    "selections": v1
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "submitOrder",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SubmitOrderPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "orderOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "__typename",
+                "args": null,
+                "storageKey": null
+              },
+              v2
+            ]
+          }
+        ]
+      }
+    ]
   }
 };
 })();
-(node as any).hash = '782db6e616700ecab8b28acdc829255f';
+(node as any).hash = 'ec2d0c50ae03c607e590c06f905b182f';
 export default node;

--- a/src/__generated__/Review_order.graphql.ts
+++ b/src/__generated__/Review_order.graphql.ts
@@ -13,9 +13,9 @@ export type Review_order = {
             readonly node: ({
                 readonly artwork: ({
                     readonly id: string;
-                    readonly artist: ({
+                    readonly artists: ReadonlyArray<({
                         readonly id: string;
-                    }) | null;
+                    }) | null> | null;
                     readonly " $fragmentRefs": ItemReview_artwork$ref;
                 }) | null;
             }) | null;
@@ -97,11 +97,11 @@ return {
                     {
                       "kind": "LinkedField",
                       "alias": null,
-                      "name": "artist",
+                      "name": "artists",
                       "storageKey": null,
                       "args": null,
                       "concreteType": "Artist",
-                      "plural": false,
+                      "plural": true,
                       "selections": [
                         v0,
                         v1
@@ -136,5 +136,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'e79bfb52f1e88625587692b0ff3fcfea';
+(node as any).hash = '370d9da157fd82506e919b9e2bcd44a3';
 export default node;

--- a/src/__generated__/Review_order.graphql.ts
+++ b/src/__generated__/Review_order.graphql.ts
@@ -13,6 +13,9 @@ export type Review_order = {
             readonly node: ({
                 readonly artwork: ({
                     readonly id: string;
+                    readonly artist: ({
+                        readonly id: string;
+                    }) | null;
                     readonly " $fragmentRefs": ItemReview_artwork$ref;
                 }) | null;
             }) | null;
@@ -33,6 +36,13 @@ var v0 = {
   "storageKey": null
 },
 v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
@@ -85,20 +95,27 @@ return {
                   "selections": [
                     v0,
                     {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "artist",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Artist",
+                      "plural": false,
+                      "selections": [
+                        v0,
+                        v1
+                      ]
+                    },
+                    {
                       "kind": "FragmentSpread",
                       "name": "ItemReview_artwork",
                       "args": null
                     },
-                    {
-                      "kind": "ScalarField",
-                      "alias": null,
-                      "name": "__id",
-                      "args": null,
-                      "storageKey": null
-                    }
+                    v1
                   ]
                 },
-                v1
+                v2
               ]
             }
           ]
@@ -115,9 +132,9 @@ return {
       "name": "ShippingAndPaymentReview_order",
       "args": null
     },
-    v1
+    v2
   ]
 };
 })();
-(node as any).hash = 'df52d5788d78942fe9c4ff41f50c9192';
+(node as any).hash = 'e79bfb52f1e88625587692b0ff3fcfea';
 export default node;

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -34,6 +34,10 @@ fragment Review_order on Order {
       node {
         artwork {
           id
+          artist {
+            id
+            __id
+          }
           ...ItemReview_artwork
           __id
         }
@@ -174,7 +178,14 @@ v3 = {
   "args": null,
   "storageKey": null
 },
-v4 = [
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -183,13 +194,6 @@ v4 = [
     "storageKey": null
   }
 ],
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
 v6 = {
   "kind": "ScalarField",
   "alias": null,
@@ -209,7 +213,7 @@ return {
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          artist {\n            id\n            __id\n          }\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -288,6 +292,13 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "medium",
+                            "args": null,
+                            "storageKey": null
+                          },
                           v3,
                           {
                             "kind": "ScalarField",
@@ -311,11 +322,17 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "ScalarField",
+                            "kind": "LinkedField",
                             "alias": null,
-                            "name": "medium",
+                            "name": "artist",
+                            "storageKey": null,
                             "args": null,
-                            "storageKey": null
+                            "concreteType": "Artist",
+                            "plural": false,
+                            "selections": [
+                              v3,
+                              v4
+                            ]
                           },
                           {
                             "kind": "LinkedField",
@@ -384,7 +401,7 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v4
+                                "selections": v5
                               },
                               {
                                 "kind": "LinkedField",
@@ -401,11 +418,11 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v4
+                                "selections": v5
                               }
                             ]
                           },
-                          v5,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -460,7 +477,7 @@ return {
             "plural": false,
             "selections": [
               v6,
-              v5,
+              v4,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
@@ -576,7 +593,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v5
+              v4
             ]
           }
         ]

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -34,7 +34,7 @@ fragment Review_order on Order {
       node {
         artwork {
           id
-          artist {
+          artists {
             id
             __id
           }
@@ -213,7 +213,7 @@ return {
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          artist {\n            id\n            __id\n          }\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          artists {\n            id\n            __id\n          }\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal\n  taxTotal\n  itemsTotal\n  buyerTotal\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -324,11 +324,11 @@ return {
                           {
                             "kind": "LinkedField",
                             "alias": null,
-                            "name": "artist",
+                            "name": "artists",
                             "storageKey": null,
                             "args": null,
                             "concreteType": "Artist",
-                            "plural": false,
+                            "plural": true,
                             "selections": [
                               v3,
                               v4


### PR DESCRIPTION
This PR addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-443

We want to handle the following errors (aside from just showing the generic modal):
- `insufficient_inventory`--> show a unique message + link user back to the artist page if they hit "continue"
- `artwork_version_mismatch` --> show a unique message + link user back to the artwork page if they hit "continue"
- `failed_charge_authorize` --> show a unique message (including what we get back from Stripe)

<img width="1440" alt="screen shot 2018-09-28 at 9 35 18 am" src="https://user-images.githubusercontent.com/2081340/46214771-d1655080-c309-11e8-99f7-7e3ee5c4c29d.png">
<img width="1436" alt="screen shot 2018-09-28 at 9 36 02 am" src="https://user-images.githubusercontent.com/2081340/46214772-d1655080-c309-11e8-83c4-031c67ba5a54.png">
