### PR TITLE
[Do Not Merge] Example test resolver issue

### DIFF
--- a/src/Apps/Artist/Routes/CV/CVItem.tsx
+++ b/src/Apps/Artist/Routes/CV/CVItem.tsx
@@ -77,6 +77,7 @@ class CVItem extends Component<CVItemProps, CVItemState> {
     ))
 
   render() {
+    console.log(this.props)
     if (
       !this.props.artist.showsConnection ||
       !this.props.artist.showsConnection.edges.length

--- a/src/Apps/Artist/Routes/CV/__tests__/CV.test.tsx
+++ b/src/Apps/Artist/Routes/CV/__tests__/CV.test.tsx
@@ -5,10 +5,7 @@ import React from "react"
 import { graphql } from "react-relay"
 import { Breakpoint } from "Utils/Responsive"
 
-import {
-  CVFixture,
-  showsConnection,
-} from "Apps/__test__/Fixtures/Artist/Routes/CV"
+import { CVFixture } from "Apps/__test__/Fixtures/Artist/Routes/CV"
 
 jest.unmock("react-relay")
 
@@ -25,11 +22,29 @@ describe("CV Route", () => {
           }
         }
       `,
+
+      // Incorrect
       mockResolvers: {
-        Viewer: () => ({ viewer: { artist_soloShows: CVFixture } }),
-        Artist: () => ({ artist: CVFixture }),
-        ShowConnection: () => showsConnection,
+        Viewer: () => ({ viewer: CVFixture }),
+        // Wrong
+        Artist: () => ({ artist: CVFixture.artist_soloShows }),
+        // Better
+        // Artist: () => CVFixture.artist_soloShows,
+
+        // Returns an undefined connection when commented out, fixed when uncommented
+        // Show: () => CVFixture.artist_soloShows.showsConnection.edges[0].node,
+
+        ShowConnection: () => CVFixture.artist_soloShows.showsConnection,
       },
+
+      // Correct
+      // mockResolvers: {
+      //   Viewer: () => CVFixture,
+      //   Artist: () => CVFixture.artist_soloShows,
+      //   Show: () => CVFixture.artist_soloShows.showsConnection.edges[0].node,
+      //   ShowConnection: () => CVFixture.artist_soloShows.showsConnection,
+      // },
+
       variables: {
         artistID: "pablo-picasso",
       },
@@ -46,8 +61,7 @@ describe("CV Route", () => {
 
     it("renders correct data", () => {
       const html = wrapper.html()
-      expect(html).toContain("Catty Art Show")
-      expect(html).toContain("Catty Partner")
+      expect(html).toContain("Picasso Prints")
     })
   })
 })

--- a/src/Apps/Artist/Routes/Shows/__test__/Shows.test.tsx
+++ b/src/Apps/Artist/Routes/Shows/__test__/Shows.test.tsx
@@ -7,10 +7,7 @@ import { Breakpoint } from "Utils/Responsive"
 
 // import { ShowsFixture } from "Apps/__test__/Fixtures/Artist/Routes/ShowsFixture"
 
-import {
-  CVFixture,
-  showsConnection,
-} from "Apps/__test__/Fixtures/Artist/Routes/CV"
+import { CVFixture } from "Apps/__test__/Fixtures/Artist/Routes/CV"
 
 jest.unmock("react-relay")
 
@@ -29,8 +26,8 @@ describe("Shows Route", () => {
       `,
       mockResolvers: {
         Viewer: () => ({ viewer: { artist_currentShows: CVFixture } }),
-        Artist: () => ({ artist: CVFixture }),
-        ShowConnection: () => showsConnection,
+        Artist: () => ({ artist: CVFixture.artist_fairBooths }),
+        ShowConnection: () => CVFixture.artist_fairBooths.showsConnection,
       },
       variables: {
         artistID: "pablo-picasso",
@@ -48,8 +45,7 @@ describe("Shows Route", () => {
 
     it("to render proper data", () => {
       const html = wrapper.html()
-      expect(html).toContain("Catty Art Show")
-      expect(html).toContain("Catty Partner")
+      expect(html).toContain("Jaime Eguiguren- Art")
     })
   })
 })

--- a/src/Apps/__test__/Fixtures/Artist/Routes/CV.tsx
+++ b/src/Apps/__test__/Fixtures/Artist/Routes/CV.tsx
@@ -1,32 +1,83 @@
-export const showsConnection = {
-  pageInfo: {
-    hasNextPage: true,
-    endCursor: "YXJyYXljb25uZWN0aW9uOjk=",
-  },
-  edges: [
-    {
-      cursor: "YXJyYXljb25uZWN0aW9uOjA=",
-      node: {
-        __id:
-          "U2hvdzp0d28tcGFsbXMtdHdvLXBhbG1zLWF0LWlmcGRhLWZpbmUtYXJ0LXByaW50LWZhaXItMjAxOA==",
-        city: null,
-        href: "/show/two-palms-two-palms-at-ifpda-fine-art-print-fair-2018",
-        name: "Catty Art Show",
-        partner: {
-          __typename: "Partner",
-          name: "Catty Partner",
-          href: "/two-palms",
-          __id: "UGFydG5lcjp0d28tcGFsbXM=",
-        },
-        start_at: "2018",
-        __typename: "Show",
-      },
-    },
-  ],
-}
-
 export const CVFixture = {
-  __id: "",
-  id: "cecily-brown",
-  showsConnection: { showsConnection },
+  artist_soloShows: {
+    id: "pablo-picasso",
+    showsConnection: {
+      pageInfo: { hasNextPage: true, endCursor: "YXJyYXljb25uZWN0aW9uOjk=" },
+      edges: [
+        {
+          node: {
+            __id: "U2hvdzp3YWRhLWdhcm91LXRva3lvLXBpY2Fzc28tcHJpbnRzLTE=",
+            partner: {
+              __typename: "Partner",
+              name: "Wada Garou Tokyo",
+              href: "/wada-garou-tokyo",
+              __id: "UGFydG5lcjp3YWRhLWdhcm91LXRva3lv",
+            },
+            name: "Picasso Prints",
+            start_at: "2018",
+            city: null,
+            href: "/show/wada-garou-tokyo-picasso-prints-1",
+            __typename: "Show",
+          },
+          cursor: "YXJyYXljb25uZWN0aW9uOjA=",
+        },
+      ],
+    },
+    __id: "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+  },
+  artist_groupShows: {
+    id: "pablo-picasso",
+    showsConnection: {
+      pageInfo: { hasNextPage: true, endCursor: "YXJyYXljb25uZWN0aW9uOjk=" },
+      edges: [
+        {
+          node: {
+            __id:
+              "U2hvdzpsYXJzZW4tZ2FsbGVyeS0yMDE4LWxhcnNlbi1hcnQtYXVjdGlvbg==",
+            partner: {
+              __typename: "Partner",
+              name: "Larsen Gallery",
+              href: "/larsen-gallery",
+              __id: "UGFydG5lcjpsYXJzZW4tZ2FsbGVyeQ==",
+            },
+            name: "2018 Larsen Art Auction",
+            start_at: "2018",
+            city: "Scottsdale",
+            href: "/show/larsen-gallery-2018-larsen-art-auction",
+            __typename: "Show",
+          },
+          cursor: "YXJyYXljb25uZWN0aW9uOjA=",
+        },
+      ],
+    },
+    __id: "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+  },
+  artist_fairBooths: {
+    id: "pablo-picasso",
+    showsConnection: {
+      pageInfo: { hasNextPage: true, endCursor: "YXJyYXljb25uZWN0aW9uOjk=" },
+      edges: [
+        {
+          node: {
+            __id:
+              "U2hvdzpqYWltZS1lZ3VpZ3VyZW4tYXJ0LWFuZC1hbnRpcXVlcy1qYWltZS1lZ3VpZ3VyZW4tYXJ0LWFuZC1hbnRpcXVlcy1hdC10ZWZhZi1uZXcteW9yay1mYWxsLTIwMTg=",
+            partner: {
+              __typename: "Partner",
+              name: "Jaime Eguiguren- Art & Antiques",
+              href: "/jaime-eguiguren-art-and-antiques",
+              __id: "UGFydG5lcjpqYWltZS1lZ3VpZ3VyZW4tYXJ0LWFuZC1hbnRpcXVlcw==",
+            },
+            name: "Jaime Eguiguren- Art & Antiques at TEFAF New York Fall 2018",
+            start_at: "2018",
+            city: null,
+            href:
+              "/show/jaime-eguiguren-art-and-antiques-jaime-eguiguren-art-and-antiques-at-tefaf-new-york-fall-2018",
+            __typename: "Show",
+          },
+          cursor: "YXJyYXljb25uZWN0aW9uOjA=",
+        },
+      ],
+    },
+    __id: "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4566,11 +4566,6 @@ class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
   integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
-  dependencies:
-    arr-union "^3.1.0"
-    define-property "^0.2.5"
-    isobject "^3.0.0"
-    static-extend "^0.1.1"
 
 classnames@^2.2.3, classnames@^2.2.4, classnames@^2.2.6:
   version "2.2.6"
@@ -5469,7 +5464,7 @@ deep-object-diff@^1.1.0:
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
 
-deepmerge@^2.1.1:
+deepmerge@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
@@ -12658,12 +12653,12 @@ react-toggle@^4.0.2:
   dependencies:
     classnames "^2.2.5"
 
-react-tracking@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.4.1.tgz#2a85793326aadefa9c3955332181279904fa72c4"
-  integrity sha512-945FcLuEjUSFCWF9zRPVLU9pNZf3lDO2GNhICWv3ZtqTkeI6eo2vzvrOSb5SaMYevesdwAIFmmQGCx8tmnZI6Q==
+react-tracking@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.6.0.tgz#b093e88b161252457307fff1bec622eecc7894b4"
+  integrity sha512-S+BylXekrspRlJ6CTfrrSO/CAlyQv0pl6iEiiNLLQwmFpBNpg6O8fyC1tC6y8o/Ta5Mv9YS6sB6LseRwiQmEyQ==
   dependencies:
-    deepmerge "^2.1.1"
+    deepmerge "^2.2.1"
     hoist-non-react-statics "^3.0.1"
 
 react-transition-group@^2.0.0, react-transition-group@^2.2.0, react-transition-group@^2.3.0:


### PR DESCRIPTION
When playing with some tests using the new `renderRelayTree` I noticed that its not exactly clear how to populate connection data correctly or to track down where problems occur:

To repo: 
- `yarn install` to apply patch package (which just drops a `console.log` in the right spot in `relay-mock-network-layer`)
- `yarn jest src/Apps/Artist/Routes/CV/__tests__/CV.test.tsx --watch --verbose false` (the verbose bit is to preserve console.logs) 

When first running the test you'll see a log of response data coming from `relay-mock-network-layer` that _seems_ correct. After that log is a log from `CVItem` logging out its props. Looking inside, the first and second items have an undefined `showsConnection`. This was eventually semi-fixed due to adjustments made to the mocking code (enough to assume the structure is valid to get the test fully passing), and then finally there's the fully-correct implementation (that's commented out). 

Another thing to note is that in `src/__generated__/CV_Test_Query.graphql.ts` it doesn't list out all of the required types needed to mock the resolvers as `Show` and `ShowConnection` is missing. A developer would have to infer it from the query key name though I imagine there might be some way for tooling to grab the correct info. 

I guess this again goes back to how to help surface issues for devs trying to mock out complex pages that cross over a few areas in MP, as it took a while to find the thread that led to the issue due to two silent errors.

Here's a screencap of CV.test: 

![test](https://user-images.githubusercontent.com/236943/47595654-37a7b800-d936-11e8-9129-0c71ba444d2d.gif)

