### PR TITLE
[PATCH revert] Revert "[Router] Move hydration data outside of React's control."

### DIFF
--- a/src/Artsy/Router/Components/Hydrator.tsx
+++ b/src/Artsy/Router/Components/Hydrator.tsx
@@ -1,0 +1,45 @@
+import React, { SFC } from "react"
+import serialize from "serialize-javascript"
+
+export interface HydratorProps {
+  loadableState?: {
+    getScriptTag: () => string
+  }
+  data?: object[]
+  url?: string
+}
+
+export const Hydrator: SFC<HydratorProps> = props => {
+  const { loadableState, data = {}, children } = props
+
+  let hydrationData
+  try {
+    hydrationData = serialize(data, {
+      isJSON: true,
+    })
+  } catch (error) {
+    hydrationData = "{}"
+    console.error("reaction/Router/AppShell Error serializing data:", error)
+  }
+
+  return (
+    <div>
+      <div
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: `
+            ${loadableState ? loadableState.getScriptTag() : ""}
+
+            <script>
+              var __RELAY_BOOTSTRAP__ = ${serialize(hydrationData, {
+                isJSON: true,
+              })};
+            </script>
+          `,
+        }}
+      />
+
+      {children}
+    </div>
+  )
+}

--- a/src/Artsy/Router/Components/__tests__/Hydrator.test.tsx
+++ b/src/Artsy/Router/Components/__tests__/Hydrator.test.tsx
@@ -1,0 +1,40 @@
+import { Hydrator } from "Artsy/Router/Components/Hydrator"
+import { mount } from "enzyme"
+import React from "react"
+
+describe("AppShell", () => {
+  const getWrapper = (props = {}) => {
+    return mount(<Hydrator {...props} />)
+  }
+
+  it("does not inject loadable-components script tags if not provide", () => {
+    expect(getWrapper().html()).not.toContain("__LOADABLE_STATE__")
+  })
+
+  it("injects loadable-components script tags if provided", () => {
+    expect(
+      getWrapper({
+        loadableState: {
+          getScriptTag: () => "__LOADABLE_STATE__",
+        },
+      }).html()
+    ).toContain("__LOADABLE_STATE__")
+  })
+
+  it("injects default __RELAY_BOOTSTRAP__ {} hydration variable if no data", () => {
+    expect(getWrapper().html()).toContain('__RELAY_BOOTSTRAP__ = "{}"')
+  })
+
+  it("injects __RELAY_BOOTSTRAP__ hydration variable", () => {
+    const data = ["hello"]
+    expect(
+      getWrapper({
+        data,
+      }).html()
+    ).toContain("hello")
+  })
+
+  it("renders children", () => {
+    expect(mount(<Hydrator>child</Hydrator>).html()).toContain("child")
+  })
+})

--- a/src/Artsy/Router/__tests__/buildServerApp.test.tsx
+++ b/src/Artsy/Router/__tests__/buildServerApp.test.tsx
@@ -23,7 +23,7 @@ describe("buildServerApp", () => {
     Component = defaultComponent,
     options = {},
   } = {}) => {
-    const { ServerApp, status, headTags, scripts } = await buildServerApp({
+    const { ServerApp, status, headTags } = await buildServerApp({
       routes: [
         {
           path: "/",
@@ -38,7 +38,6 @@ describe("buildServerApp", () => {
       wrapper: render(<ServerApp />),
       status,
       headTags,
-      scripts,
     }
   }
 
@@ -48,9 +47,9 @@ describe("buildServerApp", () => {
   })
 
   it("bootstraps relay and loadable-components SSR data", async () => {
-    const { scripts } = await getWrapper()
-    expect(scripts).toContain("__RELAY_BOOTSTRAP__")
-    expect(scripts).toContain("__LOADABLE_STATE__")
+    const { wrapper } = await getWrapper()
+    expect(wrapper.html()).toContain("__RELAY_BOOTSTRAP__")
+    expect(wrapper.html()).toContain("__LOADABLE_STATE__")
   })
 
   it("resolves with a 200 status if url matches request", async () => {

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -1,5 +1,6 @@
 import { createEnvironment } from "Artsy/Relay/createEnvironment"
 import { Boot } from "Artsy/Router/Components/Boot"
+import { Hydrator } from "Artsy/Router/Components/Hydrator"
 import BrowserProtocol from "farce/lib/BrowserProtocol"
 import HashProtocol from "farce/lib/HashProtocol"
 import MemoryProtocol from "farce/lib/MemoryProtocol"
@@ -80,7 +81,9 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
             resolver={resolver}
             routes={routes}
           >
-            <Router resolver={resolver} />
+            <Hydrator>
+              <Router resolver={resolver} />
+            </Hydrator>
           </Boot>
         )
       }


### PR DESCRIPTION
Reverts artsy/reaction#1573 
Related https://github.com/artsy/force/pull/3112

This seemed to be a bit of a red herring so going to revert and revisit later. 

(Not sure how to semver a major number revert, so just gonna patch it) 