### PR TITLE
Automatically opt-in mobile users who sign up from an editorial page to the daily newsletter

### DIFF
--- a/src/Components/Publishing/Banner/Banner.tsx
+++ b/src/Components/Publishing/Banner/Banner.tsx
@@ -57,6 +57,7 @@ export class BannerWrapper extends Component<{ article: ArticleData }, State> {
     return (
       <MinimalCtaBanner
         href={`/sign_up?${qs.stringify({
+          action: "editorialSignup",
           intent: "viewed editorial",
           trigger: "click",
           contextModule: "auth minimal cta banner",


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-858

This PR updates the CTA banner on the mobile Article view so that we will be able to automatically opt-in mobile users who sign up from an editorial page to the daily newsletter.

I'm sure this looks like a very weird PR, but the `editorialSignup` action will be added to Force by https://github.com/artsy/force/pull/3049 and Reaction depends on it. It is safe to add an `action`, and once https://github.com/artsy/force/pull/3049 is merged the `checkForAfterSignUpAction` function will automatically start making a call to Sailthru.