### PR TITLE
[FIX bnmo] Updates to Billing Address Behavior

### DIFF
--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -33,7 +33,7 @@ export const emptyAddress: Address = Object.freeze({
 })
 export interface AddressFormProps {
   onChange: AddressChangeHandler
-  defaultValue?: Partial<Address>
+  value?: Partial<Address>
   billing?: boolean
   continentalUsOnly?: boolean
   errors?: AddressErrors
@@ -50,7 +50,7 @@ export class AddressForm extends React.Component<
   state = {
     address: {
       ...emptyAddress,
-      ...this.props.defaultValue,
+      ...this.props.value,
     },
   }
 
@@ -81,7 +81,7 @@ export class AddressForm extends React.Component<
             title="Full name"
             autoCapitalize="words"
             autoCorrect="off"
-            defaultValue={this.props.defaultValue.name}
+            value={this.props.value.name}
             onChange={this.changeEventHandler("name")}
             error={this.props.errors && this.props.errors.name}
             block
@@ -115,7 +115,7 @@ export class AddressForm extends React.Component<
               title="Postal code"
               autoCapitalize="characters"
               autoCorrect="off"
-              defaultValue={this.props.defaultValue.postalCode}
+              value={this.props.value.postalCode}
               onChange={this.changeEventHandler("postalCode")}
               error={this.props.errors && this.props.errors.postalCode}
               block
@@ -129,7 +129,7 @@ export class AddressForm extends React.Component<
               placeholder="Add street address"
               title="Address line 1"
               autoCapitalize="words"
-              defaultValue={this.props.defaultValue.addressLine1}
+              value={this.props.value.addressLine1}
               onChange={this.changeEventHandler("addressLine1")}
               error={this.props.errors && this.props.errors.addressLine1}
               block
@@ -142,7 +142,7 @@ export class AddressForm extends React.Component<
               placeholder="Add apt, floor, suite, etc."
               title="Address line 2 (optional)"
               autoCapitalize="words"
-              defaultValue={this.props.defaultValue.addressLine2}
+              value={this.props.value.addressLine2}
               onChange={this.changeEventHandler("addressLine2")}
               block
             />
@@ -155,7 +155,7 @@ export class AddressForm extends React.Component<
               placeholder="Add city"
               title="City"
               autoCapitalize="words"
-              defaultValue={this.props.defaultValue.city}
+              value={this.props.value.city}
               onChange={this.changeEventHandler("city")}
               error={this.props.errors && this.props.errors.city}
               block
@@ -168,7 +168,7 @@ export class AddressForm extends React.Component<
               title="State, province, or region"
               autoCapitalize="words"
               autoCorrect="off"
-              defaultValue={this.props.defaultValue.region}
+              value={this.props.value.region}
               onChange={this.changeEventHandler("region")}
               error={this.props.errors && this.props.errors.region}
               block
@@ -184,7 +184,7 @@ export class AddressForm extends React.Component<
                 description="Required for shipping logistics"
                 placeholder="Add phone"
                 pattern="[0-9]*"
-                defaultValue={this.props.defaultValue.phoneNumber}
+                value={this.props.value.phoneNumber}
                 onChange={this.changeEventHandler("phoneNumber")}
                 error={this.props.errors && this.props.errors.phoneNumber}
                 block

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -65,24 +65,9 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
   }
 
   startingAddress(): Address {
-    const { creditCard } = this.props.order
-
-    if (creditCard) {
-      return {
-        ...emptyAddress,
-        name: creditCard.name,
-        country: creditCard.country,
-        postalCode: creditCard.postal_code,
-        addressLine1: creditCard.street1,
-        addressLine2: creditCard.street2,
-        city: creditCard.city,
-        region: creditCard.state,
-      }
-    } else {
-      return {
-        ...emptyAddress,
-        country: "US",
-      }
+    return {
+      ...emptyAddress,
+      country: "US",
     }
   }
 
@@ -127,6 +112,15 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
   }
 
   handleChangeHideBillingAddress = (hideBillingAddress: boolean) => {
+    if (!hideBillingAddress) {
+      this.setState({
+        address: {
+          ...emptyAddress,
+          country: "US",
+        },
+      })
+    }
+
     this.setState({ hideBillingAddress })
   }
 
@@ -202,7 +196,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
                       )}
                       <Collapse open={this.needsAddress()}>
                         <AddressForm
-                          defaultValue={address}
+                          value={address}
                           errors={addressErrors}
                           onChange={this.onAddressChange}
                           billing

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -305,7 +305,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                       }
                     >
                       <AddressForm
-                        defaultValue={address}
+                        value={address}
                         errors={addressErrors}
                         onChange={this.onAddressChange}
                         continentalUsOnly={artwork.shipsToContinentalUSOnly}

