### PR TITLE
Refactor redirect logic

### DIFF
--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -157,6 +157,10 @@ export const shouldRedirect = ({
   location: Location
   order: routes_OrderQueryResponse["order"]
 }) => {
+  if (!order) {
+    return false
+  }
+
   const locationParts = location.pathname.split("/").slice(3)
 
   function traverse(node: RedirectRecord, path: string[]): void {

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -38,8 +38,14 @@ export const routes: RouteConfig[] = [
           name
         }
         order: ecommerceOrder(id: $orderID) {
+          id
           mode
           state
+          ... on OfferOrder {
+            myLastOffer {
+              id
+            }
+          }
           requestedFulfillment {
             __typename
           }

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -38,6 +38,7 @@ export const routes: RouteConfig[] = [
           name
         }
         order: ecommerceOrder(id: $orderID) {
+          mode
           state
           requestedFulfillment {
             __typename
@@ -54,12 +55,15 @@ export const routes: RouteConfig[] = [
           creditCard {
             id
           }
+          ... on OfferOrder {
+            awaitingResponseFrom
+          }
         }
       }
     `,
     render: ({ Component, props }) => {
       if (Component && props) {
-        if (!shouldRedirect(props)) {
+        if (!shouldRedirect(props as any)) {
           return <Component {...props} />
         }
       }

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -188,6 +188,7 @@ storiesOf("Apps/Order Page/Counter Offer", module).add("Respond", () => (
           .subtract(1, "day")
           .toISOString(),
       },
+      awaitingResponseFrom: "BUYER",
       offers: { edges: Offers },
       buyer: Buyer,
     })}

--- a/src/__generated__/routes_OrderQuery.graphql.ts
+++ b/src/__generated__/routes_OrderQuery.graphql.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
+export type OrderModeEnum = "BUY" | "OFFER" | "%future added value";
+export type OrderParticipantEnum = "BUYER" | "SELLER" | "%future added value";
 export type routes_OrderQueryVariables = {
     readonly orderID: string;
 };
@@ -9,6 +11,7 @@ export type routes_OrderQueryResponse = {
         readonly name: string | null;
     }) | null;
     readonly order: ({
+        readonly mode: OrderModeEnum | null;
         readonly state: string | null;
         readonly requestedFulfillment: ({
             readonly __typename: string;
@@ -25,6 +28,7 @@ export type routes_OrderQueryResponse = {
         readonly creditCard: ({
             readonly id: string;
         }) | null;
+        readonly awaitingResponseFrom?: OrderParticipantEnum | null;
     }) | null;
 };
 export type routes_OrderQuery = {
@@ -44,6 +48,7 @@ query routes_OrderQuery(
   }
   order: ecommerceOrder(id: $orderID) {
     __typename
+    mode
     state
     requestedFulfillment {
       __typename
@@ -62,6 +67,9 @@ query routes_OrderQuery(
     creditCard {
       id
       __id
+    }
+    ... on OfferOrder {
+      awaitingResponseFrom
     }
     __id: id
   }
@@ -114,18 +122,25 @@ v3 = [
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "state",
+  "name": "mode",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "state",
   "args": null,
   "storageKey": null
 },
 v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "requestedFulfillment",
@@ -134,10 +149,10 @@ v6 = {
   "concreteType": null,
   "plural": false,
   "selections": [
-    v5
+    v6
   ]
 },
-v7 = [
+v8 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -147,14 +162,14 @@ v7 = [
   },
   v1
 ],
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "lineItems",
@@ -189,16 +204,16 @@ v9 = {
               "args": null,
               "concreteType": "Artwork",
               "plural": false,
-              "selections": v7
+              "selections": v8
             },
-            v8
+            v9
           ]
         }
       ]
     }
   ]
 },
-v10 = {
+v11 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "creditCard",
@@ -206,14 +221,27 @@ v10 = {
   "args": null,
   "concreteType": "CreditCard",
   "plural": false,
-  "selections": v7
+  "selections": v8
+},
+v12 = {
+  "kind": "InlineFragment",
+  "type": "OfferOrder",
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "awaitingResponseFrom",
+      "args": null,
+      "storageKey": null
+    }
+  ]
 };
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_OrderQuery",
   "id": null,
-  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    state\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
+  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    mode\n    state\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    ... on OfferOrder {\n      awaitingResponseFrom\n    }\n    __id: id\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -233,10 +261,12 @@ return {
         "plural": false,
         "selections": [
           v4,
-          v6,
-          v9,
+          v5,
+          v7,
           v10,
-          v8
+          v11,
+          v9,
+          v12
         ]
       }
     ]
@@ -256,17 +286,19 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v5,
-          v4,
           v6,
-          v9,
+          v4,
+          v5,
+          v7,
           v10,
-          v8
+          v11,
+          v9,
+          v12
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = 'a5f42ca394d331b958b93e77a997506d';
+(node as any).hash = '041cd59a0d9e656aaaf1061ac1991a1f';
 export default node;

--- a/src/__generated__/routes_OrderQuery.graphql.ts
+++ b/src/__generated__/routes_OrderQuery.graphql.ts
@@ -11,6 +11,7 @@ export type routes_OrderQueryResponse = {
         readonly name: string | null;
     }) | null;
     readonly order: ({
+        readonly id: string | null;
         readonly mode: OrderModeEnum | null;
         readonly state: string | null;
         readonly requestedFulfillment: ({
@@ -27,6 +28,9 @@ export type routes_OrderQueryResponse = {
         }) | null;
         readonly creditCard: ({
             readonly id: string;
+        }) | null;
+        readonly myLastOffer?: ({
+            readonly id: string | null;
         }) | null;
         readonly awaitingResponseFrom?: OrderParticipantEnum | null;
     }) | null;
@@ -48,8 +52,16 @@ query routes_OrderQuery(
   }
   order: ecommerceOrder(id: $orderID) {
     __typename
+    id
     mode
     state
+    ... on OfferOrder {
+      myLastOffer {
+        id
+        __id: id
+      }
+      awaitingResponseFrom
+    }
     requestedFulfillment {
       __typename
     }
@@ -67,9 +79,6 @@ query routes_OrderQuery(
     creditCard {
       id
       __id
-    }
-    ... on OfferOrder {
-      awaitingResponseFrom
     }
     __id: id
   }
@@ -122,25 +131,32 @@ v3 = [
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "mode",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "state",
+  "name": "mode",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "state",
   "args": null,
   "storageKey": null
 },
 v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "requestedFulfillment",
@@ -149,27 +165,21 @@ v7 = {
   "concreteType": null,
   "plural": false,
   "selections": [
-    v6
+    v7
   ]
 },
-v8 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "id",
-    "args": null,
-    "storageKey": null
-  },
+v9 = [
+  v4,
   v1
 ],
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "lineItems",
@@ -204,16 +214,16 @@ v10 = {
               "args": null,
               "concreteType": "Artwork",
               "plural": false,
-              "selections": v8
+              "selections": v9
             },
-            v9
+            v10
           ]
         }
       ]
     }
   ]
 },
-v11 = {
+v12 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "creditCard",
@@ -221,12 +231,25 @@ v11 = {
   "args": null,
   "concreteType": "CreditCard",
   "plural": false,
-  "selections": v8
+  "selections": v9
 },
-v12 = {
+v13 = {
   "kind": "InlineFragment",
   "type": "OfferOrder",
   "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "myLastOffer",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Offer",
+      "plural": false,
+      "selections": [
+        v4,
+        v10
+      ]
+    },
     {
       "kind": "ScalarField",
       "alias": null,
@@ -241,7 +264,7 @@ return {
   "operationKind": "query",
   "name": "routes_OrderQuery",
   "id": null,
-  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    mode\n    state\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    ... on OfferOrder {\n      awaitingResponseFrom\n    }\n    __id: id\n  }\n}\n",
+  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    id\n    mode\n    state\n    ... on OfferOrder {\n      myLastOffer {\n        id\n        __id: id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -262,11 +285,12 @@ return {
         "selections": [
           v4,
           v5,
-          v7,
-          v10,
+          v6,
+          v8,
           v11,
-          v9,
-          v12
+          v12,
+          v10,
+          v13
         ]
       }
     ]
@@ -286,19 +310,20 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v6,
+          v7,
           v4,
           v5,
-          v7,
-          v10,
+          v6,
+          v8,
           v11,
-          v9,
-          v12
+          v12,
+          v10,
+          v13
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = '041cd59a0d9e656aaaf1061ac1991a1f';
+(node as any).hash = '3108a4804a568117e7648269beeac008';
 export default node;


### PR DESCRIPTION
## What why?

this PR was originally just adding some extra redirect logic to what we already had, but that code was getting messy and hard to reason about so (╯°□°）╯︵ ┻━┻ 

Here's something declarative and tree-structured which is supposed to be a lot easier to read and modify, if more verbose.

@ashfurrow @williardx When adding new routes for the `/review/decline` and `/review/accept` pages make sure to add redirect logic for them in here too. You can add new children to the existing entry for  `review`, just like you will in `routes.tsx`. Let me know if anything could be clearer! :pray:

*also achieved the original goal of this PR by adding redirect logic for the `respond` page and as a bonus the `offer` page.* https://artsyproduct.atlassian.net/browse/PURCHASE-677 :tada: