### PR TITLE
Adds a warning when there are more than 15 modfied gnerated files

### DIFF
--- a/danger/pr.ts
+++ b/danger/pr.ts
@@ -4,5 +4,13 @@ const trivialPR = bodyAndTitle.includes("trivial")
 
 if (pr.assignee === null) {
   const method = trivialPR ? warn : fail
-  method("Please assign someone to merge this PR, and optionally include people who should review.")
+  method(
+    "Please assign someone to merge this PR, and optionally include people who should review."
+  )
+}
+
+const generatedOnly = (file: string) => file.includes("src/__generated__/")
+const modifiedGeneratedFiles = danger.git.modified_files.filter(generatedOnly)
+if (modifiedGeneratedFiles.length > 15) {
+  warn(`There are ${modifiedGeneratedFiles.length} generated files modified.`)
 }


### PR DESCRIPTION
We want to try grab a copy of re-ordered generated files when it happens, so this adds a danger rule to highlight it in the PR, then we can look at the computer closer to the moment