### PR TITLE
[PATCH makeOffer] Transaction Summary UI tweaks

### DIFF
--- a/src/Apps/Order/Components/TransactionSummary.tsx
+++ b/src/Apps/Order/Components/TransactionSummary.tsx
@@ -2,6 +2,7 @@ import { TransactionSummary_order } from "__generated__/TransactionSummary_order
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
+import { Responsive } from "Utils/Responsive"
 
 import {
   Box,
@@ -140,22 +141,30 @@ const Entry = ({
   value: React.ReactNode
   final?: boolean
 }) => (
-  <Flex justifyContent="space-between" alignItems="baseline">
-    <div>
-      <Serif size="2" color="black60">
-        {label}
-      </Serif>
-    </div>
-    <div>
-      <Serif
-        size="2"
-        color={final ? "black100" : "black60"}
-        weight={final ? "semibold" : "regular"}
-      >
-        {value}
-      </Serif>
-    </div>
-  </Flex>
+  <Responsive>
+    {({ xs }) => {
+      const size = xs ? "2" : "3"
+
+      return (
+        <Flex justifyContent="space-between" alignItems="baseline">
+          <div>
+            <Serif size={size} color="black60">
+              {label}
+            </Serif>
+          </div>
+          <div>
+            <Serif
+              size={size}
+              color={final ? "black100" : "black60"}
+              weight={final ? "semibold" : "regular"}
+            >
+              {value}
+            </Serif>
+          </div>
+        </Flex>
+      )
+    }}
+  </Responsive>
 )
 
 const SecondaryEntry = ({

--- a/src/Apps/Order/Components/TransactionSummary.tsx
+++ b/src/Apps/Order/Components/TransactionSummary.tsx
@@ -96,7 +96,7 @@ export class TransactionSummary extends React.Component<
             <>
               <Entry label="Your offer" value={offerOverride || offerTotal} />
               {Boolean(itemsTotal) && (
-                <Entry label="List price" secondary value={itemsTotal} />
+                <SecondaryEntry label="List price" value={itemsTotal} />
               )}
 
               <Spacer mb={2} />
@@ -135,39 +135,46 @@ const Entry = ({
   label,
   value,
   final,
-  secondary,
 }: {
   label: React.ReactNode
   value: React.ReactNode
   final?: boolean
-  secondary?: boolean
 }) => (
   <Flex justifyContent="space-between" alignItems="baseline">
     <div>
-      {secondary ? (
-        <Sans size="2" color="black30">
-          {label}
-        </Sans>
-      ) : (
-        <Serif size="2" color="black60">
-          {label}
-        </Serif>
-      )}
+      <Serif size="2" color="black60">
+        {label}
+      </Serif>
     </div>
     <div>
-      {secondary ? (
-        <Sans size="2" color="black30">
-          {value}
-        </Sans>
-      ) : (
-        <Serif
-          size="2"
-          color={final ? "black100" : "black60"}
-          weight={final ? "semibold" : "regular"}
-        >
-          {value}
-        </Serif>
-      )}
+      <Serif
+        size="2"
+        color={final ? "black100" : "black60"}
+        weight={final ? "semibold" : "regular"}
+      >
+        {value}
+      </Serif>
+    </div>
+  </Flex>
+)
+
+const SecondaryEntry = ({
+  label,
+  value,
+}: {
+  label: React.ReactNode
+  value: React.ReactNode
+}) => (
+  <Flex justifyContent="space-between" alignItems="baseline">
+    <div>
+      <Sans size="2" color="black30">
+        {label}
+      </Sans>
+    </div>
+    <div>
+      <Sans size="2" color="black30">
+        {value}
+      </Sans>
     </div>
   </Flex>
 )

--- a/src/Apps/Order/Components/TransactionSummary.tsx
+++ b/src/Apps/Order/Components/TransactionSummary.tsx
@@ -167,12 +167,12 @@ const SecondaryEntry = ({
 }) => (
   <Flex justifyContent="space-between" alignItems="baseline">
     <div>
-      <Sans size="2" color="black30">
+      <Sans size="2" color="black60">
         {label}
       </Sans>
     </div>
     <div>
-      <Sans size="2" color="black30">
+      <Sans size="2" color="black60">
         {value}
       </Sans>
     </div>


### PR DESCRIPTION
This PR makes a few modifications to the `<TransactionSummary>` component, mostly visual. It includes:

1. A refactor of the `<Entry>` helper component into two helper components - `<Entry>` and `<SecondaryEntry>`. `<Entry>` previously took a prop named `secondary`, which toggled the look of the entry item slightly. It was two very separate code paths, though, and refactoring to two separate components made making changes to the entry items more intuitive.
2. Larger font sizes for primary entry items at breakpoints larger than "xs". This was accomplished with the `<Responsive>` component, because I didn't see a way in [palette.artsy.net](https://palette.artsy.net/#/docs-typography) to send an array of font sizes to typographical components. I did raise that question in the #design-system Slack channel though, and it sounds like we might be able to add this ability to palette. That shouldn't hold up this PR, though, in my opinion.
3. Modification to the secondary entry item to use black60 instead of black30, to match the Zeplin prototype.