### PR TITLE
Ensure build queues if any previous job still running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
       - queue/until_front_of_line:
           time: "2" # how long a queue will wait until the job exits
           only-on-branch: master # restrict queueing to a specific branch (default *)
+          consider-job: false # block whole workflow if any job still running
 
 workflows:
   build_and_verify:


### PR DESCRIPTION
I've been testing out the queuing behavior from #1615 and I noticed it wasn't queueing as I expected. I expected it to queue if any job from the last build was still running, but it wasn't doing that. Looks like it's due to this config option missing. 