### PR TITLE
@sweir27 => Bring back BNMO lab feature to enable features

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -66,7 +66,11 @@ class Filter extends Component<Props> {
       agg => agg.slice === "MAJOR_PERIOD"
     )
 
-    const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW
+    const hasLabFeature =
+      user &&
+      user.lab_features &&
+      user.lab_features.includes("New Buy Now Flow")
+    const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || hasLabFeature
 
     return (
       <>

--- a/src/Apps/Collect/Components/ArtworkGrid/index.tsx
+++ b/src/Apps/Collect/Components/ArtworkGrid/index.tsx
@@ -166,7 +166,11 @@ class Filter extends Component<Props, State> {
   }
 
   renderFilters({ user, filters, mediator, hideTopBorder }) {
-    const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW
+    const hasLabFeature =
+      user &&
+      user.lab_features &&
+      user.lab_features.includes("New Buy Now Flow")
+    const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || hasLabFeature
 
     const { filter_artworks } = this.props.viewer
     const { aggregations } = filter_artworks

--- a/src/Apps/WorksForYou/index.tsx
+++ b/src/Apps/WorksForYou/index.tsx
@@ -35,7 +35,11 @@ export class WorksForYou extends Component<Props> {
     return (
       <ContextConsumer>
         {({ relayEnvironment, user }) => {
-          const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW
+          const hasLabFeature =
+            user &&
+            user.lab_features &&
+            user.lab_features.includes("New Buy Now Flow")
+          const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || hasLabFeature
 
           return (
             <>

--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -166,7 +166,12 @@ export class Details extends React.Component<Props, null> {
     return (
       <ContextConsumer>
         {({ user }) => {
-          const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW
+          const hasLabFeature =
+            user &&
+            user.lab_features &&
+            user.lab_features.includes("New Buy Now Flow")
+          const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || hasLabFeature
+
           return (
             <>
               {enableBuyNowFlow && this.saleInfoLine()}

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -140,7 +140,12 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
       userSpread = { user }
     }
 
-    const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW
+    const hasLabFeature =
+      user &&
+      user.lab_features &&
+      user.lab_features.includes("New Buy Now Flow")
+    const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || hasLabFeature
+
     return (
       <Responsive>
         {({ hover, ...breakpoints }) => {

--- a/src/Components/Artwork/Metadata.tsx
+++ b/src/Components/Artwork/Metadata.tsx
@@ -30,7 +30,11 @@ export class MetadataContainer extends React.Component<MetadataProps> {
     return (
       <ContextConsumer>
         {({ user }) => {
-          const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW
+          const hasLabFeature =
+            user &&
+            user.lab_features &&
+            user.lab_features.includes("New Buy Now Flow")
+          const enableBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || hasLabFeature
 
           const detailsContent = (
             <div className={className}>


### PR DESCRIPTION
You correctly brought up that we should probably have kept the lab feature, and just added the feature flag, rather than replacing the lab feature completely with the feature flag.

In this way, we can still launch/turn off the feature via config change, yet the lab feature continues to allow certain users (admins) to test it out even if while it's turned off.