### PR TITLE
[FIX BNMOrouting] Extracts redirects for order app into routes config

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -81,18 +81,10 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
   }
 
   render() {
-    const { children, location, router, order, params } = this.props
+    const { children, order } = this.props
 
     if (!order) {
       return <ErrorPage code={404} />
-    }
-
-    if (
-      order &&
-      order.state !== "PENDING" &&
-      !location.pathname.includes("status")
-    ) {
-      router.replace(`/order2/${params.orderID}/status`)
     }
 
     return (

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -162,6 +162,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
   }
 
   onMutationError(errors, errorModalTitle?, errorModalMessage?) {
+    console.error("Shipping/index.tsx", errors)
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -20,10 +20,9 @@ jest.mock("react-stripe-elements", () => ({
 }))
 
 describe("OrderApp routing redirects", () => {
+  // FIXME: move to DevTools folder
   async function render(url, mockResolvers) {
-    const network = createMockNetworkLayer({
-      ...mockResolvers,
-    })
+    const network = createMockNetworkLayer(mockResolvers)
     const source = new RecordSource()
     const store = new Store(source)
     const environment = new Environment({ network, store })
@@ -48,6 +47,7 @@ describe("OrderApp routing redirects", () => {
     })
     expect(redirect).toBe(undefined)
   })
+
   it("redirects to the status route if the order is not pending", async () => {
     const { redirect } = await render("/order2/1234/shipping", {
       Order: () => ({

--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -1,15 +1,144 @@
+import { routes } from "Apps/Order/routes"
 import { ContextProvider } from "Artsy/Router"
 import { mount } from "enzyme"
+import { Resolver } from "found-relay"
+import createRender from "found/lib/createRender"
+import getFarceResult from "found/lib/server/getFarceResult"
 import React from "react"
-import { HeadProvider } from "react-head"
-import { Meta } from "react-head"
+import { HeadProvider, Meta } from "react-head"
 import { ErrorPage } from "../../../Components/ErrorPage"
 import { OrderApp } from "../OrderApp"
+
+import { createMockNetworkLayer } from "Artsy/Relay/createMockNetworkLayer"
+import { Environment, RecordSource, Store } from "relay-runtime"
 
 jest.mock("react-stripe-elements", () => ({
   Elements: ({ children }) => children,
   StripeProvider: ({ children }) => children,
+  CardElement: () => jest.fn(),
+  injectStripe: () => jest.fn(),
 }))
+
+describe("OrderApp routing redirects", () => {
+  async function render(url, mockResolvers) {
+    const network = createMockNetworkLayer({
+      ...mockResolvers,
+    })
+    const source = new RecordSource()
+    const store = new Store(source)
+    const environment = new Environment({ network, store })
+
+    return await getFarceResult({
+      url,
+      routeConfig: routes,
+      resolver: new Resolver(environment),
+      render: createRender({}),
+    })
+  }
+
+  it("does not redirect to the status route if the order is pending", async () => {
+    const { redirect } = await render("/order2/1234/shipping", {
+      Order: () => ({
+        id: 1234,
+        state: "PENDING",
+        requestedFulfillment: {
+          __typename: "Pickup",
+        },
+      }),
+    })
+    expect(redirect).toBe(undefined)
+  })
+  it("redirects to the status route if the order is not pending", async () => {
+    const { redirect } = await render("/order2/1234/shipping", {
+      Order: () => ({
+        id: 1234,
+        state: "ABANDONED",
+        requestedFulfillment: {
+          __typename: "Pickup",
+        },
+      }),
+    })
+    expect(redirect.url).toBe("/order2/1234/status")
+  })
+
+  it("stays on the shipping route if no shipping option is set", async () => {
+    const { redirect } = await render("/order2/1234/shipping", {
+      Order: () => ({
+        id: 1234,
+        state: "PENDING",
+        requestedFulfillment: null,
+      }),
+    })
+    expect(redirect).toBe(undefined)
+  })
+
+  it("redirects to the shipping route from the payment route if no shipping option was set", async () => {
+    const { redirect } = await render("/order2/1234/payment", {
+      Order: () => ({
+        id: 1234,
+        state: "PENDING",
+        requestedFulfillment: null,
+      }),
+    })
+    expect(redirect.url).toBe("/order2/1234/shipping")
+  })
+
+  it("stays on the payment route if there is shipping but no payment info", async () => {
+    const { redirect } = await render("/order2/1234/payment", {
+      Order: () => ({
+        id: 1234,
+        state: "PENDING",
+        requestedFulfillment: {
+          __typename: "Ship",
+        },
+        creditCard: null,
+      }),
+    })
+    expect(redirect).toBe(undefined)
+  })
+
+  it("redirects to the shipping route from the review route if no shipping option was set", async () => {
+    const { redirect } = await render("/order2/1234/review", {
+      Order: () => ({
+        id: 1234,
+        state: "PENDING",
+        requestedFulfillment: null,
+        creditCard: null,
+      }),
+    })
+    expect(redirect.url).toBe("/order2/1234/shipping")
+  })
+
+  it("redirects to the payment route from the review route if no credit card is set", async () => {
+    const { redirect } = await render("/order2/1234/review", {
+      Order: () => ({
+        id: 1234,
+        state: "PENDING",
+        requestedFulfillment: {
+          __typename: "Ship",
+        },
+        creditCard: null,
+      }),
+    })
+    expect(redirect.url).toBe("/order2/1234/payment")
+  })
+
+  it("stays on the review route if there are payment and shipping options set", async () => {
+    const { redirect } = await render("/order2/1234/review", {
+      Order: () => ({
+        id: 1234,
+        state: "PENDING",
+        requestedFulfillment: {
+          __typename: "Ship",
+        },
+        creditCard: {
+          id: "12345",
+        },
+      }),
+    })
+    expect(redirect).toBe(undefined)
+  })
+})
 
 describe("OrderApp", () => {
   const getWrapper = ({ props, context }) => {
@@ -46,30 +175,6 @@ describe("OrderApp", () => {
       routes: [],
     }
   }
-
-  it("does not redirect to the Status route when the order is pending", () => {
-    const replace = jest.fn()
-    const props = getProps({
-      state: "PENDING",
-      location: "/order/123/shipping",
-      replace,
-    })
-    // @ts-ignore
-    getWrapper({ props })
-    expect(replace).not.toBeCalledWith("/order2/123/status")
-  })
-
-  it("redirects to the Status route when the order is not pending", () => {
-    const replace = jest.fn()
-    const props = getProps({
-      state: "SUBMITTED",
-      location: "/order/123/review",
-      replace,
-    })
-    // @ts-ignore
-    getWrapper({ props })
-    expect(replace).toBeCalledWith("/order2/123/status")
-  })
 
   it("omits meta viewport tag unless Eigen", () => {
     const props = getProps()

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -1,0 +1,60 @@
+import { Location, RedirectException, RouteConfig, Router } from "found"
+import { OrderApp } from "./OrderApp"
+
+const LEAVE_MESSAGING =
+  "Are you sure you want to refresh? Your changes will not be saved."
+
+export const confirmRouteExit = (
+  newLocation: Location,
+  oldLocation: Location,
+  router: Router
+) => {
+  // Refresh -- On refresh newLocation is null
+  if (!newLocation || newLocation.pathname === oldLocation.pathname) {
+    // Most browsers will ignore this and supply their own messaging for refresh
+    return LEAVE_MESSAGING
+  }
+
+  // Attempting to navigate to another route in the orders app
+  const match = router.matcher.match(newLocation)
+  if (match) {
+    const matchedRoutes: RouteConfig[] | null = router.matcher.getRoutes(match)
+    if (matchedRoutes && matchedRoutes[0].Component === OrderApp) {
+      return true
+    }
+  }
+
+  return LEAVE_MESSAGING
+}
+
+export const shouldRedirect = props => {
+  const { location, order, params } = props as any
+
+  if (
+    order &&
+    order.state !== "PENDING" &&
+    !location.pathname.includes("status")
+  ) {
+    // Redirect to status page if the order is no longer PENDING (means it can't be edited anymore)
+    throw new RedirectException(`/order2/${params.orderID}/status`)
+  } else if (
+    order &&
+    !order.requestedFulfillment &&
+    !location.pathname.includes("shipping")
+  ) {
+    // Redirect to shipping page if no shipping info has been set
+    throw new RedirectException(`/order2/${params.orderID}/shipping`)
+  } else if (
+    order &&
+    !order.creditCard &&
+    !(
+      location.pathname.includes("payment") ||
+      location.pathname.includes("shipping")
+    )
+  ) {
+    // Redirect to payment page if there is shipping but _no_ credit card
+    throw new RedirectException(`/order2/${params.orderID}/payment`)
+  } else {
+    return false
+  }
+}

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -1,11 +1,6 @@
-import {
-  Location,
-  Redirect,
-  RedirectException,
-  RouteConfig,
-  Router,
-} from "found"
-import React from "react"
+import { confirmRouteExit, shouldRedirect } from "Apps/Order/redirects"
+import { Redirect, RouteConfig } from "found"
+import * as React from "react"
 import { graphql } from "react-relay"
 import { OrderApp } from "./OrderApp"
 
@@ -31,64 +26,6 @@ import { ReviewProps } from "./Routes/Review"
 import { ShippingProps } from "./Routes/Shipping"
 // @ts-ignore
 import { StatusProps } from "./Routes/Status"
-
-const LEAVE_MESSAGING =
-  "Are you sure you want to refresh? Your changes will not be saved."
-
-const confirmRouteExit = (
-  newLocation: Location,
-  oldLocation: Location,
-  router: Router
-) => {
-  // Refresh -- On refresh newLocation is null
-  if (!newLocation || newLocation.pathname === oldLocation.pathname) {
-    // Most browsers will ignore this and supply their own messaging for refresh
-    return LEAVE_MESSAGING
-  }
-
-  // Attempting to navigate to another route in the orders app
-  const match = router.matcher.match(newLocation)
-  if (match) {
-    const matchedRoutes: RouteConfig[] | null = router.matcher.getRoutes(match)
-    if (matchedRoutes && matchedRoutes[0].Component === OrderApp) {
-      return true
-    }
-  }
-
-  return LEAVE_MESSAGING
-}
-
-const shouldRedirect = props => {
-  const { location, order, params } = props as any
-
-  if (
-    order &&
-    order.state !== "PENDING" &&
-    !location.pathname.includes("status")
-  ) {
-    // Redirect to status page if the order is no longer PENDING (means it can't be edited anymore)
-    throw new RedirectException(`/order2/${params.orderID}/status`)
-  } else if (
-    order &&
-    !order.requestedFulfillment &&
-    !location.pathname.includes("shipping")
-  ) {
-    // Redirect to shipping page if no shipping info has been set
-    throw new RedirectException(`/order2/${params.orderID}/shipping`)
-  } else if (
-    order &&
-    !order.creditCard &&
-    !(
-      location.pathname.includes("payment") ||
-      location.pathname.includes("shipping")
-    )
-  ) {
-    // Redirect to payment page if there is shipping but _no_ credit card
-    throw new RedirectException(`/order2/${params.orderID}/payment`)
-  } else {
-    return false
-  }
-}
 
 // FIXME:
 // * `render` functions requires casting

--- a/src/__generated__/routes_OrderQuery.graphql.ts
+++ b/src/__generated__/routes_OrderQuery.graphql.ts
@@ -10,6 +10,12 @@ export type routes_OrderQueryResponse = {
     }) | null;
     readonly order: ({
         readonly state: string | null;
+        readonly requestedFulfillment: ({
+            readonly __typename: string;
+        }) | null;
+        readonly creditCard: ({
+            readonly id: string;
+        }) | null;
     }) | null;
 };
 export type routes_OrderQuery = {
@@ -29,6 +35,13 @@ query routes_OrderQuery(
   }
   order: ecommerceOrder(id: $orderID) {
     state
+    requestedFulfillment {
+      __typename
+    }
+    creditCard {
+      id
+      __id
+    }
     __id: id
   }
 }
@@ -43,7 +56,14 @@ var v0 = [
     "defaultValue": null
   }
 ],
-v1 = [
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v2 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -60,13 +80,7 @@ v1 = [
         "args": null,
         "storageKey": null
       },
-      {
-        "kind": "ScalarField",
-        "alias": null,
-        "name": "__id",
-        "args": null,
-        "storageKey": null
-      }
+      v1
     ]
   },
   {
@@ -93,6 +107,43 @@ v1 = [
         "storageKey": null
       },
       {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "requestedFulfillment",
+        "storageKey": null,
+        "args": null,
+        "concreteType": null,
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "__typename",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      },
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "creditCard",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "CreditCard",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          v1
+        ]
+      },
+      {
         "kind": "ScalarField",
         "alias": "__id",
         "name": "id",
@@ -107,7 +158,7 @@ return {
   "operationKind": "query",
   "name": "routes_OrderQuery",
   "id": null,
-  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    state\n    __id: id\n  }\n}\n",
+  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    state\n    requestedFulfillment {\n      __typename\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -115,15 +166,15 @@ return {
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": v0,
-    "selections": v1
+    "selections": v2
   },
   "operation": {
     "kind": "Operation",
     "name": "routes_OrderQuery",
     "argumentDefinitions": v0,
-    "selections": v1
+    "selections": v2
   }
 };
 })();
-(node as any).hash = 'cd8f6d53d89a5c0f91d324f56b102830';
+(node as any).hash = 'a3058d3342922022ac9960c0e813b8d9';
 export default node;


### PR DESCRIPTION
This PR addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-453

Thanks to @damassi for figuring this out with me! 

This PR moves all routing/redirect logic (that is meant to happen _before_ render) into the root of the `OrderApp`. At first I tried to stick this logic into the sub-routes (i.e. `Payment/index`) but kept getting issues with trying to reference client-side methods on the server. (While doing this I noticed that the existing redirect implementation was also broken for the same reason).

One way to fix that ☝️ is to repeat logic in the `render()` function and in `componentDidMount` in order to redirect (and not render anything server-side), but only in the cases we specify.

This becomes unwieldy. Turns out `found` has redirect handling, and sticking it in the root route means we can be selective about only fetching the data we need to make this decision.

cc @zephraph 