### PR TITLE
Buy Now QA Fixes

### DIFF
--- a/src/Apps/Order/Components/ShippingAndPaymentSummary.tsx
+++ b/src/Apps/Order/Components/ShippingAndPaymentSummary.tsx
@@ -35,8 +35,8 @@ export const ShippingAndPaymentSummary = ({
         >
           {showPickupCopy(state) && (
             <Serif size="3t">
-              You’ll be appointed an Artsy specialist within 2 business days to
-              handle pickup logistics.
+              After your order is confirmed, a specialist will contact you
+              within 2 business days to coordinate pickup.
             </Serif>
           )}
         </StepSummaryItem>

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -243,6 +243,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
         <ErrorModal
           onClose={this.onCloseModal}
           show={this.state.isErrorModalOpen}
+          contactEmail="orders@artsy.net"
           detailText={this.state.errorModalMessage}
         />
       </>

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -197,7 +197,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
                           selected={this.state.hideBillingAddress}
                           onSelect={this.handleChangeHideBillingAddress}
                         >
-                          Use shipping address.
+                          Billing and shipping addresses are the same
                         </Checkbox>
                       )}
                       <Collapse open={this.needsAddress()}>

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -286,6 +286,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
           onClose={this.onCloseModal}
           show={this.state.isErrorModalOpen}
           detailText={this.state.errorModalMessage}
+          contactEmail="orders@artsy.net"
           headerText={this.state.errorModalTitle}
           ctaAction={this.state.errorModalCtaAction}
         />

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -351,6 +351,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
         <ErrorModal
           onClose={this.onCloseModal}
           show={this.state.isErrorModalOpen}
+          contactEmail="orders@artsy.net"
           detailText={this.state.errorModalMessage}
           headerText={this.state.errorModalTitle}
         />

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -22,11 +22,20 @@ storiesOf("Apps/Order Page", module)
   .add("Review", () => <Router initialRoute="/orders/123/review" />)
 
 storiesOf("Apps/Order Page/Status", module)
