### PR TITLE
Show $0.00 dollars if shipping or tax is free

### DIFF
--- a/src/Apps/Order/Components/__stories__/TransactionSummary.story.tsx
+++ b/src/Apps/Order/Components/__stories__/TransactionSummary.story.tsx
@@ -35,7 +35,9 @@ storiesOf("Apps/Order Page/Components", module)
               " $refType": null,
               itemsTotal: "£3,024.89",
               shippingTotal: "£132.32",
+              shippingTotalCents: 13232,
               taxTotal: "£232.23",
+              taxTotalCents: 23223,
               buyerTotal: "£1,200,823.33",
               lineItems: makeLineItem({
                 artistName: "Francesca DiMattio",
@@ -58,7 +60,9 @@ storiesOf("Apps/Order Page/Components", module)
             " $refType": null,
             itemsTotal: "£3,024.89",
             shippingTotal: "£132.32",
+            shippingTotalCents: 13232,
             taxTotal: "£232.23",
+            taxTotalCents: 23223,
             buyerTotal: "£1,200,823.33",
             lineItems: makeLineItem({
               artistName: "Francesca DiMattio and Orta Theroxicus",

--- a/src/Apps/Order/Components/__tests__/TransactionSummary.test.tsx
+++ b/src/Apps/Order/Components/__tests__/TransactionSummary.test.tsx
@@ -1,0 +1,87 @@
+import { render } from "enzyme"
+import React from "react"
+import { TransactionSummary } from "../TransactionSummary"
+
+describe("TransactionSummary", () => {
+  it("shows the shipping and tax price if it's greater than 0", () => {
+    const transactionSummary = render(
+      <TransactionSummary order={transactionSummaryOrder} />
+    )
+
+    const text = transactionSummary.text()
+
+    expect(text).toMatch("Price$200.00")
+    expect(text).toMatch("Shipping$12.00")
+    expect(text).toMatch("Tax$3.25")
+    expect(text).toMatch("Total$215.25")
+  })
+
+  it("shows the shipping and tax price as dashes if null", () => {
+    const transactionSummary = render(
+      <TransactionSummary
+        order={{
+          ...transactionSummaryOrder,
+          taxTotal: null,
+          taxTotalCents: null,
+          shippingTotal: null,
+          shippingTotalCents: null,
+        }}
+      />
+    )
+
+    const text = transactionSummary.text()
+
+    expect(text).toMatch("Price$200.00")
+    expect(text).toMatch("Shipping—")
+    expect(text).toMatch("Tax—")
+    expect(text).toMatch("Total$215.25")
+  })
+
+  it("shows the shipping and tax price as $0.00 if zero cents", () => {
+    const transactionSummary = render(
+      <TransactionSummary
+        order={{
+          ...transactionSummaryOrder,
+          taxTotal: null,
+          taxTotalCents: 0,
+          shippingTotal: null,
+          shippingTotalCents: 0,
+        }}
+      />
+    )
+
+    const text = transactionSummary.text()
+
+    expect(text).toMatch("Price$200.00")
+    expect(text).toMatch("Shipping$0.00")
+    expect(text).toMatch("Tax$0.00")
+    expect(text).toMatch("Total$215.25")
+  })
+})
+
+const transactionSummaryOrder = {
+  shippingTotal: "$12.00",
+  shippingTotalCents: "1200",
+  taxTotal: "$3.25",
+  taxTotalCents: "325",
+  itemsTotal: "$200.00",
+  buyerTotal: "$215.25",
+  seller: { name: "Gagosian Gallery" },
+  lineItems: {
+    edges: [
+      {
+        node: {
+          artwork: {
+            artist_names: "Andy Warhol and Friends",
+            title: "My Artwork",
+            date: "2001",
+            shippingOrigin: "NY, NY",
+            image: {
+              resized_transactionSummary: { url: "https://blah.jpg" },
+            },
+          },
+        },
+      },
+    ],
+  },
+}

--- a/src/__generated__/StatusQuery.graphql.ts
+++ b/src/__generated__/StatusQuery.graphql.ts
@@ -65,7 +65,9 @@ fragment Status_order on Order {
 
 fragment TransactionSummary_order on Order {
   shippingTotal(precision: 2)
+  shippingTotalCents
   taxTotal(precision: 2)
+  taxTotalCents
   itemsTotal(precision: 2)
   buyerTotal(precision: 2)
   seller {
@@ -177,7 +179,28 @@ v1 = {
   "args": null,
   "storageKey": null
 },
-v2 = [
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -185,27 +208,6 @@ v2 = [
     "type": "Int"
   }
 ],
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
 v6 = {
   "kind": "ScalarField",
   "alias": null,
@@ -227,7 +229,7 @@ return {
   "operationKind": "query",
   "name": "StatusQuery",
   "id": null,
-  "text": "query StatusQuery {\n  order(id: \"42\") {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  state\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      __typename\n    }\n    ... on Pickup {\n      __typename\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              __id: id\n            }\n          }\n        }\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  taxTotal(precision: 2)\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query StatusQuery {\n  order(id: \"42\") {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  state\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      __typename\n    }\n    ... on Pickup {\n      __typename\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              __id: id\n            }\n          }\n        }\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -272,11 +274,11 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "itemsTotal",
-            "args": v2,
-            "storageKey": "itemsTotal(precision:2)"
+            "name": "taxTotalCents",
+            "args": null,
+            "storageKey": null
           },
-          v3,
+          v2,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -293,12 +295,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v4,
+              v3,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v5,
+                  v4,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -356,14 +358,21 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "shippingTotal",
-            "args": v2,
+            "args": v5,
             "storageKey": "shippingTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "shippingTotalCents",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "taxTotal",
-            "args": v2,
+            "args": v5,
             "storageKey": "taxTotal(precision:2)"
           },
           {
@@ -376,8 +385,15 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "itemsTotal",
+            "args": v5,
+            "storageKey": "itemsTotal(precision:2)"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "buyerTotal",
-            "args": v2,
+            "args": v5,
             "storageKey": "buyerTotal(precision:2)"
           },
           {
@@ -389,13 +405,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v4,
+              v3,
               v6,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v5
+                  v4
                 ]
               }
             ]
@@ -510,7 +526,7 @@ return {
                             ]
                           },
                           v6,
-                          v3,
+                          v2,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/TransactionSummary_order.graphql.ts
+++ b/src/__generated__/TransactionSummary_order.graphql.ts
@@ -5,7 +5,9 @@ declare const _TransactionSummary_order$ref: unique symbol;
 export type TransactionSummary_order$ref = typeof _TransactionSummary_order$ref;
 export type TransactionSummary_order = {
     readonly shippingTotal: string | null;
+    readonly shippingTotalCents: number | null;
     readonly taxTotal: string | null;
+    readonly taxTotalCents: number | null;
     readonly itemsTotal: string | null;
     readonly buyerTotal: string | null;
     readonly seller: ({
@@ -73,9 +75,23 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
+      "name": "shippingTotalCents",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
       "name": "taxTotal",
       "args": v0,
       "storageKey": "taxTotal(precision:2)"
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "taxTotalCents",
+      "args": null,
+      "storageKey": null
     },
     {
       "kind": "ScalarField",
@@ -230,5 +246,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '660e2fa4c1c289134155a071361ed09c';
+(node as any).hash = '4f991b676af8fbbbe34e0c86f83e398d';
 export default node;

--- a/src/__generated__/routes_PaymentQuery.graphql.ts
+++ b/src/__generated__/routes_PaymentQuery.graphql.ts
@@ -71,7 +71,9 @@ fragment Payment_order on Order {
 
 fragment TransactionSummary_order on Order {
   shippingTotal(precision: 2)
+  shippingTotalCents
   taxTotal(precision: 2)
+  taxTotalCents
   itemsTotal(precision: 2)
   buyerTotal(precision: 2)
   seller {
@@ -133,62 +135,62 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "city",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "country",
-  "args": null,
-  "storageKey": null
-},
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
-v8 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v9 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "precision",
     "value": 2,
     "type": "Int"
   }
-];
+],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "city",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "country",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_PaymentQuery",
   "id": null,
-  "text": "query routes_PaymentQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Payment_order\n    __id: id\n  }\n}\n\nfragment Payment_order on Order {\n  id\n  creditCard {\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postal_code\n    __id\n  }\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on Pickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  taxTotal(precision: 2)\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_PaymentQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Payment_order\n    __id: id\n  }\n}\n\nfragment Payment_order on Order {\n  id\n  creditCard {\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postal_code\n    __id\n  }\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on Pickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -230,50 +232,14 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
-          v3,
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "creditCard",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "CreditCard",
-            "plural": false,
-            "selections": [
-              v4,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "street1",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "street2",
-                "args": null,
-                "storageKey": null
-              },
-              v5,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "state",
-                "args": null,
-                "storageKey": null
-              },
-              v6,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "postal_code",
-                "args": null,
-                "storageKey": null
-              },
-              v7
-            ]
+            "name": "taxTotal",
+            "args": v3,
+            "storageKey": "taxTotal(precision:2)"
           },
+          v4,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -283,7 +249,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v8,
+              v5,
               {
                 "kind": "InlineFragment",
                 "type": "Pickup",
@@ -301,7 +267,7 @@ return {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v4,
+                  v6,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -316,7 +282,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v5,
+                  v7,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -324,7 +290,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v6,
+                  v8,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -372,8 +338,8 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v3,
-                          v7,
+                          v4,
+                          v9,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -451,28 +417,78 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "shippingTotal",
-            "args": v9,
+            "args": v3,
             "storageKey": "shippingTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "taxTotal",
-            "args": v9,
-            "storageKey": "taxTotal(precision:2)"
+            "name": "shippingTotalCents",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCard",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CreditCard",
+            "plural": false,
+            "selections": [
+              v6,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "street1",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "street2",
+                "args": null,
+                "storageKey": null
+              },
+              v7,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "state",
+                "args": null,
+                "storageKey": null
+              },
+              v8,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "postal_code",
+                "args": null,
+                "storageKey": null
+              },
+              v9
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "taxTotalCents",
+            "args": null,
+            "storageKey": null
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v9,
+            "args": v3,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "buyerTotal",
-            "args": v9,
+            "args": v3,
             "storageKey": "buyerTotal(precision:2)"
           },
           {
@@ -484,13 +500,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v8,
-              v7,
+              v5,
+              v9,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v4
+                  v6
                 ]
               }
             ]

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -72,7 +72,9 @@ fragment ItemReview_artwork on Artwork {
 
 fragment TransactionSummary_order on Order {
   shippingTotal(precision: 2)
+  shippingTotalCents
   taxTotal(precision: 2)
+  taxTotalCents
   itemsTotal(precision: 2)
   buyerTotal(precision: 2)
   seller {
@@ -171,35 +173,35 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = {
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "precision",
+    "value": 2,
+    "type": "Int"
+  }
+],
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v6 = [
   {
     "kind": "ScalarField",
     "alias": null,
     "name": "url",
     "args": null,
     "storageKey": null
-  }
-],
-v6 = [
-  {
-    "kind": "Literal",
-    "name": "precision",
-    "value": 2,
-    "type": "Int"
   }
 ],
 v7 = {
@@ -221,7 +223,7 @@ return {
   "operationKind": "query",
   "name": "routes_ReviewQuery",
   "id": null,
-  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          artists {\n            id\n            __id\n          }\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  taxTotal(precision: 2)\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query routes_ReviewQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Review_order\n    __id: id\n  }\n}\n\nfragment Review_order on Order {\n  id\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          artists {\n            id\n            __id\n          }\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentReview_order\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -263,7 +265,42 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
-          v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "itemsTotal",
+            "args": v3,
+            "storageKey": "itemsTotal(precision:2)"
+          },
+          v4,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingTotal",
+            "args": v3,
+            "storageKey": "shippingTotal(precision:2)"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingTotalCents",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "taxTotal",
+            "args": v3,
+            "storageKey": "taxTotal(precision:2)"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "taxTotalCents",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -307,7 +344,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -338,8 +375,8 @@ return {
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v3,
-                              v4
+                              v4,
+                              v5
                             ]
                           },
                           {
@@ -409,7 +446,7 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v5
+                                "selections": v6
                               },
                               {
                                 "kind": "LinkedField",
@@ -426,11 +463,11 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v5
+                                "selections": v6
                               }
                             ]
                           },
