### PR TITLE
Update npmignore to include only necessary client artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .storybook/.DS_Store
 .storybook/manager.js
 .vscode/cSpell.json
+*.tgz
 assets/reaction-force.js
 public/assets/fonts
 dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,13 +1,6 @@
-.awcache
-.vscode
-.env*
-.storybook
-.fusebox
-.babelrc
-
-externals
-src
-__mocks__
-reaction-force.js
-reaction-force.js.map
-gulpfile.js
+# Ignore everything except what's explicitly whitelisted
+*
+!dist/**
+dist/**/__mocks__/*
+dist/**/__tests__/*
+dist/**/__stories__/*

--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
   "repository": "https://github.com/artsy/reaction.git",
   "author": "Art.sy Inc <it@artsymail.com>",
   "license": "MIT",
-  "files": [
-    "assets",
-    "data",
-    "dist",
-    "docs"
-  ],
   "peerDependencies": {
     "dd-trace": "^0.6.0",
     "react": "^16.5.0",


### PR DESCRIPTION
I noticed that we were shipping a lot of unnecessary stuff with reaction. 

New package size: 1.9MB, 2322 files
Old package size: 2.0MB, 2717 files

Maybe not a _huge_ improvement, but it's better. 