### PR TITLE
[PATCH publishing] Support custom editorial articles

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -14,6 +14,7 @@ import { ArticleData, DisplayData } from "./Typings"
 
 export interface ArticleProps {
   article: ArticleData
+  customEditorial?: string
   relatedArticles?: any
   relatedArticlesForPanel?: any
   relatedArticlesForCanvas?: any

--- a/src/Components/Publishing/EditorialFeature/Components/Eoy2018Artists.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Eoy2018Artists.tsx
@@ -1,0 +1,42 @@
+import {
+  ArticleProps,
+  FeatureLayout,
+} from "Components/Publishing/Layouts/FeatureLayout"
+import { Nav } from "Components/Publishing/Nav/Nav"
+import React from "react"
+import styled from "styled-components"
+
+export const Eoy2018Artists: React.SFC<ArticleProps> = props => {
+  return (
+    <ArticleWrapper>
+      <Nav canFix={false} transparent />
+      <FeatureLayout {...props} />
+    </ArticleWrapper>
+  )
+}
+
+const ArticleWrapper = styled.div`
+  background: blue;
+  color: white;
+  padding-top: 75px;
+
+  .content-end {
+    background: white;
+  }
+
+  div[class^="FeatureInnerContent__"] {
+    color: white;
+  }
+  div[class^="Author__"] {
+    color: white;
+    &:before {
+      background-color: white;
+    }
+  }
+  .Byline {
+    color: white;
+    svg path {
+      fill: white;
+    }
+  }
+`

--- a/src/Components/Publishing/EditorialFeature/Components/Eoy2018Culture.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Eoy2018Culture.tsx
@@ -1,0 +1,21 @@
+import {
+  ArticleProps,
+  FeatureLayout,
+} from "Components/Publishing/Layouts/FeatureLayout"
+import { Nav } from "Components/Publishing/Nav/Nav"
+import React from "react"
+import styled from "styled-components"
+
+export const Eoy2018Culture: React.SFC<ArticleProps> = props => {
+  return (
+    <ArticleWrapper>
+      <Nav canFix={false} transparent />
+      <FeatureLayout {...props} />
+    </ArticleWrapper>
+  )
+}
+
+const ArticleWrapper = styled.div`
+  background: yellow;
+  padding-top: 75px;
+`

--- a/src/Components/Publishing/EditorialFeature/EditorialFeature.tsx
+++ b/src/Components/Publishing/EditorialFeature/EditorialFeature.tsx
@@ -1,0 +1,21 @@
+import {
+  ArticleProps,
+  FeatureLayout,
+} from "Components/Publishing/Layouts/FeatureLayout"
+import React from "react"
+import { Eoy2018Artists } from "./Components/Eoy2018Artists"
+import { Eoy2018Culture } from "./Components/Eoy2018Culture"
+
+export const EditorialFeature: React.SFC<ArticleProps> = props => {
+  switch (props.customEditorial) {
+    case "EOY_2018_1": {
+      return <Eoy2018Artists {...props} />
+    }
+    case "EOY_2018_2": {
+      return <Eoy2018Culture {...props} />
+    }
+    default: {
+      return <FeatureLayout {...props} />
+    }
+  }
+}

--- a/src/Components/Publishing/EditorialFeature/__tests__/EditorialFeature.test.tsx
+++ b/src/Components/Publishing/EditorialFeature/__tests__/EditorialFeature.test.tsx
@@ -1,0 +1,48 @@
+import { FeatureArticle } from "Components/Publishing/Fixtures/Articles"
+import {
+  ArticleProps,
+  FeatureLayout,
+} from "Components/Publishing/Layouts/FeatureLayout"
+import { mount } from "enzyme"
+import React from "react"
+import { Eoy2018Artists } from "../Components/Eoy2018Artists"
+import { Eoy2018Culture } from "../Components/Eoy2018Culture"
+import { EditorialFeature } from "../EditorialFeature"
+
+jest.mock(
+  "Components/Publishing/Sections/FullscreenViewer/withFullScreen",
+  () => ({
+    withFullScreen: x => x,
+  })
+)
+
+describe("EditorialFeature", () => {
+  let props: ArticleProps
+  const getWrapper = (passedProps = props) => {
+    return mount(<EditorialFeature {...passedProps} />)
+  }
+
+  beforeEach(() => {
+    props = {
+      article: FeatureArticle,
+    }
+  })
+
+  it("Renders template for feature layout by default", () => {
+    props.customEditorial = "COOL_ARTICLE"
+    const component = getWrapper(props)
+    expect(component.find(FeatureLayout)).toBeTruthy()
+  })
+
+  it("Renders template for EOY_2018_1 article", () => {
+    props.customEditorial = "EOY_2018_1"
+    const component = getWrapper(props)
+    expect(component.find(Eoy2018Artists)).toBeTruthy()
+  })
+
+  it("Renders template for EOY_2018_2 article", () => {
+    props.customEditorial = "EOY_2018_2"
+    const component = getWrapper(props)
+    expect(component.find(Eoy2018Culture)).toBeTruthy()
+  })
+})

--- a/src/Components/Publishing/Header/Layouts/Components/FeatureTextHeader.tsx
+++ b/src/Components/Publishing/Header/Layouts/Components/FeatureTextHeader.tsx
@@ -69,7 +69,9 @@ const TextHeaderContainer = styled.div.attrs<{ isEditing?: boolean }>({})`
     props.isEditing &&
     `
     margin-top: 0;
-  `} ${Title} {
+  `};
+
+  ${Title} {
     margin-bottom: 150px;
   }
 

