### PR TITLE
[FIX display] Fixes an issue where display logo is not centered properly

### DIFF
--- a/src/Components/Publishing/Display/Canvas/CanvasText.tsx
+++ b/src/Components/Publishing/Display/Canvas/CanvasText.tsx
@@ -43,7 +43,6 @@ const Div: StyledFunction<DivProps> = styled.div
 const Img: StyledFunction<DivProps> = styled.img
 
 const Logo = Img`
-  width: 100%;
   height: 100%;
   object-fit: contain;
   object-position: left;

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayCanvas.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`snapshot renders the canvas in overlay layout 1`] = `
 .c5 {
-  width: 100%;
   height: 100%;
   object-fit: contain;
   object-position: left;
@@ -341,7 +340,6 @@ exports[`snapshot renders the canvas in slideshow layout 1`] = `
 }
 
 .c7 {
-  width: 100%;
   height: 100%;
   object-fit: contain;
   object-position: left;
@@ -741,7 +739,6 @@ exports[`snapshot renders the canvas in slideshow layout 1`] = `
 
 exports[`snapshot renders the canvas in standard layout with image 1`] = `
 .c6 {
-  width: 100%;
   height: 100%;
   object-fit: contain;
   object-position: left;
@@ -1054,7 +1051,6 @@ exports[`snapshot renders the canvas in standard layout with image 1`] = `
 
 exports[`snapshot renders the canvas in standard layout with video 1`] = `
 .c9 {
-  width: 100%;
   height: 100%;
   object-fit: contain;
   object-position: left;


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/GROW-998

It seems that the logo image is already centered and the `width: 100%` could be removed. There may be some historical reasons why this is there, but this seems to be working without it on all the responsive sizes we have support for, with logo images in a different aspect ratio.

## Before

<img width="1267" alt="screen shot 2018-11-15 at 17 44 02" src="https://user-images.githubusercontent.com/386234/48540695-241cbb00-e8fe-11e8-8d66-80bf78ad921c.png">

## After

<img width="1271" alt="screen shot 2018-11-15 at 17 42 56" src="https://user-images.githubusercontent.com/386234/48540701-267f1500-e8fe-11e8-8414-2a218d47de8c.png">
