### PR TITLE
MockQueryRenderer improvements

### DIFF
--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -62,10 +62,7 @@ storiesOf("Apps/Order Page/Components", module).add(
           <MockRelayRenderer
             Component={ShippingAndPaymentSummary}
             mockResolvers={{
-              Order: (...anything) => {
-                console.log("HEY!!!", anything)
-                return order
-              },
+              Order: () => order,
             }}
             query={orderQuery}
           />

--- a/src/DevTools/MockRelayRenderer.tsx
+++ b/src/DevTools/MockRelayRenderer.tsx
@@ -132,7 +132,7 @@ export class MockRelayRenderer<
 
     if (this.state.caughtError) {
       const { error, errorInfo } = this.state.caughtError
-      console.log({ error, errorInfo })
+      console.error({ error, errorInfo })
       return `Error occurred while rendering Relay component: ${error}`
     }
 

--- a/src/DevTools/MockRelayRenderer.tsx
+++ b/src/DevTools/MockRelayRenderer.tsx
@@ -23,6 +23,13 @@ export interface MockRelayRendererProps<
   mockResolvers: IMocks
 }
 
+export interface MockRelayRendererState {
+  caughtError: {
+    error: any
+    errorInfo: any
+  }
+}
+
 /**
  * Renders a tree of Relay containers with a mocked local instance of the
  * metaphysics schema.
@@ -100,7 +107,15 @@ export interface MockRelayRendererProps<
  */
 export class MockRelayRenderer<
   T extends OperationBase = OperationDefaults
-> extends React.Component<MockRelayRendererProps<T>> {
+> extends React.Component<MockRelayRendererProps<T>, MockRelayRendererState> {
+  state = {
+    caughtError: undefined,
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ caughtError: { error, errorInfo } })
+  }
+
   render() {
     // TODO: When extracting these test utils to their own package, this check
     //       should probably become a custom TSLint rule, as there’s no good way
@@ -113,6 +128,12 @@ export class MockRelayRenderer<
         "The `react-relay` module has been mocked, be sure to unmock it with: " +
           '`jest.unmock("react-relay")`'
       )
+    }
+
+    if (this.state.caughtError) {
+      const { error, errorInfo } = this.state.caughtError
+      console.log({ error, errorInfo })
+      return `Error occurred while rendering Relay component: ${error}`
     }
 
     const { Component, variables, query, mockResolvers } = this.props

--- a/src/DevTools/__test__/MockRelayRenderer.test.tsx
+++ b/src/DevTools/__test__/MockRelayRenderer.test.tsx
@@ -1,7 +1,12 @@
 import { mount } from "enzyme"
 import * as React from "react"
 import { MockRelayRenderer } from "../MockRelayRenderer"
-import { Artwork, query, renderToString } from "./MockRelayRendererFixtures"
+import {
+  Artwork,
+  badQuery,
+  query,
+  renderToString,
+} from "./MockRelayRendererFixtures"
 
 jest.unmock("react-relay")
 
