### PR TITLE
Add Sentry to Reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
   "dependencies": {
     "@artsy/palette": "^2.19.9",
     "@artsy/react-responsive-media": "^1.0.5",
+    "@sentry/browser": "^4.2.3",
     "cheerio": "^1.0.0-rc.2",
     "farce": "^0.2.6",
     "formik": "^0.11.11",

--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -18,6 +18,7 @@ import {
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
 import { get } from "Utils/get"
+import createLogger from "Utils/logger"
 import { Responsive } from "Utils/Responsive"
 import { OrderStepper } from "../../Components/OrderStepper"
 
@@ -35,6 +36,8 @@ export interface OfferState {
   errorModalTitle: string
   errorModalMessage: string
 }
+
+const logger = createLogger("Order/Routes/Offer/index.tsx")
 
 export class OfferRoute extends Component<OfferProps, OfferState> {
   state = {
@@ -102,7 +105,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
   }
 
   onMutationError(errors, errorModalTitle?, errorModalMessage?) {
-    console.error("Offer/index.tsx", errors)
+    logger.error(errors)
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -33,6 +33,7 @@ import { injectStripe, ReactStripeElements } from "react-stripe-elements"
 import { Collapse } from "Styleguide/Components"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
+import createLogger from "Utils/logger"
 import { Responsive } from "Utils/Responsive"
 
 export const ContinueButton = props => (
@@ -58,6 +59,8 @@ interface PaymentState {
   isErrorModalOpen: boolean
   errorModalMessage: string
 }
+
+const logger = createLogger("Order/Routes/Payment/index.tsx")
 
 @track()
 export class PaymentRoute extends Component<PaymentProps, PaymentState> {
@@ -418,7 +421,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
   }
 
   private onMutationError(errors, errorModalMessage?) {
-    console.error("Order/Routes/Payment/index.tsx", errors)
+    logger.error(errors)
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -19,6 +19,7 @@ import {
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
 import { get } from "Utils/get"
+import createLogger from "Utils/logger"
 import { Responsive } from "Utils/Responsive"
 import { Helper } from "../../Components/Helper"
 import { TransactionSummaryFragmentContainer as TransactionSummary } from "../../Components/TransactionSummary"
@@ -39,6 +40,8 @@ interface ReviewState {
   errorModalTitle: string
   errorModalCtaAction: () => null
 }
+
+const logger = createLogger("Order/Routes/Review/index.tsx")
 
 @track()
 export class ReviewRoute extends Component<ReviewProps, ReviewState> {
@@ -181,7 +184,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
     errorModalMessage?,
     errorModalCtaAction?
   ) {
-    console.error("Order/Routes/Review/index.tsx", errors)
+    logger.error(errors)
     this.setState({
       isSubmitting: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -41,6 +41,7 @@ import { Collapse } from "Styleguide/Components"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
 import { get } from "Utils/get"
+import createLogger from "Utils/logger"
 import { Responsive } from "Utils/Responsive"
 
 export interface ShippingProps {
@@ -60,6 +61,9 @@ export interface ShippingState {
   errorModalTitle: string
   errorModalMessage: string
 }
+
+const logger = createLogger("Order/Routes/Shipping/index.tsx")
+
 @track()
 export class ShippingRoute extends Component<ShippingProps, ShippingState> {
   state = {
@@ -214,7 +218,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
   }
 
   onMutationError(errors, errorModalTitle?, errorModalMessage?) {
-    console.error("Shipping/index.tsx", errors)
+    logger.error(errors)
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Artsy/Router/Components/Boot.tsx
+++ b/src/Artsy/Router/Components/Boot.tsx
@@ -1,10 +1,12 @@
 import { Theme, themeProps } from "@artsy/palette"
+import * as Sentry from "@sentry/browser"
 import { track } from "Artsy/Analytics"
 import * as Artsy from "Artsy/SystemContext"
 import { ResolverUtils, RouteConfig } from "found"
 import React from "react"
 import { HeadProvider } from "react-head"
 import { Environment } from "relay-runtime"
+import { data as sd } from "sharify"
 import { GridThemeProvider } from "styled-bootstrap-grid"
 import { GlobalStyles } from "Styleguide/Elements/GlobalStyles"
 import { Grid } from "Styleguide/Elements/Grid"
@@ -29,6 +31,10 @@ export interface BootProps {
   dispatch: data => Events.postEvent(data),
 })
 export class Boot extends React.Component<BootProps> {
+  componentDidMount() {
+    Sentry.init({ dsn: sd.SENTRY_PUBLIC_DSN })
+  }
+
   render() {
     const { children, context, headTags = [], ...props } = this.props
     const contextProps = {

--- a/src/Artsy/Router/Components/Boot.tsx
+++ b/src/Artsy/Router/Components/Boot.tsx
@@ -2,6 +2,7 @@ import { Theme, themeProps } from "@artsy/palette"
 import * as Sentry from "@sentry/browser"
 import { track } from "Artsy/Analytics"
 import * as Artsy from "Artsy/SystemContext"
+import { ErrorBoundary } from "Components/ErrorBoundary"
 import { ResolverUtils, RouteConfig } from "found"
 import React from "react"
 import { HeadProvider } from "react-head"
@@ -43,29 +44,31 @@ export class Boot extends React.Component<BootProps> {
     }
 
     return (
-      <HeadProvider headTags={headTags}>
-        <StateProvider>
-          <Artsy.ContextProvider {...contextProps}>
-            <ResponsiveProvider
-              mediaQueries={themeProps.mediaQueries}
-              initialMatchingMediaQueries={props.initialMatchingMediaQueries}
-            >
-              <Theme>
-                <GridThemeProvider gridTheme={themeProps.grid}>
-                  <Grid fluid>
-                    <GlobalStyles>
-                      {children}
-                      {process.env.NODE_ENV === "development" && (
-                        <BreakpointVisualizer />
-                      )}
-                    </GlobalStyles>
-                  </Grid>
-                </GridThemeProvider>
-              </Theme>
-            </ResponsiveProvider>
-          </Artsy.ContextProvider>
-        </StateProvider>
-      </HeadProvider>
+      <ErrorBoundary>
+        <HeadProvider headTags={headTags}>
+          <StateProvider>
+            <Artsy.ContextProvider {...contextProps}>
+              <ResponsiveProvider
+                mediaQueries={themeProps.mediaQueries}
+                initialMatchingMediaQueries={props.initialMatchingMediaQueries}
+              >
+                <Theme>
+                  <GridThemeProvider gridTheme={themeProps.grid}>
+                    <Grid fluid>
+                      <GlobalStyles>
+                        {children}
+                        {process.env.NODE_ENV === "development" && (
+                          <BreakpointVisualizer />
+                        )}
+                      </GlobalStyles>
+                    </Grid>
+                  </GridThemeProvider>
+                </Theme>
+              </ResponsiveProvider>
+            </Artsy.ContextProvider>
+          </StateProvider>
+        </HeadProvider>
+      </ErrorBoundary>
     )
   }
 }

--- a/src/Artsy/Router/Components/__test__/Boot.test.tsx
+++ b/src/Artsy/Router/Components/__test__/Boot.test.tsx
@@ -1,5 +1,6 @@
 import { Boot } from "Artsy/Router"
 import { ContextConsumer } from "Artsy/Router"
+import { ErrorBoundary } from "Components/ErrorBoundary"
 import { mount } from "enzyme"
 import React from "react"
 
@@ -54,5 +55,21 @@ describe("Boot", () => {
 
   it("injects Grid", () => {
     expect(mount(<Boot {...bootProps} />).find("Grid").length).toEqual(1)
+  })
+
+  it("catches errors with componentDidCatch", () => {
+    console.error = jest.fn()
+    const BrokenComponent = () => {
+      throw new Error("error message")
+      return <div>error</div>
+    }
+
+    jest.spyOn(ErrorBoundary.prototype, "componentDidCatch")
+    mount(
+      <Boot {...bootProps}>
+        <BrokenComponent />
+      </Boot>
+    )
+    expect(ErrorBoundary.prototype.componentDidCatch).toHaveBeenCalled()
   })
 })

--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -1,12 +1,15 @@
 import React from "react"
+import createLogger from "Utils/logger"
 
 interface Props {
   children?: any
 }
 
+const logger = createLogger()
+
 export class ErrorBoundary extends React.Component<Props> {
   componentDidCatch(error, errorInfo) {
-    console.error(error)
+    logger.error(error, errorInfo)
   }
 
   render() {

--- a/src/Utils/__test__/errors.test.ts
+++ b/src/Utils/__test__/errors.test.ts
@@ -8,7 +8,8 @@ describe("errors", () => {
     it("returns true if an object implements the ErrorInfo interface", () => {
       const errorInfo = { componentStack: "someString", anotherKey: 0 }
       expect(isErrorInfo(errorInfo)).toBe(true)
-
+    })
+    it("returns false if an object does not implement the ErrorInfo interface", () => {
       const notErrorInfo = { anotherKey: 0 }
       expect(isErrorInfo(notErrorInfo)).toBe(false)
     })

--- a/src/Utils/__test__/errors.test.ts
+++ b/src/Utils/__test__/errors.test.ts
@@ -13,7 +13,7 @@ describe("errors", () => {
       expect(isErrorInfo(notErrorInfo)).toBe(false)
     })
   })
-  describe("#sendErrorToServie", () => {
+  describe("#sendErrorToService", () => {
     it("sends an error to Sentry", () => {
       const errorInfo = { componentStack: "more error info" }
       sendErrorToService(new Error("msg"), errorInfo)

--- a/src/Utils/__test__/errors.test.ts
+++ b/src/Utils/__test__/errors.test.ts
@@ -1,0 +1,23 @@
+import * as Sentry from "@sentry/browser"
+import { isErrorInfo, sendErrorToService } from "Utils/errors"
+
+jest.mock("@sentry/browser")
+
+describe("errors", () => {
+  describe("#isErrorInfo", () => {
+    it("returns true if an object implements the ErrorInfo interface", () => {
+      const errorInfo = { componentStack: "someString", anotherKey: 0 }
+      expect(isErrorInfo(errorInfo)).toBe(true)
+
+      const notErrorInfo = { anotherKey: 0 }
+      expect(isErrorInfo(notErrorInfo)).toBe(false)
+    })
+  })
+  describe("#sendErrorToServie", () => {
+    it("sends an error to Sentry", () => {
+      const errorInfo = { componentStack: "more error info" }
+      sendErrorToService(new Error("msg"), errorInfo)
+      expect(Sentry.withScope).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/Utils/__test__/logger.test.ts
+++ b/src/Utils/__test__/logger.test.ts
@@ -1,0 +1,65 @@
+import { sendErrorToService } from "Utils/errors"
+import createLogger from "Utils/logger"
+
+jest.mock("Utils/errors")
+
+describe("logger", () => {
+  describe("#createLogger", () => {
+    let logger
+    beforeEach(() => {
+      console.log = jest.fn()
+      console.warn = jest.fn()
+      console.error = jest.fn()
+      logger = createLogger("testing")
+    })
+
+    describe("#log", () => {
+      it("logs given statements with console.log", () => {
+        logger.log("msg")
+        expect(console.log).toBeCalledWith("testing |", "msg", "\n")
+      })
+    })
+
+    describe("#warn", () => {
+      it("logs given warnings with console.warn", () => {
+        logger.warn("msg")
+        expect(console.warn).toBeCalledWith("testing |", "msg", "\n")
+      })
+    })
+
+    describe("#error", () => {
+      describe("when it should not capture errors", () => {
+        it("does not send errors to service", () => {
+          logger.error(new Error("msg"))
+          expect(sendErrorToService).not.toHaveBeenCalled()
+        })
+      })
+
+      describe("when it should capture errors", () => {
+        let originalEnv
+        beforeAll(() => {
+          originalEnv = process.env
+          process.env = Object.assign({}, originalEnv, {
+            NODE_ENV: "staging",
+          })
+        })
+
+        afterAll(() => {
+          process.env = originalEnv(sendErrorToService as any).mockReset()
+        })
+
+        it("sends errors to service", () => {
+          const err = new Error("msg")
+          logger.error(err)
+          expect(sendErrorToService).toHaveBeenCalledWith(err, undefined)
+        })
+      })
+
+      it("logs given errors with console.error", () => {
+        const err = new Error("msg")
+        logger.error(err)
+        expect(console.error).toBeCalledWith("testing |", err, "\n")
+      })
+    })
+  })
+})

--- a/src/Utils/__test__/logger.test.ts
+++ b/src/Utils/__test__/logger.test.ts
@@ -45,7 +45,8 @@ describe("logger", () => {
         })
 
         afterAll(() => {
-          process.env = originalEnv(sendErrorToService as any).mockReset()
+          process.env = originalEnv
+          ;(sendErrorToService as any).mockReset()
         })
 
         it("sends errors to service", () => {

--- a/src/Utils/errors.tsx
+++ b/src/Utils/errors.tsx
@@ -1,3 +1,25 @@
+import * as Sentry from "@sentry/browser"
+
 export class NetworkError extends Error {
   response: any
+}
+
+interface ErrorInfo {
+  componentStack: string
+}
+
+// We don't know what we'll receive through `logger.error` but sometimes
+// we expect an ErrorInfo object if an error is thrown in an error boundary.
+// We want to be able to check if an object implements the expected ErrorInfo
+// interface so we can pass it along to Sentry.
+export const isErrorInfo = (arg: any): arg is ErrorInfo =>
+  !!(arg && arg.componentStack && typeof arg.componentStack === "string")
+
+export const sendErrorToService = (error: Error, errorInfo?: ErrorInfo) => {
+  Sentry.withScope(scope => {
+    Object.keys(errorInfo).forEach(key => {
+      scope.setExtra(key, errorInfo[key])
+    })
+    Sentry.captureException(error)
+  })
 }

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -1,4 +1,3 @@
-import { head } from "lodash"
 import { isErrorInfo, sendErrorToService } from "Utils/errors"
 
 export const shouldCaptureError = (environment: string) =>
@@ -15,8 +14,8 @@ export default function createLogger(namespace = "reaction") {
       console.warn(formattedNamespace, ...warnings, "\n")
     },
     error: (...errors) => {
-      const error = head(errors.filter(e => e instanceof Error))
-      const errorInfo = head(errors.filter(e => isErrorInfo(e)))
+      const error = errors.find(e => e instanceof Error)
+      const errorInfo = errors.find(isErrorInfo)
 
       if (error && shouldCaptureError(process.env.NODE_ENV)) {
         sendErrorToService(error, errorInfo)

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -1,0 +1,28 @@
+import { head } from "lodash"
+import { isErrorInfo, sendErrorToService } from "Utils/errors"
+
+export const shouldCaptureError = (environment: string) =>
+  environment === "staging" || environment === "production"
+
+export default function createLogger(namespace = "reaction") {
+  const formattedNamespace = `${namespace} |`
+
+  return {
+    log: (...messages) => {
+      console.log(formattedNamespace, ...messages, "\n")
+    },
+    warn: (...warnings) => {
+      console.warn(formattedNamespace, ...warnings, "\n")
+    },
+    error: (...errors) => {
+      const error = head(errors.filter(e => e instanceof Error))
+      const errorInfo = head(errors.filter(e => isErrorInfo(e)))
+
+      if (error && shouldCaptureError(process.env.NODE_ENV)) {
+        sendErrorToService(error, errorInfo)
+      }
+
+      console.error(formattedNamespace, ...errors, "\n")
+    },
+  }
+}

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -21,6 +21,7 @@ declare module "sharify" {
       readonly GEMINI_CLOUDFRONT_URL: string
       readonly METAPHYSICS_ENDPOINT: string
       readonly NODE_ENV: string
+      readonly SENTRY_PUBLIC_DSN: string
       readonly STRIPE_PUBLISHABLE_KEY: string
       readonly XAPP_TOKEN: string
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,6 +1486,53 @@
     into-stream "^3.1.0"
     lodash "^4.17.4"
 
+"@sentry/browser@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-4.2.3.tgz#8ee405ba5cad5875945ebbfd5441daa9771bff7f"
+  integrity sha512-XvuIc1aclz4zuP2LamDuSy62/gl1mmNxzF+Ni5L8mcghBDq0urnOdkblVQgzqGoH8mc2QfjEctGa5djWxg3Bpg==
+  dependencies:
+    "@sentry/core" "4.2.3"
+    "@sentry/types" "4.2.3"
+    "@sentry/utils" "4.2.3"
+
+"@sentry/core@4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-4.2.3.tgz#58d45e0e6b3f805e9ccd2c32fdff40bc612a7f80"
+  integrity sha512-xo5rvksftnaEdnKbdokyfuqgMnuqw1DFp0lDboIFHlEBcQde/AdThEgLujJWmbVNI3Cg7g8/HvP65f7QBjKfOw==
+  dependencies:
+    "@sentry/hub" "4.2.3"
+    "@sentry/minimal" "4.2.3"
+    "@sentry/types" "4.2.3"
+    "@sentry/utils" "4.2.3"
+
+"@sentry/hub@4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-4.2.3.tgz#90b84d351051cd537e36836d38dd4ae4b90617bb"
+  integrity sha512-7Jc/wz3vybYm1RX2wk/4zAQS8fo3uxvXYBkRfpm3OmnGgTlwDEmJwtegeGWFqufxLl85brZ19V1KAdulmO206A==
+  dependencies:
+    "@sentry/types" "4.2.3"
+    "@sentry/utils" "4.2.3"
+
+"@sentry/minimal@4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-4.2.3.tgz#f7cde49e797fa75df652bcb95fb06a8a4df4d7ac"
+  integrity sha512-Hus7LUeJDGsYpT2RTe6bUjG7mHG9uQoyDmW6pYUMN2dhD+cP5cPoTIXO4yxokwgAeDa+GH2/UXoASWc4s2eA2w==
+  dependencies:
+    "@sentry/hub" "4.2.3"
+    "@sentry/types" "4.2.3"
+
+"@sentry/types@4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.2.3.tgz#e53df8ac5c2419d333be8671972a2db6d34de230"
+  integrity sha512-Z7laXlLtLSEXcKzgcD2caWPMTM8sAvR86rssYM5uYb3azC5PO0aAvuhjokkdv1+Ke1Bg7lkaNZamiCSyaH/9xg==
+
+"@sentry/utils@4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-4.2.3.tgz#46119e0938308245054984303ee1b049a7ab7523"
+  integrity sha512-D6+M1081wCwGp8adWV3KFOxrxFmVyjMJ45x6/TnYvXdgDyc+t28oil21FHeKhwjld9eMqgQ5Tf1OOvos1MNBQg==
+  dependencies:
+    "@sentry/types" "4.2.3"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"


### PR DESCRIPTION
~WIP to rebuild commit history -- otherwise, code changes are ready for review.~

Addresses [PURCHASE-570](https://artsyproduct.atlassian.net/browse/PURCHASE-570).

### Problem
We want to be able to factor in client-side errors into our analysis of the buy now checkout funnel.

### Solution
Add Sentry to Reaction and capture errors for all apps since currently we don't capture any errors.

### What changed
- Added `@sentry/browser` package
- Added new `logger` that allows us to add custom behavior before calling out normal `console.*` statements. For `logger.error`, we send an error to Sentry before calling `console.error`.
- Wrapped `Boot` in `ErrorBoundary` component to catch errors
- Replaced `console.error` statements in Order app with `logger.error`