### PR TITLE
Add analytics tracking for "read more" in Collection pages

### DIFF
--- a/src/Apps/Collect/CollectionApp.tsx
+++ b/src/Apps/Collect/CollectionApp.tsx
@@ -1,5 +1,7 @@
 import { Box } from "@artsy/palette"
 import { CollectionApp_collection } from "__generated__/CollectionApp_collection.graphql"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { FrameWithRecentlyViewed } from "Components/FrameWithRecentlyViewed"
 import { HttpError } from "found"
 import React, { Component } from "react"
@@ -14,6 +16,9 @@ interface CollectionAppProps {
   collection: CollectionApp_collection
 }
 
+@track({
+  context_module: Schema.ContextModule.CollectionDescription,
+})
 export class CollectionApp extends Component<CollectionAppProps> {
   collectionNotFound = collection => {
     if (!collection) {

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -203,6 +203,11 @@ export enum ContextModule {
    * Buy Now Make Offer ("Works For You")
    */
   BNMOBanner = "BNMO Banner",
+
+  /**
+   * Collection page
+   */
+  CollectionDescription = "CollectionDescription",
 }
 
 export enum Flow {

--- a/src/Styleguide/Components/ReadMore.tsx
+++ b/src/Styleguide/Components/ReadMore.tsx
@@ -50,6 +50,7 @@ export class ReadMore extends Component<ReadMoreProps, ReadMoreState> {
   @track({
     action_type: Schema.ActionType.Click,
     subject: "Read more",
+    type: "button",
   })
   expandText() {
     this.setState(


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-983

This PR adds `{ "context_module": "CollectionDescription", "type": "button" }` to the existing analytics payload. Here is the actual payload sent to Segment:

<img width="674" alt="analytics" src="https://user-images.githubusercontent.com/386234/48533031-2ecb5600-e8e6-11e8-85fd-37084c544b94.png">
