### PR TITLE
[vscode] Update vscode-apollo config to ignore unwanted validation

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -5,6 +5,17 @@ module.exports = {
       name: "local",
       localSchemaFile: "data/schema.graphql",
     },
+    excludeValidationRules: [
+      // Default of vscode-apollo.
+      "NoUnusedFragments",
+      // A default of vscode-apollo, but we also need it because of Relay’s
+      // client-side directives.
+      "KnownDirectives",
+      // Added because Relay has ‘local’ variables (defined with the
+      // `@argumentDefinitions` directive) and these don’t need to be defined on
+      // the operation.
+      "NoUndefinedVariables",
+    ],
     includes: ["src/**/*.{ts,tsx,graphql}"],
     excludes: ["**/node_modules", "**/__tests__"],
     tagName: "graphql",

--- a/src/Artsy/Router/Components/PreloadLink.tsx
+++ b/src/Artsy/Router/Components/PreloadLink.tsx
@@ -104,11 +104,7 @@ const _PreloadLink: React.SFC<PreloadLinkProps> = preloadLinkProps => {
      *   {
      *     path: '/home',
      *     Component: () => <div>Home!</div>
-     *     query: graphql`
-     *       query routes_HomeQuery {
-     *         ...
-     *       }
-     *     `
+     *     query: ...
      *   }
      * ]
      */


### PR DESCRIPTION
This relies on our fork of the extension (`Artsy.vscode-apollo`) until there’s movement on: https://github.com/apollographql/apollo-tooling/pull/800