### PR TITLE
User sees appropriate error page when trying to access an order they don't have access to

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -1,6 +1,7 @@
 import { Spacer } from "@artsy/palette"
 import { routes_OrderQueryResponse } from "__generated__/routes_OrderQuery.graphql"
 import { ContextConsumer } from "Artsy/SystemContext"
+import { ErrorPage } from "Components/ErrorPage"
 import { Location, RouteConfig, Router } from "found"
 import React from "react"
 import { Meta, Title } from "react-head"
@@ -82,6 +83,10 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
   render() {
     const { children, location, router, order, params } = this.props
 
+    if (!order) {
+      return <ErrorPage code={404} />
+    }
+
     if (
       order &&
       order.state !== "PENDING" &&
@@ -89,6 +94,7 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
     ) {
       router.replace(`/order2/${params.orderID}/status`)
     }
+
     return (
       <ContextConsumer>
         {({ isEigen }) => (

--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -3,6 +3,7 @@ import { mount } from "enzyme"
 import React from "react"
 import { HeadProvider } from "react-head"
 import { Meta } from "react-head"
+import { ErrorPage } from "../../../Components/ErrorPage"
 import { OrderApp } from "../OrderApp"
 
 jest.mock("react-stripe-elements", () => ({
@@ -86,5 +87,19 @@ describe("OrderApp", () => {
       .find(Meta)
       .filterWhere(meta => meta.props().name === "viewport")
     expect(viewportMetaTags.length).toBe(1)
+  })
+
+  it("shows an error page if the order is missing", () => {
+    const props = getProps()
+    const subject = getWrapper({
+      props: { ...props, order: null },
+      context: { isEigen: true },
+    })
+
+    const viewportMetaTags = subject.find(ErrorPage)
+
+    expect(subject.find(ErrorPage).text()).toContain(
+      "Sorry, the page you were looking for doesn’t exist at this URL."
+    )
   })
 })

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -16,6 +16,8 @@ import { StatusFragmentContainer as StatusRoute } from "Apps/Order/Routes/Status
 import { ComponentClass, StatelessComponent } from "react"
 
 // @ts-ignore
+import { ErrorPage } from "Components/ErrorPage"
+// @ts-ignore
 import { PaymentProps } from "./Routes/Payment"
 // @ts-ignore
 import { ReviewProps } from "./Routes/Review"
@@ -122,8 +124,7 @@ export const routes: RouteConfig[] = [
       {
         path: "*",
         Component: props => {
-          console.warn("Route not found: ", props)
-          return <div>Page not found</div>
+          return <ErrorPage code={404} />
         },
       },
     ],


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-351

We discussed showing the header or not with @briansw @zephraph and @sweir27 and decided this is ok for now.

# Screenshot

<img width="1385" alt="screen shot 2018-09-28 at 7 00 17 pm" src="https://user-images.githubusercontent.com/386234/46237167-c386ee00-c350-11e8-86ad-eb3b13f19c9f.png">
