### PR TITLE
[FEATURE BNMO] Add responsive prop and styling to ModalWrapper

### DIFF
--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -9,7 +9,7 @@ import { HeadProvider, Meta } from "react-head"
 import { ErrorPage } from "../../../Components/ErrorPage"
 import { OrderApp } from "../OrderApp"
 
-import { createMockNetworkLayer } from "Artsy/Relay/createMockNetworkLayer"
+import { createMockNetworkLayer } from "DevTools/createMockNetworkLayer"
 import { Environment, RecordSource, Store } from "relay-runtime"
 
 jest.mock("react-stripe-elements", () => ({

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -65,6 +65,7 @@ export class Modal extends React.Component<ModalProps> {
         show={show}
         isWide={isWide}
         image={image}
+        fullscreenResponsiveModal
       >
         <CloseButton name="close" onClick={this.close} />
 

--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -10,6 +10,7 @@ export interface ModalWrapperProps extends React.HTMLProps<ModalWrapper> {
   cta?: CtaProps
   onClose?: () => void
   isWide?: boolean
+  fullscreenResponsiveModal?: boolean
   image?: string
   show?: boolean
 }
@@ -74,7 +75,7 @@ export class ModalWrapper extends React.Component<
   }
 
   render(): JSX.Element {
-    const { children, isWide, image } = this.props
+    const { children, isWide, fullscreenResponsiveModal, image } = this.props
     const { isShown, isAnimating } = this.state
 
     if (isShown) {
@@ -96,8 +97,14 @@ export class ModalWrapper extends React.Component<
             unmountOnExit
             timeout={{ enter: 10, exit: 200 }}
           >
-            <ModalContainer isWide={isWide} image={image}>
-              <ModalInner>{children}</ModalInner>
+            <ModalContainer
+              fullscreenResponsiveModal={fullscreenResponsiveModal}
+              isWide={isWide}
+              image={image}
+            >
+              <ModalInner fullscreenResponsiveModal={fullscreenResponsiveModal}>
+                {children}
+              </ModalInner>
             </ModalContainer>
           </FadeTransition>
         </Wrapper>
@@ -142,6 +149,7 @@ export const ModalOverlay = styled.div`
 
 export const ModalContainer = styled.div.attrs<{
   isWide?: boolean
+  fullscreenResponsiveModal?: boolean
   image?: string
 }>({})`
   position: fixed;
@@ -155,20 +163,30 @@ export const ModalContainer = styled.div.attrs<{
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
   animation: ${slideUp} 250ms linear;
 
-  ${media.sm`
-    width: 100%;
-    border-radius: 0;
-  `};
+  ${props =>
+    props.fullscreenResponsiveModal
+      ? media.sm`
+          width: 100%;
+          border-radius: 0;
+        `
+      : media.sm`
+          width: calc(100vw - 20px);
+          border-radius: 2px;
+        `};
 `
 
-const ModalInner = styled.div`
+const ModalInner = styled.div.attrs<{ fullscreenResponsiveModal?: boolean }>(
+  {}
+)`
   /* disabling scrolling until custom scrollbars are implemented */
   /* overflow-y: scroll; */
   max-height: calc(100vh - 80px);
-  ${media.sm`
-    max-height: 100vh;
-    height: 100vh
-  `};
+  ${props =>
+    props.fullscreenResponsiveModal &&
+    media.sm`
+      max-height: 100vh;
+      height: 100vh
+    `};
 `
 
 export default ModalWrapper

--- a/src/Components/Modal/__tests__/ErrorModal.test.tsx
+++ b/src/Components/Modal/__tests__/ErrorModal.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme"
 import React from "react"
 import { Dismiss, ErrorModal, ModalButton } from "../ErrorModal"
+import { ModalWrapper } from "../ModalWrapper"
 
 describe("ErrorModal", () => {
   const getWrapper = inputs => {
@@ -49,6 +50,13 @@ describe("ErrorModal", () => {
       expect(text).toContain("Custom header")
       expect(text).toContain("A custom error detail.")
       expect(text).toContain("OK")
+    })
+
+    it("Renders a responsive modal", () => {
+      const component = getWrapper(props)
+      expect(
+        component.find(ModalWrapper).props().fullscreenResponsiveModal
+      ).toBe(true)
     })
 
     it("Clicking on the continue button closes the modal", () => {

--- a/src/Components/Modal/__tests__/ErrorModal.test.tsx
+++ b/src/Components/Modal/__tests__/ErrorModal.test.tsx
@@ -56,7 +56,7 @@ describe("ErrorModal", () => {
       const component = getWrapper(props)
       expect(
         component.find(ModalWrapper).props().fullscreenResponsiveModal
-      ).toBe(true)
+      ).toBeUndefined()
     })
 
     it("Clicking on the continue button closes the modal", () => {

--- a/src/Components/Modal/__tests__/ModalWrapper.test.tsx
+++ b/src/Components/Modal/__tests__/ModalWrapper.test.tsx
@@ -16,6 +16,7 @@ describe("Modal", () => {
     props = {
       onClose: jest.fn(),
       blurContainerSelector: "",
+      fullscreenResponsiveModal: true,
     }
   })
 


### PR DESCRIPTION
Implements [PURCHASE-471](https://github.com/artsy/reaction/compare/master...javamonn:purchase-471-responsive-error-modal?expand=1).

Adds an `isResponsive` prop to `ModalWrapper`  to implement the responsive modal styling seen [here](https://app.zeplin.io/project/5ab94282c124db8d58365b47/screen/5b6dca0f88ebbc1cd4521d7c). Right now, the `ErrorModal` is only user of this styling. The alternate way to approach this would've been to add something like a `ResponsiveModalWrapper`, but the behavior appears to be the same outside a few lines of style differences.

As seen in storybook:

<img width="724" alt="screen shot 2018-10-02 at 5 04 30 pm" src="https://user-images.githubusercontent.com/5216744/46377276-28e72180-c666-11e8-8d20-ce28182b8acb.png">