--- a/src/Apps/Order/Routes/__tests__/Payment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.test.tsx
@@ -7,7 +7,7 @@ import {
   PickupOrder,
   UntouchedOrder,
 } from "Apps/__test__/Fixtures/Order"
-import { Input } from "../../../../Components/Input"
+import { Input, InputProps } from "../../../../Components/Input"
 import { Collapse } from "../../../../Styleguide/Components"
 import { CreditCardInput } from "../../Components/CreditCardInput"
 import {
@@ -86,7 +86,30 @@ describe("Payment", () => {
     expect(paymentRoute.find(Collapse).props().open).toBe(true)
   })
 
-  it("pre-populates with available details when returning to the payment route", () => {
+  it.only("removes all data when the billing address form is hidden", () => {
+    const paymentRoute = mount(<PaymentRoute {...testProps} />)
+    // expand address form
+    paymentRoute.find(Checkbox).simulate("click")
+
+    const nameInput = paymentRoute
+      .find(Input)
+      .filterWhere(wrapper => wrapper.props().title === "Full name")
+      .find("input")
+    nameInput.instance().value = "Dr Collector"
+    nameInput.simulate("change")
+    expect(nameInput.instance().value).toEqual("Dr Collector")
+
+    // hide address form
+    paymentRoute.find(Checkbox).simulate("click")
+
+    // expand address form again
+    paymentRoute.find(Checkbox).simulate("click")
+
+    // expect name to be empty
+    expect(nameInput.instance().value).toEqual("")
+  })
+
+  it("does not pre-populate with available details when returning to the payment route", () => {
     const paymentRoute = mount(
       <PaymentRoute
         {...testProps}
@@ -106,14 +129,14 @@ describe("Payment", () => {
       />
     )
 
-    expect(paymentRoute.find(AddressForm).props().defaultValue).toEqual({
-      name: "Artsy UK Ltd",
-      addressLine1: "14 Gower's Walk",
-      addressLine2: "Suite 2.5, The Loom",
-      city: "London",
-      region: "Whitechapel",
-      postalCode: "E1 8PY",
-      country: "UK",
+    expect(paymentRoute.find(AddressForm).props().value).toEqual({
+      name: "",
+      addressLine1: "",
+      addressLine2: "",
+      city: "",
+      region: "",
+      postalCode: "",
+      country: "US",
       phoneNumber: "",
     })
   })

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -243,7 +243,7 @@ describe("Shipping", () => {
           wrapper => (wrapper.props() as InputProps).title === "Full name"
         )
 
-      expect((input.props() as InputProps).defaultValue).toBe(
+      expect((input.props() as InputProps).value).toBe(
         testProps.order.requestedFulfillment.name
       )
     })

--- a/src/DevTools/renderRelayTree.tsx
+++ b/src/DevTools/renderRelayTree.tsx
@@ -7,14 +7,14 @@ import { renderUntil, RenderUntilCallback } from "./renderUntil"
  * Renders a tree of Relay containers with a mocked local instance of the
  * metaphysics schema and resolves the returned promise once loading data and
  * rendering (including waterfall requests) has finished.
- * 
+ *
  * It does this by checking the tree for the existence of an element with the
  * class defined by `LoadingClassName` from the `renderWithLoadProgress` module.
  * I.e. as long as at least 1 element exists in the tree with that class name,
  * rendering is not considered finished. Use the `renderWithLoadProgress`
  * function for your `QueryRenderer` where possible, as it will do this plumbing
  * by default.
- * 
+ *
  * @note
  * Use this function in tests, but not storybooks. For storybooks you should
  * usually use {@link MockRelayRenderer}.
@@ -25,7 +25,7 @@ import { renderUntil, RenderUntilCallback } from "./renderUntil"
  * @param until
  * An optional callback that is used to test wether rendering should be
  * considered finished. This is a regular enzyme wrapper.
- * 
+ *
  * @param wrapper
  * An optional component that the Relay tree should be nested in. Use this to
  * e.g. setup any context provider components etc.
@@ -34,7 +34,7 @@ import { renderUntil, RenderUntilCallback } from "./renderUntil"
  *
    ```tsx
    jest.unmock("react-relay")
- 
+
    const Artwork = createFragmentContainer(
      props => (
        <div>


### PR DESCRIPTION
This PR updates our billing address form in the following ways:
- Never populate it from existing data (since we're always clearing your payment details, it was weird to pre-populate your billing info).
- Clicking hide/show billing address clears the form

![clear-billing](https://user-images.githubusercontent.com/2081340/46979965-1f67ab80-d0a1-11e8-8f38-c0a0fcb088c6.gif)
