### PR TITLE
[FIX BNMO] Allow order2 and orders as valid paths

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -324,7 +324,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
           } = data
 
           if (orderOrError.order) {
-            this.props.router.push(`/order2/${this.props.order.id}/review`)
+            this.props.router.push(`/orders/${this.props.order.id}/review`)
           } else {
             this.onMutationError(errors || orderOrError)
           }

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -117,7 +117,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                   }
                 }
               } else {
-                this.props.router.push(`/order2/${this.props.order.id}/status`)
+                this.props.router.push(`/orders/${this.props.order.id}/status`)
               }
             },
             onError: this.onMutationError.bind(this),
@@ -169,11 +169,11 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
   }
 
   onChangePayment() {
-    this.props.router.push(`/order2/${this.props.order.id}/payment`)
+    this.props.router.push(`/orders/${this.props.order.id}/payment`)
   }
 
   onChangeShipping() {
-    this.props.router.push(`/order2/${this.props.order.id}/shipping`)
+    this.props.router.push(`/orders/${this.props.order.id}/shipping`)
   }
 
   onCloseModal = () => {

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -180,7 +180,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                   this.onMutationError(orderOrError.error)
                 }
               } else {
-                this.props.router.push(`/order2/${this.props.order.id}/payment`)
+                this.props.router.push(`/orders/${this.props.order.id}/payment`)
               }
             },
             onError: this.onMutationError.bind(this),

