### PR TITLE
[DevTools] make renderUntil an enzyme API extension.

### DIFF
--- a/src/DevTools/__test__/renderUntil.test.tsx
+++ b/src/DevTools/__test__/renderUntil.test.tsx
@@ -1,3 +1,4 @@
+import { mount } from "enzyme"
 import * as React from "react"
 import { Responsive } from "Utils/Responsive"
 import { MockBoot } from "../MockBoot"
@@ -31,50 +32,56 @@ class Component extends React.Component {
 }
 
 describe("renderUntil", () => {
-  it("yields an enzyme wrapper to the `until` block until it returns true", async () => {
-    const states = []
-    await renderUntil(wrapper => {
-      const text = wrapper.find("div").text()
-      states.push(text)
-      return text !== "Loading"
-    }, <Component />)
-    expect(states).toEqual(["Loading", "ohai"])
+  describe("as an enzyme API extension", () => {
+    it("yields an enzyme wrapper to the `until` block until it returns true", async () => {
+      const states = []
+      await mount(<Component />).renderUntil(tree => {
+        const text = tree.find("div").text()
+        states.push(text)
+        return text !== "Loading"
+      })
+      expect(states).toEqual(["Loading", "ohai"])
+    })
+
+    it("resolves the promise with an enzyme wrapper with the final state", async () => {
+      const wrapper = await mount(<Component />).renderUntil(
+        tree => tree.find("div").text() !== "Loading"
+      )
+      expect(wrapper.find("div").text()).toEqual("ohai")
+    })
   })
 
-  it("resolves the promise with an enzyme wrapper with the final state", async () => {
-    const tree = await renderUntil(
-      wrapper => wrapper.find("div").text() !== "Loading",
-      <Component />
-    )
-    expect(tree.find("div").text()).toEqual("ohai")
-  })
+  describe("deprecated usage", () => {
+    it("yields an enzyme wrapper to the `until` block until it returns true", async () => {
+      const states = []
+      await renderUntil(wrapper => {
+        const text = wrapper.find("div").text()
+        states.push(text)
+        return text !== "Loading"
+      }, <Component />)
+      expect(states).toEqual(["Loading", "ohai"])
+    })
 
-  it("plays well with the Responsive component", async () => {
-    const tree = await renderUntil(
-      wrapper => wrapper.find(Component).text() !== "Loading",
-      <MockBoot breakpoint="xs">
-        <Component>
-          <Responsive>
-            {({ xs }) => xs && <span>Such response</span>}
-          </Responsive>
-        </Component>
-      </MockBoot>
-    )
-    expect(tree.find("span").text()).toEqual("Such response")
-  })
+    it("resolves the promise with an enzyme wrapper with the final state", async () => {
+      const tree = await renderUntil(
+        wrapper => wrapper.find("div").text() !== "Loading",
+        <Component />
+      )
+      expect(tree.find("div").text()).toEqual("ohai")
+    })
 
-  // TODO: Whatever way I try to test this, it just doesn’t work as expected.
-  // it("rejects the promise when a render error occurs", () => {
-  //   return renderUntil(wrapper => {
-  //     setImmediate(() => {
-  //       wrapper
-  //         .find(Component)
-  //         .first()
-  //         .simulateError(new Error("ohnoes"))
-  //     })
-  //     return false
-  //   }, <Component />).then(wrapper => {
-  //     expect(wrapper.find("div").text()).toEqual("ohai")
-  //   })
-  // })
+    it("plays well with the Responsive component", async () => {
+      const tree = await renderUntil(
+        wrapper => wrapper.find(Component).text() !== "Loading",
+        <MockBoot breakpoint="xs">
+          <Component>
+            <Responsive>
+              {({ xs }) => xs && <span>Such response</span>}
+            </Responsive>
+          </Component>
+        </MockBoot>
+      )
+      expect(tree.find("span").text()).toEqual("Such response")
+    })
+  })
 })

--- a/src/DevTools/enzyme+renderUntil.d.ts
+++ b/src/DevTools/enzyme+renderUntil.d.ts
@@ -2,22 +2,22 @@ import { ReactWrapper } from "enzyme"
 import * as React from "react"
 
 declare module "enzyme" {
-  export type RenderUntilCallback<P = {}, S = {}, C = React.Component> = (
+  export type RenderUntilPredicate<P, S, C> = (
     wrapper: ReactWrapper<P, S, C>
   ) => boolean
 
   export interface ReactWrapper<P = {}, S = {}, C = React.Component> {
     /**
-     * Continuously checks an asynchronously rendered tree until it is considered
-     * done, as per the provided callback.
+     * Continuously checks an asynchronously rendered tree until it is
+     * considered done, as per the provided predicate function.
      * 
      * @param until
-     * A callback that is used to test wether rendering should be considered
-     * finished. This is a regular enzyme wrapper.
+     * A predicate function that is used to test wether rendering should be
+     * considered finished. This is a regular enzyme wrapper.
      *
      * @returns
-     * A promise that will resolve with an enzyme wrapper containing the rendered
-     * tree.
+     * A promise that will resolve with an enzyme wrapper containing the
+     * rendered tree.
      *
      * @example
      *
@@ -49,7 +49,7 @@ declare module "enzyme" {
     *
     */
     renderUntil(
-      until: RenderUntilCallback<P, S, C>
+      predicate: RenderUntilPredicate<P, S, C>
     ): Promise<ReactWrapper<P, S, C>>
   }
 }

--- a/src/DevTools/enzyme+renderUntil.d.ts
+++ b/src/DevTools/enzyme+renderUntil.d.ts
@@ -1,0 +1,55 @@
+import { ReactWrapper } from "enzyme"
+import * as React from "react"
+
+declare module "enzyme" {
+  export type RenderUntilCallback<P = {}, S = {}, C = React.Component> = (
+    wrapper: ReactWrapper<P, S, C>
+  ) => boolean
+
+  export interface ReactWrapper<P = {}, S = {}, C = React.Component> {
+    /**
+     * Continuously checks an asynchronously rendered tree until it is considered
+     * done, as per the provided callback.
+     * 
+     * @param until
+     * A callback that is used to test wether rendering should be considered
+     * finished. This is a regular enzyme wrapper.
+     *
+     * @returns
+     * A promise that will resolve with an enzyme wrapper containing the rendered
+     * tree.
+     *
+     * @example
+     *
+       ```tsx
+      class Component extends React.Component {
+        state = {
+          data: "Loading",
+        }
+      
+        // After mounting and the initial render, trigger another render with data.
+        componentDidMount() {
+          setImmediate(() => {
+            this.setState({ data: "ohai" })
+          })
+        }
+      
+        render() {
+          return <div>{this.state.data}</div>
+        }
+      }
+      
+      it("resolves the promise with an enzyme wrapper with the final state", async () => {
+        const wrapper = await mount(<Component />).renderUntil(
+          n => n.find("div").text() !== "Loading"
+        )
+        expect(wrapper.find("div").text()).toEqual("ohai")
+      })
+      ```
+    *
+    */
+    renderUntil(
+      until: RenderUntilCallback<P, S, C>
+    ): Promise<ReactWrapper<P, S, C>>
+  }
+}

--- a/src/DevTools/renderRelayTree.tsx
+++ b/src/DevTools/renderRelayTree.tsx
@@ -103,7 +103,7 @@ export function renderRelayTree<
     Component,
     query,
     mockResolvers,
-    renderUntil: renderUntilCallback,
+    renderUntil: renderUntilPredicate,
     variables,
     wrapper,
   } = params
@@ -116,6 +116,6 @@ export function renderRelayTree<
     />
   )
   return mount<C, P, S>(wrapper ? wrapper(renderer) : renderer).renderUntil(
-    renderUntilCallback || RelayFinishedLoading
+    renderUntilPredicate || RelayFinishedLoading
   )
 }

