### PR TITLE
Use scroll management for found

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "formik": "^0.11.11",
     "found": "^0.3.14",
     "found-relay": "^0.3.1",
+    "found-scroll": "^0.1.5",
     "history": "^4.6.1",
     "isomorphic-fetch": "^2.2.1",
     "jsonp": "^0.2.1",

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -6,6 +6,7 @@ import HashProtocol from "farce/lib/HashProtocol"
 import MemoryProtocol from "farce/lib/MemoryProtocol"
 import queryMiddleware from "farce/lib/queryMiddleware"
 import { Resolver } from "found-relay"
+import { ScrollManager } from "found-scroll"
 import createInitialFarceRouter from "found/lib/createInitialFarceRouter"
 import createRender from "found/lib/createRender"
 import { loadComponents } from "loadable-components"
@@ -58,7 +59,11 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         historyOptions: history.options,
         routeConfig: routes,
         resolver,
-        render,
+        render: renderArgs => (
+          <ScrollManager renderArgs={renderArgs}>
+            {render(renderArgs)}
+          </ScrollManager>
+        ),
       })
 
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6377,7 +6377,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-farce@^0.2.6:
+farce@^0.2.1, farce@^0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/farce/-/farce-0.2.6.tgz#3d307fae9eac46a148fd5535dee2dfbcf653ba83"
   integrity sha1-PTB/rp6sRqFI/VU13uLfvPZTuoM=
@@ -6760,6 +6760,15 @@ found-relay@^0.3.1:
     prop-types "^15.6.2"
     prop-types-extra "^1.1.0"
     warning "^4.0.2"
+
+found-scroll@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/found-scroll/-/found-scroll-0.1.5.tgz#23b6a127dde05572c573b71048798a5eaea35add"
+  integrity sha1-I7ahJ93gVXLFc7cQSHmKXq6jWt0=
+  dependencies:
+    farce "^0.2.1"
+    prop-types "^15.6.0"
+    scroll-behavior "^0.9.3"
 
 found@^0.3.14:
   version "0.3.14"
@@ -13599,6 +13608,14 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+scroll-behavior@^0.9.3:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.9.tgz#ebfe0658455b82ad885b66195215416674dacce2"
+  integrity sha1-6/4GWEVbgq2IW2YZUhVBZnTazOI=
+  dependencies:
+    dom-helpers "^3.2.1"
+    invariant "^2.2.2"
 
 semantic-release-cli@^4.0.1:
   version "4.0.3"


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-572

This PR fixes a general problem with our `found` (router) setup. It was not preserving browser behaviour regarding scroll position when navigating between pages. Luckily someone made this `found-scroll` package which is a drop-in decorator providing the correct behaviour. I had a little play around in the order app and it seems to work perfectly.

I tried to calculate what impact it has on bundle size, but webpack keeps running out of memory when I try to build force right now. I'm guessing it's < 1kb judging from the look of the code but could be wrong.