### PR TITLE
Scroll payment form to top after entering credit card

### DIFF
--- a/src/Components/Payment/PaymentForm.tsx
+++ b/src/Components/Payment/PaymentForm.tsx
@@ -210,6 +210,7 @@ class PaymentForm extends Component<PaymentFormProps, PaymentFormState> {
               addressTouched: {},
             })
             this.cardElement && this.cardElement.cardInputElement.clear()
+            window.scrollTo(0, 0)
           } else {
             this.onMutationError(
               errors || creditCardOrError.mutationError,


### PR DESCRIPTION
#minor adjustment (we can always revisit later) to scroll to the top of the page after you enter a credit card.