-                          v4,
+                          v5,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -450,29 +487,8 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "shippingTotal",
-            "args": v6,
-            "storageKey": "shippingTotal(precision:2)"
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "taxTotal",
-            "args": v6,
-            "storageKey": "taxTotal(precision:2)"
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "itemsTotal",
-            "args": v6,
-            "storageKey": "itemsTotal(precision:2)"
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "buyerTotal",
-            "args": v6,
+            "args": v3,
             "storageKey": "buyerTotal(precision:2)"
           },
           {
@@ -485,7 +501,7 @@ return {
             "plural": false,
             "selections": [
               v7,
-              v4,
+              v5,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
@@ -601,7 +617,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v4
+              v5
             ]
           }
         ]

--- a/src/__generated__/routes_ShippingQuery.graphql.ts
+++ b/src/__generated__/routes_ShippingQuery.graphql.ts
@@ -62,7 +62,9 @@ fragment Shipping_order on Order {
 
 fragment TransactionSummary_order on Order {
   shippingTotal(precision: 2)
+  shippingTotalCents
   taxTotal(precision: 2)
+  taxTotalCents
   itemsTotal(precision: 2)
   buyerTotal(precision: 2)
   seller {
@@ -124,48 +126,48 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
-v7 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "precision",
     "value": 2,
     "type": "Int"
   }
-];
+],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_ShippingQuery",
   "id": null,