--- a/src/Apps/Order/Routes/__tests__/Payment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.test.tsx
@@ -294,7 +294,7 @@ describe("Payment", () => {
     fillAddressForm(paymentRoute, validAddress)
     paymentRoute.find(ContinueButton).simulate("click")
 
-    expect(testProps.router.push).toHaveBeenCalledWith("/order2/1234/review")
+    expect(testProps.router.push).toHaveBeenCalledWith("/orders/1234/review")
   })
 
   it("shows an error modal when there is an error in CreateCreditCardPayload", () => {

--- a/src/Apps/Order/Routes/__tests__/Review.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.test.tsx
@@ -53,7 +53,7 @@ describe("Review", () => {
     )
     component.find(Button).simulate("click")
     expect(commitMutation).toHaveBeenCalledTimes(1)
-    expect(pushMock).toBeCalledWith("/order2/1234/status")
+    expect(pushMock).toBeCalledWith("/orders/1234/status")
   })
 
   it("takes the user back to the /shipping view", () => {
@@ -63,7 +63,7 @@ describe("Review", () => {
       .first()
       .find("a")
       .simulate("click")
-    expect(pushMock).toBeCalledWith("/order2/1234/shipping")
+    expect(pushMock).toBeCalledWith("/orders/1234/shipping")
   })
 
   it("takes the user back to the /payment view", () => {
@@ -73,7 +73,7 @@ describe("Review", () => {
       .last()
       .find("a")
       .simulate("click")
-    expect(pushMock).toBeCalledWith("/order2/1234/shipping")
+    expect(pushMock).toBeCalledWith("/orders/1234/shipping")
   })
 
   it("shows an error modal when there is an error in submitOrderPayload", () => {

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -140,7 +140,7 @@ describe("Shipping", () => {
 
       component.find("Button").simulate("click")
 
-      expect(testProps.router.push).toHaveBeenCalledWith("/order2/1234/payment")
+      expect(testProps.router.push).toHaveBeenCalledWith("/orders/1234/payment")
     })
 
     it("shows the button spinner while loading the mutation", () => {

--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -36,7 +36,7 @@ describe("OrderApp routing redirects", () => {
   }
 
   it("does not redirect to the status route if the order is pending", async () => {
-    const { redirect } = await render("/order2/1234/shipping", {
+    const { redirect } = await render("/orders/1234/shipping", {
       Order: () => ({
         id: 1234,
         state: "PENDING",
@@ -49,7 +49,7 @@ describe("OrderApp routing redirects", () => {
   })
 
   it("redirects to the status route if the order is not pending", async () => {
-    const { redirect } = await render("/order2/1234/shipping", {
+    const { redirect } = await render("/orders/1234/shipping", {
       Order: () => ({
         id: 1234,
         state: "ABANDONED",
@@ -58,11 +58,11 @@ describe("OrderApp routing redirects", () => {
         },
       }),
     })
-    expect(redirect.url).toBe("/order2/1234/status")
+    expect(redirect.url).toBe("/orders/1234/status")
   })
 
   it("stays on the shipping route if no shipping option is set", async () => {
-    const { redirect } = await render("/order2/1234/shipping", {
+    const { redirect } = await render("/orders/1234/shipping", {
       Order: () => ({
         id: 1234,
         state: "PENDING",
@@ -73,18 +73,18 @@ describe("OrderApp routing redirects", () => {
   })
 
   it("redirects to the shipping route from the payment route if no shipping option was set", async () => {
-    const { redirect } = await render("/order2/1234/payment", {
+    const { redirect } = await render("/orders/1234/payment", {
       Order: () => ({
         id: 1234,
         state: "PENDING",
         requestedFulfillment: null,
       }),
     })
-    expect(redirect.url).toBe("/order2/1234/shipping")
+    expect(redirect.url).toBe("/orders/1234/shipping")
   })
 
   it("stays on the payment route if there is shipping but no payment info", async () => {
-    const { redirect } = await render("/order2/1234/payment", {
+    const { redirect } = await render("/orders/1234/payment", {
       Order: () => ({
         id: 1234,
         state: "PENDING",
@@ -98,7 +98,7 @@ describe("OrderApp routing redirects", () => {
   })
 
   it("redirects to the shipping route from the review route if no shipping option was set", async () => {
-    const { redirect } = await render("/order2/1234/review", {
+    const { redirect } = await render("/orders/1234/review", {
       Order: () => ({
         id: 1234,
         state: "PENDING",
@@ -106,11 +106,11 @@ describe("OrderApp routing redirects", () => {
         creditCard: null,
       }),
     })
-    expect(redirect.url).toBe("/order2/1234/shipping")
+    expect(redirect.url).toBe("/orders/1234/shipping")
   })
 
   it("redirects to the payment route from the review route if no credit card is set", async () => {
-    const { redirect } = await render("/order2/1234/review", {
+    const { redirect } = await render("/orders/1234/review", {
       Order: () => ({
         id: 1234,
         state: "PENDING",
@@ -120,11 +120,11 @@ describe("OrderApp routing redirects", () => {
         creditCard: null,
       }),
     })
-    expect(redirect.url).toBe("/order2/1234/payment")
+    expect(redirect.url).toBe("/orders/1234/payment")
   })
 
   it("stays on the review route if there are payment and shipping options set", async () => {
-    const { redirect } = await render("/order2/1234/review", {
+    const { redirect } = await render("/orders/1234/review", {
       Order: () => ({
         id: 1234,
         state: "PENDING",

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -36,14 +36,14 @@ export const shouldRedirect = props => {
     !location.pathname.includes("status")
   ) {
     // Redirect to status page if the order is no longer PENDING (means it can't be edited anymore)
-    throw new RedirectException(`/order2/${params.orderID}/status`)
+    throw new RedirectException(`/orders/${params.orderID}/status`)
   } else if (
     order &&
     !order.requestedFulfillment &&
     !location.pathname.includes("shipping")
   ) {
     // Redirect to shipping page if no shipping info has been set
-    throw new RedirectException(`/order2/${params.orderID}/shipping`)
+    throw new RedirectException(`/orders/${params.orderID}/shipping`)
   } else if (
     order &&
     !order.creditCard &&
@@ -53,7 +53,7 @@ export const shouldRedirect = props => {
     )
   ) {
     // Redirect to payment page if there is shipping but _no_ credit card
-    throw new RedirectException(`/order2/${params.orderID}/payment`)
+    throw new RedirectException(`/orders/${params.orderID}/payment`)
   } else {
     return false
   }

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -31,7 +31,7 @@ import { StatusProps } from "./Routes/Status"
 // * `render` functions requires casting
 export const routes: RouteConfig[] = [
   {
-    path: "/order2/:orderID",
+    path: "/order(2|s)/:orderID",
     Component: OrderApp,
     query: graphql`
       query routes_OrderQuery($orderID: String!) {
@@ -107,7 +107,7 @@ export const routes: RouteConfig[] = [
       new Redirect({
         // For now, redirect the empty route to the shipping page
         from: "/",
-        to: "/order2/:orderID/shipping",
+        to: "/orders/:orderID/shipping",
       }) as any,
       {
         path: "*",

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -18,13 +18,13 @@ const Router = props => (
 )
 
 storiesOf("Apps/Order Page", module)
-  .add("Shipping", () => <Router initialRoute="/order2/123/shipping" />)
-  .add("Review", () => <Router initialRoute="/order2/123/review" />)
+  .add("Shipping", () => <Router initialRoute="/orders/123/shipping" />)
+  .add("Review", () => <Router initialRoute="/orders/123/review" />)
 
 storiesOf("Apps/Order Page/Status", module)
   .add("submitted", () => (
     <Router
-      initialRoute="/order2/123/status"
+      initialRoute="/orders/123/status"
       mockResolvers={mockResolver({
         ...OrderWithShippingDetails,
         state: "SUBMITTED",
@@ -33,7 +33,7 @@ storiesOf("Apps/Order Page/Status", module)
   ))
   .add("approved (ship)", () => (
     <Router
-      initialRoute="/order2/123/status"
+      initialRoute="/orders/123/status"
       mockResolvers={mockResolver({
         ...OrderWithShippingDetails,
         state: "APPROVED",
@@ -42,13 +42,13 @@ storiesOf("Apps/Order Page/Status", module)
   ))
   .add("approved (pickup)", () => (
     <Router
-      initialRoute="/order2/123/status"
+      initialRoute="/orders/123/status"
       mockResolvers={mockResolver({ ...PickupOrder, state: "APPROVED" })}
     />
   ))
   .add("fulfilled (ship)", () => (
     <Router
-      initialRoute="/order2/123/status"
+      initialRoute="/orders/123/status"
       mockResolvers={mockResolver({
         ...OrderWithShippingDetails,
         state: "FULFILLED",
@@ -57,13 +57,13 @@ storiesOf("Apps/Order Page/Status", module)
   ))
   .add("fulfilled (pickup)", () => (
     <Router
-      initialRoute="/order2/123/status"
+      initialRoute="/orders/123/status"
       mockResolvers={mockResolver({ ...PickupOrder, state: "FULFILLED" })}
     />
   ))
   .add("canceled (ship)", () => (
     <Router
-      initialRoute="/order2/123/status"
+      initialRoute="/orders/123/status"
       mockResolvers={mockResolver({
         ...OrderWithShippingDetails,
         state: "CANCELED",
@@ -72,16 +72,16 @@ storiesOf("Apps/Order Page/Status", module)
   ))
   .add("canceled (pickup)", () => (
     <Router
-      initialRoute="/order2/123/status"
+      initialRoute="/orders/123/status"
       mockResolvers={mockResolver({ ...PickupOrder, state: "CANCELED" })}
     />
   ))
 
 storiesOf("Apps/Order Page/Payment", module)
-  .add("With 'Ship'", () => <Router initialRoute="/order2/123/payment" />)
+  .add("With 'Ship'", () => <Router initialRoute="/orders/123/payment" />)
   .add("With 'Pickup'", () => (
     <Router
-      initialRoute="/order2/123/payment"
+      initialRoute="/orders/123/payment"
       mockResolvers={mockResolver(PickupOrder)}
     />
   ))


### PR DESCRIPTION
This is the first step for updating our routing to be `/orders/:orderID`. 

Once this version of reaction is deployed, Force will need to be updated to handle the new route!