### PR TITLE
fix centering of image right/left buttons

### DIFF
--- a/src/Apps/Artwork/Components/ImageCarousel.tsx
+++ b/src/Apps/Artwork/Components/ImageCarousel.tsx
@@ -70,6 +70,7 @@ const Button = styled.a`
 
 const NavigationButtonContainer = styled.div`
   width: 40px;
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
Currently:
![screen shot 2018-11-26 at 2 29 33 pm](https://user-images.githubusercontent.com/437156/49037495-60ff7200-f188-11e8-84c4-0f3516b5e96f.png)


With 100% height set:
![screen shot 2018-11-26 at 2 32 32 pm](https://user-images.githubusercontent.com/437156/49037518-6d83ca80-f188-11e8-8f18-990488e2599f.png)

Looks like container has a height but the `NavigationButtonContainer` does not.  The icon button intended to be centered in 100% height.
