### PR TITLE
Adds note about `@ts-check`

### DIFF
--- a/tslint/README.md
+++ b/tslint/README.md
@@ -1,6 +1,6 @@
 ## Steps to adding a custom TSLint rule
 
-1.  Make a new file, the name is important, it must be camel-case and not a `.ts` file.
+1.  Make a new file, the name is important, it must be camel-case and not a `.ts` file (the `@ts-check` declaration at the top of each file uses JSDoc to check types while developing rules – [read here](https://github.com/Microsoft/TypeScript/wiki/Type-Checking-JavaScript-Files) for more info).
 1.  You will need to convert your camelCase name to kebab-case and add it to the [`tslint.json`](../tslint.json)
 
     E.g. `noDoingAnythingRule.js` -> `no-doing-anything` and:


### PR DESCRIPTION
The [docs](https://palantir.github.io/tslint/develop/custom-rules/) we link to all talk about writing `.ts` files, though our docs recommended not to do that. I asked @orta and he described how these files are outside our `src` directory, which is the root of our TypeScript, so there's a high cost to including them in our pipeline compared to the value we already get with `@ts-check`. I'd never heard of it so I added a link to the docs where it would've answered my question.