-  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  state\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          shipsToContinentalUSOnly\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  taxTotal(precision: 2)\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_ShippingQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on Order {\n  id\n  state\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          shipsToContinentalUSOnly\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionSummary_order\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -207,14 +209,14 @@ return {
         "concreteType": "Order",
         "plural": false,
         "selections": [
-          v3,
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "state",
-            "args": null,
-            "storageKey": null
+            "name": "taxTotal",
+            "args": v3,
+            "storageKey": "taxTotal(precision:2)"
           },
+          v4,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -224,12 +226,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v4,
+              v5,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v5,
+                  v6,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -319,7 +321,7 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v3,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -334,7 +336,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v6,
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -412,28 +414,42 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "shippingTotal",
-            "args": v7,
+            "args": v3,
             "storageKey": "shippingTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "taxTotal",
-            "args": v7,
-            "storageKey": "taxTotal(precision:2)"
+            "name": "shippingTotalCents",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "state",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "taxTotalCents",
+            "args": null,
+            "storageKey": null
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v7,
+            "args": v3,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "buyerTotal",
-            "args": v7,
+            "args": v3,
             "storageKey": "buyerTotal(precision:2)"
           },
           {
@@ -445,13 +461,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v4,
-              v6,
+              v5,
+              v7,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v5
+                  v6
                 ]
               }
             ]

