### PR TITLE
Work around a bug where the last page of pagination is not working

### DIFF
--- a/src/Apps/Collect/Components/ArtworkGrid/CollectArtworkGrid.tsx
+++ b/src/Apps/Collect/Components/ArtworkGrid/CollectArtworkGrid.tsx
@@ -106,6 +106,7 @@ class Artworks extends Component<Props, LoadingAreaState> {
                           this.loadNext(filters, mediator)
                         }}
                         scrollTo="#jump--collectArtworkGrid"
+                        displayLast={false}
                       />
                     </Box>
                   </LoadingArea>

--- a/src/Styleguide/Components/Pagination.tsx
+++ b/src/Styleguide/Components/Pagination.tsx
@@ -8,7 +8,10 @@ import { Responsive } from "Utils/Responsive"
 import { Pagination_pageCursors } from "__generated__/Pagination_pageCursors.graphql"
 import { createFragmentContainer, graphql } from "react-relay"
 
+const PAGE_NUMBER_CAP = 100
+
 interface Props {
+  displayLast?: boolean
   onClick?: (cursor: string, page: number) => void
   onNext?: () => void
   pageCursors: Pagination_pageCursors
@@ -18,6 +21,7 @@ interface Props {
 
 export class Pagination extends React.Component<Props> {
   static defaultProps = {
+    displayLast: true,
     onClick: _cursor => ({}),
     onNext: () => ({}),
     scrollTo: null,
@@ -62,6 +66,7 @@ export const LargePagination = (props: Props) => {
     onClick,
     onNext,
     hasNextPage,
+    displayLast,
   } = props
 
   return (
@@ -80,7 +85,9 @@ export const LargePagination = (props: Props) => {
         {last && (
           <div>
             <PageSpan mx={0.5} />
-            {renderPage(last, onClick)}
+            {displayLast
+              ? renderPage(last, onClick)
+              : last.page <= PAGE_NUMBER_CAP && renderPage(last, onClick)}
           </div>
         )}
 

--- a/src/Styleguide/Components/__tests__/Pagination.test.tsx
+++ b/src/Styleguide/Components/__tests__/Pagination.test.tsx
@@ -123,6 +123,46 @@ describe("Pagination", () => {
         expect(html).toContain(`>${page}<`)
       })
     })
+
+    it("does render a link to last page even when displayLast is false but page number does not exceed 100", () => {
+      const wrapper = mount(
+        <MockBoot>
+          <Pagination
+            hasNextPage
+            displayLast={false}
+            pageCursors={cursor}
+            {...callbacks}
+          />
+        </MockBoot>
+      )
+      const html = wrapper.html()
+      const pages = ["1", "...", "6", "7", "8", "9", "...", "20"]
+
+      pages.forEach(page => {
+        expect(html).toContain(`>${page}<`)
+      })
+    })
+
+    it("does not render a link to last page if displayLast is false and page number exceeds 100", () => {
+      const last = { page: 101, cursor: "Y3Vyc29yMw==", isCurrent: false }
+      const wrapper = mount(
+        <MockBoot>
+          <Pagination
+            hasNextPage
+            displayLast={false}
+            pageCursors={{ ...cursor, last }}
+          />
+        </MockBoot>
+      )
+      const html = wrapper.html()
+      const pages = ["1", "...", "6", "7", "8", "9", "..."]
+
+      pages.forEach(page => {
+        expect(html).toContain(`>${page}<`)
+      })
+
+      expect(html).not.toContain(">101<")
+    })
   })
 
   describe("SmallPagination", () => {


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-911

This adds a new `displayLast ` prop to the `Pagination` component so we can hide the link to the last page when it's greater than 100.

## Screenshot

![before-after-pagination](https://user-images.githubusercontent.com/386234/46966388-a2760b00-d07b-11e8-83d0-932b8f4a0bb0.png)

![pagination-less-than-100](https://user-images.githubusercontent.com/386234/46966393-a43fce80-d07b-11e8-88d5-051f49ea31e4.png)
