### PR TITLE
adding specs for sidebar metadata

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarMetadata.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarMetadata.tsx
@@ -1,6 +1,7 @@
 import { Box, Serif } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { get } from "Utils/get"
 import { ArtworkSidebarClassificationFragmentContainer as Classification } from "./ArtworkSidebarClassification"
 import { ArtworkSidebarSizeInfoFragmentContainer as SizeInfo } from "./ArtworkSidebarSizeInfo"
 import { ArtworkSidebarTitleInfoFragmentContainer as TitleInfo } from "./ArtworkSidebarTitleInfo"
@@ -16,15 +17,17 @@ export class ArtworkSidebarMetadata extends React.Component<
 > {
   render() {
     const { artwork } = this.props
+    const lotLabel = get(
+      artwork,
+      a => a.is_biddable && a.sale_artwork.lot_label
+    )
     return (
       <Box>
-        {artwork.is_biddable &&
-          artwork.sale_artwork &&
-          artwork.sale_artwork.lot_label && (
-            <Serif size="2" weight="semibold" color="black100">
-              Lot {artwork.sale_artwork.lot_label}
-            </Serif>
-          )}
+        {lotLabel && (
+          <Serif size="2" weight="semibold" color="black100">
+            Lot {lotLabel}
+          </Serif>
+        )}
         <TitleInfo artwork={artwork} />
         {artwork.edition_sets.length < 2 && <SizeInfo piece={artwork} />}
         <Classification artwork={artwork} />

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarMetadata.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarMetadata.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@artsy/palette"
+import { Box, Serif } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkSidebarClassificationFragmentContainer as Classification } from "./ArtworkSidebarClassification"
@@ -18,6 +18,13 @@ export class ArtworkSidebarMetadata extends React.Component<
     const { artwork } = this.props
     return (
       <Box>
+        {artwork.is_biddable &&
+          artwork.sale_artwork &&
+          artwork.sale_artwork.lot_label && (
+            <Serif size="2" weight="semibold" color="black100">
+              Lot {artwork.sale_artwork.lot_label}
+            </Serif>
+          )}
         <TitleInfo artwork={artwork} />
         {artwork.edition_sets.length < 2 && <SizeInfo piece={artwork} />}
         <Classification artwork={artwork} />
@@ -30,8 +37,12 @@ export const ArtworkSidebarMetadataFragmentContainer = createFragmentContainer(
   ArtworkSidebarMetadata,
   graphql`
     fragment ArtworkSidebarMetadata_artwork on Artwork {
+      is_biddable
       edition_sets {
         __id
+      }
+      sale_artwork {
+        lot_label
       }
       ...ArtworkSidebarTitleInfo_artwork
       ...ArtworkSidebarSizeInfo_piece

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarSizeInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarSizeInfo.tsx
@@ -15,6 +15,12 @@ export class ArtworkSidebarSizeInfo extends React.Component<
     const {
       piece: { dimensions, edition_of },
     } = this.props
+    if (
+      !(edition_of && edition_of.length) &&
+      !(dimensions && (dimensions.in || dimensions.cm))
+    ) {
+      return null
+    }
     return (
       <Box color="black60">
         <Serif size="2">

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarTitleInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarTitleInfo.tsx
@@ -16,9 +16,7 @@ export class ArtworkSidebarTitleInfo extends React.Component<
     return (
       <Box color="black60">
         <Serif size="2">
-          <Serif size="2" display="inline-block" italic>
-            {artwork.title}
-          </Serif>
+          <i>{artwork.title}</i>
           {artwork.date &&
             artwork.date.replace(/\s+/g, "").length > 0 &&
             ", " + artwork.date}

--- a/src/Apps/Artwork/Components/ArtworkSidebar/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Separator, Serif, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { ContextConsumer } from "Artsy/Router"
 import React, { Component } from "react"
@@ -28,14 +28,6 @@ export class ArtworkSidebar extends Component<ArtworkSidebarProps> {
       <ArtworkSidebarContainer>
         <Artists artwork={artwork} />
         <Spacer mb={2} />
-
-        {artwork.is_biddable &&
-          artwork.sale_artwork &&
-          artwork.sale_artwork.lot_label && (
-            <Serif size="2" weight="semibold" color="black100">
-              Lot {artwork.sale_artwork.lot_label}
-            </Serif>
-          )}
         <Metadata artwork={artwork} />
         <Spacer mb={2} />
 
@@ -65,14 +57,7 @@ export const ArtworkSidebarFragmentContainer = createFragmentContainer(
   ArtworkSidebar,
   graphql`
     fragment ArtworkSidebar_artwork on Artwork {
-      is_biddable
       is_in_auction
-      sale_artwork {
-        lot_label
-      }
-      sale {
-        is_closed
-      }
       ...ArtworkSidebarArtists_artwork
       ...ArtworkSidebarMetadata_artwork
       ...ArtworkSidebarAuctionPartnerInfo_artwork

--- a/src/Apps/Artwork/Components/__stories__/ArtworkSidebar/ArtworkSidebarMetadata.story.tsx
+++ b/src/Apps/Artwork/Components/__stories__/ArtworkSidebar/ArtworkSidebarMetadata.story.tsx
@@ -5,6 +5,7 @@ import {
   FilledOutMetadataMultipleEditionSets,
   FilledOutMetadataNoEditions,
   FilledOutMetadataOneEditionSet,
+  MetadataForAuctionWork,
 } from "Apps/__test__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata"
 import { ArtworkSidebarMetadata as Metadata } from "Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarMetadata"
 import { RelayStubProvider } from "DevTools/RelayStubProvider"
@@ -34,6 +35,9 @@ storiesOf("Styleguide/Artwork/Sidebar", module)
         </Section>
         <Section title="Empty metadata multiple edition sets">
           <Metadata artwork={EmptyMetadataMultipleEditionSets as any} />
+        </Section>
+        <Section title="Artwork in an auction">
+          <Metadata artwork={MetadataForAuctionWork as any} />
         </Section>
       </React.Fragment>
     )

--- a/src/Apps/Artwork/Components/__stories__/ArtworkSidebarLive.story.tsx
+++ b/src/Apps/Artwork/Components/__stories__/ArtworkSidebarLive.story.tsx
@@ -43,6 +43,9 @@ storiesOf("Styleguide/Artwork", module)
         <Section title="Multiple editions nick-brandt-rangers-line-of-with-tusks-of-killed-elephants-amboseli-2011">
           <ArtworkSidebarQueryRenderer artworkID="nick-brandt-rangers-line-of-with-tusks-of-killed-elephants-amboseli-2011" />
         </Section>
+        <Section title="Artwork with cultural maker american-18th-century-lady-wearing-a-large-white-cap">
+          <ArtworkSidebarQueryRenderer artworkID="american-18th-century-lady-wearing-a-large-white-cap" />
+        </Section>
       </React.Fragment>
     )
   })

--- a/src/Apps/Artwork/Components/__tests__/ArtworkDetails.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkDetails.test.tsx
@@ -47,9 +47,9 @@ describe("ArtworkDetails", () => {
     })
 
     it("displays partner Initials when profile is present but icon is not", async () => {
-      const data = cloneDeep(ArtworkDetailsFixture)
-      data.partner.profile.icon = null
-      const wrapper = await getWrapper(data)
+      const noIconProfile = cloneDeep(ArtworkDetailsFixture)
+      noIconProfile.partner.profile.icon = null
+      const wrapper = await getWrapper(noIconProfile)
       expect(wrapper.find("img").length).toBe(0)
       expect(wrapper.html()).toContain("S9")
     })
@@ -62,10 +62,10 @@ describe("ArtworkDetails", () => {
     })
 
     it("does not display avatar when profile is not available and no initials for partner", async () => {
-      const data = cloneDeep(ArtworkDetailsFixture)
-      data.partner.profile = null
-      data.partner.initials = null
-      const wrapper = await getWrapper(data)
+      const noIconNoInitials = cloneDeep(ArtworkDetailsFixture)
+      noIconNoInitials.partner.profile = null
+      noIconNoInitials.partner.initials = null
+      const wrapper = await getWrapper(noIconNoInitials)
       expect(wrapper.find("img").length).toBe(0)
       // This checks that Avatar div is not rendered.
       expect(wrapper.find("EntityHeader").children.length).toBe(1)

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebar.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebar.test.tsx
@@ -2,6 +2,7 @@ import { graphql } from "react-relay"
 import { renderRelayTree } from "../../../../DevTools"
 import { ArtworkSidebarFixture } from "../../../__test__/Fixtures/Artwork/ArtworkSidebar"
 import { ArtworkSidebarArtists } from "../ArtworkSidebar/ArtworkSidebarArtists"
+import { ArtworkSidebarMetadata } from "../ArtworkSidebar/ArtworkSidebarMetadata"
 import { ArtworkSidebarFragmentContainer } from "../ArtworkSidebar/index"
 
 jest.unmock("react-relay")
@@ -22,24 +23,12 @@ describe("ArtworkSidebar", () => {
       },
     })
   }
-
-  describe("ArtworkSidebarArtists", () => {
-    it("rentdes ArtworkSidebarArtists component", async () => {
-      const wrapper = await getWrapper()
-      expect(wrapper.find(ArtworkSidebarArtists).length).toBe(1)
-    })
-    it("displays artist name properly", async () => {
-      const wrapper = await getWrapper()
-      expect(wrapper.html()).toContain("Josef Albers")
-      expect(
-        wrapper.find({
-          href: "/artist/josef-albers",
-        }).length
-      ).toBe(1)
-    })
-    it("renders artist follow button properly", async () => {
-      const wrapper = await getWrapper()
-      expect(wrapper.html()).toContain("Follow")
-    })
+  it("renders ArtworkSidebarArtists component", async () => {
+    const wrapper = await getWrapper()
+    expect(wrapper.find(ArtworkSidebarArtists).length).toBe(1)
+  })
+  it("renders Metadata component", async () => {
+    const wrapper = await getWrapper()
+    expect(wrapper.find(ArtworkSidebarMetadata).length).toBe(1)
   })
 })

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarArtists.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarArtists.test.tsx
@@ -62,5 +62,10 @@ describe("ArtworkSidebarArtists", () => {
       const wrapper = await getWrapper(MultipleArtists)
       expect(wrapper.html()).not.toContain("Follow")
     })
+    it("separates artist names by comma", async () => {
+      const wrapper = await getWrapper(MultipleArtists)
+      // 2 artists are separared by 1 ,
+      expect(wrapper.html().match(", ").length).toBe(1)
+    })
   })
 })

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarArtists.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarArtists.test.tsx
@@ -1,5 +1,6 @@
 import { cloneDeep } from "lodash"
 import { graphql } from "react-relay"
