### PR TITLE
Fix a bug where the sort option is always set to "-decayed_merch" on both Collect and Collection

### DIFF
--- a/src/Apps/Collect/__tests__/routes.test.tsx
+++ b/src/Apps/Collect/__tests__/routes.test.tsx
@@ -48,6 +48,20 @@ describe("Routes", () => {
       })
     })
 
+    it("respects the sort option selected by the user", () => {
+      const props = {
+        location: {
+          query: {
+            sort: "-published_at",
+          },
+        },
+      }
+
+      expect(route.prepareVariables(params, props)).toEqual({
+        sort: "-published_at",
+      })
+    })
+
     xit("renders", async () => {
       const { element } = (await render("/collect", {
         Viewer: () => data,

--- a/src/Apps/Collect/routes.tsx
+++ b/src/Apps/Collect/routes.tsx
@@ -56,10 +56,8 @@ export const routes: RouteConfig[] = [
           props.location.query.medium = params.medium
         }
       }
-      if (!params.sort) {
-        params.sort = "-decayed_merch"
-      }
-      return { ...initialFilterState, ...params }
+
+      return { sort: "-decayed_merch", ...initialFilterState, ...params }
     },
   },
   {


### PR DESCRIPTION
While I was working on https://artsyproduct.atlassian.net/browse/GROW-976 I noticed that the `sort` options is ignored entirely on Collect and Collection. This PR updates the `prepareVariables` function to respect it properly so the page the page results will be consistent after a page refresh.