### PR TITLE
@damassi => Handle all unknown tabs by redirecting to main artist page URL

### DIFF
--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -155,18 +155,15 @@ export const routes: RouteConfig[] = [
           }
         `,
       },
-      // Redirect old Artist app links to Overview page
+      // Redirect all unhandled tabs to the artist page.
+      // Note: there is a deep-linked standalone auction-lot page
+      // in Force, under /artist/:artistID/auction-result/:id.
+      // That app needs to be mounted before this app for that to work,
+      // and not get caught here.
       new Redirect({
-        from: "/works",
+        from: "*",
         to: "/artist/:artistID",
       }) as any,
-      {
-        path: "*",
-        Component: props => {
-          console.warn("Route not found: ", props)
-          return <div>Page not found</div>
-        },
-      },
     ],
   },
 ]


### PR DESCRIPTION
Pretty simple, this just redirects all unhandled tabs back to the main artist page. That should fix the cases of `/works`, `/bleh`, etc.

There's a corresponding Force PR that switches the order of app mounting, so deep-linked standalone auction lot pages at `/artist/:artistID/auction-result/:id` still work, and don't get caught here.