### PR TITLE
Updates the cancel copy to be more generic

### DIFF
--- a/src/Apps/Order/Routes/Status/index.tsx
+++ b/src/Apps/Order/Routes/Status/index.tsx
@@ -91,11 +91,10 @@ export class StatusRoute extends Component<StatusProps> {
       case "CANCELED":
         return (
           <>
-            The work is no longer available.
-            <br />
-            <br />
-            Please allow 5-7 business days for the refund to appear on your bank
-            statement.
+            Please allow 5–7 business days for the refund to appear on your bank
+            statement. Contact{" "}
+            <a href="mailto:orders@artsy.net">orders@artsy.net</a> with any
+            questions.
           </>
         )
     }


### PR DESCRIPTION
This PR updates the cancellation message to be generic. This has evolved in a recent conversation between @briansw, @joanna20, and myself from where it was at previously. We had previously detailed a cancellation reason, but given the ambiguity and unknowns around the cases when an artwork is rejected by a seller, we've (at least temporarily) adopted this messaging. 

**NEW**
![image](https://user-images.githubusercontent.com/3087225/46230454-a7765300-c336-11e8-9d3f-904c8ad78296.png)

**OLD**
![image](https://user-images.githubusercontent.com/3087225/46230496-c4128b00-c336-11e8-8007-6307cec64ff4.png)
