### PR TITLE
add h1 tag to title for SEO

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -93,7 +93,7 @@ export class CollectionHeader extends Component<Props> {
                       </SubtitlesContainer>
                       <Spacer mt={1} />
                       <Title size={xs ? "6" : "10"} color="white100">
-                        {collection.title}
+                        <h1>{collection.title}</h1>
                       </Title>
                     </MetaContainer>
                   </Background>


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-964 

Wraps the title in an `h1` tag.