### PR TITLE
[FIX padding] Accomodate environment padding

### DIFF
--- a/src/Styleguide/Components/ReadMore.tsx
+++ b/src/Styleguide/Components/ReadMore.tsx
@@ -124,6 +124,8 @@ const Container = styled.div.attrs<ReadMoreState>({})`
 
   > span > * {
     margin-block-start: 0;
+    margin-block-end: 0;
+    padding-bottom: 1em;
   }
 
   > span > *:last-child {


### PR DESCRIPTION
Noticed that line breaks were being eaten by force's CSS reset. Not sure how to solve in a wider way ATM, but we need to keep this in mind when stitching components. 