### PR TITLE
Use a more structured type for ModalOptions.afterSignUpAction

### DIFF
--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -34,6 +34,12 @@ export interface FormProps {
   onBackButtonClicked?: (e: Event) => void
 }
 
+interface AfterSignUpAction {
+  action: "save" | "follow" | "editorialSignup"
+  objectId?: string
+  kind?: "artist" | "artworks" | "gene" | "profile" | "show"
+}
+
 export interface ModalOptions {
   /**
    * the subtitle of the form
@@ -70,7 +76,7 @@ export interface ModalOptions {
    *   objectId: artwork.id
    * }
    */
-  afterSignUpAction?: string
+  afterSignUpAction?: AfterSignUpAction
   /*
    * the location where the modal was triggered.
    */


### PR DESCRIPTION
It seems like the `afterSignUpAction` field is never a string, but an object with a required `action` and optional `objectId` and `kind`. This PR makes it more explicit and be type-safe.