### PR TITLE
Queue CI master builds for more stable deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   node: artsy/node@0.1.0
   yarn: artsy/yarn@0.0.2
+  queue: eddiewebb/queue@1.0.110
 
 jobs:
   relay:
@@ -40,14 +41,33 @@ jobs:
     steps:
       - yarn/update_dependencies
 
+  # A job responsible for ensuring only 1 master build runs at a time so that
+  # there are no deployment race conditions
+  workflow-queue:
+    executor: node/build
+    steps:
+      - queue/until_front_of_line:
+          time: "2" # how long a queue will wait until the job exits
+          only-on-branch: master # restrict queueing to a specific branch (default *)
+
 workflows:
   build_and_verify:
     jobs:
-      - update-cache
-      - relay
-      - lint
-      - type-check
-      - test
+      - update-cache:
+          requires:
+            - workflow-queue
+      - relay:
+          requires:
+            - workflow-queue
+      - lint:
+          requires:
+            - workflow-queue
+      - type-check:
+          requires:
+            - workflow-queue
+      - test:
+          requires:
+            - workflow-queue
       - deploy:
           # The deploy job is the _only_ job that should have access to our npm
           # tokens. We include a context that has our publish credentials


### PR DESCRIPTION
It's taken a while to get back to this point. This feature was initially introduced #1481. It unfortunately had to be reverted because it would fail on forks. I PR'd a fix (https://github.com/eddiewebb/circleci-queue/pull/13) so that issue should be resolved. 

Unfortunately there isn't an incredibly easy way to test this. Ultimately if the build works on master, we're in the green. I'll merge this and test it out after office hours so I can revert if there's a failure. 