### PR TITLE
Request fields necessary to update the relay store while navigating between pages

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -338,7 +338,16 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
               orderOrError {
                 ... on OrderWithMutationSuccess {
                   order {
-                    id
+                    creditCard {
+                      id
+                      name
+                      street1
+                      street2
+                      city
+                      state
+                      country
+                      postal_code
+                    }
                   }
                 }
                 ... on OrderWithMutationFailure {

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -54,6 +54,11 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               mutation ReviewSubmitOrderMutation($input: SubmitOrderInput!) {
                 ecommerceSubmitOrder(input: $input) {
                   orderOrError {
+                    ... on OrderWithMutationSuccess {
+                      order {
+                        state
+                      }
+                    }
                     ... on OrderWithMutationFailure {
                       error {
                         type

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -107,8 +107,23 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                 ecommerceSetOrderShipping(input: $input) {
                   orderOrError {
                     ... on OrderWithMutationSuccess {
+                      __typename
                       order {
+                        id
                         state
+                        requestedFulfillment {
+                          __typename
+                          ... on Ship {
+                            name
+                            addressLine1
+                            addressLine2
+                            city
+                            region
+                            country
+                            postalCode
+                            phoneNumber
+                          }
+                        }
                       }
                     }
                     ... on OrderWithMutationFailure {
@@ -342,6 +357,7 @@ export const ShippingFragmentContainer = createFragmentContainer(
   graphql`
     fragment Shipping_order on Order {
       id
+      state
       requestedFulfillment {
         __typename
         ... on Ship {

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -20,7 +20,7 @@ export const confirmRouteExit = (
   if (match) {
     const matchedRoutes: RouteConfig[] | null = router.matcher.getRoutes(match)
     if (matchedRoutes && matchedRoutes[0].Component === OrderApp) {
-      return true
+      return undefined
     }
   }
 

--- a/src/__generated__/PaymentRouteSetOrderPaymentMutation.graphql.ts
+++ b/src/__generated__/PaymentRouteSetOrderPaymentMutation.graphql.ts
@@ -13,7 +13,16 @@ export type PaymentRouteSetOrderPaymentMutationResponse = {
     readonly ecommerceSetOrderPayment: ({
         readonly orderOrError: ({
             readonly order?: ({
-                readonly id: string | null;
+                readonly creditCard: ({
+                    readonly id: string;
+                    readonly name: string | null;
+                    readonly street1: string | null;
+                    readonly street2: string | null;
+                    readonly city: string | null;
+                    readonly state: string | null;
+                    readonly country: string | null;
+                    readonly postal_code: string | null;
+                }) | null;
             }) | null;
             readonly error?: ({
                 readonly type: string;
@@ -39,7 +48,17 @@ mutation PaymentRouteSetOrderPaymentMutation(
       __typename
       ... on OrderWithMutationSuccess {
         order {
-          id
+          creditCard {
+            id
+            name
+            street1
+            street2
+            city
+            state
+            country
+            postal_code
+            __id
+          }
           __id: id
         }
       }
@@ -124,11 +143,78 @@ v3 = {
       "plural": false,
       "selections": [
         {
-          "kind": "ScalarField",
+          "kind": "LinkedField",
           "alias": null,
-          "name": "id",
+          "name": "creditCard",
+          "storageKey": null,
           "args": null,
-          "storageKey": null
+          "concreteType": "CreditCard",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "id",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "name",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "street1",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "street2",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "city",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "state",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "country",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "postal_code",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "__id",
+              "args": null,
+              "storageKey": null
+            }
+          ]
         },
         {
           "kind": "ScalarField",
@@ -146,7 +232,7 @@ return {
   "operationKind": "mutation",
   "name": "PaymentRouteSetOrderPaymentMutation",
   "id": null,
-  "text": "mutation PaymentRouteSetOrderPaymentMutation(\n  $input: SetOrderPaymentInput!\n) {\n  ecommerceSetOrderPayment(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          id\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
+  "text": "mutation PaymentRouteSetOrderPaymentMutation(\n  $input: SetOrderPaymentInput!\n) {\n  ecommerceSetOrderPayment(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          creditCard {\n            id\n            name\n            street1\n            street2\n            city\n            state\n            country\n            postal_code\n            __id\n          }\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -221,5 +307,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'e931e913800f6d3049bad7d29d9e8841';
+(node as any).hash = '788e14cf29d4978ff12b9d07d8bce050';
 export default node;

--- a/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
+++ b/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
@@ -11,6 +11,9 @@ export type ReviewSubmitOrderMutationVariables = {
 export type ReviewSubmitOrderMutationResponse = {
     readonly ecommerceSubmitOrder: ({
         readonly orderOrError: ({
+            readonly order?: ({
+                readonly state: string | null;
+            }) | null;
             readonly error?: ({
                 readonly type: string;
                 readonly code: string;
@@ -33,6 +36,12 @@ mutation ReviewSubmitOrderMutation(
   ecommerceSubmitOrder(input: $input) {
     orderOrError {
       __typename
+      ... on OrderWithMutationSuccess {
+        order {
+          state
+          __id: id
+        }
+      }
       ... on OrderWithMutationFailure {
         error {
           type
@@ -99,13 +108,44 @@ v2 = {
       ]
     }
   ]
+},
+v3 = {
+  "kind": "InlineFragment",
+  "type": "OrderWithMutationSuccess",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "order",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Order",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "state",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": "__id",
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
 };
 return {
   "kind": "Request",
   "operationKind": "mutation",
   "name": "ReviewSubmitOrderMutation",
   "id": null,
-  "text": "mutation ReviewSubmitOrderMutation(\n  $input: SubmitOrderInput!\n) {\n  ecommerceSubmitOrder(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
+  "text": "mutation ReviewSubmitOrderMutation(\n  $input: SubmitOrderInput!\n) {\n  ecommerceSubmitOrder(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          state\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -132,7 +172,8 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2
+              v2,
+              v3
             ]
           }
         ]
@@ -169,7 +210,8 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v2
+              v2,
+              v3
             ]
           }
         ]
@@ -178,5 +220,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'ada451c41a0adfffd072a19ac6269ba8';
+(node as any).hash = 'd8b9bdee6af75e80c6c0014bf9882b41';
 export default node;

--- a/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
+++ b/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
@@ -24,8 +24,25 @@ export type ShippingOrderAddressUpdateMutationVariables = {
 export type ShippingOrderAddressUpdateMutationResponse = {
     readonly ecommerceSetOrderShipping: ({
         readonly orderOrError: ({
+            readonly __typename: "OrderWithMutationSuccess";
             readonly order?: ({
+                readonly id: string | null;
                 readonly state: string | null;
+                readonly requestedFulfillment: ({
+                    readonly __typename: "Ship";
+                    readonly name: string | null;
+                    readonly addressLine1: string | null;
+                    readonly addressLine2: string | null;
+                    readonly city: string | null;
+                    readonly region: string | null;
+                    readonly country: string;
+                    readonly postalCode: string | null;
+                    readonly phoneNumber: string | null;
+                } | {
+                    /*This will never be '% other', but we need some
+                    value in case none of the concrete values match.*/
+                    readonly __typename: "%other";
+                }) | null;
             }) | null;
             readonly error?: ({
                 readonly type: string;
@@ -50,8 +67,23 @@ mutation ShippingOrderAddressUpdateMutation(
     orderOrError {
       __typename
       ... on OrderWithMutationSuccess {
+        __typename
         order {
+          id
           state
+          requestedFulfillment {
+            __typename
+            ... on Ship {
+              name
+              addressLine1
+              addressLine2
+              city
+              region
+              country
+              postalCode
+              phoneNumber
+            }
+          }
           __id: id
         }
       }
@@ -123,9 +155,17 @@ v2 = {
   ]
 },
 v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationSuccess",
   "selections": [
+    v3,
     {
       "kind": "LinkedField",
       "alias": null,
@@ -138,9 +178,90 @@ v3 = {
         {
           "kind": "ScalarField",
           "alias": null,
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
           "name": "state",
           "args": null,
           "storageKey": null
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "requestedFulfillment",
+          "storageKey": null,
+          "args": null,
+          "concreteType": null,
+          "plural": false,
+          "selections": [
+            v3,
+            {
+              "kind": "InlineFragment",
+              "type": "Ship",
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "name",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "addressLine1",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "addressLine2",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "city",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "region",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "country",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "postalCode",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "phoneNumber",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
         },
         {
           "kind": "ScalarField",
@@ -158,7 +279,7 @@ return {
   "operationKind": "mutation",
   "name": "ShippingOrderAddressUpdateMutation",
   "id": null,
-  "text": "mutation ShippingOrderAddressUpdateMutation(\n  $input: SetOrderShippingInput!\n) {\n  ecommerceSetOrderShipping(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          state\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
+  "text": "mutation ShippingOrderAddressUpdateMutation(\n  $input: SetOrderShippingInput!\n) {\n  ecommerceSetOrderShipping(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        __typename\n        order {\n          id\n          state\n          requestedFulfillment {\n            __typename\n            ... on Ship {\n              name\n              addressLine1\n              addressLine2\n              city\n              region\n              country\n              postalCode\n              phoneNumber\n            }\n          }\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -186,7 +307,7 @@ return {
             "plural": false,
             "selections": [
               v2,
-              v3
+              v4
             ]
           }
         ]
@@ -216,15 +337,9 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "__typename",
-                "args": null,
-                "storageKey": null
-              },
+              v3,
               v2,
-              v3
+              v4
             ]
           }
         ]
@@ -233,5 +348,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'c22077a59619a305104868825e6fb215';
+(node as any).hash = '46e5953502991373be73e849583f9fb9';
 export default node;

--- a/src/__generated__/Shipping_order.graphql.ts
+++ b/src/__generated__/Shipping_order.graphql.ts
@@ -6,6 +6,7 @@ declare const _Shipping_order$ref: unique symbol;
 export type Shipping_order$ref = typeof _Shipping_order$ref;
 export type Shipping_order = {
     readonly id: string | null;
+    readonly state: string | null;
     readonly requestedFulfillment: ({
         readonly __typename: "Ship";
         readonly name: string | null;
@@ -61,6 +62,13 @@ return {
   "argumentDefinitions": [],
   "selections": [
     v0,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "state",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "LinkedField",
       "alias": null,
@@ -217,5 +225,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '4f33217ba6f66907afd60846e143003a';
+(node as any).hash = '47697c5e3326df8ac42b252fea2c60d7';
 export default node;

--- a/src/__generated__/routes_ShippingQuery.graphql.ts
+++ b/src/__generated__/routes_ShippingQuery.graphql.ts
@@ -29,6 +29,7 @@ query routes_ShippingQuery(
 
 fragment Shipping_order on Order {
   id
+  state
   requestedFulfillment {
     __typename
     ... on Ship {
@@ -164,7 +165,7 @@ return {
   "operationKind": "query",
   "name": "routes_ShippingQuery",
   "id": null,
-  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          shipsToContinentalUSOnly\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  taxTotal(precision: 2)\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  state\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          shipsToContinentalUSOnly\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  taxTotal(precision: 2)\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -207,6 +208,13 @@ return {
         "plural": false,
         "selections": [
           v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "state",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "LinkedField",
             "alias": null,


### PR DESCRIPTION
This should fix the error reported in [slack](https://artsy.slack.com/archives/C9YNS4X32/p1538667329000100) where when you submit information on a page, we were:
- correctly submitting the mutation
- correctly advancing you to the next step
- _incorrectly_ at this point, your updated information hadn't entered the relay store, and so we were trying to [redirect you](https://github.com/artsy/reaction/blob/master/src/Apps/Order/redirects.tsx#L39) back to the step you were just on.
- ☝️ this made it seem like you were redirecting back to the page you were already on (a "refresh"), and so we'd show you a "Do you want to leave this page" message.

This updates our mutations to return the data that we need to update the store, so when we navigate between pages we're referencing the most up-to-date state.

**Tested locally with linked force** and the issue appears to be gone.