### PR TITLE
add metadata description for collect and collection page

### DIFF
--- a/src/Apps/Collect/CollectApp.tsx
+++ b/src/Apps/Collect/CollectApp.tsx
@@ -5,21 +5,37 @@ import { Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { CollectFrame } from "./CollectFrame"
+import { CollectMediumMetadata } from "./CollectMediumMetadata"
 import { CollectFilterFragmentContainer as ArtworkGrid } from "./Components/Base/CollectFilterContainer"
+
 export interface CollectAppProps {
   viewer?: CollectApp_viewer
 }
 
 export class CollectApp extends Component<CollectAppProps> {
   render() {
+    const medium = this.props.viewer.__fragments.CollectFilterContainer_viewer
+      .medium
+
+    const title = medium
+      ? CollectMediumMetadata[medium].title
+      : "Collect | Artsy"
+
+    const description = medium
+      ? CollectMediumMetadata[medium].description
+      : "Find artworks by subject matter, style/technique, movement, price, and gallery/institution."
+
     return (
       <CollectFrame>
-        <Title>Collect | Artsy</Title>
+        <Title>{title}</Title>
         <Meta property="og:url" content={`${sd.APP_URL}/collect`} />
         <Meta
           property="og:image"
           content={`${sd.APP_URL}/images/og_image.jpg`}
         />
+        <Meta name="description" content={description} />
+        <Meta property="og:description" content={description} />
+        <Meta property="twitter:description" content={description} />
 
         <Box mt={3} mb={4}>
           <Serif size="8">Collect art and design online</Serif>

--- a/src/Apps/Collect/CollectApp.tsx
+++ b/src/Apps/Collect/CollectApp.tsx
@@ -1,29 +1,28 @@
 import { Box, Serif } from "@artsy/palette"
 import { CollectApp_viewer } from "__generated__/CollectApp_viewer.graphql"
 import React, { Component } from "react"
-import { Meta, Title } from "react-head"
+import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { CollectFrame } from "./CollectFrame"
-import { CollectMediumMetadata } from "./CollectMediumMetadata"
+import { getMetadataForMedium } from "./CollectMediumMetadata"
 import { CollectFilterFragmentContainer as ArtworkGrid } from "./Components/Base/CollectFilterContainer"
 
 export interface CollectAppProps {
   viewer?: CollectApp_viewer
+  params?: {
+    medium: string
+  }
 }
 
 export class CollectApp extends Component<CollectAppProps> {
   render() {
-    const medium = this.props.viewer.__fragments.CollectFilterContainer_viewer
-      .medium
-
-    const title = medium
-      ? CollectMediumMetadata[medium].title
-      : "Collect | Artsy"
-
-    const description = medium
-      ? CollectMediumMetadata[medium].description
-      : "Find artworks by subject matter, style/technique, movement, price, and gallery/institution."
+    const { params } = this.props
+    const medium = params && params.medium
+    const { description, title } = getMetadataForMedium(medium)
+    const canonicalHref = medium
+      ? `${sd.APP_URL}/collect/${medium}`
+      : `${sd.APP_URL}/collect`
 
     return (
       <CollectFrame>
@@ -36,6 +35,7 @@ export class CollectApp extends Component<CollectAppProps> {
         <Meta name="description" content={description} />
         <Meta property="og:description" content={description} />
         <Meta property="twitter:description" content={description} />
+        <Link rel="canonical" href={canonicalHref} />
 
         <Box mt={3} mb={4}>
           <Serif size="8">Collect art and design online</Serif>

--- a/src/Apps/Collect/CollectMediumMetadata.ts
+++ b/src/Apps/Collect/CollectMediumMetadata.ts
@@ -1,68 +1,65 @@
-export const CollectMediumMetadata = {
-  painting: {
-    count: "250,000",
-    title: "Paintings for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 250,000 paintings on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  photography: {
-    count: "140,000",
-    title: "Photography for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 140,000 photographs on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  sculpture: {
-    count: "90,000",
-    title: "Sculptures for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 90,000 sculptures on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  prints: {
-    count: "75,000",
-    title: "Prints for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 75,000 prints on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  "work-on-paper": {
-    count: "80,000",
-    title: "Works on Paper for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 80,000 works on paper on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  drawing: {
-    count: "32,000",
-    title: "Drawings for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 32,000 drawings on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  design: {
-    count: "16,000",
-    title: "Design Works for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 16,000 design works on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  installation: {
-    count: "13,000",
-    title: "Installations for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 13,000 installations on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  "film-slash-video": {
-    count: "4,000",
-    title: "Films & Videos for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 4,000 drawings on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  jewelry: {
-    count: "3,000",
-    title: "Jewelry for Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 3,000 pieces of jewelry on Artsy, the world’s largest online marketplace for art and design.",
-  },
-  "performance-art": {
-    count: "3,000",
-    title: "Performance Art Works Sale | Collect on Artsy",
-    description:
-      "Buy, bid, and inquire on over 3,000 performance art works on Artsy, the world’s largest online marketplace for art and design.",
-  },
+export function getMetadataForMedium(medium) {
+  let title = ""
+  let mediumDescription = ""
+
+  switch (medium) {
+    case "painting":
+      title = "Paintings"
+      mediumDescription = "250,000 paintings"
+      break
+    case "photography":
+      title = "Photography"
+      mediumDescription = "140,000 photographs"
+      break
+    case "sculptures":
+      title = "Sculptures"
+      mediumDescription = "90,000 sculptures"
+      break
+    case "prints":
+      title = "Prints"
+      mediumDescription = "75,000 prints"
+      break
+    case "work-on-paper":
+      title = "Works on Paper"
+      mediumDescription = "80,000 works on paper"
+      break
+    case "drawing":
+      title = "Drawings"
+      mediumDescription = "32,000 drawings"
+      break
+    case "design":
+      title = "Design Works"
+      mediumDescription = "16,000 design works"
+      break
+    case "installation":
+      title = "Installations"
+      mediumDescription = "13,000 installations"
+      break
+    case "film-slash-video":
+      title = "Films & Videos"
+      mediumDescription = "4,000 Films & Videos works"
+      break
+    case "jewelry":
+      title = "Jewelry"
+      mediumDescription = "3,000 pieces of jewelry"
+      break
+    case "performance-art":
+      title = "Performance Art Works"
+      mediumDescription = "3,000 performance art works"
+    default:
+      null
+  }
+
+  if (title && mediumDescription) {
+    return {
+      title: `${title} for Sale | Collect on Artsy`,
+      description: `Buy, bid, and inquire on over ${mediumDescription} on Artsy, the world’s largest online marketplace for art and design.`,
+    }
+  } else {
+    return {
+      title: "Collect | Artsy",
+      description:
+        "Find artworks by subject matter, style/technique, movement, price, and gallery/institution.",
+    }
+  }
 }

--- a/src/Apps/Collect/CollectMediumMetadata.ts
+++ b/src/Apps/Collect/CollectMediumMetadata.ts
@@ -1,0 +1,68 @@
+export const CollectMediumMetadata = {
+  painting: {
+    count: "250,000",
+    title: "Paintings for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 250,000 paintings on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  photography: {
+    count: "140,000",
+    title: "Photography for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 140,000 photographs on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  sculpture: {
+    count: "90,000",
+    title: "Sculptures for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 90,000 sculptures on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  prints: {
+    count: "75,000",
+    title: "Prints for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 75,000 prints on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  "work-on-paper": {
+    count: "80,000",
+    title: "Works on Paper for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 80,000 works on paper on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  drawing: {
+    count: "32,000",
+    title: "Drawings for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 32,000 drawings on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  design: {
+    count: "16,000",
+    title: "Design Works for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 16,000 design works on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  installation: {
+    count: "13,000",
+    title: "Installations for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 13,000 installations on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  "film-slash-video": {
+    count: "4,000",
+    title: "Films & Videos for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 4,000 drawings on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  jewelry: {
+    count: "3,000",
+    title: "Jewelry for Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 3,000 pieces of jewelry on Artsy, the world’s largest online marketplace for art and design.",
+  },
+  "performance-art": {
+    count: "3,000",
+    title: "Performance Art Works Sale | Collect on Artsy",
+    description:
+      "Buy, bid, and inquire on over 3,000 performance art works on Artsy, the world’s largest online marketplace for art and design.",
+  },
+}

--- a/src/Apps/Collect/CollectionApp.tsx
+++ b/src/Apps/Collect/CollectionApp.tsx
@@ -5,6 +5,7 @@ import React, { Component } from "react"
 import { Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
+import truncate from "trunc-html"
 import { CollectFrame } from "./CollectFrame"
 import { CollectionFilterFragmentContainer as CollectionFilterContainer } from "./Components/Collection/CollectionFilterContainer"
 import { CollectionHeader } from "./Components/Collection/Header"
@@ -26,13 +27,17 @@ export class CollectionApp extends Component<CollectionAppProps> {
 
   render() {
     const { collection } = this.props
-    const { title, slug, headerImage } = collection
+    const { title, slug, headerImage, description } = collection
+    const truncatedDescription = truncate(description, 158).text
 
     return (
       <CollectFrame>
         <Title>{title} | Collect on Artsy</Title>
+        <Meta name="description" content={truncatedDescription} />
         <Meta property="og:url" content={`${sd.APP_URL}/collection/${slug}`} />
         <Meta property="og:image" content={headerImage} />
+        <Meta property="og:description" content={truncatedDescription} />
+        <Meta property="twitter:description" content={truncatedDescription} />
 
         <CollectionHeader collection={collection} />
         <Box>

--- a/src/Apps/Collect/CollectionApp.tsx
+++ b/src/Apps/Collect/CollectionApp.tsx
@@ -2,7 +2,7 @@ import { Box } from "@artsy/palette"
 import { CollectionApp_collection } from "__generated__/CollectionApp_collection.graphql"
 import { HttpError } from "found"
 import React, { Component } from "react"
-import { Meta, Title } from "react-head"
+import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import truncate from "trunc-html"
@@ -28,16 +28,21 @@ export class CollectionApp extends Component<CollectionAppProps> {
   render() {
     const { collection } = this.props
     const { title, slug, headerImage, description } = collection
-    const truncatedDescription = truncate(description, 158).text
+    const collectionHref = `${sd.APP_URL}/collection/${slug}`
+    const metadataDescription = description
+      ? `Buy, bid, and inquire on ${title} on Artsy. ` +
+        truncate(description, 158).text
+      : `Buy, bid, and inquire on ${title} on Artsy.`
 
     return (
       <CollectFrame>
         <Title>{title} | Collect on Artsy</Title>
-        <Meta name="description" content={truncatedDescription} />
-        <Meta property="og:url" content={`${sd.APP_URL}/collection/${slug}`} />
+        <Meta name="description" content={metadataDescription} />
+        <Meta property="og:url" content={collectionHref} />
         <Meta property="og:image" content={headerImage} />
-        <Meta property="og:description" content={truncatedDescription} />
-        <Meta property="twitter:description" content={truncatedDescription} />
+        <Meta property="og:description" content={metadataDescription} />
+        <Meta property="twitter:description" content={metadataDescription} />
+        <Link rel="canonical" href={collectionHref} />
 
         <CollectionHeader collection={collection} />
         <Box>

--- a/src/Apps/Collect/__tests__/CollectMediumMetadata.test.ts
+++ b/src/Apps/Collect/__tests__/CollectMediumMetadata.test.ts
@@ -1,0 +1,23 @@
+import { getMetadataForMedium } from "../CollectMediumMetadata"
+
+describe("CollectMediumMetadata", () => {
+  //
+
+  it("returns the correct title and description for photography medium", () => {
+    const metadata = getMetadataForMedium("photography")
+
+    expect(metadata.title).toBe("Photography for Sale | Collect on Artsy")
+    expect(metadata.description).toBe(
+      "Buy, bid, and inquire on over 140,000 photographs on Artsy, the world’s largest online marketplace for art and design."
+    )
+  })
+
+  it("returns the default title and description when there is no medium", () => {
+    const metadata = getMetadataForMedium("")
+
+    expect(metadata.title).toBe("Collect | Artsy")
+    expect(metadata.description).toBe(
+      "Find artworks by subject matter, style/technique, movement, price, and gallery/institution."
+    )
+  })
+})

--- a/src/Apps/Collect/__tests__/CollectMediumMetadata.test.ts
+++ b/src/Apps/Collect/__tests__/CollectMediumMetadata.test.ts
@@ -20,4 +20,23 @@ describe("CollectMediumMetadata", () => {
       "Find artworks by subject matter, style/technique, movement, price, and gallery/institution."
     )
   })
+
+  it("returns the correct title and description for design medium", () => {
+    const metadata = getMetadataForMedium("design")
+
+    expect(metadata.title).toBe("Design Works for Sale | Collect on Artsy")
+    expect(metadata.description).toBe(
+      "Buy, bid, and inquire on over 16,000 design works on Artsy, the world’s largest online marketplace for art and design."
+    )
+  })
+
+  it("returns the default title and description when there is no medium", () => {
+    const medium = undefined
+    const metadata = getMetadataForMedium(medium)
+
+    expect(metadata.title).toBe("Collect | Artsy")
+    expect(metadata.description).toBe(
+      "Find artworks by subject matter, style/technique, movement, price, and gallery/institution."
+    )
+  })
 })

--- a/src/Apps/Collect/__tests__/CollectionApp.test.tsx
+++ b/src/Apps/Collect/__tests__/CollectionApp.test.tsx
@@ -48,6 +48,8 @@ describe("CollectionApp", () => {
       </MockBoot>
     )
 
+    const title = tree.find("Title")
+    expect(title.at(0).text()).toContain("KAWS: Companions | Collect on Artsy")
     const items = tree.find("GridItem__ArtworkGridItem")
     expect(items.length).toEqual(4)
     expect(items.at(0).text()).toContain("Pinocchio, 2018")


### PR DESCRIPTION
Addresses:
https://artsyproduct.atlassian.net/browse/GROW-904
https://artsyproduct.atlassian.net/browse/GROW-931

This adds the metadata description for both `/collect` and `/collection/:slug`. It also ensure the collect page uses a custom metadata title.

ToDo:
- [x] Add a few more tests
- [x] Clean up the metadata tags in Force: https://github.com/artsy/force/pull/3062