### PR TITLE
[FIX BNMO] Card number text should be 16px and expand the clickable area for the credit card input

### DIFF
--- a/src/Apps/Order/Components/CreditCardInput.tsx
+++ b/src/Apps/Order/Components/CreditCardInput.tsx
@@ -10,12 +10,13 @@ import styled from "styled-components"
 
 export const StyledCardElement = styled(CardElement)`
   width: 100%;
+  padding: 9px 10px;
 `
 
 // Re-uses old input border behavior
 const StyledBorderBox = styled(BorderBox).attrs<InputBorderProps>({})`
   ${inputBorder};
-  padding: 9px 10px;
+  padding: 0;
   height: 40px;
 `
 

--- a/src/Apps/Order/Components/CreditCardInput.tsx
+++ b/src/Apps/Order/Components/CreditCardInput.tsx
@@ -1,4 +1,4 @@
-import { BorderBox, color, Sans } from "@artsy/palette"
+import { BorderBox, color, Sans, themeProps } from "@artsy/palette"
 import { fontFamily } from "@artsy/palette/dist/platform/fonts"
 import {
   border as inputBorder,
@@ -63,6 +63,7 @@ export class CreditCardInput extends React.Component<
                   color: color("black30"),
                 },
                 fontFamily: fontFamily.serif.regular as string,
+                fontSize: `${themeProps.typeSizes.serif["3t"].fontSize}px`,
                 fontSmoothing: "antialiased",
                 lineHeight: "20px",
               },


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-493

The reason for WIP is that the vertical text alignment looks a bit off from the center of the input. Some of you are probably already aware of the fact that this is because of the typeface, but we may be able to apply an easy fix.

## Screenshot

![screen_shot_2018-10-05_at_4_53_51_pm](https://user-images.githubusercontent.com/386234/46561544-26830280-c8c6-11e8-9b93-d1478dd78025.png)
