### PR TITLE
Fixes redirect loop on abandoned orders

### DIFF
--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -48,7 +48,7 @@ describe("OrderApp routing redirects", () => {
     expect(redirect).toBe(undefined)
   })
 
-  it("redirects to the status route if the order is not pending", async () => {
+  it("redirects to the artwork page if the order is abandoned", async () => {
     const { redirect } = await render("/orders/1234/shipping", {
       Order: () => ({
         id: 1234,
@@ -56,9 +56,34 @@ describe("OrderApp routing redirects", () => {
         requestedFulfillment: {
           __typename: "Pickup",
         },
+        lineItems: {
+          edges: [
+            {
+              node: {
+                artwork: {
+                  id: "artwork-id",
+                },
+              },
+            },
+          ],
+        },
       }),
     })
-    expect(redirect.url).toBe("/orders/1234/status")
+    expect(redirect.url).toBe("/artwork/artwork-id")
+  })
+
+  it("redirects to the home page if the order is abandoned and has no ID", async () => {
+    const { redirect } = await render("/orders/1234/shipping", {
+      Order: () => ({
+        id: 1234,
+        state: "ABANDONED",
+        requestedFulfillment: {
+          __typename: "Pickup",
+        },
+        lineItems: null,
+      }),
+    })
+    expect(redirect.url).toBe("/")
   })
 
   it("stays on the shipping route if no shipping option is set", async () => {
@@ -170,7 +195,9 @@ describe("OrderApp", () => {
         addTransitionHook: () => {},
         replace,
       },
-      order: { state: state || "PENDING" },
+      order: {
+        state: state || "PENDING",
+      },
       routeIndices: [],
       routes: [],
     }

--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -48,6 +48,19 @@ describe("OrderApp routing redirects", () => {
     expect(redirect).toBe(undefined)
   })
 
+  it("redirects to the status route if the order is not pending", async () => {
+    const { redirect } = await render("/orders/1234/shipping", {
+      Order: () => ({
+        id: 1234,
+        state: "SUBMITTED",
+        requestedFulfillment: {
+          __typename: "Pickup",
+        },
+      }),
+    })
+    expect(redirect.url).toBe("/orders/1234/status")
+  })
+
   it("redirects to the artwork page if the order is abandoned", async () => {
     const { redirect } = await render("/orders/1234/shipping", {
       Order: () => ({

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -33,6 +33,7 @@ export const shouldRedirect = props => {
 
   if (order && order.state === "ABANDONED") {
     const artworkID = get(order, o => o.lineItems.edges[0].node.artwork.id)
+    // If an artwork ID can't be found, redirect back to home page.
     throw new RedirectException(artworkID ? `/artwork/${artworkID}` : "/")
   } else if (
     order &&

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -1,4 +1,5 @@
 import { Location, RedirectException, RouteConfig, Router } from "found"
+import { get } from "Utils/get"
 import { OrderApp } from "./OrderApp"
 
 const LEAVE_MESSAGING =
@@ -30,7 +31,10 @@ export const confirmRouteExit = (
 export const shouldRedirect = props => {
   const { location, order, params } = props as any
 
-  if (
+  if (order && order.state === "ABANDONED") {
+    const artworkID = get(order, o => o.lineItems.edges[0].node.artwork.id)
+    throw new RedirectException(artworkID ? `/artwork/${artworkID}` : "/")
+  } else if (
     order &&
     order.state !== "PENDING" &&
     !location.pathname.includes("status")

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -43,6 +43,15 @@ export const routes: RouteConfig[] = [
           requestedFulfillment {
             __typename
           }
+          lineItems {
+            edges {
+              node {
+                artwork {
+                  id
+                }
+              }
+            }
+          }
           creditCard {
             id
           }

--- a/src/__generated__/routes_OrderQuery.graphql.ts
+++ b/src/__generated__/routes_OrderQuery.graphql.ts
@@ -13,6 +13,15 @@ export type routes_OrderQueryResponse = {
         readonly requestedFulfillment: ({
             readonly __typename: string;
         }) | null;
+        readonly lineItems: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly artwork: ({
+                        readonly id: string;
+                    }) | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
         readonly creditCard: ({
             readonly id: string;
         }) | null;
@@ -37,6 +46,17 @@ query routes_OrderQuery(
     state
     requestedFulfillment {
       __typename
+    }
+    lineItems {
+      edges {
+        node {
+          artwork {
+            id
+            __id
+          }
+          __id: id
+        }
+      }
     }
     creditCard {
       id
@@ -64,6 +84,23 @@ v1 = {
   "storageKey": null
 },
 v2 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "id",
+    "args": null,
+    "storageKey": null
+  },
+  v1
+],
+v3 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -127,29 +164,58 @@ v2 = [
       {
         "kind": "LinkedField",
         "alias": null,
+        "name": "lineItems",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "OrderLineItemConnection",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "edges",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "OrderLineItemEdge",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "node",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "OrderLineItem",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artwork",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": v2
+                  },
+                  v3
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedField",
+        "alias": null,
         "name": "creditCard",
         "storageKey": null,
         "args": null,
         "concreteType": "CreditCard",
         "plural": false,
-        "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "id",
-            "args": null,
-            "storageKey": null
-          },
-          v1
-        ]
+        "selections": v2
       },
-      {
-        "kind": "ScalarField",
-        "alias": "__id",
-        "name": "id",
-        "args": null,
-        "storageKey": null
-      }
+      v3
     ]
   }
 ];
@@ -158,7 +224,7 @@ return {
   "operationKind": "query",
   "name": "routes_OrderQuery",
   "id": null,
-  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    state\n    requestedFulfillment {\n      __typename\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
+  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    state\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -166,15 +232,15 @@ return {
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": v0,
-    "selections": v2
+    "selections": v4
   },
   "operation": {
     "kind": "Operation",
     "name": "routes_OrderQuery",
     "argumentDefinitions": v0,
-    "selections": v2
+    "selections": v4
   }
 };
 })();
-(node as any).hash = 'a3058d3342922022ac9960c0e813b8d9';
+(node as any).hash = 'a5f42ca394d331b958b93e77a997506d';
 export default node;


### PR DESCRIPTION
This fixes [PURCHASE-516](https://artsyproduct.atlassian.net/browse/PURCHASE-516). If we don't have an artwork ID, we fall back to redirecting to artsy.net. 