### PR TITLE
Adds mediator to OrderApp storybooks

### DIFF
--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -14,6 +14,11 @@ const Router = props => (
     routes={orderRoutes}
     mockResolvers={mockResolver()}
     historyOptions={{ useBeforeUnload: true }}
+    context={{
+      mediator: {
+        trigger: x => x,
+      },
+    }}
     {...props}
   />
 )


### PR DESCRIPTION
We're currently unable to open the storybooks for the order app since they now require `mediator` to be present in the context. 

Note that the `ShippingAndPaymentSummary` storybook is still broken, but for a different reason that will take some more investigation.