--- a/src/__generated__/routes_StatusQuery.graphql.ts
+++ b/src/__generated__/routes_StatusQuery.graphql.ts
@@ -69,7 +69,9 @@ fragment Status_order on Order {
 
 fragment TransactionSummary_order on Order {
   shippingTotal(precision: 2)
+  shippingTotalCents
   taxTotal(precision: 2)
+  taxTotalCents
   itemsTotal(precision: 2)
   buyerTotal(precision: 2)
   seller {
@@ -189,7 +191,28 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = [
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v6 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -197,27 +220,6 @@ v3 = [
     "type": "Int"
   }
 ],
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
 v7 = {
   "kind": "ScalarField",
   "alias": null,
@@ -239,7 +241,7 @@ return {
   "operationKind": "query",
   "name": "routes_StatusQuery",
   "id": null,
-  "text": "query routes_StatusQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  state\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      __typename\n    }\n    ... on Pickup {\n      __typename\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              __id: id\n            }\n          }\n        }\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  taxTotal(precision: 2)\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query routes_StatusQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on Order {\n  id\n  code\n  state\n  requestedFulfillment {\n    __typename\n    ... on Ship {\n      __typename\n    }\n    ... on Pickup {\n      __typename\n    }\n  }\n  ...TransactionSummary_order\n  ...ShippingAndPaymentSummary_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              __id: id\n            }\n          }\n        }\n        artwork {\n          id\n          ...ItemReview_artwork\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionSummary_order on Order {\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_transactionSummary: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_artwork on Artwork {\n  artist_names\n  title\n  date\n  medium\n  dimensions {\n    in\n    cm\n  }\n  attribution_class {\n    short_description\n  }\n  image {\n    resized(width: 185) {\n      url\n    }\n  }\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -284,11 +286,11 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "itemsTotal",
-            "args": v3,
-            "storageKey": "itemsTotal(precision:2)"
+            "name": "taxTotalCents",
+            "args": null,
+            "storageKey": null
           },
-          v4,
+          v3,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -305,12 +307,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v5,
+              v4,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v6,
+                  v5,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -368,14 +370,21 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "shippingTotal",
-            "args": v3,
+            "args": v6,
             "storageKey": "shippingTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "shippingTotalCents",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "taxTotal",
-            "args": v3,
+            "args": v6,
             "storageKey": "taxTotal(precision:2)"
           },
           {
@@ -388,8 +397,15 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "itemsTotal",
+            "args": v6,
+            "storageKey": "itemsTotal(precision:2)"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "buyerTotal",
-            "args": v3,
+            "args": v6,
             "storageKey": "buyerTotal(precision:2)"
           },
           {
@@ -401,13 +417,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v5,
+              v4,
               v7,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v6
+                  v5
                 ]
               }
             ]
@@ -522,7 +538,7 @@ return {
                             ]
                           },
                           v7,
-                          v4,
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,


### PR DESCRIPTION
I intend to revisit https://github.com/artsy/metaphysics/pull/1325 or come up with a more sustainable solution, but since we need this for launch tomorrow and I don't have time to do a full audit of our client apps, here's a solution that shows `$0.00` for the checkout flow (noticed we're doing a similar thing [in volt](https://github.com/artsy/volt/blob/aac5561a065c6e581c4ff644892d0b2c55071fd7/app/javascript/components/order_page/Amounts/index.jsx#L5) right now too).