### PR TITLE
Add Tracking

### DIFF
--- a/src/Apps/Artist/Components/NavigationTabs.tsx
+++ b/src/Apps/Artist/Components/NavigationTabs.tsx
@@ -11,7 +11,7 @@ interface Props {
   artist: NavigationTabs_artist
 }
 
-@track({ context_module: Schema.Context.NavigationTabs })
+@track({ context_module: Schema.ContextModule.NavigationTabs })
 export class NavigationTabs extends React.Component<Props> {
   @track((_props, _state, [tab, destination_path]: string[]) => ({
     action_type: Schema.ActionType.Click,

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -28,7 +28,7 @@ interface State {
 }
 
 @track({
-  context_module: Schema.Context.ArtistOverview,
+  context_module: Schema.ContextModule.ArtistOverview,
 })
 class OverviewRoute extends React.Component<OverviewRouteProps, State> {
   state = {

--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -7,9 +7,8 @@ import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { Mediator } from "Artsy/SystemContext"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
-import React, { SFC } from "react"
+import React, { Component } from "react"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { TrackingProp } from "react-tracking"
 import { data as sd } from "sharify"
 import { EntityHeader } from "Styleguide/Components/EntityHeader"
 import { get } from "Utils/get"
@@ -24,101 +23,107 @@ interface ArtistInfoProps {
   artist: ArtistInfo_artist
   user: User
   mediator?: Mediator
-  tracking?: TrackingProp
 }
 
 const Container = ({ children }) => (
   <StackableBorderBox p={2}>{children}</StackableBorderBox>
 )
 
-export const ArtistInfo: SFC<ArtistInfoProps> = props => {
-  const showArtistBio = !!props.artist.biography_blurb.text
-  const imageUrl = get(props, p => p.artist.image.cropped.url)
+@track({
+  context_module: Schema.ContextModule.Biography,
+})
+export class ArtistInfo extends Component<ArtistInfoProps> {
+  @track({
+    flow: Schema.Flow.ArtworkAboutTheArtist,
+    type: Schema.Type.Button,
+    label: Schema.Label.ReadMore,
+  })
+  trackArtistBioReadMoreClick() {
+    // noop
+  }
 
-  console.log(props)
-  return (
-    <>
-      <StackableBorderBox p={2} flexDirection="column">
-        <EntityHeader
-          name={props.artist.name}
-          meta={props.artist.formatted_nationality_and_birthday}
-          imageUrl={imageUrl}
-          href={props.artist.href}
-          FollowButton={
-            <FollowArtistButton
-              artist={props.artist}
-              user={props.user}
-              onOpenAuthModal={() => {
-                props.mediator.trigger("open:auth", {
-                  mode: "signup",
-                  copy: `Sign up to follow ${props.artist.name}`,
-                  signupIntent: "follow artist",
-                  afterSignUpAction: {
-                    kind: "artist",
-                    action: "follow",
-                    objectId: props.artist.id,
-                  },
-                })
-              }}
-              render={({ is_followed }) => {
-                return (
-                  <Sans
-                    size="2"
-                    weight="medium"
-                    color="black"
-                    style={{
-                      cursor: "pointer",
-                      textDecoration: "underline",
-                    }}
-                  >
-                    {is_followed ? "Following" : "Follow"}
-                  </Sans>
-                )
-              }}
-            >
-              Follow
-            </FollowArtistButton>
-          }
+  render() {
+    const showArtistBio = !!this.props.artist.biography_blurb.text
+    const imageUrl = get(this.props, p => p.artist.image.cropped.url)
+
+    return (
+      <>
+        <StackableBorderBox p={2} flexDirection="column">
+          <EntityHeader
+            name={this.props.artist.name}
+            meta={this.props.artist.formatted_nationality_and_birthday}
+            imageUrl={imageUrl}
+            href={this.props.artist.href}
+            FollowButton={
+              <FollowArtistButton
+                artist={this.props.artist}
+                user={this.props.user}
+                onOpenAuthModal={() => {
+                  this.props.mediator.trigger("open:auth", {
+                    mode: "signup",
+                    copy: `Sign up to follow ${this.props.artist.name}`,
+                    signupIntent: "follow artist",
+                    afterSignUpAction: {
+                      kind: "artist",
+                      action: "follow",
+                      objectId: this.props.artist.id,
+                    },
+                  })
+                }}
+                render={({ is_followed }) => {
+                  return (
+                    <Sans
+                      size="2"
+                      weight="medium"
+                      color="black"
+                      style={{
+                        cursor: "pointer",
+                        textDecoration: "underline",
+                      }}
+                    >
+                      {is_followed ? "Following" : "Follow"}
+                    </Sans>
+                  )
+                }}
+              >
+                Follow
+              </FollowArtistButton>
+            }
+          />
+          {showArtistBio && (
+            <>
+              <Spacer mb={1} />
+              <ArtistBio
+                bio={this.props.artist}
+                onReadMoreClicked={this.trackArtistBioReadMoreClick}
+              />
+            </>
+          )}
+        </StackableBorderBox>
+        <MarketInsights
+          artist={this.props.artist}
+          border={false}
+          Container={Container}
         />
-        {showArtistBio && (
-          <>
-            <Spacer mb={1} />
-            <ArtistBio
-              bio={props.artist}
-              onReadMoreClicked={() => {
-                props.tracking.trackEvent({
-                  flow: Schema.Flow.ArtworkAboutTheArtist,
-                  type: Schema.Type.Button,
-                  label: Schema.Label.ReadMore,
-                })
-              }}
-            />
-          </>
-        )}
-      </StackableBorderBox>
-      <MarketInsights
-        artist={props.artist}
-        border={false}
-        Container={Container}
-      />
-      <SelectedExhibitions
-        artistID={props.artist.id}
-        border={false}
-        totalExhibitions={props.artist.counts.partner_shows}
-        exhibitions={props.artist.exhibition_highlights}
-        ViewAllLink={
-          <a href={`${sd.APP_URL}/artist/${props.artist.id}/cv`}>View all</a>
-        }
-        Container={Container}
-      />
-    </>
-  )
+        <SelectedExhibitions
+          artistID={this.props.artist.id}
+          border={false}
+          totalExhibitions={this.props.artist.counts.partner_shows}
+          exhibitions={this.props.artist.exhibition_highlights}
+          ViewAllLink={
+            <a href={`${sd.APP_URL}/artist/${this.props.artist.id}/cv`}>
+              View all
+            </a>
+          }
+          Container={Container}
+        />
+      </>
+    )
+  }
 }
 
 export const ArtistInfoFragmentContainer = createFragmentContainer(
-  track({
-    context_module: Schema.ContextModule.Biography,
-  })(ArtistInfo),
+  ArtistInfo,
   graphql`
     fragment ArtistInfo_artist on Artist {
       id

--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -2,13 +2,14 @@ import { Sans, Spacer, StackableBorderBox } from "@artsy/palette"
 import { ArtistInfo_artist } from "__generated__/ArtistInfo_artist.graphql"
 import { ArtistInfoQuery } from "__generated__/ArtistInfoQuery.graphql"
 import { ContextConsumer } from "Artsy"
-import { track, Track } from "Artsy/Analytics"
+import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { Mediator } from "Artsy/SystemContext"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import React, { SFC } from "react"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { TrackingProp } from "react-tracking"
 import { data as sd } from "sharify"
 import { EntityHeader } from "Styleguide/Components/EntityHeader"
 import { get } from "Utils/get"
@@ -23,9 +24,7 @@ interface ArtistInfoProps {
   artist: ArtistInfo_artist
   user: User
   mediator?: Mediator
-  tracking?: {
-    trackEvent: Track
-  }
+  tracking?: TrackingProp
 }
 
 const Container = ({ children }) => (

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
@@ -1,12 +1,11 @@
 import { Box, Serif } from "@artsy/palette"
-import React from "react"
+import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ReadMore } from "Styleguide/Components"
 
 import { ArtworkDetailsAboutTheWorkFromArtsy_artwork } from "__generated__/ArtworkDetailsAboutTheWorkFromArtsy_artwork.graphql"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
-import { TrackingProp } from "react-tracking"
 import { Responsive } from "Utils/Responsive"
 
 export const READ_MORE_MAX_CHARS = {
@@ -16,49 +15,54 @@ export const READ_MORE_MAX_CHARS = {
 
 export interface ArtworkDetailsAboutTheWorkFromArtsyProps {
   artwork: ArtworkDetailsAboutTheWorkFromArtsy_artwork
-  tracking?: TrackingProp
 }
 
-export const ArtworkDetailsAboutTheWorkFromArtsy: React.SFC<
+@track({
+  context_module: Schema.ContextModule.AboutTheWork,
+})
+export class ArtworkDetailsAboutTheWorkFromArtsy extends Component<
   ArtworkDetailsAboutTheWorkFromArtsyProps
-> = props => {
-  const { description } = props.artwork
-  if (!description) {
-    return null
+> {
+  @track({
+    flow: Schema.Flow.ArtworkAboutTheWork,
+    type: Schema.Type.Button,
+    label: Schema.Label.ReadMore,
+  })
+  trackReadMoreClicked() {
+    // noop
   }
-  return (
-    <Responsive>
-      {({ xs }) => {
-        const maxChars = xs
-          ? READ_MORE_MAX_CHARS.xs
-          : READ_MORE_MAX_CHARS.default
 
-        return (
-          <Box pb={2}>
-            <Serif size="3">
-              <ReadMore
-                maxChars={maxChars}
-                content={description}
-                onReadMoreClicked={() => {
-                  props.tracking.trackEvent({
-                    flow: Schema.Flow.ArtworkAboutTheWork,
-                    type: Schema.Type.Button,
-                    label: Schema.Label.ReadMore,
-                  })
-                }}
-              />
-            </Serif>
-          </Box>
-        )
-      }}
-    </Responsive>
-  )
+  render() {
+    const { description } = this.props.artwork
+    if (!description) {
+      return null
+    }
+    return (
+      <Responsive>
+        {({ xs }) => {
+          const maxChars = xs
+            ? READ_MORE_MAX_CHARS.xs
+            : READ_MORE_MAX_CHARS.default
+
+          return (
+            <Box pb={2}>
+              <Serif size="3">
+                <ReadMore
+                  maxChars={maxChars}
+                  content={description}
+                  onReadMoreClicked={this.trackReadMoreClicked}
+                />
+              </Serif>
+            </Box>
+          )
+        }}
+      </Responsive>
+    )
+  }
 }
 
 export const ArtworkDetailsAboutTheWorkFromArtsyFragmentContainer = createFragmentContainer(
-  track({
-    context_module: Schema.ContextModule.AboutTheWork,
-  })(ArtworkDetailsAboutTheWorkFromArtsy),
+  ArtworkDetailsAboutTheWorkFromArtsy,
   graphql`
     fragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {
       description

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
@@ -4,8 +4,9 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { ReadMore } from "Styleguide/Components"
 
 import { ArtworkDetailsAboutTheWorkFromArtsy_artwork } from "__generated__/ArtworkDetailsAboutTheWorkFromArtsy_artwork.graphql"
-import { track, Track } from "Artsy/Analytics"
+import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
+import { TrackingProp } from "react-tracking"
 import { Responsive } from "Utils/Responsive"
 
 export const READ_MORE_MAX_CHARS = {
@@ -15,9 +16,7 @@ export const READ_MORE_MAX_CHARS = {
 
 export interface ArtworkDetailsAboutTheWorkFromArtsyProps {
   artwork: ArtworkDetailsAboutTheWorkFromArtsy_artwork
-  tracking?: {
-    trackEvent: Track
-  }
+  tracking?: TrackingProp
 }
 
 export const ArtworkDetailsAboutTheWorkFromArtsy: React.SFC<

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
@@ -4,6 +4,8 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { ReadMore } from "Styleguide/Components"
 
 import { ArtworkDetailsAboutTheWorkFromArtsy_artwork } from "__generated__/ArtworkDetailsAboutTheWorkFromArtsy_artwork.graphql"
+import { track, Track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { Responsive } from "Utils/Responsive"
 
 export const READ_MORE_MAX_CHARS = {
@@ -13,6 +15,9 @@ export const READ_MORE_MAX_CHARS = {
 
 export interface ArtworkDetailsAboutTheWorkFromArtsyProps {
   artwork: ArtworkDetailsAboutTheWorkFromArtsy_artwork
+  tracking?: {
+    trackEvent: Track
+  }
 }
 
 export const ArtworkDetailsAboutTheWorkFromArtsy: React.SFC<
@@ -32,7 +37,17 @@ export const ArtworkDetailsAboutTheWorkFromArtsy: React.SFC<
         return (
           <Box pb={2}>
             <Serif size="3">
-              <ReadMore maxChars={maxChars} content={description} />
+              <ReadMore
+                maxChars={maxChars}
+                content={description}
+                onReadMoreClicked={() => {
+                  props.tracking.trackEvent({
+                    flow: Schema.Flow.ArtworkAboutTheWork,
+                    type: Schema.Type.Button,
+                    label: Schema.Label.ReadMore,
+                  })
+                }}
+              />
             </Serif>
           </Box>
         )
@@ -42,7 +57,9 @@ export const ArtworkDetailsAboutTheWorkFromArtsy: React.SFC<
 }
 
 export const ArtworkDetailsAboutTheWorkFromArtsyFragmentContainer = createFragmentContainer(
-  ArtworkDetailsAboutTheWorkFromArtsy,
+  track({
+    context_module: Schema.ContextModule.AboutTheWork,
+  })(ArtworkDetailsAboutTheWorkFromArtsy),
   graphql`
     fragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {
       description

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -20,8 +20,14 @@ import { ContextConsumer } from "Artsy/Router"
 import { Responsive } from "Utils/Responsive"
 import { READ_MORE_MAX_CHARS } from "./ArtworkDetailsAboutTheWorkFromArtsy"
 
+import { track, Track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
+
 export interface ArtworkDetailsAboutTheWorkFromPartnerProps {
   artwork: ArtworkDetailsAboutTheWorkFromPartner_artwork
+  tracking?: {
+    trackEvent: Track
+  }
 }
 
 export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
@@ -108,6 +114,13 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
                             <ReadMore
                               maxChars={maxChars}
                               content={additional_information}
+                              onReadMoreClicked={() => {
+                                this.props.tracking.trackEvent({
+                                  flow: Schema.Flow.ArtworkAboutTheWork,
+                                  type: Schema.Type.Button,
+                                  label: Schema.Label.ReadMore,
+                                })
+                              }}
                             />
                           </Serif>
                         </React.Fragment>
@@ -125,7 +138,9 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
 }
 
 export const ArtworkDetailsAboutTheWorkFromPartnerFragmentContainer = createFragmentContainer(
-  ArtworkDetailsAboutTheWorkFromPartner,
+  track({
+    context_module: Schema.ContextModule.AboutTheWorkPartner,
+  })(ArtworkDetailsAboutTheWorkFromPartner),
   graphql`
     fragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {
       additional_information

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -22,16 +22,26 @@ import { READ_MORE_MAX_CHARS } from "./ArtworkDetailsAboutTheWorkFromArtsy"
 
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
-import { TrackingProp } from "react-tracking"
 
 export interface ArtworkDetailsAboutTheWorkFromPartnerProps {
   artwork: ArtworkDetailsAboutTheWorkFromPartner_artwork
-  tracking?: TrackingProp
 }
 
+@track({
+  context_module: Schema.ContextModule.AboutTheWorkPartner,
+})
 export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
   ArtworkDetailsAboutTheWorkFromPartnerProps
 > {
+  @track({
+    flow: Schema.Flow.ArtworkAboutTheWork,
+    type: Schema.Type.Button,
+    label: Schema.Label.ReadMore,
+  })
+  trackReadMoreClick() {
+    // noop
+  }
+
   renderProfileImage(imageUrl?: string, initials?: string) {
     return <Avatar size="xs" src={imageUrl} initials={initials} mr={1} />
   }
@@ -113,13 +123,7 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
                             <ReadMore
                               maxChars={maxChars}
                               content={additional_information}
-                              onReadMoreClicked={() => {
-                                this.props.tracking.trackEvent({
-                                  flow: Schema.Flow.ArtworkAboutTheWork,
-                                  type: Schema.Type.Button,
-                                  label: Schema.Label.ReadMore,
-                                })
-                              }}
+                              onReadMoreClicked={this.trackReadMoreClick}
                             />
                           </Serif>
                         </React.Fragment>
@@ -137,9 +141,7 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
 }
 
 export const ArtworkDetailsAboutTheWorkFromPartnerFragmentContainer = createFragmentContainer(
-  track({
-    context_module: Schema.ContextModule.AboutTheWorkPartner,
-  })(ArtworkDetailsAboutTheWorkFromPartner),
+  ArtworkDetailsAboutTheWorkFromPartner,
   graphql`
     fragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {
       additional_information

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -20,14 +20,13 @@ import { ContextConsumer } from "Artsy/Router"
 import { Responsive } from "Utils/Responsive"
 import { READ_MORE_MAX_CHARS } from "./ArtworkDetailsAboutTheWorkFromArtsy"
 
-import { track, Track } from "Artsy/Analytics"
+import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
+import { TrackingProp } from "react-tracking"
 
 export interface ArtworkDetailsAboutTheWorkFromPartnerProps {
   artwork: ArtworkDetailsAboutTheWorkFromPartner_artwork
-  tracking?: {
-    trackEvent: Track
-  }
+  tracking?: TrackingProp
 }
 
 export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<

--- a/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -13,14 +13,13 @@ import { ArtworkDetailsChecklistFragmentContainer as Checklist } from "./Artwork
 import { ArtworkDetails_artwork } from "__generated__/ArtworkDetails_artwork.graphql"
 import { ArtworkDetailsQuery } from "__generated__/ArtworkDetailsQuery.graphql"
 
-import { track, Track } from "Artsy/Analytics"
+import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
+import { TrackingProp } from "react-tracking"
 
 export interface ArtworkDetailsProps {
   artwork: ArtworkDetails_artwork
-  tracking?: {
-    trackEvent: Track
-  }
+  tracking?: TrackingProp
 }
 
 const ArtworkDetailsContainer = Box

--- a/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -13,8 +13,14 @@ import { ArtworkDetailsChecklistFragmentContainer as Checklist } from "./Artwork
 import { ArtworkDetails_artwork } from "__generated__/ArtworkDetails_artwork.graphql"
 import { ArtworkDetailsQuery } from "__generated__/ArtworkDetailsQuery.graphql"
 
+import { track, Track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
+
 export interface ArtworkDetailsProps {
   artwork: ArtworkDetails_artwork
+  tracking?: {
+    trackEvent: Track
+  }
 }
 
 const ArtworkDetailsContainer = Box
@@ -23,8 +29,16 @@ export const ArtworkDetails: React.SFC<ArtworkDetailsProps> = props => {
   const { artwork } = props
   return (
     <ArtworkDetailsContainer pb={4}>
-      <Tabs>
-        <Tab name="About the work">
+      <Tabs
+        onChange={({ data }) => {
+          props.tracking.trackEvent({
+            flow: Schema.Flow.ArtworkAboutTheArtist,
+            type: Schema.Type.Tab,
+            label: data.trackingLabel,
+          })
+        }}
+      >
+        <Tab name="About the work" data={{ trackingLabel: "about_the_work" }}>
           <AboutTheWorkFromArtsy artwork={artwork} />
           <AboutTheWorkFromPartner artwork={artwork} />
           <AdditionalInfo artwork={artwork} />
@@ -32,15 +46,22 @@ export const ArtworkDetails: React.SFC<ArtworkDetailsProps> = props => {
         </Tab>
         {artwork.articles &&
           artwork.articles.length && (
-            <Tab name="Articles">
+            <Tab name="Articles" data={{ trackingLabel: "articles" }}>
               <Articles artwork={artwork} />
             </Tab>
           )}
         {artwork.exhibition_history && (
-          <Tab name="Exhibition history">{artwork.exhibition_history}</Tab>
+          <Tab
+            name="Exhibition history"
+            data={{ trackingLabel: "exhibition_history" }}
+          >
+            {artwork.exhibition_history}
+          </Tab>
         )}
         {artwork.literature && (
-          <Tab name="Bibliography">{artwork.literature}</Tab>
+          <Tab name="Bibliography" data={{ trackingLabel: "bibliography" }}>
+            {artwork.literature}
+          </Tab>
         )}
       </Tabs>
     </ArtworkDetailsContainer>
@@ -48,7 +69,9 @@ export const ArtworkDetails: React.SFC<ArtworkDetailsProps> = props => {
 }
 
 export const ArtworkDetailsFragmentContainer = createFragmentContainer(
-  ArtworkDetails,
+  track({
+    context_module: Schema.ContextModule.ArtworkTabs,
+  })(ArtworkDetails),
   graphql`
     fragment ArtworkDetails_artwork on Artwork {
       ...ArtworkDetailsAboutTheWorkFromArtsy_artwork

--- a/src/Apps/WorksForYou/MarketingHeader.tsx
+++ b/src/Apps/WorksForYou/MarketingHeader.tsx
@@ -22,7 +22,7 @@ const COLLECT_URL = `${sd.APP_URL}/collect?split_test[new_collect_page]=new&acqu
 const VIDEO_URL = `${sd.FORCE_CLOUDFRONT_URL}/videos/9172018-bn-banner-xl.mp4`
 
 @track({
-  context_module: Schema.Context.BNMOBanner,
+  context_module: Schema.ContextModule.BNMOBanner,
 })
 export class MarketingHeader extends Component {
   @track({

--- a/src/Artsy/Analytics/Schema/ContextModule.ts
+++ b/src/Artsy/Analytics/Schema/ContextModule.ts
@@ -1,4 +1,4 @@
-import { Context } from "./Values"
+import { ContextModule as _ContextModule } from "./Values"
 
 export interface ContextModule {
   /**
@@ -6,5 +6,5 @@ export interface ContextModule {
    * it does not need to be, as long as given the name it should be clear what
    * part of the page is being referred to.
    */
-  context_module: Context
+  context_module: _ContextModule
 }

--- a/src/Artsy/Analytics/Schema/Flow.ts
+++ b/src/Artsy/Analytics/Schema/Flow.ts
@@ -1,0 +1,8 @@
+import { Flow as _Flow } from "./Values"
+
+export interface Flow {
+  /**
+   * TODO: Descriptor
+   */
+  flow: _Flow
+}

--- a/src/Artsy/Analytics/Schema/Label.ts
+++ b/src/Artsy/Analytics/Schema/Label.ts
@@ -1,0 +1,8 @@
+import { Label as _Label } from "./Values"
+
+export interface Label {
+  /**
+   * The label of element being iteracted with
+   */
+  label: _Label
+}

--- a/src/Artsy/Analytics/Schema/Type.ts
+++ b/src/Artsy/Analytics/Schema/Type.ts
@@ -1,0 +1,8 @@
+import { Type as _Type } from "./Values"
+
+export interface Type {
+  /**
+   * Identifier of the type of element being clicked
+   */
+  type: _Type
+}

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -79,6 +79,7 @@ export enum ActionName {
    */
   ArtistFollow = "artistFollow",
   ArtistUnfollow = "artistUnfollow",
+  ArtworkAboutTheWork = "Artwork about the work",
 
   /**
    * Authentication
@@ -153,15 +154,23 @@ export enum Subject {
 /**
  * Identifier of a conceptual module on the page.
  */
-export enum Context {
+export enum ContextModule {
   Header = "Header",
   NavigationTabs = "NavigationTabs",
 
   /**
    * Artist page
    */
+  AboutTheWork = "About the work",
+  AboutTheWorkPartner = "About the Work (Partner)",
   ArtistOverview = "ArtistOverview",
   ArtistBio = "ArtistBio",
+  Biography = "Biography",
+
+  /**
+   * Artwork page
+   */
+  ArtworkTabs = "Artwork tabs",
 
   /*
   * Articles
@@ -180,4 +189,22 @@ export enum Context {
    * Buy Now Make Offer ("Works For You")
    */
   BNMOBanner = "BNMO Banner",
+}
+
+export enum Flow {
+  ArtworkAboutTheWork = "Artwork about the work",
+  ArtworkAboutTheArtist = "Artwork about the artist",
+}
+
+export enum Label {
+  AboutTheWork = "about_the_work",
+  Articles = "articles",
+  Biography = "biography",
+  ExhibitionHighlights = "exhibition_highlights",
+  ReadMore = "ReadMore",
+}
+
+export enum Type {
+  Button = "Button",
+  Tab = "Tab",
 }

--- a/src/Artsy/Analytics/Schema/index.ts
+++ b/src/Artsy/Analytics/Schema/index.ts
@@ -7,24 +7,32 @@
  *   `ContextPage` and `Result`.
  */
 
-export * from "./ContextPage"
-export * from "./ContextModule"
-export * from "./Interaction"
-export * from "./Result"
+// TODO: Do we need to export these?
+// export * from "./ContextPage"
+// export * from "./ContextModule"
+// export * from "./Interaction"
+// export * from "./Result"
+
 export * from "./Values"
 
 import { ContextModule } from "./ContextModule"
 import { ContextPage } from "./ContextPage"
+import { Flow } from "./Flow"
 import { AuthenticationInteraction, Interaction } from "./Interaction"
+import { Label } from "./Label"
 import { Failure, Success } from "./Result"
+import { Type } from "./Type"
 
 export type Trackables =
   | AuthenticationInteraction
   | ContextModule
   | ContextPage
+  | Flow
   | Interaction
+  | Label
   | Success
   | Failure
+  | Type
 
 /**
  * A sentinel type used to signal that anything goes in order to be able to

--- a/src/Artsy/Analytics/Schema/index.ts
+++ b/src/Artsy/Analytics/Schema/index.ts
@@ -7,12 +7,6 @@
  *   `ContextPage` and `Result`.
  */
 
-// TODO: Do we need to export these?
-// export * from "./ContextPage"
-// export * from "./ContextModule"
-// export * from "./Interaction"
-// export * from "./Result"
-
 export * from "./Values"
 
 import { ContextModule } from "./ContextModule"

--- a/src/Components/Authentication/Desktop/Components/DesktopModal.tsx
+++ b/src/Components/Authentication/Desktop/Components/DesktopModal.tsx
@@ -2,6 +2,7 @@ import { ModalOptions } from "Components/Authentication/Types"
 import Modal, { ModalProps } from "Components/Modal/Modal"
 import React, { Component } from "react"
 import track from "react-tracking"
+import { TrackingProp } from "react-tracking"
 import Events from "Utils/Events"
 
 export interface DesktopModalProps extends ModalProps {
@@ -10,7 +11,7 @@ export interface DesktopModalProps extends ModalProps {
   onTypeChange?: (options: ModalOptions) => void
   show?: boolean
   subtitle?: string
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 @track({}, { dispatch: data => Events.postEvent(data) })

--- a/src/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/Components/Authentication/Desktop/ModalManager.tsx
@@ -1,5 +1,6 @@
 import { FormikProps } from "formik"
 import React, { Component } from "react"
+import { TrackingProp } from "react-tracking"
 
 import { DesktopModal } from "Components/Authentication/Desktop/Components/DesktopModal"
 import { FormSwitcher } from "Components/Authentication/FormSwitcher"
@@ -18,7 +19,7 @@ export interface ModalManagerProps {
   }
   csrf?: string
   redirectTo?: string
-  tracking?: any
+  tracking?: TrackingProp
   type?: ModalType
   handleSubmit?: (
     type: ModalType,

--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -1,6 +1,6 @@
 import qs from "querystring"
 import React from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import Events from "Utils/Events"
 
 import { ForgotPasswordForm } from "Components/Authentication/Desktop/ForgotPasswordForm"
@@ -26,7 +26,7 @@ export interface FormSwitcherProps {
   onFacebookLogin?: (e: Event) => void
   onTwitterLogin?: (e: Event) => void
   options: ModalOptions
-  tracking?: any
+  tracking?: TrackingProp
   type: ModalType
   submitUrls?: { [P in ModalType]: string } & {
     facebook?: string

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -2,7 +2,7 @@ import { FollowArtistButtonMutation } from "__generated__/FollowArtistButtonMuta
 import * as Artsy from "Artsy/SystemContext"
 import { extend } from "lodash"
 import React from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import { RecordSourceSelectorProxy, SelectorData } from "relay-runtime"
 import { FollowArtistButton_artist } from "../../__generated__/FollowArtistButton_artist.graphql"
 import { FollowButton } from "./Button"
@@ -22,7 +22,7 @@ interface Props
     Artsy.ContextProps {
   relay?: RelayProp
   artist?: FollowArtistButton_artist
-  tracking?: any
+  tracking?: TrackingProp
   trackingData?: FollowTrackingData
   onOpenAuthModal?: (type: "register" | "login", config?: object) => void
 

--- a/src/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/Components/FollowButton/FollowGeneButton.tsx
@@ -8,7 +8,7 @@ import {
   graphql,
   RelayProp,
 } from "react-relay"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import { FollowGeneButton_gene } from "../../__generated__/FollowGeneButton_gene.graphql"
 import { FollowButtonDeprecated } from "./ButtonDeprecated"
 import { FollowTrackingData } from "./Typings"
@@ -16,7 +16,7 @@ import { FollowTrackingData } from "./Typings"
 interface Props extends React.HTMLProps<FollowGeneButton>, Artsy.ContextProps {
   relay?: RelayProp
   gene?: FollowGeneButton_gene
-  tracking?: any
+  tracking?: TrackingProp
   trackingData?: FollowTrackingData
   onOpenAuthModal?: (type: "register" | "login", config?: object) => void
 }

--- a/src/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/Components/FollowButton/FollowProfileButton.tsx
@@ -2,7 +2,7 @@ import { FollowProfileButtonMutation } from "__generated__/FollowProfileButtonMu
 import * as Artsy from "Artsy/SystemContext"
 import { extend } from "lodash"
 import React from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import { FollowProfileButton_profile } from "../../__generated__/FollowProfileButton_profile.graphql"
 import { FollowButton } from "./Button"
 import { FollowTrackingData } from "./Typings"
@@ -20,7 +20,7 @@ interface Props
     Artsy.ContextProps {
   relay?: RelayProp
   profile?: FollowProfileButton_profile
-  tracking?: any
+  tracking?: TrackingProp
   trackingData?: FollowTrackingData
   onOpenAuthModal?: (type: "register" | "login", config?: object) => void
 

--- a/src/Components/MinimalCtaBanner.tsx
+++ b/src/Components/MinimalCtaBanner.tsx
@@ -20,7 +20,7 @@ export interface State {
   dismissed: boolean
 }
 
-@track({ context_module: Schema.Context.MinimalCtaBanner })
+@track({ context_module: Schema.ContextModule.MinimalCtaBanner })
 export class MinimalCtaBanner extends React.Component<
   MinimalCtaBannerProps,
   State

--- a/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
@@ -13,7 +13,7 @@ import {
   QueryRenderer,
   RelayProp,
 } from "react-relay"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import { RecordSourceSelectorProxy } from "relay-runtime"
 import Events from "../../../../Utils/Events"
 import ReplaceTransition from "../../../Animation/ReplaceTransition"
@@ -24,7 +24,7 @@ type Artist = ArtistSearchResultsContent_viewer["match_artist"][0]
 
 export interface ContainerProps extends FollowProps {
   term: string
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 interface Props extends React.HTMLProps<HTMLAnchorElement>, ContainerProps {

--- a/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
+++ b/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
@@ -13,7 +13,7 @@ import {
   QueryRenderer,
   RelayProp,
 } from "react-relay"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import { RecordSourceSelectorProxy } from "relay-runtime"
 import Events from "../../../../Utils/Events"
 import ReplaceTransition from "../../../Animation/ReplaceTransition"
@@ -33,7 +33,7 @@ interface Artist {
 }
 
 export interface RelayProps {
-  tracking?: any
+  tracking?: TrackingProp
   relay?: RelayProp
   popular_artists: PopularArtistsContent_popular_artists
 }

--- a/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
@@ -14,7 +14,7 @@ import {
   QueryRenderer,
   RelayProp,
 } from "react-relay"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import { RecordSourceSelectorProxy } from "relay-runtime"
 import styled from "styled-components"
 import Events from "../../../../Utils/Events"
@@ -29,7 +29,7 @@ interface ContainerProps extends FollowProps {
 }
 
 interface Props extends React.HTMLProps<HTMLAnchorElement>, ContainerProps {
-  tracking?: any
+  tracking?: TrackingProp
   relay?: RelayProp
   viewer: GeneSearchResultsContent_viewer
 }

--- a/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
+++ b/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
@@ -13,7 +13,7 @@ import {
   QueryRenderer,
   RelayProp,
 } from "react-relay"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import { RecordSourceSelectorProxy } from "relay-runtime"
 import Events from "../../../../Utils/Events"
 import ReplaceTransition from "../../../Animation/ReplaceTransition"
@@ -25,7 +25,7 @@ type Gene = SuggestedGenesContent_suggested_genes[0]
 interface Props extends React.HTMLProps<HTMLAnchorElement>, FollowProps {
   relay?: RelayProp
   suggested_genes: SuggestedGenesContent_suggested_genes
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 @track({}, { dispatch: data => Events.postEvent(data) })

--- a/src/Components/Onboarding/Wizard.tsx
+++ b/src/Components/Onboarding/Wizard.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Redirect, Route } from "react-router"
 
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import Events from "../../Utils/Events"
 import { ProgressIndicator } from "../ProgressIndicator"
 
@@ -21,7 +21,7 @@ const STEPS = [
 
 export interface Props {
   redirectTo?: string
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 export interface State {

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import Events from "../../Utils/Events"
 
 import { BannerWrapper } from "./Banner/Banner"
@@ -30,7 +30,7 @@ export interface ArticleProps {
   display?: DisplayData
   showTooltips?: boolean
   slideIndex?: number
-  tracking?: any
+  tracking?: TrackingProp
   closeViewer?: () => void
   viewerIsOpen?: boolean
   onOpenAuthModal?: (type: "register" | "login", config: object) => void

--- a/src/Components/Publishing/Byline/Share.tsx
+++ b/src/Components/Publishing/Byline/Share.tsx
@@ -1,6 +1,6 @@
 import { Sans } from "@artsy/palette"
 import React from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import Events from "../../../Utils/Events"
 import { pMedia } from "../../Helpers"
@@ -13,7 +13,7 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
   title: string
   articleId?: string
   color?: string
-  tracking?: any
+  tracking?: TrackingProp
   trackingData?: any
   hasLabel?: boolean
   isMobile?: boolean

--- a/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasVideo.tsx
@@ -2,7 +2,7 @@ import { pMedia } from "Components/Helpers"
 import { VideoControls } from "Components/Publishing/Sections/VideoControls"
 import { memoize, once } from "lodash"
 import React, { Component } from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import { resize } from "Utils/resizer"
 
@@ -11,7 +11,7 @@ export interface CanvasVideoProps {
   coverUrl?: string
   src: any
   onInit?: any
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 @track()

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -1,7 +1,7 @@
 import { avantgarde, garamond, unica } from "Assets/Fonts"
 import { get, memoize } from "lodash"
 import React, { Component, HTMLProps } from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import Waypoint from "react-waypoint"
 import styled from "styled-components"
 import Colors from "../../../Assets/Colors"
@@ -19,7 +19,7 @@ export interface DisplayPanelProps extends React.HTMLProps<HTMLDivElement> {
   article?: any
   isMobile?: boolean
   unit: any
-  tracking?: any
+  tracking?: TrackingProp
   renderTime?: number
 }
 

--- a/src/Components/Publishing/Email/EmailPanel.tsx
+++ b/src/Components/Publishing/Email/EmailPanel.tsx
@@ -1,6 +1,6 @@
 import { avantgarde, unica } from "Assets/Fonts"
 import React from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import request from "superagent"
 import Colors from "../../../Assets/Colors"
@@ -11,7 +11,7 @@ import { EMAIL_REGEX } from "../Constants"
 
 interface EmailPanelProps {
   signupUrl: string
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 interface EmailPanelState {

--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -2,7 +2,7 @@ import { color } from "@artsy/palette"
 import { unica } from "Assets/Fonts"
 import { once } from "lodash"
 import React, { Component } from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import { pMedia } from "../../Helpers"
 import { NewsHeadline } from "../News/NewsHeadline"
@@ -19,7 +19,7 @@ interface Props {
   onExpand?: () => void
   relatedArticlesForCanvas?: RelatedArticleCanvasData[]
   renderTime?: number
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 interface State {

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -51,7 +51,7 @@ export class StandardLayout extends React.Component<
 
     return {
       action_type: Schema.ActionType.Click,
-      context_module: Schema.Context.ReadMore,
+      context_module: Schema.ContextModule.ReadMore,
       destination_path: getEditorialHref(layout, slug),
       subject: Schema.Subject.ReadMore,
       referrer,

--- a/src/Components/Publishing/Partner/PartnerBlock.tsx
+++ b/src/Components/Publishing/Partner/PartnerBlock.tsx
@@ -1,14 +1,14 @@
 import { unica } from "Assets/Fonts"
 import { pMedia } from "Components/Helpers"
 import React from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import { resize } from "Utils/resizer"
 
 interface Props {
   logo: string
   url: string
-  tracking?: any
+  tracking?: TrackingProp
   trackingData?: any
 }
 

--- a/src/Components/Publishing/ReadMore/ReadMoreButton.tsx
+++ b/src/Components/Publishing/ReadMore/ReadMoreButton.tsx
@@ -14,7 +14,7 @@ interface ReadMoreProps {
 }
 
 @track({
-  context_module: Schema.Context.ReadMore,
+  context_module: Schema.ContextModule.ReadMore,
   subject: Schema.Subject.ReadMore,
 })
 export class ReadMoreButton extends React.Component<ReadMoreProps> {

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCard.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCard.tsx
@@ -1,7 +1,7 @@
 import { Sans } from "@artsy/palette"
 import { garamond, unica } from "Assets/Fonts"
 import React, { Component } from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import { crop } from "../../../../Utils/resizer"
 import { pMedia } from "../../../Helpers"
@@ -19,7 +19,7 @@ interface Props {
   editTitle?: any
   editImage?: any
   series?: any
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 interface LinkProps extends Props, React.HTMLProps<HTMLLinkElement> {

--- a/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
@@ -25,7 +25,7 @@ interface ScrollingContainerProps {
 
 @track({
   // TODO: reevalutate double naming of context/schema
-  context_module: Schema.Context.FurtherReading,
+  context_module: Schema.ContextModule.FurtherReading,
   subject: Schema.Subject.FurtherReading,
 })
 export class RelatedArticlesCanvas extends React.Component<

--- a/src/Components/Publishing/RelatedArticles/Panel/RelatedArticlesPanel.tsx
+++ b/src/Components/Publishing/RelatedArticles/Panel/RelatedArticlesPanel.tsx
@@ -15,7 +15,7 @@ interface RelatedArticlesPanelProps extends React.HTMLProps<HTMLDivElement> {
 
 @track({
   // TODO: reevalutate double naming of context/schema
-  context_module: Schema.Context.RelatedArticles,
+  context_module: Schema.ContextModule.RelatedArticles,
   subject: Schema.Subject.RelatedArticles,
 })
 export class RelatedArticlesPanel extends React.Component<

--- a/src/Components/Publishing/Sections/Video.tsx
+++ b/src/Components/Publishing/Sections/Video.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import sizeMe from "react-sizeme"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled, { StyledFunction } from "styled-components"
 import urlParser from "url"
 import Events from "../../../Utils/Events"
@@ -23,7 +23,7 @@ interface VideoProps {
     cover_image_url?: string
   }
   size?: any
-  tracking?: any
+  tracking?: TrackingProp
   trackingData?: any
   layout?: ArticleLayout
 }

--- a/src/Components/Publishing/Series/SeriesAbout.tsx
+++ b/src/Components/Publishing/Series/SeriesAbout.tsx
@@ -1,7 +1,7 @@
 import { unica } from "Assets/Fonts"
 import React, { Component } from "react"
 import { Col, Row } from "react-styled-flexboxgrid"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import { media } from "../../Helpers"
 import { PartnerBlock, PartnerBlockContainer } from "../Partner/PartnerBlock"
@@ -13,7 +13,7 @@ interface Props {
   color?: string
   editDescription?: any
   editSubTitle?: any
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 @track()

--- a/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/ArtistToolTip.tsx
@@ -5,7 +5,7 @@ import { map } from "lodash"
 import PropTypes from "prop-types"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import fillwidthDimensions from "../../../Utils/fillwidth"
 import { FollowTrackingData } from "../../FollowButton/Typings"
@@ -14,7 +14,7 @@ import { NewFeature } from "./Components/NewFeature"
 
 export interface ArtistToolTipProps {
   artist: ArtistToolTip_artist
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 export class ArtistToolTip extends React.Component<ArtistToolTipProps> {

--- a/src/Components/Publishing/ToolTip/GeneToolTip.tsx
+++ b/src/Components/Publishing/ToolTip/GeneToolTip.tsx
@@ -4,7 +4,7 @@ import { FollowGeneButtonFragmentContainer as FollowGeneButton } from "Component
 import PropTypes from "prop-types"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import { FollowTrackingData } from "../../FollowButton/Typings"
 import { getFullArtsyHref } from "../Constants"
@@ -13,7 +13,7 @@ import { NewFeature, NewFeatureContainer } from "./Components/NewFeature"
 
 export interface GeneProps {
   gene: GeneToolTip_gene
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 export class GeneToolTip extends React.Component<GeneProps> {

--- a/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
+++ b/src/Components/Publishing/ToolTip/LinkWithTooltip.tsx
@@ -3,7 +3,7 @@ import { defer } from "lodash"
 import PropTypes from "prop-types"
 import React, { Component } from "react"
 import { findDOMNode } from "react-dom"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import { parse as parseURL } from "url"
 import FadeTransition from "../../Animation/FadeTransition"
@@ -11,7 +11,7 @@ import { ToolTip } from "./ToolTip"
 
 interface Props {
   url: string
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 interface State {

--- a/src/Components/Publishing/Video/Player/VideoPlayer.tsx
+++ b/src/Components/Publishing/Video/Player/VideoPlayer.tsx
@@ -1,6 +1,6 @@
 import { memoize } from "lodash"
 import React, { Component } from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 // @ts-ignore
 import styled, { StyledComponentClass, StyledFunction } from "styled-components"
 import {
@@ -18,7 +18,7 @@ export interface VideoPlayerProps extends React.HTMLProps<HTMLDivElement> {
   title?: string
   notifyPlayToggle?: (e) => void
   forcePlay?: boolean
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 export interface VideoPlayerState {

--- a/src/Components/Publishing/Video/VideoCover.tsx
+++ b/src/Components/Publishing/Video/VideoCover.tsx
@@ -1,7 +1,7 @@
 import { garamond } from "Assets/Fonts"
 import { Col } from "Components/Grid"
 import React, { Component } from "react"
-import track from "react-tracking"
+import track, { TrackingProp } from "react-tracking"
 import styled, { StyledFunction } from "styled-components"
 import { media as mediaQueries } from "../../Helpers"
 import { IconVideoPlay } from "../Icon/IconVideoPlay"
@@ -18,7 +18,7 @@ interface Props {
   playVideo?: () => void
   seriesLink?: string
   seriesTitle?: string
-  tracking?: any
+  tracking?: TrackingProp
 }
 
 interface CoverProps {

--- a/src/Components/Publishing/__stories__/ToolTip.story.tsx
+++ b/src/Components/Publishing/__stories__/ToolTip.story.tsx
@@ -6,7 +6,7 @@ import { LinkWithTooltip } from "Components/Publishing/ToolTip/LinkWithTooltip"
 import { TooltipsData } from "Components/Publishing/ToolTip/TooltipsDataLoader"
 import React from "react"
 
-const tracking = { trackEvent: x => x }
+const tracking = { trackEvent: x => x, getTrackingData: x => x } as any
 
 storiesOf("Publishing/ToolTips/", module)
   .add("Artist", () => {

--- a/src/Styleguide/Components/ArtistBio.tsx
+++ b/src/Styleguide/Components/ArtistBio.tsx
@@ -18,7 +18,7 @@ export const MAX_CHARS = {
   default: 320,
 }
 
-@track({ context_module: Schema.Context.ArtistBio })
+@track({ context_module: Schema.ContextModule.ArtistBio })
 export class ArtistBio extends React.Component<Props> {
   render() {
     return (

--- a/src/Styleguide/Components/ReadMore.tsx
+++ b/src/Styleguide/Components/ReadMore.tsx
@@ -102,7 +102,6 @@ const ReadMoreLinkContainer = styled.span`
   cursor: pointer;
   text-decoration: underline;
   display: inline-block;
-  white-space: nowrap;
 `
 
 // NOTE: Couldn't use @artsy/palette / Sans due to root element being a `div`;


### PR DESCRIPTION
Adds tracking for: 

- https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&modal=detail&selectedIssue=DISCO-361&sprint=143
- https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&modal=detail&selectedIssue=DISCO-362&sprint=143
- https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&modal=detail&selectedIssue=DISCO-363&sprint=143
- https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&modal=detail&selectedIssue=DISCO-324

Additionally, adds a few new tracking fields to the main Trackables type: 
- `Flow`
- `Label`
- `Type`

so that things match up to tracking code segment props: 

```ms
analytics.track('Click', {
  context_module: 'Biography',
  flow: 'Artwork about the artist',
  type: 'Button',
  label: 'Read more',
})
```
-> 
```js
props.track({
  flow: Schema.Flow.ArtworkAboutTheWork,
  type: Schema.Type.Button,
  label: Schema.Label.ReadMore,
})
```

Also refactors `Schema.Context` to `Schema.ContextModule` to map 1:1 to segment property. 

As a follow up to the discussion started in https://github.com/artsy/reaction/issues/1386 around these new patterns, after working through these tickets there was definitely more duplicate data than expected across all three tickets that lends itself to a schema. 