### PR TITLE
[FIX BNMO] set height of CreditCardInput to prevent size changes

### DIFF
--- a/src/Apps/Order/Components/CreditCardInput.tsx
+++ b/src/Apps/Order/Components/CreditCardInput.tsx
@@ -15,6 +15,8 @@ export const StyledCardElement = styled(CardElement)`
 // Re-uses old input border behavior
 const StyledBorderBox = styled(BorderBox).attrs<InputBorderProps>({})`
   ${inputBorder};
+  padding: 9px 10px;
+  height: 40px;
 `
 
 interface CreditCardInputProps {


### PR DESCRIPTION
Sets a hardcoded height on the container wrapping `react-stripe-elements/CardElement` so that the size of the input is consistent before and after Stripe is able to initialize. The result:

![2018-10-04 14 34 58](https://user-images.githubusercontent.com/5216744/46495610-dc295500-c7e3-11e8-8d17-601f5bcec4fe.gif)

Hardcoding the height is non-ideal and could present an issue if height of the inner iframe that Stripe mounts changes, but I couldn't find an alternate way to accomplish keeping a consistent input height. Some other approaches we could consider:

- The [demo linked](https://jsfiddle.net/attystripe/xux7qzch/) the [react-stripe-elements](https://github.com/stripe/react-stripe-elements#demo) repo takes the approach of _completely_ hiding the input prior to Stripe initializing. I think this would require us still assuming some height in order to leave empty space for the input in the payment form, or hiding the form completely.
- We could call [`injectStripe`](https://github.com/stripe/react-stripe-elements#injectstripe-hoc) earlier (on `/shipping`) so that Stripe is pre-initialized once the user navigates to `/payment`. This would reduce the load time of the input but not eliminate it: `Stripe.js` would already be fetched or in the process of fetching, but the iframe responsible for rendering the credit card input and other Stripe elements resources would still need to be fetched. To work around this we could maybe pre-render the `CardElement` offscreen. We would want to combine this approach with the changes here to handle cases where `/payment` is the entry point for a session.