### PR TITLE
Storybook fix

### DIFF
--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -54,91 +54,80 @@ const orderQuery = graphql`
 
 storiesOf("Apps/Order Page/Components", module).add(
   "ShippingAndPaymentSummary",
-  () => {
-    return (
-      <React.Fragment>
-        <Section title="Shipping and Payment Summary">
-          <h4>Delivery</h4>
-          <Flex flexDirection="column" width={300}>
-            <MockRelayRenderer
-              Component={ShippingAndPaymentSummary}
-              mockResolvers={{ Order: () => order }}
-              query={orderQuery}
-            />
-          </Flex>
-          <h4>Pickup</h4>
-          <Flex flexDirection="column" width={300}>
-            <MockRelayRenderer
-              Component={ShippingAndPaymentSummary}
-              mockResolvers={{
-                Order: () => ({
-                  ...order,
-                  requestedFulfillment: {
-                    __typename: "Pickup",
-                  },
-                }),
-              }}
-              query={orderQuery}
-            />
-          </Flex>
-        </Section>
-        <Section title="Shipping and Payment Review">
-          <h4>Delivery</h4>
-          <Flex flexDirection="column" width={300}>
-            <MockRelayRenderer
-              Component={(props: any) => (
-                <ShippingAndPaymentReview
-                  onChangePayment={() => alert("clicked")}
-                  onChangeShipping={() => alert("clicked")}
-                  {...props}
-                />
-              )}
-              mockResolvers={{
-                Order: () => order,
-              }}
-              query={orderQuery}
-            />
-          </Flex>
-          <h4>Pickup</h4>
-          <Flex flexDirection="column" width={300}>
-            <MockRelayRenderer
-              Component={(props: any) => (
-                <ShippingAndPaymentReview
-                  onChangePayment={() => alert("clicked")}
-                  onChangeShipping={() => alert("clicked")}
-                  {...props}
-                />
-              )}
-              mockResolvers={{
-                Order: () => ({
-                  ...order,
-                  requestedFulfillment: {
-                    __typename: "Pickup",
-                  },
-                }),
-              }}
-              query={orderQuery}
-            />
-          </Flex>
-        </Section>
-        <Section title="Credit card details">
-          <Flex flexDirection="column" width={300} mb={2}>
-            <CreditCardDetails {...order.creditCard} brand="Visa" />
-          </Flex>
-          <Flex flexDirection="column" width={300} mb={2}>
-            <CreditCardDetails {...order.creditCard} brand="Mastercard" />
-          </Flex>
-          <Flex flexDirection="column" width={300} mb={2}>
-            <CreditCardDetails {...order.creditCard} brand="Discover" />
-          </Flex>
-          <Flex flexDirection="column" width={300} mb={2}>
-            <CreditCardDetails {...order.creditCard} brand="American Express" />
-          </Flex>
-          <Flex flexDirection="column" width={300}>
-            <CreditCardDetails {...order.creditCard} brand="unknown" />
-          </Flex>
-        </Section>
-      </React.Fragment>
-    )
-  }
+  () => (
+    <>
+      <Section title="Shipping and Payment Summary">
+        <h4>Delivery</h4>
+        <Flex flexDirection="column" width={300}>
+          <MockRelayRenderer
+            Component={ShippingAndPaymentSummary}
+            mockResolvers={{
+              Order: (...anything) => {
+                console.log("HEY!!!", anything)
+                return order
+              },
+            }}
+            query={orderQuery}
+          />
+        </Flex>
+      </Section>
+
+      <Section title="Shipping and Payment Review">
+        <h4>Delivery</h4>
+        <Flex flexDirection="column" width={300}>
+          <MockRelayRenderer
+            Component={(props: any) => (
+              <ShippingAndPaymentReview
+                onChangePayment={() => alert("clicked")}
+                onChangeShipping={() => alert("clicked")}
+                {...props}
+              />
+            )}
+            mockResolvers={{
+              Order: () => order,
+            }}
+            query={orderQuery}
+          />
+        </Flex>
+        <h4>Pickup</h4>
+        <Flex flexDirection="column" width={300}>
+          <MockRelayRenderer
+            Component={(props: any) => (
+              <ShippingAndPaymentReview
+                onChangePayment={() => alert("clicked")}
+                onChangeShipping={() => alert("clicked")}
+                {...props}
+              />
+            )}
+            mockResolvers={{
+              Order: () => ({
+                ...order,
+                requestedFulfillment: {
+                  __typename: "Pickup",
+                },
+              }),
+            }}
+            query={orderQuery}
+          />
+        </Flex>
+      </Section>
+      <Section title="Credit card details">
+        <Flex flexDirection="column" width={300} mb={2}>
+          <CreditCardDetails {...order.creditCard} brand="Visa" />
+        </Flex>
+        <Flex flexDirection="column" width={300} mb={2}>
+          <CreditCardDetails {...order.creditCard} brand="Mastercard" />
+        </Flex>
+        <Flex flexDirection="column" width={300} mb={2}>
+          <CreditCardDetails {...order.creditCard} brand="Discover" />
+        </Flex>
+        <Flex flexDirection="column" width={300} mb={2}>
+          <CreditCardDetails {...order.creditCard} brand="American Express" />
+        </Flex>
+        <Flex flexDirection="column" width={300}>
+          <CreditCardDetails {...order.creditCard} brand="unknown" />
+        </Flex>
+      </Section>
+    </>
+  )
 )

--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -45,7 +45,7 @@ const order: ShippingAndPaymentReview_order &
 
 const orderQuery = graphql`
   query ShippingAndPaymentDetailsQuery {
-    ecommerceOrder(id: "foo") {
+    order: ecommerceOrder(id: "foo") {
       ...ShippingAndPaymentSummary_order
       ...ShippingAndPaymentReview_order
     }

--- a/src/__generated__/ShippingAndPaymentDetailsQuery.graphql.ts
+++ b/src/__generated__/ShippingAndPaymentDetailsQuery.graphql.ts
@@ -5,7 +5,7 @@ import { ShippingAndPaymentReview_order$ref } from "./ShippingAndPaymentReview_o
 import { ShippingAndPaymentSummary_order$ref } from "./ShippingAndPaymentSummary_order.graphql";
 export type ShippingAndPaymentDetailsQueryVariables = {};
 export type ShippingAndPaymentDetailsQueryResponse = {
-    readonly ecommerceOrder: ({
+    readonly order: ({
         readonly " $fragmentRefs": ShippingAndPaymentSummary_order$ref & ShippingAndPaymentReview_order$ref;
     }) | null;
 };
@@ -18,7 +18,7 @@ export type ShippingAndPaymentDetailsQuery = {
 
 /*
 query ShippingAndPaymentDetailsQuery {
-  ecommerceOrder(id: "foo") {
+  order: ecommerceOrder(id: "foo") {
     ...ShippingAndPaymentSummary_order
     ...ShippingAndPaymentReview_order
     __id: id
@@ -118,7 +118,7 @@ return {
   "operationKind": "query",
   "name": "ShippingAndPaymentDetailsQuery",
   "id": null,
-  "text": "query ShippingAndPaymentDetailsQuery {\n  ecommerceOrder(id: \"foo\") {\n    ...ShippingAndPaymentSummary_order\n    ...ShippingAndPaymentReview_order\n    __id: id\n  }\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query ShippingAndPaymentDetailsQuery {\n  order: ecommerceOrder(id: \"foo\") {\n    ...ShippingAndPaymentSummary_order\n    ...ShippingAndPaymentReview_order\n    __id: id\n  }\n}\n\nfragment ShippingAndPaymentSummary_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAndPaymentReview_order on Order {\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -129,7 +129,7 @@ return {
     "selections": [
       {
         "kind": "LinkedField",
-        "alias": null,
+        "alias": "order",
         "name": "ecommerceOrder",
         "storageKey": "ecommerceOrder(id:\"foo\")",
         "args": v0,
@@ -158,7 +158,7 @@ return {
     "selections": [
       {
         "kind": "LinkedField",
-        "alias": null,
+        "alias": "order",
         "name": "ecommerceOrder",
         "storageKey": "ecommerceOrder(id:\"foo\")",
         "args": v0,
@@ -352,5 +352,5 @@ return {
   }
 };
 })();
-(node as any).hash = '4b970acf593539de047184f756ccb82c';
+(node as any).hash = '12d0982905e17e0658cff7975cc336af';
 export default node;


### PR DESCRIPTION
This PR fixes the `ShippingAndPaymentSummary` story and switches to new `<></>` fragment syntax.

The problem with the storybook was that the query we were feeding in was requesting (and getting back from the mock network layer) an `Order` labelled `ecommerceOrder`, not `order` [as we do in the actual query](https://github.com/artsy/reaction/blob/dc6c47f1927c2f961aa73b09dbff5c24c2ffc64d/src/Apps/Order/routes.tsx#L42). 