### PR TITLE
DISCO-513: Prefer partner info to `collecting_institution` field in artwork sidebar

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
@@ -29,13 +29,6 @@ export class ArtworkSidebarPartnerInfo extends React.Component<
       </Serif>
     )
   }
-  renderCollectingInstitution() {
-    return (
-      <Serif size="3" pt={1}>
-        {this.props.artwork.collecting_institution}
-      </Serif>
-    )
-  }
   renderLocations(locationNames) {
     return (
       <Serif size="2" display="inline-block" pl={1} pt={0.3}>
@@ -54,26 +47,22 @@ export class ArtworkSidebarPartnerInfo extends React.Component<
       filterLocations(artwork.partner.locations)
     return (
       <Box pb={3}>
-        {artwork && artwork.collecting_institution ? (
-          this.renderCollectingInstitution()
-        ) : (
-          <React.Fragment>
-            {this.renderPartnerName()}
-            {locationNames &&
-              locationNames.length > 0 && (
-                <Box>
-                  <Flex width="100%" pt={1}>
-                    <Flex flexDirection="column">
-                      <Location />
-                    </Flex>
-                    <Flex flexDirection="column">
-                      {this.renderLocations(locationNames)}
-                    </Flex>
+        <React.Fragment>
+          {this.renderPartnerName()}
+          {locationNames &&
+            locationNames.length > 0 && (
+              <Box>
+                <Flex width="100%" pt={1}>
+                  <Flex flexDirection="column">
+                    <Location />
                   </Flex>
-                </Box>
-              )}
-          </React.Fragment>
-        )}
+                  <Flex flexDirection="column">
+                    {this.renderLocations(locationNames)}
+                  </Flex>
+                </Flex>
+              </Box>
+            )}
+        </React.Fragment>
       </Box>
     )
   }
@@ -83,7 +72,6 @@ export const ArtworkSidebarPartnerInfoFragmentContainer = createFragmentContaine
   ArtworkSidebarPartnerInfo,
   graphql`
     fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
-      collecting_institution
       partner {
         __id
         name


### PR DESCRIPTION
This commit updates the sidebar for the Responsive Artwork Page (RAP) to prefer an artwork's associated partner information to the older `collecting_institution` field. We would eventually like to deprecate and remove the `collecting_institution` field altogether.

The `collecting_institution` field on an artwork is a string representation of the institution loaning the work to another partner.

Quoting from a colleague here:

> Basically, at a number of different points we’ve wanted to clean up our institutional artwork records that predate the `Permanent Collection` / `On Loan` statuses, but it’s proved really tough because `collecting_institution` has historically been used for things that are  _both_ on loan _and_ permanent collection.

Additional Context:

- https://artsy.slack.com/archives/CAZG82X4G/p1542669633601900 :lock: 
- https://artsy.slack.com/archives/CAZG82X4G/p1540477290000100 :lock: 
- https://github.com/artsy/gravity/pull/11790 :lock: 

ticket: https://artsyproduct.atlassian.net/browse/DISCO-513 :lock: 