-  .add("submitted", () => (
+  .add("submitted (ship)", () => (
     <Router
       initialRoute="/orders/123/status"
       mockResolvers={mockResolver({
         ...OrderWithShippingDetails,
+        state: "SUBMITTED",
+      })}
+    />
+  ))
+  .add("submitted (pickup)", () => (
+    <Router
+      initialRoute="/orders/123/status"
+      mockResolvers={mockResolver({
+        ...PickupOrder,
         state: "SUBMITTED",
       })}
     />

--- a/src/Components/Modal/ErrorModal.tsx
+++ b/src/Components/Modal/ErrorModal.tsx
@@ -7,6 +7,7 @@ interface ErrorModalProps extends React.HTMLProps<HTMLDivElement> {
   show?: boolean
   headerText?: string
   detailText?: string
+  contactEmail?: string // Used in default detailText if none is specified.
   closeText?: string
   onClose?: () => void
   ctaAction?: () => void
@@ -28,9 +29,11 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
       onClose,
       headerText,
       detailText,
+      contactEmail,
       closeText,
       ctaAction,
     } = this.props
+    const emailAddress = contactEmail ? contactEmail : "support@artsy.net"
 
     return (
       <ModalWrapper show={show} onClose={onClose} width={ModalWidth.Narrow}>
@@ -42,7 +45,7 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
             {detailText || (
               <>
                 Something went wrong. Please try again or contact{" "}
-                <Link href="mailto:support@artsy.net">support@artsy.net</Link>.
+                <Link href={`mailto:${emailAddress}`}>{emailAddress}</Link>.
               </>
             )}
           </Sans>

--- a/src/Components/Modal/ErrorModal.tsx
+++ b/src/Components/Modal/ErrorModal.tsx
@@ -1,5 +1,5 @@
 import { color, Flex, Sans } from "@artsy/palette"
-import { ModalWrapper } from "Components/Modal/ModalWrapper"
+import { ModalWidth, ModalWrapper } from "Components/Modal/ModalWrapper"
 import React from "react"
 import styled from "styled-components"
 
@@ -33,7 +33,7 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
     } = this.props
 
     return (
-      <ModalWrapper show={show} onClose={onClose}>
+      <ModalWrapper show={show} onClose={onClose} width={ModalWidth.Narrow}>
         <Flex flexDirection="column" pt={2} px={2}>
           <Sans size="4" weight="medium" mb={10}>
             {headerText}

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -3,7 +3,7 @@ import Icon from "Components/Icon"
 import React from "react"
 import styled from "styled-components"
 
-import { ModalWrapper } from "Components/Modal/ModalWrapper"
+import { ModalWidth, ModalWrapper } from "Components/Modal/ModalWrapper"
 import { media } from "../Helpers"
 import { CtaProps, ModalCta } from "./ModalCta"
 import { ModalHeader } from "./ModalHeader"
@@ -63,7 +63,7 @@ export class Modal extends React.Component<ModalProps> {
         cta={cta}
         onClose={onClose}
         show={show}
-        isWide={isWide}
+        width={isWide ? ModalWidth.Wide : ModalWidth.Normal}
         image={image}
         fullscreenResponsiveModal
       >

--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -5,11 +5,17 @@ import FadeTransition from "../Animation/FadeTransition"
 import { media } from "../Helpers"
 import { CtaProps } from "./ModalCta"
 
+export enum ModalWidth {
+  Narrow = "280px",
+  Normal = "900px",
+  Wide = "440px",
+}
+
 export interface ModalWrapperProps extends React.HTMLProps<ModalWrapper> {
   blurContainerSelector?: string
   cta?: CtaProps
   onClose?: () => void
-  isWide?: boolean
+  width?: ModalWidth
   fullscreenResponsiveModal?: boolean
   image?: string
   show?: boolean
@@ -75,7 +81,7 @@ export class ModalWrapper extends React.Component<
   }
 
   render(): JSX.Element {
-    const { children, isWide, fullscreenResponsiveModal, image } = this.props
+    const { children, width, fullscreenResponsiveModal, image } = this.props
     const { isShown, isAnimating } = this.state
 
     if (isShown) {
@@ -99,7 +105,7 @@ export class ModalWrapper extends React.Component<
           >
             <ModalContainer
               fullscreenResponsiveModal={fullscreenResponsiveModal}
-              isWide={isWide}
+              width={width}
               image={image}
             >
               <ModalInner fullscreenResponsiveModal={fullscreenResponsiveModal}>
@@ -148,7 +154,7 @@ export const ModalOverlay = styled.div`
 `
 
 export const ModalContainer = styled.div.attrs<{
-  isWide?: boolean
+  width: ModalWidth
   fullscreenResponsiveModal?: boolean
   image?: string
 }>({})`
@@ -157,7 +163,7 @@ export const ModalContainer = styled.div.attrs<{
   left: 50%;
   transform: translate(-50%, -50%);
   background: #fff;
-  width: ${props => (props.isWide || props.image ? "900px" : "440px")};
+  width: ${props => (props.image ? ModalWidth.Wide : props.width)};
   height: min-content;
   border-radius: 5px;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);

--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -7,8 +7,8 @@ import { CtaProps } from "./ModalCta"
 
 export enum ModalWidth {
   Narrow = "280px",
-  Normal = "900px",
-  Wide = "440px",
+  Normal = "440px",
+  Wide = "900px",
 }
 
 export interface ModalWrapperProps extends React.HTMLProps<ModalWrapper> {
@@ -154,7 +154,7 @@ export const ModalOverlay = styled.div`
 `
 
 export const ModalContainer = styled.div.attrs<{
-  width: ModalWidth
+  width?: ModalWidth
   fullscreenResponsiveModal?: boolean
   image?: string
 }>({})`
@@ -163,7 +163,13 @@ export const ModalContainer = styled.div.attrs<{
   left: 50%;
   transform: translate(-50%, -50%);
   background: #fff;
-  width: ${props => (props.image ? ModalWidth.Wide : props.width)};
+  width: ${props => {
+    if (props.image) {
+      return ModalWidth.Wide
+    } else {
+      return props.width ? props.width : ModalWidth.Normal
+    }
+  }};
   height: min-content;
   border-radius: 5px;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);

--- a/src/Components/Modal/__tests__/ErrorModal.test.tsx
+++ b/src/Components/Modal/__tests__/ErrorModal.test.tsx
@@ -31,6 +31,19 @@ describe("ErrorModal", () => {
       expect(text).toContain("Continue")
     })
 
+    it("Renders with default text and custom contact email if no other props are specified", () => {
+      const component = getWrapper({
+        ...props,
+        contactEmail: "orders@artsy.net",
+      })
+      const text = component.text()
+      expect(text).toContain("An error occurred")
+      expect(text).toContain(
+        "Something went wrong. Please try again or contact orders@artsy.net."
+      )
+      expect(text).toContain("Continue")
+    })
+
     it("Renders with a specified detailText", () => {
       props.detailText = "A custom error detail."
       const component = getWrapper(props)

--- a/src/Components/__stories__/ErrorModal.story.tsx
+++ b/src/Components/__stories__/ErrorModal.story.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { ErrorModal } from "../Modal/ErrorModal"
+
+storiesOf("Components/Error Modal", module)
+  .add("Default", () => <ErrorModal show />)
+  .add("With custom text", () => (
+    <ErrorModal
+      show
+      headerText="Custom header text goes here"
+      detailText="This is the customized detail text of the error modal, it has details."
+      closeText="Close this error!"
+    />
+  ))

--- a/src/Components/__stories__/ErrorModal.story.tsx
+++ b/src/Components/__stories__/ErrorModal.story.tsx
@@ -4,6 +4,9 @@ import { ErrorModal } from "../Modal/ErrorModal"
 
 storiesOf("Components/Error Modal", module)
   .add("Default", () => <ErrorModal show />)
+  .add("With custom contactEmail", () => (
+    <ErrorModal show contactEmail="ash@artsy.net" />
+  ))
   .add("With custom text", () => (
     <ErrorModal
       show

--- a/src/Styleguide/Components/CountrySelect.tsx
+++ b/src/Styleguide/Components/CountrySelect.tsx
@@ -194,7 +194,7 @@ const COUNTRY_SELECT_OPTIONS = [
   { text: "Reunion", value: "RE" },
   { text: "Romania", value: "RO" },
   { text: "Russian Federation", value: "RU" },
-  { text: "RWANDA", value: "RW" },
+  { text: "Rwanda", value: "RW" },
   { text: "Saint Helena", value: "SH" },
   { text: "Saint Kitts and Nevis", value: "KN" },
   { text: "Saint Lucia", value: "LC" },


### PR DESCRIPTION
This PR is for [PURCHASE-561](https://artsyproduct.atlassian.net/browse/PURCHASE-561) and addresses the following QA items:

- Corrects case of "RWANDA"
- Several copy changes
- Changing email address for Order app errors to orders@artsy.net (in a way that makes ErrorModal still usable from non-Orders components)
- Makes the error modal narrow (changes `isWide` prop of `ModalContainer` to an enum called `width`, let me know what you think)
- Adds some stories to make testing these changes easier

I've kept these in individual commits so that we can cherry-pick some if one change is blocking or something. 