+import { FollowArtistButton } from "../../../../../Components/FollowButton/FollowArtistButton"
 import { renderRelayTree } from "../../../../../DevTools"
 import {
   MultipleArtists,
@@ -11,6 +12,8 @@ jest.unmock("react-relay")
 
 describe("ArtworkSidebarArtists", () => {
   const data = null
+  let wrapper = null
+
   const getWrapper = async (response = SingleFollowedArtist) => {
     return await renderRelayTree({
       Component: ArtworkSidebarArtistsFragmentContainer,
@@ -26,25 +29,28 @@ describe("ArtworkSidebarArtists", () => {
       },
     })
   }
+
   describe("ArtworkSidebarArtists with one artist", () => {
-    it("displays artist name for single artist", async () => {
-      const wrapper = await getWrapper()
-      expect(wrapper.html()).toContain("Josef Albers")
-      expect(
-        wrapper.find({
-          href: "/artist/josef-albers",
-        }).length
-      ).toBe(1)
+    beforeAll(async () => {
+      wrapper = await getWrapper()
     })
-    it("renders artist follow button for single artist", async () => {
-      const wrapper = await getWrapper()
+
+    it("displays artist name for single artist", () => {
+      expect(wrapper.html()).toContain("Josef Albers")
+      expect(wrapper.find({ href: "/artist/josef-albers" }).length).toBe(1)
+    })
+
+    it("renders artist follow button for single artist", () => {
       expect(wrapper.html()).toContain("Follow")
     })
   })
 
   describe("ArtworkSidebarArtists with multiple artists", () => {
-    it("displays artist names for multiople artists", async () => {
-      const wrapper = await getWrapper(MultipleArtists)
+    beforeAll(async () => {
+      wrapper = await getWrapper(MultipleArtists)
+    })
+
+    it("displays artist names for multiople artists", () => {
       expect(wrapper.html()).toContain("Josef Albers")
       expect(
         wrapper.find({
@@ -58,14 +64,14 @@ describe("ArtworkSidebarArtists", () => {
         }).length
       ).toBe(1)
     })
-    it("does not display follow buttons", async () => {
-      const wrapper = await getWrapper(MultipleArtists)
+
+    it("does not render follow buttons", () => {
+      expect(wrapper.find(FollowArtistButton).length).toBe(0)
       expect(wrapper.html()).not.toContain("Follow")
     })
-    it("separates artist names by comma", async () => {
-      const wrapper = await getWrapper(MultipleArtists)
-      // 2 artists are separared by 1 ,
-      expect(wrapper.html().match(", ").length).toBe(1)
+
+    it("separates artist names by comma", () => {
+      expect(wrapper.text()).toBe("Josef Albers, Ed Ruscha")
     })
   })
 })

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarMetadata.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarMetadata.test.tsx
@@ -16,6 +16,8 @@ jest.unmock("react-relay")
 
 describe("ArtworkSidebarMetadata", () => {
   const data = null
+  let wrapper = null
+
   const getWrapper = async (response = FilledOutMetadataNoEditions) => {
     return await renderRelayTree({
       Component: ArtworkSidebarMetadataFragmentContainer,
@@ -31,75 +33,85 @@ describe("ArtworkSidebarMetadata", () => {
       },
     })
   }
+
   describe("for non editioned artwork", () => {
-    it("displays title and year", async () => {
-      const wrapper = await getWrapper()
+    beforeAll(async () => {
+      wrapper = await getWrapper()
+    })
+
+    it("displays title and year", () => {
       expect(wrapper.html()).toContain("<i>Easel (Vydock)</i>, 1995")
     })
-    it("displays medium", async () => {
-      const wrapper = await getWrapper()
+
+    it("displays medium", () => {
       expect(wrapper.html()).toContain(
         "Acrylic and graphite on bonded aluminium"
       )
     })
-    it("displays dimentions", async () => {
-      const wrapper = await getWrapper()
+
+    it("displays dimentions", () => {
       expect(wrapper.html()).toContain("97 × 15 in; 246.4 × 38.1 cm")
     })
-    it("displays classification", async () => {
-      const wrapper = await getWrapper()
+
+    it("displays classification", () => {
       expect(wrapper.html()).toContain("This is a unique work")
     })
   })
 
   describe("for artwork with one edition", () => {
-    it("displays title and year", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+    beforeAll(async () => {
+      wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+    })
+
+    it("displays title and year", () => {
       expect(wrapper.html()).toContain("<i>Sun Keyed</i>, 1972")
     })
-    it("displays medium", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+
+    it("displays medium", () => {
       expect(wrapper.html()).toContain("Serigraph")
     })
-    it("displays edition dimentions", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+
+    it("displays edition dimentions", () => {
       expect(wrapper.html()).toContain("14 × 18 in; 35.6 × 45.7 cm")
     })
-    it("displays edition details", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+
+    it("displays edition details", () => {
       expect(wrapper.html()).toContain("Edition of 3000")
     })
-    it("displays classification", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+
+    it("displays classification", () => {
       expect(wrapper.html()).toContain("This is part of a limited edition set")
     })
   })
 
   describe("for artwork with multiple editions", () => {
-    it("displays title and year", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+    beforeAll(async () => {
+      wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+    })
+
+    it("displays title and year", () => {
       expect(wrapper.html()).toContain("<i>Abstract 36742</i>, 2018")
     })
-    it("displays medium", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+
+    it("displays medium", () => {
       expect(wrapper.html()).toContain("Premium high gloss archival print")
     })
-    it("does not render edition dimentions or details", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+
+    it("does not render edition dimentions or details", () => {
       expect(wrapper.find(ArtworkSidebarSizeInfo).length).toBe(0)
       const html = wrapper.html()
       expect(html).not.toContain("40 × 42 in; cm: 101.6 × 106.7 cm")
       expect(html).not.toContain("Edition of 3000")
     })
-    it("displays classification", async () => {
-      const wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+
+    it("displays classification", () => {
       expect(wrapper.html()).toContain("This is part of a limited edition set")
     })
   })
 
   describe("for artwork with minimal metadata", () => {
     it("only displays title info", async () => {
-      const wrapper = await getWrapper(EmptyMetadataNoEditions)
+      wrapper = await getWrapper(EmptyMetadataNoEditions)
       const html = wrapper.html()
       expect(html).toContain("<i>Empty metadata / No editions</i>")
       expect(html).not.toContain("<i>Empty metadata / No editions<i>,")
@@ -109,34 +121,36 @@ describe("ArtworkSidebarMetadata", () => {
   })
 
   describe("for artwork in an auction", () => {
-    it("displays lot number when present for biddable works", async () => {
-      const wrapper = await getWrapper(MetadataForAuctionWork)
+    beforeAll(async () => {
+      wrapper = await getWrapper(MetadataForAuctionWork)
+    })
+
+    it("displays lot number when present for biddable works", () => {
       expect(wrapper.html()).toContain("Lot 210")
     })
 
     it("does not display lot number when present if work is not biddable(auction closed)", async () => {
       const closedAuctionArtwork = cloneDeep(MetadataForAuctionWork)
       closedAuctionArtwork.is_biddable = false
-      const wrapper = await getWrapper(closedAuctionArtwork)
+      wrapper = await getWrapper(closedAuctionArtwork)
       expect(wrapper.html()).not.toContain("Lot 210")
     })
 
-    it("displays title and year", async () => {
-      const wrapper = await getWrapper(MetadataForAuctionWork)
+    it("displays title and year", () => {
       expect(wrapper.html()).toContain(
         '<i>Then the boy displayed to the Dervish his bosom, saying: "Look at my breasts which be goodlier than the breasts of maidens and my lipdews are sweeter than sugar candy...", from Four Tales from the Arabian Nights</i>, 1948'
       )
     })
-    it("displays medium", async () => {
-      const wrapper = await getWrapper(MetadataForAuctionWork)
+
+    it("displays medium", () => {
       expect(wrapper.html()).toContain("Lithograph in colors, on laid paper")
     })
-    it("displays edition dimentions", async () => {
-      const wrapper = await getWrapper(MetadataForAuctionWork)
+
+    it("displays edition dimentions", () => {
       expect(wrapper.html()).toContain("17 × 13 in; 43.2 × 33 cm")
     })
-    it("displays classification", async () => {
-      const wrapper = await getWrapper(MetadataForAuctionWork)
+
+    it("displays classification", () => {
       expect(wrapper.html()).toContain("This is part of a limited edition set")
     })
   })

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarMetadata.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarMetadata.test.tsx
@@ -1,0 +1,143 @@
+import { cloneDeep } from "lodash"
+import { graphql } from "react-relay"
+import { renderRelayTree } from "../../../../../DevTools"
+import {
+  EmptyMetadataNoEditions,
+  FilledOutMetadataMultipleEditionSets,
+  FilledOutMetadataNoEditions,
+  FilledOutMetadataOneEditionSet,
+  MetadataForAuctionWork,
+} from "../../../../__test__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata"
+import { ArtworkSidebarClassification } from "../../ArtworkSidebar/ArtworkSidebarClassification"
+import { ArtworkSidebarMetadataFragmentContainer } from "../../ArtworkSidebar/ArtworkSidebarMetadata"
+import { ArtworkSidebarSizeInfo } from "../../ArtworkSidebar/ArtworkSidebarSizeInfo"
+
+jest.unmock("react-relay")
+
+describe("ArtworkSidebarMetadata", () => {
+  const data = null
+  const getWrapper = async (response = FilledOutMetadataNoEditions) => {
+    return await renderRelayTree({
+      Component: ArtworkSidebarMetadataFragmentContainer,
+      query: graphql`
+        query ArtworkSidebarMetadata_Test_Query {
+          artwork(id: "josef-albers-homage-to-the-square-85") {
+            ...ArtworkSidebarMetadata_artwork
+          }
+        }
+      `,
+      mockResolvers: {
+        Artwork: () => response,
+      },
+    })
+  }
+  describe("for non editioned artwork", () => {
+    it("displays title and year", async () => {
+      const wrapper = await getWrapper()
+      expect(wrapper.html()).toContain("<i>Easel (Vydock)</i>, 1995")
+    })
+    it("displays medium", async () => {
+      const wrapper = await getWrapper()
+      expect(wrapper.html()).toContain(
+        "Acrylic and graphite on bonded aluminium"
+      )
+    })
+    it("displays dimentions", async () => {
+      const wrapper = await getWrapper()
+      expect(wrapper.html()).toContain("97 × 15 in; 246.4 × 38.1 cm")
+    })
+    it("displays classification", async () => {
+      const wrapper = await getWrapper()
+      expect(wrapper.html()).toContain("This is a unique work")
+    })
+  })
+
+  describe("for artwork with one edition", () => {
+    it("displays title and year", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+      expect(wrapper.html()).toContain("<i>Sun Keyed</i>, 1972")
+    })
+    it("displays medium", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+      expect(wrapper.html()).toContain("Serigraph")
+    })
+    it("displays edition dimentions", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+      expect(wrapper.html()).toContain("14 × 18 in; 35.6 × 45.7 cm")
+    })
+    it("displays edition details", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+      expect(wrapper.html()).toContain("Edition of 3000")
+    })
+    it("displays classification", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
+      expect(wrapper.html()).toContain("This is part of a limited edition set")
+    })
+  })
+
+  describe("for artwork with multiple editions", () => {
+    it("displays title and year", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+      expect(wrapper.html()).toContain("<i>Abstract 36742</i>, 2018")
+    })
+    it("displays medium", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+      expect(wrapper.html()).toContain("Premium high gloss archival print")
+    })
+    it("does not render edition dimentions or details", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+      expect(wrapper.find(ArtworkSidebarSizeInfo).length).toBe(0)
+      const html = wrapper.html()
+      expect(html).not.toContain("40 × 42 in; cm: 101.6 × 106.7 cm")
+      expect(html).not.toContain("Edition of 3000")
+    })
+    it("displays classification", async () => {
+      const wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
+      expect(wrapper.html()).toContain("This is part of a limited edition set")
+    })
+  })
+
+  describe("for artwork with minimal metadata", () => {
+    it("only displays title info", async () => {
+      const wrapper = await getWrapper(EmptyMetadataNoEditions)
+      const html = wrapper.html()
+      expect(html).toContain("<i>Empty metadata / No editions</i>")
+      expect(html).not.toContain("<i>Empty metadata / No editions<i>,")
+      expect(wrapper.find(ArtworkSidebarSizeInfo).html()).toBe(null)
+      expect(wrapper.find(ArtworkSidebarClassification).html()).toBe(null)
+    })
+  })
+
+  describe("for artwork in an auction", () => {
+    it("displays lot number when present for biddable works", async () => {
+      const wrapper = await getWrapper(MetadataForAuctionWork)
+      expect(wrapper.html()).toContain("Lot 210")
+    })
+
+    it("does not display lot number when present if work is not biddable(auction closed)", async () => {
+      const closedAuctionArtwork = cloneDeep(MetadataForAuctionWork)
+      closedAuctionArtwork.is_biddable = false
+      const wrapper = await getWrapper(closedAuctionArtwork)
+      expect(wrapper.html()).not.toContain("Lot 210")
+    })
+
+    it("displays title and year", async () => {
+      const wrapper = await getWrapper(MetadataForAuctionWork)
+      expect(wrapper.html()).toContain(
+        '<i>Then the boy displayed to the Dervish his bosom, saying: "Look at my breasts which be goodlier than the breasts of maidens and my lipdews are sweeter than sugar candy...", from Four Tales from the Arabian Nights</i>, 1948'
+      )
+    })
+    it("displays medium", async () => {
+      const wrapper = await getWrapper(MetadataForAuctionWork)
+      expect(wrapper.html()).toContain("Lithograph in colors, on laid paper")
+    })
+    it("displays edition dimentions", async () => {
+      const wrapper = await getWrapper(MetadataForAuctionWork)
+      expect(wrapper.html()).toContain("17 × 13 in; 43.2 × 33 cm")
+    })
+    it("displays classification", async () => {
+      const wrapper = await getWrapper(MetadataForAuctionWork)
+      expect(wrapper.html()).toContain("This is part of a limited edition set")
+    })
+  })
+})

--- a/src/Apps/__test__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata.ts
+++ b/src/Apps/__test__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata.ts
@@ -1,50 +1,73 @@
 export const FilledOutMetadataNoEditions = {
   __id: "filled_out_metadata_no_editions",
-  title: "Full metadata / No editions",
-  date: "2016-2017",
-  medium:
-    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
+  is_biddable: false,
+  sale_artwork: null,
+  title: "Easel (Vydock)",
+  date: "1995",
+  medium: "Acrylic and graphite on bonded aluminium",
+  edition_sets: [],
   dimensions: {
-    in: "48 2/5 in diameter",
-    cm: "123 cm diameter",
+    in: "97 × 15 in",
+    cm: "246.4 × 38.1 cm",
   },
   edition_of: null,
   attribution_class: {
-    short_description: "This is a made-to-order piece",
+    short_description: "This is a unique work",
   },
-  edition_sets: [],
 }
 
 export const FilledOutMetadataOneEditionSet = {
-  __id: "filled_out_metadata_one_editions_set",
-  title: "Full metadata / One Edition Set",
-  date: "2016-2017",
-  medium:
-    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
-  dimensions: { in: "4 3/10 × 8 7/10 × 13 in", cm: "11 × 22 × 33 cm" },
-  edition_of: "Edition of 21",
-  attribution_class: { short_description: "This is a made-to-order piece" },
-  edition_sets: [{ __id: "5b1ffd455405ff0020d933bb" }],
+  __id: "filled_out_metadata_one_editions_set:richard-anuszkiewicz-sun-keyed",
+  is_biddable: false,
+  sale_artwork: null,
+  title: "Sun Keyed",
+  date: "1972",
+  medium: "Serigraph",
+  edition_sets: [
+    {
+      __id: "RWRpdGlvblNldDo1NzIzYTIzNTEzOWIyMTEyNzEwMDAzNzY=",
+      dimensions: { in: "14 × 18 in", cm: "35.6 × 45.7 cm" },
+      edition_of: "Edition of 3000",
+    },
+  ],
+  dimensions: { in: "14 × 18 in", cm: "35.6 × 45.7 cm" },
+  edition_of: "Edition of 3000",
+  attribution_class: {
+    short_description: "This is part of a limited edition set",
+  },
 }
 
 export const FilledOutMetadataMultipleEditionSets = {
-  __id: "filled_out_metadata_multiple_editions",
-  title: "Full metadata / Multiple edition sets",
-  date: "2016-2017",
-  medium:
-    "Hand selected materials to print this piece were sourced from the old villages on magic lands",
-  dimensions: { in: "22 × 33 × 11 in", cm: "55.9 × 83.8 × 27.9 cm" },
-  edition_of: null,
-  attribution_class: { short_description: "This is a made-to-order piece" },
+  __id: "filled_out_multiple_edition_set:kim-keever-abstract-36742",
+  is_biddable: false,
+  sale_artwork: null,
+  title: "Abstract 36742",
+  date: "2018",
+  medium: "Premium high gloss archival print",
   edition_sets: [
-    { __id: "5b1ffd455405ff0020d933bb" },
-    { __id: "5b1ffdb20923cc00205152d3" },
+    {
+      __id: "RWRpdGlvblNldDo1YjIyOWFkNmE2Y2E2ZDEzNjkxOWZkZTY=",
+      dimensions: { in: "24 × 26 in", cm: "61 × 66 cm" },
+      edition_of: "",
+    },
+    {
+      __id: "RWRpdGlvblNldDo1YjIyOWFkNjViMmZiYTE3NmZjOTliZmU=",
+      dimensions: { in: "40 × 42 in", cm: "101.6 × 106.7 cm" },
+      edition_of: "Edition of 3000",
+    },
   ],
+  dimensions: { in: "40 × 42 in", cm: "101.6 × 106.7 cm" },
+  edition_of: "Edition of 3000",
+  attribution_class: {
+    short_description: "This is part of a limited edition set",
+  },
 }
 
 export const EmptyMetadataNoEditions = {
   __id: "empty_metadata_no_editions",
   title: "Empty metadata / No editions",
+  is_biddable: false,
+  sale_artwork: null,
   date: " ",
   medium: "",
   dimensions: { in: null, cm: null },
@@ -56,6 +79,8 @@ export const EmptyMetadataNoEditions = {
 export const EmptyMetadataOneEditionSet = {
   __id: "empty_metadata_one_edition",
   title: "Empty metadata / One edition set",
+  is_biddable: false,
+  sale_artwork: null,
   date: " ",
   medium: "",
   dimensions: { in: null, cm: null },
@@ -67,6 +92,8 @@ export const EmptyMetadataOneEditionSet = {
 export const EmptyMetadataMultipleEditionSets = {
   __id: "empty_metadata_multple_editions",
   title: "Empty metadata / Multiple edition Sets",
+  is_biddable: false,
+  sale_artwork: null,
   date: " ",
   medium: "",
   dimensions: { in: null, cm: null },
@@ -76,4 +103,21 @@ export const EmptyMetadataMultipleEditionSets = {
     { __id: "5b1ffd455405ff0020d933bb" },
     { __id: "5b1ffdb20923cc00205152d3" },
   ],
+}
+
+export const MetadataForAuctionWork = {
+  __id:
+    "metadata_for_auction_work:marc-chagall-then-the-boy-displayed-to-the-dervish-his-bosom-saying-look-at-my-breasts-which-be-goodlier-than-the-breasts-of-maidens-and-my-lipdews-are-sweeter-than-sugar-candy-dot-dot-dot-from-four-tales-from-the-arabian-nights",
+  is_biddable: true,
+  sale_artwork: { lot_label: "210" },
+  title:
+    'Then the boy displayed to the Dervish his bosom, saying: "Look at my breasts which be goodlier than the breasts of maidens and my lipdews are sweeter than sugar candy...", from Four Tales from the Arabian Nights',
+  date: "1948",
+  medium: "Lithograph in colors, on laid paper",
+  edition_sets: [],
+  dimensions: { in: "17 × 13 in", cm: "43.2 × 33 cm" },
+  edition_of: null,
+  attribution_class: {
+    short_description: "This is part of a limited edition set",
+  },
 }

--- a/src/__generated__/ArtworkSidebarMetadata_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebarMetadata_Test_Query.graphql.ts
@@ -1,0 +1,250 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { ArtworkSidebarMetadata_artwork$ref } from "./ArtworkSidebarMetadata_artwork.graphql";
+export type ArtworkSidebarMetadata_Test_QueryVariables = {};
+export type ArtworkSidebarMetadata_Test_QueryResponse = {
+    readonly artwork: ({
+        readonly " $fragmentRefs": ArtworkSidebarMetadata_artwork$ref;
+    }) | null;
+};
+export type ArtworkSidebarMetadata_Test_Query = {
+    readonly response: ArtworkSidebarMetadata_Test_QueryResponse;
+    readonly variables: ArtworkSidebarMetadata_Test_QueryVariables;
+};
+
+
+
+/*
+query ArtworkSidebarMetadata_Test_Query {
+  artwork(id: "josef-albers-homage-to-the-square-85") {
+    ...ArtworkSidebarMetadata_artwork
+    __id
+  }
+}
+
+fragment ArtworkSidebarMetadata_artwork on Artwork {
+  is_biddable
+  edition_sets {
+    __id
+  }
+  sale_artwork {
+    lot_label
+    __id
+  }
+  ...ArtworkSidebarTitleInfo_artwork
+  ...ArtworkSidebarSizeInfo_piece
+  ...ArtworkSidebarClassification_artwork
+  __id
+}
+
+fragment ArtworkSidebarTitleInfo_artwork on Artwork {
+  title
+  date
+  medium
+  __id
+}
+
+fragment ArtworkSidebarSizeInfo_piece on Sellable {
+  dimensions {
+    in
+    cm
+  }
+  edition_of
+  ... on Node {
+    __id
+  }
+  ... on EditionSet {
+    __id
+  }
+}
+
+fragment ArtworkSidebarClassification_artwork on Artwork {
+  attribution_class {
+    short_description
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "josef-albers-homage-to-the-square-85",
+    "type": "String!"
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "ArtworkSidebarMetadata_Test_Query",
+  "id": null,
+  "text": "query ArtworkSidebarMetadata_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebarMetadata_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtworkSidebarMetadata_Test_Query",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artwork",
+        "storageKey": "artwork(id:\"josef-albers-homage-to-the-square-85\")",
+        "args": v0,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtworkSidebarMetadata_artwork",
+            "args": null
+          },
+          v1
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtworkSidebarMetadata_Test_Query",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artwork",
+        "storageKey": "artwork(id:\"josef-albers-homage-to-the-square-85\")",
+        "args": v0,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "medium",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "is_biddable",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "sale_artwork",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "SaleArtwork",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "lot_label",
+                "args": null,
+                "storageKey": null
+              },
+              v1
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "date",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "edition_sets",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "EditionSet",
+            "plural": true,
+            "selections": [
+              v1
+            ]
+          },
+          v1,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "dimensions",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "dimensions",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "in",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "cm",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "edition_of",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "attribution_class",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "short_description",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'cb586082eb43a241dfa26a3ee0d38bc7';
+export default node;

--- a/src/__generated__/ArtworkSidebarMetadata_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarMetadata_artwork.graphql.ts
@@ -7,9 +7,13 @@ import { ArtworkSidebarTitleInfo_artwork$ref } from "./ArtworkSidebarTitleInfo_a
 declare const _ArtworkSidebarMetadata_artwork$ref: unique symbol;
 export type ArtworkSidebarMetadata_artwork$ref = typeof _ArtworkSidebarMetadata_artwork$ref;
 export type ArtworkSidebarMetadata_artwork = {
+    readonly is_biddable: boolean | null;
     readonly edition_sets: ReadonlyArray<({
         readonly __id: string;
     }) | null> | null;
+    readonly sale_artwork: ({
+        readonly lot_label: string | null;
+    }) | null;
     readonly " $fragmentRefs": ArtworkSidebarTitleInfo_artwork$ref & ArtworkSidebarSizeInfo_piece$ref & ArtworkSidebarClassification_artwork$ref;
     readonly " $refType": ArtworkSidebarMetadata_artwork$ref;
 };
@@ -32,6 +36,13 @@ return {
   "argumentDefinitions": [],
   "selections": [
     {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_biddable",
+      "args": null,
+      "storageKey": null
+    },
+    {
       "kind": "LinkedField",
       "alias": null,
       "name": "edition_sets",
@@ -40,6 +51,25 @@ return {
       "concreteType": "EditionSet",
       "plural": true,
       "selections": [
+        v0
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "sale_artwork",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "SaleArtwork",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "lot_label",
+          "args": null,
+          "storageKey": null
+        },
         v0
       ]
     },
@@ -62,5 +92,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'b989f89262b9a42e30332c3a0244dd8a';
+(node as any).hash = '04f48094f4aca61848838f497c242421';
 export default node;

--- a/src/__generated__/ArtworkSidebarQuery.graphql.ts
+++ b/src/__generated__/ArtworkSidebarQuery.graphql.ts
@@ -28,16 +28,7 @@ query ArtworkSidebarQuery(
 }
 
 fragment ArtworkSidebar_artwork on Artwork {
-  is_biddable
   is_in_auction
-  sale_artwork {
-    lot_label
-    __id
-  }
-  sale {
-    is_closed
-    __id
-  }
   ...ArtworkSidebarArtists_artwork
   ...ArtworkSidebarMetadata_artwork
   ...ArtworkSidebarAuctionPartnerInfo_artwork
@@ -61,7 +52,12 @@ fragment ArtworkSidebarArtists_artwork on Artwork {
 }
 
 fragment ArtworkSidebarMetadata_artwork on Artwork {
+  is_biddable
   edition_sets {
+    __id
+  }
+  sale_artwork {
+    lot_label
     __id
   }
   ...ArtworkSidebarTitleInfo_artwork
@@ -247,6 +243,13 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "edition_of",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "dimensions",
@@ -271,7 +274,7 @@ v3 = {
     }
   ]
 },
-v4 = [
+v5 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -280,24 +283,17 @@ v4 = [
     "storageKey": null
   }
 ],
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "href",
-  "args": null,
-  "storageKey": null
-},
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "edition_of",
+  "name": "href",
   "args": null,
   "storageKey": null
 };
@@ -306,7 +302,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkSidebarQuery",
   "id": null,
-  "text": "query ArtworkSidebarQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkSidebar_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_biddable\n  is_in_auction\n  sale_artwork {\n    lot_label\n    __id\n  }\n  sale {\n    is_closed\n    __id\n  }\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  edition_sets {\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  collecting_institution\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  __id\n  is_in_auction\n  is_for_sale\n  artists {\n    __id\n    is_consignable\n  }\n  sale {\n    is_closed\n    __id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query ArtworkSidebarQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkSidebar_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  collecting_institution\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  __id\n  is_in_auction\n  is_for_sale\n  artists {\n    __id\n    is_consignable\n  }\n  sale {\n    is_closed\n    __id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -352,9 +348,31 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "is_in_auction",
+            "args": null,
+            "storageKey": null
+          },
+          v2,
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "is_biddable",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "edition_sets",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "EditionSet",
+            "plural": true,
+            "selections": [
+              v2,
+              v4,
+              v3
+            ]
           },
           {
             "kind": "LinkedField",
@@ -409,7 +427,7 @@ return {
                 "args": null,
                 "concreteType": "SaleArtworkCurrentBid",
                 "plural": false,
-                "selections": v4
+                "selections": v5
               },
               {
                 "kind": "LinkedField",
@@ -437,7 +455,140 @@ return {
                 "args": null,
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
-                "selections": v4
+                "selections": v5
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "date",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "medium",
+            "args": null,
+            "storageKey": null
+          },
+          v4,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artists",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              v2,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              },
+              v6,
+              v7,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_followed",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "follows",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_consignable",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "collecting_institution",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "attribution_class",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "short_description",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              v2,
+              v6,
+              v7,
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "locations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Location",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "city",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v2
+                ]
               }
             ]
           },
@@ -453,7 +604,7 @@ return {
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_closed",
+                "name": "is_with_buyers_premium",
                 "args": null,
                 "storageKey": null
               },
@@ -461,14 +612,14 @@ return {
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_with_buyers_premium",
+                "name": "is_open",
                 "args": null,
                 "storageKey": null
               },
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_open",
+                "name": "is_closed",
                 "args": null,
                 "storageKey": null
               },
@@ -517,161 +668,6 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "artists",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Artist",
-            "plural": true,
-            "selections": [
-              v2,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "id",
-                "args": null,
-                "storageKey": null
-              },
-              v5,
-              v6,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_followed",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "counts",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtistCounts",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "follows",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_consignable",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          v2,
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "edition_sets",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "EditionSet",
-            "plural": true,
-            "selections": [
-              v2,
-              v3,
-              v7
-            ]
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "medium",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "is_in_auction",
-            "args": null,
-            "storageKey": null
-          },
-          v7,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "collecting_institution",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "attribution_class",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "AttributionClass",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "short_description",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "partner",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Partner",
-            "plural": false,
-            "selections": [
-              v2,
-              v5,
-              v6,
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "locations",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Location",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "city",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  v2
-                ]
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
             "name": "myLotStanding",
             "storageKey": "myLotStanding(live:true)",
             "args": [
@@ -709,7 +705,7 @@ return {
                     "args": null,
                     "concreteType": "BidderPositionMaxBid",
                     "plural": false,
-                    "selections": v4
+                    "selections": v5
                   },
                   v2
                 ]

--- a/src/__generated__/ArtworkSidebar_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebar_Test_Query.graphql.ts
@@ -24,16 +24,7 @@ query ArtworkSidebar_Test_Query {
 }
 
 fragment ArtworkSidebar_artwork on Artwork {
-  is_biddable
   is_in_auction
-  sale_artwork {
-    lot_label
-    __id
-  }
-  sale {
-    is_closed
-    __id
-  }
   ...ArtworkSidebarArtists_artwork
   ...ArtworkSidebarMetadata_artwork
   ...ArtworkSidebarAuctionPartnerInfo_artwork
@@ -57,7 +48,12 @@ fragment ArtworkSidebarArtists_artwork on Artwork {
 }
 
 fragment ArtworkSidebarMetadata_artwork on Artwork {
+  is_biddable
   edition_sets {
+    __id
+  }
+  sale_artwork {
+    lot_label
     __id
   }
   ...ArtworkSidebarTitleInfo_artwork
@@ -235,6 +231,13 @@ v1 = {
   "storageKey": null
 },
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "edition_of",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "dimensions",
@@ -259,7 +262,7 @@ v2 = {
     }
   ]
 },
-v3 = [
+v4 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -268,24 +271,17 @@ v3 = [
     "storageKey": null
   }
 ],
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "href",
-  "args": null,
-  "storageKey": null
-},
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "edition_of",
+  "name": "href",
   "args": null,
   "storageKey": null
 };
@@ -294,7 +290,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkSidebar_Test_Query",
   "id": null,
-  "text": "query ArtworkSidebar_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebar_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_biddable\n  is_in_auction\n  sale_artwork {\n    lot_label\n    __id\n  }\n  sale {\n    is_closed\n    __id\n  }\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  edition_sets {\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  collecting_institution\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  __id\n  is_in_auction\n  is_for_sale\n  artists {\n    __id\n    is_consignable\n  }\n  sale {\n    is_closed\n    __id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query ArtworkSidebar_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebar_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  collecting_institution\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  __id\n  is_in_auction\n  is_for_sale\n  artists {\n    __id\n    is_consignable\n  }\n  sale {\n    is_closed\n    __id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -340,9 +336,31 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "is_in_auction",
+            "args": null,
+            "storageKey": null
+          },
+          v1,
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "is_biddable",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "edition_sets",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "EditionSet",
+            "plural": true,
+            "selections": [
+              v1,
+              v3,
+              v2
+            ]
           },
           {
             "kind": "LinkedField",
@@ -397,7 +415,7 @@ return {
                 "args": null,
                 "concreteType": "SaleArtworkCurrentBid",
                 "plural": false,
-                "selections": v3
+                "selections": v4
               },
               {
                 "kind": "LinkedField",
@@ -425,7 +443,140 @@ return {
                 "args": null,
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
-                "selections": v3
+                "selections": v4
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "date",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "medium",
+            "args": null,
+            "storageKey": null
+          },
+          v3,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artists",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              v1,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              },
+              v5,
+              v6,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_followed",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "follows",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_consignable",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "collecting_institution",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "attribution_class",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "short_description",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              v1,
+              v5,
+              v6,
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "locations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Location",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "city",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v1
+                ]
               }
             ]
           },
@@ -441,7 +592,7 @@ return {
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_closed",
+                "name": "is_with_buyers_premium",
                 "args": null,
                 "storageKey": null
               },
@@ -449,14 +600,14 @@ return {
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_with_buyers_premium",
+                "name": "is_open",
                 "args": null,
                 "storageKey": null
               },
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_open",
+                "name": "is_closed",
                 "args": null,
                 "storageKey": null
               },
@@ -505,161 +656,6 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "artists",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Artist",
-            "plural": true,
-            "selections": [
-              v1,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "id",
-                "args": null,
-                "storageKey": null
-              },
-              v4,
-              v5,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_followed",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "counts",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtistCounts",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "follows",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_consignable",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          v1,
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "edition_sets",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "EditionSet",
-            "plural": true,
-            "selections": [
-              v1,
-              v2,
-              v6
-            ]
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "medium",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "is_in_auction",
-            "args": null,
-            "storageKey": null
-          },
-          v6,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "collecting_institution",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "attribution_class",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "AttributionClass",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "short_description",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "partner",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Partner",
-            "plural": false,
-            "selections": [
-              v1,
-              v4,
-              v5,
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "locations",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Location",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "city",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  v1
-                ]
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
             "name": "myLotStanding",
             "storageKey": "myLotStanding(live:true)",
             "args": [
@@ -697,7 +693,7 @@ return {
                     "args": null,
                     "concreteType": "BidderPositionMaxBid",
                     "plural": false,
-                    "selections": v3
+                    "selections": v4
                   },
                   v1
                 ]

--- a/src/__generated__/ArtworkSidebar_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebar_artwork.graphql.ts
@@ -12,29 +12,14 @@ import { ArtworkSidebarPartnerInfo_artwork$ref } from "./ArtworkSidebarPartnerIn
 declare const _ArtworkSidebar_artwork$ref: unique symbol;
 export type ArtworkSidebar_artwork$ref = typeof _ArtworkSidebar_artwork$ref;
 export type ArtworkSidebar_artwork = {
-    readonly is_biddable: boolean | null;
     readonly is_in_auction: boolean | null;
-    readonly sale_artwork: ({
-        readonly lot_label: string | null;
-    }) | null;
-    readonly sale: ({
-        readonly is_closed: boolean | null;
-    }) | null;
     readonly " $fragmentRefs": ArtworkSidebarArtists_artwork$ref & ArtworkSidebarMetadata_artwork$ref & ArtworkSidebarAuctionPartnerInfo_artwork$ref & ArtworkSidebarCurrentBidInfo_artwork$ref & ArtworkSidebarBidAction_artwork$ref & ArtworkSidebarCommercial_artwork$ref & ArtworkSidebarPartnerInfo_artwork$ref & ArtworkSidebarExtraLinks_artwork$ref;
     readonly " $refType": ArtworkSidebar_artwork$ref;
 };
 
 
 
-const node: ConcreteFragment = (function(){
-var v0 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-};
-return {
+const node: ConcreteFragment = {
   "kind": "Fragment",
   "name": "ArtworkSidebar_artwork",
   "type": "Artwork",
@@ -42,54 +27,11 @@ return {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "FragmentSpread",
-      "name": "ArtworkSidebarAuctionPartnerInfo_artwork",
-      "args": null
-    },
-    {
       "kind": "ScalarField",
       "alias": null,
-      "name": "is_biddable",
+      "name": "is_in_auction",
       "args": null,
       "storageKey": null
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "sale_artwork",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "SaleArtwork",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "lot_label",
-          "args": null,
-          "storageKey": null
-        },
-        v0
-      ]
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "sale",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "Sale",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "is_closed",
-          "args": null,
-          "storageKey": null
-        },
-        v0
-      ]
     },
     {
       "kind": "FragmentSpread",
@@ -102,11 +44,9 @@ return {
       "args": null
     },
     {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_in_auction",
-      "args": null,
-      "storageKey": null
+      "kind": "FragmentSpread",
+      "name": "ArtworkSidebarAuctionPartnerInfo_artwork",
+      "args": null
     },
     {
       "kind": "FragmentSpread",
@@ -133,9 +73,14 @@ return {
       "name": "ArtworkSidebarExtraLinks_artwork",
       "args": null
     },
-    v0
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "__id",
+      "args": null,
+      "storageKey": null
+    }
   ]
 };
-})();
-(node as any).hash = '51e7c9bbf35e04036955a48d82590b4d';
+(node as any).hash = 'ef35603ebb4962f5dda7f9b37731efef';
 export default node;

--- a/src/__generated__/routes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/routes_ArtworkQuery.graphql.ts
@@ -39,16 +39,7 @@ fragment ArtworkApp_artwork on Artwork {
 }
 
 fragment ArtworkSidebar_artwork on Artwork {
-  is_biddable
   is_in_auction
-  sale_artwork {
-    lot_label
-    __id
-  }
-  sale {
-    is_closed
-    __id
-  }
   ...ArtworkSidebarArtists_artwork
   ...ArtworkSidebarMetadata_artwork
   ...ArtworkSidebarAuctionPartnerInfo_artwork
@@ -169,7 +160,12 @@ fragment ArtworkSidebarArtists_artwork on Artwork {
 }
 
 fragment ArtworkSidebarMetadata_artwork on Artwork {
+  is_biddable
   edition_sets {
+    __id
+  }
+  sale_artwork {
+    lot_label
     __id
   }
   ...ArtworkSidebarTitleInfo_artwork
@@ -361,37 +357,28 @@ v3 = {
   "args": null,
   "storageKey": null
 },
-v4 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "display",
-    "args": null,
-    "storageKey": null
-  }
-],
-v5 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_followed",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v7 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "dimensions",
@@ -416,13 +403,22 @@ v8 = {
     }
   ]
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "edition_of",
   "args": null,
   "storageKey": null
 },
+v9 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "display",
+    "args": null,
+    "storageKey": null
+  }
+],
 v10 = [
   {
     "kind": "Literal",
@@ -452,7 +448,7 @@ return {
   "operationKind": "query",
   "name": "routes_ArtworkQuery",
   "id": null,
-  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  artist {\n    id\n    __id\n  }\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_biddable\n  is_in_auction\n  sale_artwork {\n    lot_label\n    __id\n  }\n  sale {\n    is_closed\n    __id\n  }\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsChecklist_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  is_in_auction\n  additional_information(format: HTML)\n  partner {\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsChecklist_artwork on Artwork {\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  edition_sets {\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  collecting_institution\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  __id\n  is_in_auction\n  is_for_sale\n  artists {\n    __id\n    is_consignable\n  }\n  sale {\n    is_closed\n    __id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  artist {\n    id\n    __id\n  }\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsChecklist_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  is_in_auction\n  additional_information(format: HTML)\n  partner {\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsChecklist_artwork on Artwork {\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  collecting_institution\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  __id\n  is_in_auction\n  is_for_sale\n  artists {\n    __id\n    is_consignable\n  }\n  sale {\n    is_closed\n    __id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -505,16 +501,72 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "is_in_auction",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artists",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              v2,
+              v3,
+              v4,
+              v5,
+              v6,
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "follows",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_consignable",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          v2,
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "is_biddable",
             "args": null,
             "storageKey": null
           },
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "is_in_auction",
+            "name": "edition_sets",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
+            "concreteType": "EditionSet",
+            "plural": true,
+            "selections": [
+              v2,
+              v7,
+              v8
+            ]
           },
           {
             "kind": "LinkedField",
@@ -569,7 +621,7 @@ return {
                 "args": null,
                 "concreteType": "SaleArtworkCurrentBid",
                 "plural": false,
-                "selections": v4
+                "selections": v9
               },
               {
                 "kind": "LinkedField",
@@ -597,7 +649,134 @@ return {
                 "args": null,
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
-                "selections": v4
+                "selections": v9
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "date",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "medium",
+            "args": null,
+            "storageKey": null
+          },
+          v7,
+          v8,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "exhibition_history",
+            "args": v10,
+            "storageKey": "exhibition_history(format:\"HTML\")"
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "attribution_class",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "short_description",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              v2,
+              v4,
+              v5,
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "locations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Location",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "city",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v2
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "initials",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "profile",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Profile",
+                "plural": false,
+                "selections": [
+                  v2,
+                  v3,
+                  v6,
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "icon",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "url",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "square140",
+                            "type": "[String]"
+                          }
+                        ],
+                        "storageKey": "url(version:\"square140\")"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -613,7 +792,7 @@ return {
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_closed",
+                "name": "is_with_buyers_premium",
                 "args": null,
                 "storageKey": null
               },
@@ -621,14 +800,14 @@ return {
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_with_buyers_premium",
+                "name": "is_open",
                 "args": null,
                 "storageKey": null
               },
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "is_open",
+                "name": "is_closed",
                 "args": null,
                 "storageKey": null
               },
@@ -677,189 +856,6 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "artists",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Artist",
-            "plural": true,
-            "selections": [
-              v2,
-              v3,
-              v5,
-              v6,
-              v7,
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "counts",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtistCounts",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "follows",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_consignable",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          v2,
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "edition_sets",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "EditionSet",
-            "plural": true,
-            "selections": [
-              v2,
-              v8,
-              v9
-            ]
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "medium",
-            "args": null,
-            "storageKey": null
-          },
-          v8,
-          v9,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "exhibition_history",
-            "args": v10,
-            "storageKey": "exhibition_history(format:\"HTML\")"
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "attribution_class",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "AttributionClass",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "short_description",
-                "args": null,
-                "storageKey": null
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "partner",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Partner",
-            "plural": false,
-            "selections": [
-              v2,
-              v5,
-              v6,
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "locations",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Location",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "city",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  v2
-                ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "initials",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "profile",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Profile",
-                "plural": false,
-                "selections": [
-                  v2,
-                  v3,
-                  v7,
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "icon",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "Image",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "url",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "version",
-                            "value": "square140",
-                            "type": "[String]"
-                          }
-                        ],
-                        "storageKey": "url(version:\"square140\")"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
             "name": "myLotStanding",
             "storageKey": "myLotStanding(live:true)",
             "args": [
@@ -897,7 +893,7 @@ return {
                     "args": null,
                     "concreteType": "BidderPositionMaxBid",
                     "plural": false,
-                    "selections": v4
+                    "selections": v9
                   },
                   v2
                 ]
@@ -1045,11 +1041,11 @@ return {
                 "concreteType": "Author",
                 "plural": false,
                 "selections": [
-                  v5,
+                  v4,
                   v2
                 ]
               },
-              v6,
+              v5,
               {
                 "kind": "ScalarField",
                 "alias": null,


### PR DESCRIPTION
This brings the metadata to almost production state. We are still missing the explanation modal for Classification sting, but otherwise this should be in a ready to put on artwork page state(just for this component:).

I'll work on classification modal next.