### PR TITLE
give image default aspect ratio in case we don't get one from gravity

### DIFF
--- a/src/Components/Artwork/FillwidthItem.tsx
+++ b/src/Components/Artwork/FillwidthItem.tsx
@@ -13,6 +13,7 @@ import { Mediator } from "Artsy/SystemContext"
 import styled, { StyledComponentClass } from "styled-components"
 
 const IMAGE_QUALITY = 80
+const FALLBACK_RATIO = 1
 
 const Image = styled.img`
   width: 100%;
@@ -64,8 +65,10 @@ export class FillwidthItemContainer extends React.Component<
 
     // Either scale or crop, based on if an aspect ratio is available.
     const type = aspect_ratio ? "fit" : "fill"
+    // In case aspect ratio is not available we still want to try to get some width
+    const ratio = aspect_ratio || FALLBACK_RATIO
     const height = this.props.imageHeight * window.devicePixelRatio
-    const width = Math.floor(height * aspect_ratio * window.devicePixelRatio)
+    const width = Math.floor(height * ratio * window.devicePixelRatio)
 
     // tslint:disable-next-line:max-line-length
     return `${

--- a/src/Styleguide/Components/RecentlyViewed.tsx
+++ b/src/Styleguide/Components/RecentlyViewed.tsx
@@ -15,6 +15,7 @@ export interface RecentlyViewedProps {
 }
 
 const HEIGHT = 180
+const FALLBACK_RATIO = 1
 
 export const RecentlyViewed: React.SFC<RecentlyViewedProps> = props => {
   const { me } = props
@@ -42,13 +43,14 @@ export const RecentlyViewed: React.SFC<RecentlyViewedProps> = props => {
                       image: { aspect_ratio },
                     },
                   } = artwork
+                  const ratio = aspect_ratio || FALLBACK_RATIO
 
                   return (
                     <FillwidthItem
                       artwork={artwork.node}
                       targetHeight={HEIGHT}
                       imageHeight={HEIGHT}
-                      width={HEIGHT * aspect_ratio}
+                      width={HEIGHT * ratio}
                       margin={10}
                       useRelay={props.useRelay}
                       user={user}


### PR DESCRIPTION
@mzikherman - based on discussion here: https://artsy.slack.com/archives/CAZG82X4G/p1540825452041200

I think this might fix the immediate issue I was seeing when image is not displayed at all and there is no width for the item:
![screen shot 2018-10-29 at 11 59 33 am](https://user-images.githubusercontent.com/437156/47662834-20550e80-db72-11e8-93c5-2ecce10abea3.png)

This fix might make those images scale strangely but I think it's still better than current situation.