--- a/src/Components/Publishing/Layouts/ArticleWithFullScreen.tsx
+++ b/src/Components/Publishing/Layouts/ArticleWithFullScreen.tsx
@@ -1,3 +1,4 @@
+import { EditorialFeature } from "Components/Publishing/EditorialFeature/EditorialFeature"
 import { cloneDeep, extend, includes, map } from "lodash"
 import React from "react"
 import track from "react-tracking"
@@ -62,6 +63,7 @@ export class ArticleWithFullScreen extends React.Component<
     const { article, fullscreenImages } = this.state
     const {
       closeViewer,
+      customEditorial,
       slideIndex,
       viewerIsOpen,
       onOpenAuthModal,
@@ -76,7 +78,11 @@ export class ArticleWithFullScreen extends React.Component<
         onOpenAuthModal={onOpenAuthModal}
       >
         {article.layout === "feature" ? (
-          <FeatureLayout {...articleProps} />
+          customEditorial ? (
+            <EditorialFeature {...articleProps} />
+          ) : (
+            <FeatureLayout {...articleProps} />
+          )
         ) : (
           <StandardLayout {...articleProps} />
         )}

--- a/src/Components/Publishing/Layouts/FeatureLayout.tsx
+++ b/src/Components/Publishing/Layouts/FeatureLayout.tsx
@@ -12,6 +12,7 @@ import { CanvasFooter } from "./Components/CanvasFooter"
 
 export interface ArticleProps {
   article: ArticleData
+  customEditorial?: string
   display?: DisplayData
   isMobile?: boolean
   isSuper?: boolean
@@ -23,6 +24,7 @@ export interface ArticleProps {
 export const FeatureLayout: React.SFC<ArticleProps> = props => {
   const {
     article,
+    customEditorial,
     display,
     isMobile,
     isSuper,
@@ -62,14 +64,15 @@ export const FeatureLayout: React.SFC<ArticleProps> = props => {
 
       {seriesArticle && <ArticleCardsBlock {...props} />}
 
-      {(hasRelated || display) && (
-        <CanvasFooter
-          article={article}
-          display={display}
-          relatedArticles={relatedArticlesForCanvas}
-          renderTime={renderTime}
-        />
-      )}
+      {(hasRelated || display) &&
+        !customEditorial && (
+          <CanvasFooter
+            article={article}
+            display={display}
+            relatedArticles={relatedArticlesForCanvas}
+            renderTime={renderTime}
+          />
+        )}
     </FeatureLayoutContainer>
   )
 }


### PR DESCRIPTION
<img width="1391" alt="screen shot 2018-11-20 at 15 36 11" src="https://user-images.githubusercontent.com/1497424/48803061-e98c9700-ecde-11e8-9ed8-38eab74f68b5.png">

Addresses https://artsyproduct.atlassian.net/browse/GROW-1020

Related to https://github.com/artsy/force/pull/3103

Sets up components for one-off editorial features, and adds placeholder templates `Eoy2018Artists` and `Eoy2018Culture` for forthcoming end-of-year features.

Adds support for `customEditorial` prop in Articles, and routes feature articles to custom template if present.

Template wraps a feature article allowing us to add custom elements and override article default styles.