### PR TITLE
[FEATURE publishing] add pixel tracking code on articles for sponsors

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -3,6 +3,7 @@ import track, { TrackingProp } from "react-tracking"
 import Events from "../../Utils/Events"
 
 import { BannerWrapper } from "./Banner/Banner"
+import { PixelTracker } from "./Display/ExternalTrackers"
 import ArticleWithFullScreen from "./Layouts/ArticleWithFullScreen"
 import { ClassicLayout } from "./Layouts/ClassicLayout"
 import { NewsLayout } from "./Layouts/NewsLayout"
@@ -80,13 +81,29 @@ export class Article extends React.Component<ArticleProps> {
     )
   }
 
+  sponsorPixelTrackingCode = article => {
+    if (article.sponsor && article.sponsor.pixel_tracking_code) {
+      return article.sponsor
+    } else if (
+      article.seriesArticle &&
+      article.seriesArticle.sponsor &&
+      article.seriesArticle.sponsor.pixel_tracking_code
+    ) {
+      return article.seriesArticle.sponsor
+    }
+  }
+
   render() {
+    const { article } = this.props
+    const trackingCode = this.sponsorPixelTrackingCode(article)
+
     return (
       <FullScreenProvider>
         {this.getArticleLayout()}
-        {this.shouldRenderSignUpCta() && (
-          <BannerWrapper article={this.props.article} />
+        {trackingCode && (
+          <PixelTracker unit={trackingCode} date={this.props.renderTime} />
         )}
+        {this.shouldRenderSignUpCta() && <BannerWrapper article={article} />}
       </FullScreenProvider>
     )
   }

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -586,6 +586,7 @@ export const Sponsor = {
     partner_dark_logo:
       "https://artsy-media-uploads.s3.amazonaws.com/AjncVmjZHFM4Z-0b6nPz8A%2FGUCCI.png",
     partner_logo_link: "http://artsy.net",
+    pixel_tracking_code: "http://sometrackingcodeurl.com/12345",
   },
 }
 

--- a/src/Components/Publishing/__tests__/Article.test.tsx
+++ b/src/Components/Publishing/__tests__/Article.test.tsx
@@ -6,11 +6,13 @@ import {
   FeatureArticle,
   NewsArticle,
   SeriesArticle,
+  SponsoredArticle,
   StandardArticle,
   VideoArticle,
 } from "../Fixtures/Articles"
 
 import { BannerWrapper } from "../Banner/Banner"
+import { PixelTracker } from "../Display/ExternalTrackers"
 import { ArticleWithFullScreen } from "../Layouts/ArticleWithFullScreen"
 import { NewsLayout } from "../Layouts/NewsLayout"
 import { SeriesLayout } from "../Layouts/SeriesLayout"
@@ -75,4 +77,16 @@ it("does not render separate BannerWrapper for articles after the initial articl
     />
   )
   expect(article.find(BannerWrapper).length).toBe(0)
+})
+
+it("renders PixelTracker when there is a sponsor pixel tracking code", () => {
+  const article = mount(<Article article={SponsoredArticle} />)
+
+  expect(article.find(PixelTracker).length).toBe(1)
+})
+
+it("does not render PixelTracker when there is no sponsor pixel tracking code", () => {
+  const article = mount(<Article article={SeriesArticle} />)
+
+  expect(article.find(PixelTracker).length).toBe(0)
 })


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-772

This adds `<PixelTracker>` when there is a sponsor pixel tracking code present. This is depends on an update to the article query in Force: https://github.com/artsy/force/pull/3069 