### PR TITLE
[PATCH collections] fixes spacing on the collections page

### DIFF
--- a/src/Apps/Collections/Components/CollectionsGrid.tsx
+++ b/src/Apps/Collections/Components/CollectionsGrid.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Sans, Separator } from "@artsy/palette"
+import { Box, Flex, Sans, Separator, Spacer } from "@artsy/palette"
 import React, { Component } from "react"
 import { EntityHeader } from "Styleguide/Components/EntityHeader"
 import { slugify } from "underscore.string"
@@ -53,9 +53,13 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
             )
           })}
 
-          <Media greaterThan="xs">
-            {hasShortRow && <Box width={["100%", "30%"]} />}
-          </Media>
+          {hasShortRow && (
+            <Media greaterThan="xs">
+              {(_, renderChildren) =>
+                renderChildren && <Spacer width={["100%", "30%"]} />
+              }
+            </Media>
+          )}
         </Flex>
       </Box>
     )


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-1014

This fixes the spacing issue on the collections page. 

Before:
![screen shot 2018-11-27 at 5 39 00 pm](https://user-images.githubusercontent.com/5201004/49116384-5cf85080-f26b-11e8-8f5e-e84591560b8a.png)


After:
![screen shot 2018-11-27 at 5 34 49 pm](https://user-images.githubusercontent.com/5201004/49116339-3a663780-f26b-11e8-94de-0592ef2a2a60.png)

Thanks for the help @l2succes 