--- a/src/DevTools/renderRelayTree.tsx
+++ b/src/DevTools/renderRelayTree.tsx
@@ -1,8 +1,18 @@
 import { LoadingClassName } from "Artsy/Relay/renderWithLoadProgress"
+import "DevTools/renderUntil"
+import { mount, RenderUntilCallback } from "enzyme"
 import React from "react"
 import { Variables } from "relay-runtime"
 import { MockRelayRenderer, MockRelayRendererProps } from "./MockRelayRenderer"
-import { renderUntil, RenderUntilCallback } from "./renderUntil"
+
+/**
+ * A {@link ReactWrapper.prototype.renderUntil} callback implementation that
+ * passes when no more loading indicators exist in the tree. Use this when you
+ * need to use `renderUntil` directly, such as after making updates to a Relay
+ * tree.
+ */
+export const RelayFinishedLoading: RenderUntilCallback = tree =>
+  !tree.find(`.${LoadingClassName}`).length
 
 /**
  * Renders a tree of Relay containers with a mocked local instance of the
@@ -105,8 +115,7 @@ export function renderRelayTree<
       variables={variables}
     />
   )
-  return renderUntil<P, S, C>(
-    renderUntilCallback || (tree => !tree.find(`.${LoadingClassName}`).length),
-    wrapper ? wrapper(renderer) : renderer
+  return mount<C, P, S>(wrapper ? wrapper(renderer) : renderer).renderUntil(
+    renderUntilCallback || RelayFinishedLoading
   )
 }

--- a/src/DevTools/renderRelayTree.tsx
+++ b/src/DevTools/renderRelayTree.tsx
@@ -1,6 +1,6 @@
 import { LoadingClassName } from "Artsy/Relay/renderWithLoadProgress"
 import "DevTools/renderUntil"
-import { mount, RenderUntilCallback } from "enzyme"
+import { mount, RenderUntilPredicate } from "enzyme"
 import React from "react"
 import { Variables } from "relay-runtime"
 import { MockRelayRenderer, MockRelayRendererProps } from "./MockRelayRenderer"
@@ -11,7 +11,7 @@ import { MockRelayRenderer, MockRelayRendererProps } from "./MockRelayRenderer"
  * need to use `renderUntil` directly, such as after making updates to a Relay
  * tree.
  */
