### PR TITLE
[PATCH collection] remove html comment from title metatag

### DIFF
--- a/src/Apps/Collect/CollectionApp.tsx
+++ b/src/Apps/Collect/CollectionApp.tsx
@@ -41,7 +41,7 @@ export class CollectionApp extends Component<CollectionAppProps> {
 
     return (
       <FrameWithRecentlyViewed>
-        <Title>{title} | Collect on Artsy</Title>
+        <Title>{`${title} | Collect on Artsy`}</Title>
         <Meta name="description" content={metadataDescription} />
         <Meta property="og:url" content={collectionHref} />
         <Meta property="og:image" content={headerImage} />


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-1029

Before we were passing the title variable and a string. This caused two separate string and where I believe the extra html comment comes from.

Before:
![screen shot 2018-11-29 at 4 07 27 pm](https://user-images.githubusercontent.com/5201004/49252003-e71df180-f3f0-11e8-966f-13e6eeae995e.png)

After:
![screen shot 2018-11-29 at 4 08 24 pm](https://user-images.githubusercontent.com/5201004/49252061-07e64700-f3f1-11e8-977e-939710ecb192.png)
