### PR TITLE
[FEATURE BNMO] Display error modal on unsupported shipping location

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -137,16 +137,29 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
 
               if (orderOrError.error) {
                 const errorCode = orderOrError.error.code
+                const errorData = get(
+                  orderOrError,
+                  o => JSON.parse(o.error.data),
+                  {}
+                )
                 if (
-                  errorCode &&
-                  (errorCode === "missing_region" ||
-                    errorCode === "missing_country" ||
-                    errorCode === "missing_postal_code")
+                  errorCode === "missing_region" ||
+                  errorCode === "missing_country" ||
+                  errorCode === "missing_postal_code"
                 ) {
                   this.onMutationError(
                     orderOrError.error,
                     "Invalid address",
                     "There was an error processing your address. Please review and try again."
+                  )
+                } else if (
+                  errorCode === "unsupported_shipping_location" &&
+                  errorData.failure_code === "domestic_shipping_only"
+                ) {
+                  this.onMutationError(
+                    orderOrError.error,
+                    "Can't ship to that address",
+                    "This work can only be shipped to the continental United States."
                   )
                 } else {
                   this.onMutationError(orderOrError.error)


### PR DESCRIPTION
Displays an error modal using the `unsupported_shipping_location` error validation introduced in https://github.com/artsy/exchange/pull/204.

<img width="1440" alt="screen shot 2018-10-02 at 3 20 03 pm" src="https://user-images.githubusercontent.com/5216744/46372678-d7d13080-c659-11e8-99b1-2ed0f7e88c1b.png">