-export const RelayFinishedLoading: RenderUntilCallback = tree =>
+export const RelayFinishedLoading: RenderUntilPredicate<any, any, any> = tree =>
   !tree.find(`.${LoadingClassName}`).length
 
 /**
@@ -34,8 +34,8 @@ export const RelayFinishedLoading: RenderUntilCallback = tree =>
  * See {@link MockRelayRenderer}
  *
  * @param until
- * An optional callback that is used to test wether rendering should be
- * considered finished. This is a regular enzyme wrapper.
+ * An optional predicate function that is used to test wether rendering should
+ * be considered finished. This is a regular enzyme wrapper.
  *
  * @param wrapper
  * An optional component that the Relay tree should be nested in. Use this to
@@ -94,7 +94,7 @@ export function renderRelayTree<
   C extends React.Component = React.Component
 >(
   params: MockRelayRendererProps & {
-    renderUntil?: RenderUntilCallback<P, S, C>
+    renderUntil?: RenderUntilPredicate<P, S, C>
     variables?: Variables
     wrapper?: (renderer: JSX.Element) => JSX.Element
   }

--- a/src/DevTools/renderUntil.tsx
+++ b/src/DevTools/renderUntil.tsx
@@ -1,97 +1,20 @@
-import { mount, ReactWrapper } from "enzyme"
+import { mount, ReactWrapper, RenderUntilCallback } from "enzyme"
 import * as React from "react"
 
-class ErrorBoundary extends React.Component<{ onError: (error) => void }> {
-  state = {
-    errorOccurred: false,
-  }
-
-  componentDidCatch(error, info) {
-    this.setState({ errorOccurred: true }, () => {
-      this.props.onError(error)
-    })
-  }
-
-  render() {
-    if (this.state.errorOccurred) {
-      return null
-    }
-    return this.props.children
-  }
-}
-
-export type RenderUntilCallback<
+function renderUntil<
   P = {},
   S = {},
   C extends React.Component = React.Component
-> = (wrapper: ReactWrapper<P, S, C>) => boolean
-
-/**
- * Continuously checks an asynchronously rendered tree until it is considered
- * done, as per the provided callback.
- * 
- * @param until
- * A callback that is used to test wether rendering should be considered
- * finished. This is a regular enzyme wrapper.
- *
- * @param element
- * The tree to render.
- *
- * @returns
- * A promise that will resolve with an enzyme wrapper containing the rendered
- * tree.
- *
- * @example
- *
-   ```tsx
-   class Component extends React.Component {
-     state = {
-       data: "Loading",
-     }
-  
-     // After mounting and the initial render, trigger another render with data.
-     componentDidMount() {
-       setImmediate(() => {
-         this.setState({ data: "ohai" })
-       })
-     }
-  
-     render() {
-       return <div>{this.state.data}</div>
-     }
-   }
-   
-   it("resolves the promise with an enzyme wrapper with the final state", async () => {
-     const tree = await renderUntil(
-       wrapper => wrapper.find("div").text() !== "Loading",
-       <Component />
-     )
-     expect(tree.find("div").text()).toEqual("ohai")
-   })
-   ```
- *
- */
-export function renderUntil<
-  P = {},
-  S = {},
-  C extends React.Component = React.Component
->(until: RenderUntilCallback<P, S, C>, element: React.ReactElement<P>) {
-  return new Promise<ReactWrapper<P, S, C>>((resolve, reject) => {
-    /**
-     * In case of an uncaught error, be sure to reject the promise ASAP and
-     * with a helpful error.
-     */
-    const tree = mount<C, P, S>(
-      <ErrorBoundary onError={reject}>{element}</ErrorBoundary>
-    )
+>(until: RenderUntilCallback<P, S, C>) {
+  return new Promise<ReactWrapper<P, S, C>>(resolve => {
     /**
      * Continuously lets JS/React continue doing its async work and then check
-     * if the sentinel selector matches any elements, in which case the tree
-     * is ready to be recorded.
+     * if the callback matches what the user expects, in which case the tree is
+     * ready to be asserted on.
      */
     const wait = () => {
-      if (until(tree)) {
-        resolve(tree)
+      if (until(this)) {
+        resolve(this)
       } else {
         setImmediate(() => {
           /**
@@ -99,7 +22,7 @@ export function renderUntil<
            * tree gets re-rendered to reflect any changes caused by props or
            * state changes.
            */
-          tree.update()
+          this.update()
           wait()
         })
       }
@@ -110,3 +33,23 @@ export function renderUntil<
     wait()
   })
 }
+
+ReactWrapper.prototype.renderUntil = renderUntil
+
+/**
+ * @deprecated Use {@link ReactWrapper.prototype.renderUntil} instead.
+ */
+function deprecated_renderUntil<
+  P = {},
+  S = {},
+  C extends React.Component = React.Component
+>(until: RenderUntilCallback<P, S, C>, element: React.ReactElement<P>) {
+  /**
+   * In case of an uncaught error, be sure to reject the promise ASAP and
+   * with a helpful error.
+   */
+  const tree = mount<C, P, S>(element)
+  return tree.renderUntil(until)
+}
+
+export { deprecated_renderUntil as renderUntil }

--- a/src/DevTools/renderUntil.tsx
+++ b/src/DevTools/renderUntil.tsx
@@ -34,6 +34,8 @@ function renderUntil<
   })
 }
 
+// TODO: Depending on this discussion move this upstream
+// https://github.com/airbnb/enzyme/issues/1878.
 ReactWrapper.prototype.renderUntil = renderUntil
 
 /**

--- a/src/DevTools/renderUntil.tsx
+++ b/src/DevTools/renderUntil.tsx
@@ -1,11 +1,11 @@
-import { mount, ReactWrapper, RenderUntilCallback } from "enzyme"
+import { mount, ReactWrapper, RenderUntilPredicate } from "enzyme"
 import * as React from "react"
 
 function renderUntil<
   P = {},
   S = {},
   C extends React.Component = React.Component
->(until: RenderUntilCallback<P, S, C>) {
+>(predicate: RenderUntilPredicate<P, S, C>) {
   return new Promise<ReactWrapper<P, S, C>>(resolve => {
     /**
      * Continuously lets JS/React continue doing its async work and then check
@@ -13,7 +13,7 @@ function renderUntil<
      * ready to be asserted on.
      */
     const wait = () => {
-      if (until(this)) {
+      if (predicate(this)) {
         resolve(this)
       } else {
         setImmediate(() => {
@@ -43,7 +43,7 @@ function deprecated_renderUntil<
   P = {},
   S = {},
   C extends React.Component = React.Component
->(until: RenderUntilCallback<P, S, C>, element: React.ReactElement<P>) {
+>(until: RenderUntilPredicate<P, S, C>, element: React.ReactElement<P>) {
   /**
    * In case of an uncaught error, be sure to reject the promise ASAP and
    * with a helpful error.

--- a/src/setup_jest.ts
+++ b/src/setup_jest.ts
@@ -15,6 +15,7 @@ jest.mock("react-sizeme", () => jest.fn(c => d => d))
  */
 beforeEach(() => expect.hasAssertions())
 
+import "DevTools/renderUntil"
 Enzyme.configure({ adapter: new Adapter() })
 
 import "jsdom"


### PR DESCRIPTION
In response to https://github.com/artsy/reaction/pull/1462#issuecomment-433348087, with this change it will be possible to easily render updates after e.g. interacting with a React tree and triggering a Relay refetch/pagination.

This can also easily be PR’ed upstream to enzyme.