### PR TITLE
Update circle ci to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ filter_master: &filter_master
       only:
         - master
 
-version: 2
+version: 2.1
 jobs:
   relay:
     <<: *setup_workspace


### PR DESCRIPTION
Circle CI doesn't seem to want to upgrade build versions until the version specified is in master. This is change just bumps the version to get it running there. 