### PR TITLE
[TRIVIAL] rename EOY keys

### DIFF
--- a/src/Components/Publishing/EditorialFeature/EditorialFeature.tsx
+++ b/src/Components/Publishing/EditorialFeature/EditorialFeature.tsx
@@ -8,10 +8,10 @@ import { Eoy2018Culture } from "./Components/Eoy2018Culture"
 
 export const EditorialFeature: React.SFC<ArticleProps> = props => {
   switch (props.customEditorial) {
-    case "EOY_2018_1": {
+    case "EOY_2018_ARTISTS": {
       return <Eoy2018Artists {...props} />
     }
-    case "EOY_2018_2": {
+    case "EOY_2018_CULTURE": {
       return <Eoy2018Culture {...props} />
     }
     default: {

--- a/src/Components/Publishing/EditorialFeature/__tests__/EditorialFeature.test.tsx
+++ b/src/Components/Publishing/EditorialFeature/__tests__/EditorialFeature.test.tsx
@@ -34,14 +34,14 @@ describe("EditorialFeature", () => {
     expect(component.find(FeatureLayout)).toBeTruthy()
   })
 
-  it("Renders template for EOY_2018_1 article", () => {
-    props.customEditorial = "EOY_2018_1"
+  it("Renders template for EOY_2018_ARTISTS article", () => {
+    props.customEditorial = "EOY_2018_ARTISTS"
     const component = getWrapper(props)
     expect(component.find(Eoy2018Artists)).toBeTruthy()
   })
 
-  it("Renders template for EOY_2018_2 article", () => {
-    props.customEditorial = "EOY_2018_2"
+  it("Renders template for EOY_2018_CULTURE article", () => {
+    props.customEditorial = "EOY_2018_CULTURE"
     const component = getWrapper(props)
     expect(component.find(Eoy2018Culture)).toBeTruthy()
   })


### PR DESCRIPTION
Per @xtina-starr's suggestion, renames keys for EOY articles to describe article content/match component names.