@@ -30,6 +35,38 @@ describe("MockRelayRenderer", () => {
             <div>Mona Lisa</div>
           </div>
         )
+      )
+      done()
+    }, 10)
+  })
+
+  it("renders an error when child components throw", done => {
+    console.log = () => null // MockRelayRenderer prints out error info to the console, let's silence it.
+    const tree = mount(
+      <MockRelayRenderer
+        Component={Artwork}
+        query={badQuery}
+        mockResolvers={{
+          Artwork: () => ({
+            title: "Mona Lisa",
+            image: {
+              url: "http://test/image.jpg",
+            },
+            artist: null,
+          }),
+        }}
+      />
+    )
+    tree.setState({
+      caughtError: {
+        error: new Error("Hey it's an error!"),
+        errorInfo: {},
+      },
+    })
+    setTimeout(() => {
+      console.log(tree.text())
+      expect(tree.update().text()).toEqual(
+        "Error occurred while rendering Relay component: Error: Hey it's an error!"
       )
       done()
     }, 10)

--- a/src/DevTools/__test__/MockRelayRenderer.test.tsx
+++ b/src/DevTools/__test__/MockRelayRenderer.test.tsx
@@ -1,3 +1,4 @@
+import { renderUntil } from "DevTools/renderUntil"
 import { mount } from "enzyme"
 import * as React from "react"
 import { MockRelayRenderer } from "../MockRelayRenderer"
@@ -11,8 +12,9 @@ import {
 jest.unmock("react-relay")
 
 describe("MockRelayRenderer", () => {
-  it("renders a Relay tree", done => {
-    const tree = mount(
+  it("renders a Relay tree", async () => {
+    const tree = await renderUntil(
+      wrapper => wrapper.text().includes("Mona Lisa"),
       <MockRelayRenderer
         Component={Artwork}
         query={query}
@@ -27,17 +29,14 @@ describe("MockRelayRenderer", () => {
         }}
       />
     )
-    setTimeout(() => {
-      expect(tree.html()).toEqual(
-        renderToString(
-          <div>
-            <img src="http://test/image.jpg" />
-            <div>Mona Lisa</div>
-          </div>
-        )
+    expect(tree.html()).toEqual(
+      renderToString(
+        <div>
+          <img src="http://test/image.jpg" />
+          <div>Mona Lisa</div>
+        </div>
       )
-      done()
-    }, 10)
+    )
   })
 
   it("renders an error when child components throw", () => {

--- a/src/DevTools/__test__/MockRelayRenderer.test.tsx
+++ b/src/DevTools/__test__/MockRelayRenderer.test.tsx
@@ -40,8 +40,8 @@ describe("MockRelayRenderer", () => {
     }, 10)
   })
 
-  it("renders an error when child components throw", done => {
-    console.log = () => null // MockRelayRenderer prints out error info to the console, let's silence it.
+  it("renders an error when child components throw", () => {
+    console.error = () => null // MockRelayRenderer prints out error info to the console, let's silence it.
     const tree = mount(
       <MockRelayRenderer
         Component={Artwork}
@@ -63,12 +63,8 @@ describe("MockRelayRenderer", () => {
         errorInfo: {},
       },
     })
-    setTimeout(() => {
-      console.log(tree.text())
-      expect(tree.update().text()).toEqual(
-        "Error occurred while rendering Relay component: Error: Hey it's an error!"
-      )
-      done()
-    }, 10)
+    expect(tree.update().text()).toEqual(
+      "Error occurred while rendering Relay component: Error: Hey it's an error!"
+    )
   })
 })

--- a/src/DevTools/__test__/MockRelayRendererFixtures.tsx
+++ b/src/DevTools/__test__/MockRelayRendererFixtures.tsx
@@ -83,6 +83,15 @@ export const query = graphql`
   }
 `
 
+// Bad query has a misnamed top-level property.
+export const badQuery = graphql`
+  query MockRelayRendererFixturesBadQuery {
+    something_that_is_not_expected: artwork(id: "mona-lisa") {
+      ...MockRelayRendererFixtures_artwork
+    }
+  }
+`
+
 export function renderToString(element: JSX.Element) {
   return cheerio.html(render(element))
 }

--- a/src/__generated__/MockRelayRendererFixturesBadQuery.graphql.ts
+++ b/src/__generated__/MockRelayRendererFixturesBadQuery.graphql.ts
@@ -1,0 +1,159 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { MockRelayRendererFixtures_artwork$ref } from "./MockRelayRendererFixtures_artwork.graphql";
+export type MockRelayRendererFixturesBadQueryVariables = {};
+export type MockRelayRendererFixturesBadQueryResponse = {
+    readonly something_that_is_not_expected: ({
+        readonly " $fragmentRefs": MockRelayRendererFixtures_artwork$ref;
+    }) | null;
+};
+export type MockRelayRendererFixturesBadQuery = {
+    readonly response: MockRelayRendererFixturesBadQueryResponse;
+    readonly variables: MockRelayRendererFixturesBadQueryVariables;
+};
+
+
+
+/*
+query MockRelayRendererFixturesBadQuery {
+  something_that_is_not_expected: artwork(id: "mona-lisa") {
+    ...MockRelayRendererFixtures_artwork
+    __id
+  }
+}
+
+fragment MockRelayRendererFixtures_artwork on Artwork {
+  image {
+    url
+  }
+  artist {
+    id
+    __id
+  }
+  ...MockRelayRendererFixtures_artworkMetadata
+  __id
+}
+
+fragment MockRelayRendererFixtures_artworkMetadata on Artwork {
+  title
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "mona-lisa",
+    "type": "String!"
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "MockRelayRendererFixturesBadQuery",
+  "id": null,
+  "text": "query MockRelayRendererFixturesBadQuery {\n  something_that_is_not_expected: artwork(id: \"mona-lisa\") {\n    ...MockRelayRendererFixtures_artwork\n    __id\n  }\n}\n\nfragment MockRelayRendererFixtures_artwork on Artwork {\n  image {\n    url\n  }\n  artist {\n    id\n    __id\n  }\n  ...MockRelayRendererFixtures_artworkMetadata\n  __id\n}\n\nfragment MockRelayRendererFixtures_artworkMetadata on Artwork {\n  title\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "MockRelayRendererFixturesBadQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "something_that_is_not_expected",
+        "name": "artwork",
+        "storageKey": "artwork(id:\"mona-lisa\")",
+        "args": v0,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "MockRelayRendererFixtures_artwork",
+            "args": null
+          },
+          v1
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "MockRelayRendererFixturesBadQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "something_that_is_not_expected",
+        "name": "artwork",
+        "storageKey": "artwork(id:\"mona-lisa\")",
+        "args": v0,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artist",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Artist",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              },
+              v1
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          v1
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'ab040493eb68f4cb47eb0f983cd4fdb2';
+export default node;


### PR DESCRIPTION
This PR is a followup from #1438. When we discussed my change in the Purchase team knowledge share the next day, we agreed that better surfacing of errors in storybooks would be helpful for debugging (as there are apparently other broken storybooks in Reaction).

So my solution was to turn `MockRelayRenderer` into an [error boundary](https://reactjs.org/docs/error-boundaries.html), put any caught errors into the component's `state`, and use that state to indicate something went wrong. It looks like `renderWithLoadProgress` _was_ catching errors (as marked in the comments) but was returning `null` instead, leading to blank screens:

<img width="2128" alt="screen shot 2018-10-25 at 4 08 52 pm" src="https://user-images.githubusercontent.com/498212/47527778-6576f900-d871-11e8-83c8-70671a666a14.png">

A blank screen is probably what we want, for users, so I didn't want to change the behaviour of `renderWithLoadProgress`.

If developers opened the console and scrolled through all the logs of a broken storybook, they might find this error:

```
Warning: createFragmentSpecResolver: Expected prop `order` to be supplied to `Relay(ShippingAndPaymentSummary)`, but got `undefined`. Pass an explicit `null` if this is intentional.
```

But that's not a great developer experience. This PR surfaces the error from the component in the browser:

<img width="2128" alt="screen shot 2018-10-25 at 3 54 30 pm" src="https://user-images.githubusercontent.com/498212/47527811-80496d80-d871-11e8-87e9-2018391f2ebb.png">

I'm open to feedback on wording, etc.

I also removed an errant `console.log` I accidentally left in #1438.