### PR TITLE
[PATCH logging] Add `ErrorWithMetadata` class and use when logging errors with metadata

### DIFF
--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "react-relay"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
+import { ErrorWithMetadata } from "Utils/errors"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
@@ -109,7 +110,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
   }
 
   onMutationError(errors, errorModalTitle?, errorModalMessage?) {
-    logger.error(errors)
+    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -98,7 +98,12 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
             } = data
 
             if (orderOrError.error) {
-              this.onMutationError(orderOrError.error)
+              this.onMutationError(
+                new ErrorWithMetadata(
+                  orderOrError.error.code,
+                  orderOrError.error
+                )
+              )
             } else {
               this.props.router.push(`/orders/${this.props.order.id}/shipping`)
             }
@@ -109,8 +114,8 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     })
   }
 
-  onMutationError(errors, errorModalTitle?, errorModalMessage?) {
-    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
+  onMutationError(error, errorModalTitle?, errorModalMessage?) {
+    logger.error(error)
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -40,6 +40,7 @@ import {
 import { injectStripe, ReactStripeElements } from "react-stripe-elements"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
+import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 
@@ -414,7 +415,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
   }
 
   private onMutationError(errors, errorModalMessage?) {
-    logger.error(errors)
+    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -319,7 +319,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
             })
           } else {
             if (errors) {
-              errors.map(err => this.onMutationError(err))
+              errors.forEach(this.onMutationError.bind(this))
             } else {
               const mutationError = creditCardOrError.mutationError
               this.onMutationError(
@@ -374,7 +374,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
             this.props.router.push(`/orders/${this.props.order.id}/review`)
           } else {
             if (errors) {
-              errors.map(err => this.onMutationError(err))
+              errors.forEach(this.onMutationError.bind(this))
             } else {
               const orderError = orderOrError.error
               this.onMutationError(

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -318,11 +318,15 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
               creditCardId: creditCardOrError.creditCard.id,
             })
           } else {
-            this.onMutationError(
-              errors || creditCardOrError.mutationError,
-              creditCardOrError.mutationError &&
-                creditCardOrError.mutationError.detail
-            )
+            if (errors) {
+              errors.map(err => this.onMutationError(err))
+            } else {
+              const mutationError = creditCardOrError.mutationError
+              this.onMutationError(
+                new ErrorWithMetadata(mutationError.message, mutationError),
+                mutationError.detail
+              )
+            }
           }
         },
         onError: this.onMutationError.bind(this),
@@ -369,7 +373,14 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
           if (orderOrError.order) {
             this.props.router.push(`/orders/${this.props.order.id}/review`)
           } else {
-            this.onMutationError(errors || orderOrError)
+            if (errors) {
+              errors.map(err => this.onMutationError(err))
+            } else {
+              const orderError = orderOrError.error
+              this.onMutationError(
+                new ErrorWithMetadata(orderError.code, orderError)
+              )
+            }
           }
         },
         onError: this.onMutationError.bind(this),
@@ -414,8 +425,8 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     )
   }
 
-  private onMutationError(errors, errorModalMessage?) {
-    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
+  private onMutationError(error, errorModalMessage?) {
+    logger.error(error)
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -139,7 +139,9 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                     break
                   }
                   default: {
-                    this.onMutationError(error)
+                    this.onMutationError(
+                      new ErrorWithMetadata(error.code, error)
+                    )
                     break
                   }
                 }

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "react-relay"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
+import { ErrorWithMetadata } from "Utils/errors"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
@@ -184,7 +185,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
     errorModalMessage?,
     errorModalCtaAction?
   ) {
-    logger.error(errors)
+    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
     this.setState({
       isSubmitting: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -113,7 +113,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                   case "insufficient_inventory": {
                     const artistId = this.artistId()
                     this.onMutationError(
-                      error,
+                      new ErrorWithMetadata(error.code, error),
                       "Not available",
                       "Sorry, the work is no longer available.",
                       artistId ? this.routeToArtistPage.bind(this) : null
@@ -123,7 +123,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                   case "failed_charge_authorize": {
                     const parsedData = JSON.parse(error.data)
                     this.onMutationError(
-                      error,
+                      new ErrorWithMetadata(error.code, error),
                       "An error occurred",
                       parsedData.failure_message
                     )
@@ -131,7 +131,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                   }
                   case "artwork_version_mismatch": {
                     this.onMutationError(
-                      error,
+                      new ErrorWithMetadata(error.code, error),
                       "Work has been updated",
                       "Something about the work changed since you started checkout. Please review the work before submitting your order.",
                       this.routeToArtworkPage.bind(this)
@@ -180,12 +180,12 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
   }
 
   private onMutationError(
-    errors,
+    error,
     errorModalTitle?,
     errorModalMessage?,
     errorModalCtaAction?
   ) {
-    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
+    logger.error(error)
     this.setState({
       isSubmitting: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -191,7 +191,10 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                   errorCode === "missing_postal_code"
                 ) {
                   this.onMutationError(
-                    orderOrError.error,
+                    new ErrorWithMetadata(
+                      orderOrError.error.code,
+                      orderOrError.error
+                    ),
                     "Invalid address",
                     "There was an error processing your address. Please review and try again."
                   )
@@ -200,12 +203,20 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                   errorData.failure_code === "domestic_shipping_only"
                 ) {
                   this.onMutationError(
-                    orderOrError.error,
+                    new ErrorWithMetadata(
+                      orderOrError.error.code,
+                      orderOrError.error
+                    ),
                     "Can't ship to that address",
                     "This work can only be shipped to the continental United States."
                   )
                 } else {
-                  this.onMutationError(orderOrError.error)
+                  this.onMutationError(
+                    new ErrorWithMetadata(
+                      orderOrError.error.code,
+                      orderOrError.error
+                    )
+                  )
                 }
               } else {
                 this.props.router.push(`/orders/${this.props.order.id}/payment`)
@@ -218,8 +229,8 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     })
   }
 
-  onMutationError(errors, errorModalTitle?, errorModalMessage?) {
-    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
+  onMutationError(error, errorModalTitle?, errorModalMessage?) {
+    logger.error(error)
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -40,6 +40,7 @@ import {
 } from "react-relay"
 import { Col, Row } from "Styleguide/Elements/Grid"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
+import { ErrorWithMetadata } from "Utils/errors"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
@@ -218,7 +219,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
   }
 
   onMutationError(errors, errorModalTitle?, errorModalMessage?) {
-    logger.error(errors)
+    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 
 interface Props {
@@ -9,7 +10,7 @@ const logger = createLogger()
 
 export class ErrorBoundary extends React.Component<Props> {
   componentDidCatch(error, errorInfo) {
-    logger.error(error, errorInfo)
+    logger.error(new ErrorWithMetadata(error.message, errorInfo))
   }
 
   render() {

--- a/src/Components/Payment/PaymentForm.tsx
+++ b/src/Components/Payment/PaymentForm.tsx
@@ -222,7 +222,7 @@ class PaymentForm extends Component<PaymentFormProps, PaymentFormState> {
             window.scrollTo(0, 0)
           } else {
             if (errors) {
-              errors.map(err => this.onMutationError(err))
+              errors.forEach(this.onMutationError.bind(this))
             } else {
               const mutationError = creditCardOrError.mutationError
               this.onMutationError(

--- a/src/Components/Payment/PaymentForm.tsx
+++ b/src/Components/Payment/PaymentForm.tsx
@@ -221,11 +221,15 @@ class PaymentForm extends Component<PaymentFormProps, PaymentFormState> {
             this.cardElement && this.cardElement.cardInputElement.clear()
             window.scrollTo(0, 0)
           } else {
-            this.onMutationError(
-              errors || creditCardOrError.mutationError,
-              creditCardOrError.mutationError &&
-                creditCardOrError.mutationError.detail
-            )
+            if (errors) {
+              errors.map(err => this.onMutationError(err))
+            } else {
+              const mutationError = creditCardOrError.mutationError
+              this.onMutationError(
+                new ErrorWithMetadata(mutationError.message, mutationError),
+                mutationError.detail
+              )
+            }
           }
         },
         onError: this.onMutationError.bind(this),
@@ -261,8 +265,8 @@ class PaymentForm extends Component<PaymentFormProps, PaymentFormState> {
     )
   }
 
-  private onMutationError(errors, errorModalMessage?) {
-    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
+  private onMutationError(error, errorModalMessage?) {
+    logger.error(error)
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Components/Payment/PaymentForm.tsx
+++ b/src/Components/Payment/PaymentForm.tsx
@@ -15,6 +15,7 @@ import React, { Component } from "react"
 import { commitMutation, graphql, RelayProp } from "react-relay"
 import { injectStripe, ReactStripeElements } from "react-stripe-elements"
 import { ConnectionHandler } from "relay-runtime"
+import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 import { Responsive } from "Utils/Responsive"
 
@@ -261,7 +262,7 @@ class PaymentForm extends Component<PaymentFormProps, PaymentFormState> {
   }
 
   private onMutationError(errors, errorModalMessage?) {
-    logger.error(errors)
+    logger.error(new ErrorWithMetadata(errors.message || errors.data, errors))
     this.setState({
       isCommittingMutation: false,
       isErrorModalOpen: true,

--- a/src/Utils/__tests__/errors.test.ts
+++ b/src/Utils/__tests__/errors.test.ts
@@ -1,28 +1,27 @@
 import * as Sentry from "@sentry/browser"
-import { ErrorWithMetadata, sendErrorToService } from "Utils/errors"
+import { ErrorWithMetadata, reportError } from "Utils/errors"
 
 jest.mock("@sentry/browser")
 
 describe("errors", () => {
-  describe("#ErrorWithMetadata", () => {
-    // todo
-  })
-  describe("#sendErrorToService", () => {
-    describe("with an Error (without metadata)", () => {
-      it("sends an error to Sentry", () => {
-        sendErrorToService(new Error("msg"))
-        expect(Sentry.withScope).toHaveBeenCalled()
-      })
+  describe("#reportError", () => {
+    const scope = { setExtra: jest.fn() }
+    const err = new Error("some error")
+    const errWithMetadata = new ErrorWithMetadata("some message", {
+      foo: "bar",
     })
-    describe("with an ErrorWithMetadata", () => {
-      it("sends an error to Sentry", () => {
-        const errorMetadata = { someProp: "more error info" }
-        sendErrorToService(new ErrorWithMetadata("msg", errorMetadata))
-        expect(Sentry.withScope).toHaveBeenCalled()
-      })
-      it("sets metadata on Sentry scope", () => {
-        // todo
-      })
+    it("does not call setExtra on scope if the error has no metadata", () => {
+      scope.setExtra.mockReset()
+      reportError(err)(scope)
+      expect(scope.setExtra).not.toBeCalled()
+    })
+    it("calls setExtra on scope for errors with metadata", () => {
+      reportError(errWithMetadata)(scope)
+      expect(scope.setExtra).toBeCalledWith("foo", "bar")
+    })
+    it("sends the error to Sentry", () => {
+      reportError(errWithMetadata)(scope)
+      expect(Sentry.captureException).toBeCalledWith(err)
     })
   })
 })

--- a/src/Utils/__tests__/errors.test.ts
+++ b/src/Utils/__tests__/errors.test.ts
@@ -1,24 +1,28 @@
 import * as Sentry from "@sentry/browser"
-import { isErrorInfo, sendErrorToService } from "Utils/errors"
+import { ErrorWithMetadata, sendErrorToService } from "Utils/errors"
 
 jest.mock("@sentry/browser")
 
 describe("errors", () => {
-  describe("#isErrorInfo", () => {
-    it("returns true if an object implements the ErrorInfo interface", () => {
-      const errorInfo = { componentStack: "someString", anotherKey: 0 }
-      expect(isErrorInfo(errorInfo)).toBe(true)
-    })
-    it("returns false if an object does not implement the ErrorInfo interface", () => {
-      const notErrorInfo = { anotherKey: 0 }
-      expect(isErrorInfo(notErrorInfo)).toBe(false)
-    })
+  describe("#ErrorWithMetadata", () => {
+    // todo
   })
   describe("#sendErrorToService", () => {
-    it("sends an error to Sentry", () => {
-      const errorInfo = { componentStack: "more error info" }
-      sendErrorToService(new Error("msg"), errorInfo)
-      expect(Sentry.withScope).toHaveBeenCalled()
+    describe("with an Error (without metadata)", () => {
+      it("sends an error to Sentry", () => {
+        sendErrorToService(new Error("msg"))
+        expect(Sentry.withScope).toHaveBeenCalled()
+      })
+    })
+    describe("with an ErrorWithMetadata", () => {
+      it("sends an error to Sentry", () => {
+        const errorMetadata = { someProp: "more error info" }
+        sendErrorToService(new ErrorWithMetadata("msg", errorMetadata))
+        expect(Sentry.withScope).toHaveBeenCalled()
+      })
+      it("sets metadata on Sentry scope", () => {
+        // todo
+      })
     })
   })
 })

--- a/src/Utils/__tests__/errors.test.ts
+++ b/src/Utils/__tests__/errors.test.ts
@@ -5,20 +5,26 @@ jest.mock("@sentry/browser")
 
 describe("errors", () => {
   describe("#reportError", () => {
-    const scope = { setExtra: jest.fn() }
     const err = new Error("some error")
     const errWithMetadata = new ErrorWithMetadata("some message", {
       foo: "bar",
     })
+    let scope
+
+    beforeEach(() => {
+      scope = { setExtra: jest.fn() }
+    })
+
     it("does not call setExtra on scope if the error has no metadata", () => {
-      scope.setExtra.mockReset()
       reportError(err)(scope)
       expect(scope.setExtra).not.toBeCalled()
     })
+
     it("calls setExtra on scope for errors with metadata", () => {
       reportError(errWithMetadata)(scope)
       expect(scope.setExtra).toBeCalledWith("foo", "bar")
     })
+
     it("sends the error to Sentry", () => {
       reportError(errWithMetadata)(scope)
       expect(Sentry.captureException).toBeCalledWith(err)

--- a/src/Utils/__tests__/logger.test.ts
+++ b/src/Utils/__tests__/logger.test.ts
@@ -53,7 +53,7 @@ describe("logger", () => {
         it("sends errors to service", () => {
           const err = new Error("msg")
           logger.error(err)
-          expect(sendErrorToService).toHaveBeenCalledWith(err, undefined)
+          expect(sendErrorToService).toHaveBeenCalledWith(err)
         })
       })
 

--- a/src/Utils/errors.tsx
+++ b/src/Utils/errors.tsx
@@ -6,7 +6,7 @@ export class NetworkError extends Error {
 
 export class ErrorWithMetadata extends Error {
   metadata: object
-  decoratedMessage: string
+
   constructor(message, metadata = {}) {
     super(message)
     this.metadata = metadata
@@ -18,8 +18,8 @@ export class ErrorWithMetadata extends Error {
 
 export const reportError = error => scope => {
   if (error instanceof ErrorWithMetadata) {
-    Object.keys(error.metadata).forEach(key => {
-      scope.setExtra(key, error.metadata[key])
+    Object.entries(error.metadata).forEach(([key, value]) => {
+      scope.setExtra(key, value)
     })
   }
   Sentry.captureException(error)

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -1,4 +1,4 @@
-import { isErrorInfo, sendErrorToService } from "Utils/errors"
+import { sendErrorToService } from "Utils/errors"
 
 export const shouldCaptureError = (environment: string) =>
   environment === "staging" || environment === "production"
@@ -15,10 +15,9 @@ export default function createLogger(namespace = "reaction") {
     },
     error: (...errors) => {
       const error = errors.find(e => e instanceof Error)
-      const errorInfo = errors.find(isErrorInfo)
 
       if (error && shouldCaptureError(process.env.NODE_ENV)) {
-        sendErrorToService(error, errorInfo)
+        sendErrorToService(error)
       }
 
       console.error(formattedNamespace, ...errors, "\n")


### PR DESCRIPTION
This is a somewhat in-the-weeds PR, so please let me know if something doesn't make sense!

### Problem
In https://github.com/artsy/reaction/pull/1479, I created a [method to send errors to Sentry](https://github.com/artsy/reaction/blob/30b0755443b48f9c64b8000ce2312d5de54548d0/src/Utils/errors.tsx#L18) and added that method to the newly-created [`logger.error` method](https://github.com/artsy/reaction/blob/30b0755443b48f9c64b8000ce2312d5de54548d0/src/Utils/logger.ts#L16). The idea was that if you're logging an error you likely want to send that error to an error-capturing service anyway.

The issue is that the code doesn't capture mutation errors from Metaphysics, and we need it to do that. On mutation error, we receive an object that represents an error and contains multiple relevant fields for the error. Currently we just pass in that object to the logger, but since [it's not actually an `Error` object we don't end up sending it to Sentry](https://github.com/artsy/reaction/blob/30b0755443b48f9c64b8000ce2312d5de54548d0/src/Utils/logger.ts#L17). We want to convert this object into an error (which Sentry expects), log it and send the error and extra fields to Sentry so that we can properly track mutation errors.

### Solution

Turns out this isn't straightforward! Here are some possible approaches and their pitfalls:

1. Create a new `Error` and pass in the stringified error object from Metaphysics as the message.

This will work, but we won't be taking advantage of Sentry's ability to associate the metadata with the error since all the metadata will be in the message. We'll have to parse JSON from the error message in Sentry in order to understand what the error is, which makes the data more difficult to deal with.

2. Create a new `Error` from what we get back from Metaphysics and pass the error along with the metadata as an `ErrorInfo` object to the logger.

`ErrorInfo` is an object that we pass along to Sentry to associate metadata with that error. This sounds good, but is made difficult by the fact that there's no good way to pick out the `ErrorInfo` in the logger input (which doesn't have any limitations on what it can accept). While `ErrorInfo` _does_ have an interface that we currently use to [figure out which of the inputs implements `ErrorInfo`](https://github.com/artsy/reaction/blob/30b0755443b48f9c64b8000ce2312d5de54548d0/src/Utils/logger.ts#L18), we don't actually need it like I originally thought. Sentry doesn't have any limitations on what we pass in as extra fields, so there's no need to check. `ErrorInfo` can  be any object, and so with that change there's no way to distinguish between `ErrorInfo` and another object in the logger input.

3. Create a custom `ReactionError` class and add metadata as a property of that object. Get rid of the `ErrorInfo` object, and use the metadata on the `ReactionError` object when setting the metadata for Sentry. Use this error for all errors we want to send to Sentry, including our mutation errors.

This could work, but it feels a little strange. It's something new that other developers will have to think about when doing error handling. [`componentDidCatch` in `ErrorBoundary` returns an error and metadata object separately](https://github.com/artsy/reaction/blob/30b0755443b48f9c64b8000ce2312d5de54548d0/src/Components/ErrorBoundary.tsx#L11), so we'd have to convert that error into a new `ReactionError` with the associated metadata to properly capture everything, which is awkward.

4. Don't send an error to Sentry when we call `logger.error`, and instead send errors to Sentry separately with `sendErrorToService`.

This works, too, but is also awkward because we probably want to call `sendErrorToService` whenever we call `logger.error`. Still, this is nice because we don't have to worry about what's happening in `logger.error` in order to send an error to Sentry.

**After all that, option (4) seems like the most reasonable option to me**, despite the fact that I don't like having to use `sendErrorToService` all over the place. We could create a new wrapper method `logAndSendErrorToService` to get around that. It does make the logger a somewhat useless wrapper for `console`, but I don't see an immediate reason to get rid of it.

Thoughts / other ideas?