### PR TITLE
 Add auction partner name, estimate and premium

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.tsx
@@ -1,4 +1,7 @@
-import { Box, Serif } from "@artsy/palette"
+import { Box, Link, Serif } from "@artsy/palette"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
+import { ContextConsumer } from "Artsy/Router"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -8,34 +11,56 @@ export interface ArtworkSidebarAuctionPartnerInfoProps {
   artwork: ArtworkSidebarAuctionPartnerInfo_artwork
 }
 
+@track()
 export class ArtworkSidebarAuctionPartnerInfo extends React.Component<
   ArtworkSidebarAuctionPartnerInfoProps
 > {
+  @track(() => ({
+    context_module: Schema.ContextModule.Sidebar,
+    action_type: Schema.ActionType.Click,
+    subject: Schema.Subject.AuctionBuyerPremium,
+    type: Schema.Type.Link,
+  }))
+  onClickBuyerPremium(mediator) {
+    mediator &&
+      mediator.trigger &&
+      mediator.trigger("openAuctionBuyerPremium", {
+        auctionId: this.props.artwork.sale._id,
+      })
+  }
+
   render() {
-    const { artwork } = this.props
-    if (!artwork.is_biddable) {
+    const { partner, sale_artwork, sale } = this.props.artwork
+    if (sale.is_closed) {
       return null
     }
     return (
-      <Box pb={3}>
-        {artwork.partner && (
-          <Serif size="2" weight="semibold" color="black100">
-            {artwork.partner.name}
-          </Serif>
+      <ContextConsumer>
+        {({ mediator }) => (
+          <Box pb={3}>
+            {partner && (
+              <Serif size="2" weight="semibold" color="black100">
+                {partner.name}
+              </Serif>
+            )}
+            {sale_artwork &&
+              sale_artwork.estimate && (
+                <Serif size="2" color="black60">
+                  Estimated value: {sale_artwork.estimate}
+                </Serif>
+              )}
+            {sale &&
+              sale.is_with_buyers_premium && (
+                <Serif size="2" color="black60">
+                  This work has a{" "}
+                  <Link onClick={this.onClickBuyerPremium.bind(this, mediator)}>
+                    buyer's premium
+                  </Link>.
+                </Serif>
+              )}
+          </Box>
         )}
-        {artwork.sale_artwork &&
-          artwork.sale_artwork.estimate && (
-            <Serif size="2" color="black60">
-              Estimated value: {artwork.sale_artwork.estimate}
-            </Serif>
-          )}
-        {artwork.sale &&
-          artwork.sale.is_with_buyers_premium && (
-            <Serif size="2" color="black60">
-              This work has a <a href="#">buyer's premium</a>.
-            </Serif>
-          )}
-      </Box>
+      </ContextConsumer>
     )
   }
 }
@@ -44,15 +69,17 @@ export const ArtworkSidebarAuctionPartnerInfoFragmentContainer = createFragmentC
   ArtworkSidebarAuctionPartnerInfo,
   graphql`
     fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
-      is_biddable
+      _id
       partner {
-        __id
+        _id
         name
       }
       sale_artwork {
         estimate
       }
       sale {
+        _id
+        is_closed
         is_with_buyers_premium
       }
     }

--- a/src/Apps/Artwork/Components/__stories__/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.story.tsx
+++ b/src/Apps/Artwork/Components/__stories__/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.story.tsx
@@ -1,4 +1,6 @@
 import {
+  ArtworkAuctionPreview,
+  ArtworkClosedAuction,
   ArtworkNoEstimateNoPremium,
   ArtworkWithEstimateAndPremium,
   ArtworkWithEstimateNoPremium,
@@ -21,6 +23,12 @@ storiesOf("Styleguide/Artwork/Sidebar", module).add(
         </Section>
         <Section title="Artwork with estimate and buyer's premium">
           <AuctionPartnerInfo artwork={ArtworkWithEstimateAndPremium as any} />
+        </Section>
+        <Section title="Closed Auction">
+          <AuctionPartnerInfo artwork={ArtworkClosedAuction as any} />
+        </Section>
+        <Section title="Auction in preview">
+          <AuctionPartnerInfo artwork={ArtworkAuctionPreview as any} />
         </Section>
       </React.Fragment>
     )

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.test.tsx
@@ -1,0 +1,65 @@
+import { ArtworkWithEstimateAndPremium } from "Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo"
+import { ArtworkSidebarAuctionPartnerInfoFragmentContainer } from "Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo"
+import { renderRelayTree } from "DevTools"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+describe("ArtworkSidebarAuctionPartnerInfo", () => {
+  const getWrapper = async response => {
+    return await renderRelayTree({
+      Component: ArtworkSidebarAuctionPartnerInfoFragmentContainer,
+      query: graphql`
+        query ArtworkSidebarAuctionPartnerInfo_Test_Query {
+          artwork(id: "auction_artwork_estimate_premium") {
+            ...ArtworkSidebarAuctionPartnerInfo_artwork
+          }
+        }
+      `,
+      mockResolvers: {
+        Artwork: () => response,
+      },
+    })
+  }
+
+  let artwork
+
+  describe("ArtworkSidebarAuctionPartnerInfo", () => {
+    beforeEach(() => {
+      artwork = Object.assign({}, ArtworkWithEstimateAndPremium)
+    })
+
+    it("displays partner name, estimate and premium", async () => {
+      const wrapper = await getWrapper(artwork)
+
+      expect(wrapper.text()).toContain(artwork.partner.name)
+      expect(wrapper.text()).toContain(
+        "Estimated value: " + artwork.sale_artwork.estimate
+      )
+      expect(wrapper.text()).toContain("buyer's premium")
+    })
+
+    it("displays artwork without premium", async () => {
+      artwork.sale.is_with_buyers_premium = null
+
+      const wrapper = await getWrapper(artwork)
+
+      expect(wrapper.text()).not.toContain("buyer's premium")
+    })
+
+    it("displays artwork without estimate", async () => {
+      artwork.sale_artwork.estimate = null
+
+      const wrapper = await getWrapper(artwork)
+
+      expect(wrapper.text()).not.toContain("Estimated value")
+    })
+
+    it("does not display anything for closed auctions", async () => {
+      artwork.sale.is_closed = true
+
+      const wrapper = await getWrapper(artwork)
+      expect(wrapper.html()).toBeNull()
+    })
+  })
+})

--- a/src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.ts
+++ b/src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.ts
@@ -1,35 +1,79 @@
+export const ArtworkClosedAuction = {
+  _id: "artwork_auction_closed",
+  partner: {
+    _id: "5acd52b11a1e866b17e16045",
+    name: "Art For Life: Benefit Auction 2018",
+  },
+  sale_artwork: {
+    estimate: "$5,000",
+  },
+  sale: {
+    _id: "5bdb70e27ffd411bc71ee16c",
+    is_closed: true,
+    is_with_buyers_premium: null,
+  },
+}
+
+export const ArtworkAuctionPreview = {
+  _id: "artwork_auction_preview",
+  partner: {
+    _id: "553e693d7261695a85350100",
+    name: "Christie's",
+  },
+  sale_artwork: {
+    estimate: "$500,000–$700,000",
+  },
+  sale: {
+    _id: "5c05aa507c4cf06fa475b354",
+    is_closed: false,
+    is_with_buyers_premium: true,
+  },
+}
+
 export const ArtworkNoEstimateNoPremium = {
   _id: "auction_artwork",
-  is_biddable: true,
   partner: {
-    __id: "phillips",
-    name: "Phillips",
+    _id: "5bd72842658111197ca3e697",
+    name: "Fountain House Gallery: Benefit Auction 2018",
   },
-  sale_artwork: { estimate: null },
+  sale_artwork: {
+    estimate: null,
+  },
   sale: {
-    is_with_buyers_premium: false,
+    _id: "5bd7286433a1110029a0e9ec",
+    is_closed: false,
+    is_with_buyers_premium: null,
   },
 }
 
 export const ArtworkWithEstimateNoPremium = {
-  _id: "auction_artwork",
-  is_biddable: true,
-  partner: { __id: "phillips", name: "Phillips" },
-  sale_artwork: { estimate: "$300 - $500" },
-  sale: { is_with_buyers_premium: false },
+  _id: "auction_artwork_estimate",
+  partner: {
+    _id: "5a3842668b0c1457e619554e",
+    name: "Heather James Fine Art: Benefit Auction 2018",
+  },
+  sale_artwork: {
+    estimate: "$3,500",
+  },
+  sale: {
+    _id: "5bf2c924a4685802e05a1456",
+    is_closed: false,
+    is_with_buyers_premium: null,
+  },
 }
 
 export const ArtworkWithEstimateAndPremium = {
-  _id: "auction_artwork",
-  is_biddable: true,
+  _id: "auction_artwork_estimate_premium",
   partner: {
-    __id: "phillips",
-    name: "Phillips",
+    _id: "5a84a434275b247345983eac",
+    name: "Bruun Rasmussen",
   },
   sale_artwork: {
-    estimate: "$300 - $500",
+    estimate: "DKK 100,000–DKK 125,000",
   },
   sale: {
+    _id: "5bedc643023c175c11b9ee9c",
+    is_closed: false,
     is_with_buyers_premium: true,
   },
 }

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -168,6 +168,7 @@ export enum Subject {
   AuctionConditionsOfSale = "conditions of sale",
   AuctionFAQ = "auction faq",
   AuctionAskSpecialist = "ask a specialist",
+  AuctionBuyerPremium = "Buyer premium",
 
   CollectorFAQ = "collector faq",
 

--- a/src/__generated__/ArtworkSidebarAuctionPartnerInfo_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebarAuctionPartnerInfo_Test_Query.graphql.ts
@@ -1,0 +1,192 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { ArtworkSidebarAuctionPartnerInfo_artwork$ref } from "./ArtworkSidebarAuctionPartnerInfo_artwork.graphql";
+export type ArtworkSidebarAuctionPartnerInfo_Test_QueryVariables = {};
+export type ArtworkSidebarAuctionPartnerInfo_Test_QueryResponse = {
+    readonly artwork: ({
+        readonly " $fragmentRefs": ArtworkSidebarAuctionPartnerInfo_artwork$ref;
+    }) | null;
+};
+export type ArtworkSidebarAuctionPartnerInfo_Test_Query = {
+    readonly response: ArtworkSidebarAuctionPartnerInfo_Test_QueryResponse;
+    readonly variables: ArtworkSidebarAuctionPartnerInfo_Test_QueryVariables;
+};
+
+
+
+/*
+query ArtworkSidebarAuctionPartnerInfo_Test_Query {
+  artwork(id: "auction_artwork_estimate_premium") {
+    ...ArtworkSidebarAuctionPartnerInfo_artwork
+    __id
+  }
+}
+
+fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
+  _id
+  partner {
+    _id
+    name
+    __id
+  }
+  sale_artwork {
+    estimate
+    __id
+  }
+  sale {
+    _id
+    is_closed
+    is_with_buyers_premium
+    __id
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "auction_artwork_estimate_premium",
+    "type": "String!"
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "_id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "ArtworkSidebarAuctionPartnerInfo_Test_Query",
+  "id": null,
+  "text": "query ArtworkSidebarAuctionPartnerInfo_Test_Query {\n  artwork(id: \"auction_artwork_estimate_premium\") {\n    ...ArtworkSidebarAuctionPartnerInfo_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtworkSidebarAuctionPartnerInfo_Test_Query",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artwork",
+        "storageKey": "artwork(id:\"auction_artwork_estimate_premium\")",
+        "args": v0,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtworkSidebarAuctionPartnerInfo_artwork",
+            "args": null
+          },
+          v1
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtworkSidebarAuctionPartnerInfo_Test_Query",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artwork",
+        "storageKey": "artwork(id:\"auction_artwork_estimate_premium\")",
+        "args": v0,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          v2,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              v2,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "name",
+                "args": null,
+                "storageKey": null
+              },
+              v1
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "sale_artwork",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "SaleArtwork",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "estimate",
+                "args": null,
+                "storageKey": null
+              },
+              v1
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "sale",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Sale",
+            "plural": false,
+            "selections": [
+              v2,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_closed",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_with_buyers_premium",
+                "args": null,
+                "storageKey": null
+              },
+              v1
+            ]
+          },
+          v1
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '61df51c013d5fd8dd2fce1e68b6aa953';
+export default node;

--- a/src/__generated__/ArtworkSidebarAuctionPartnerInfo_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarAuctionPartnerInfo_artwork.graphql.ts
@@ -4,15 +4,17 @@ import { ConcreteFragment } from "relay-runtime";
 declare const _ArtworkSidebarAuctionPartnerInfo_artwork$ref: unique symbol;
 export type ArtworkSidebarAuctionPartnerInfo_artwork$ref = typeof _ArtworkSidebarAuctionPartnerInfo_artwork$ref;
 export type ArtworkSidebarAuctionPartnerInfo_artwork = {
-    readonly is_biddable: boolean | null;
+    readonly _id: string;
     readonly partner: ({
-        readonly __id: string;
+        readonly _id: string;
         readonly name: string | null;
     }) | null;
     readonly sale_artwork: ({
         readonly estimate: string | null;
     }) | null;
     readonly sale: ({
+        readonly _id: string;
+        readonly is_closed: boolean | null;
         readonly is_with_buyers_premium: boolean | null;
     }) | null;
     readonly " $refType": ArtworkSidebarAuctionPartnerInfo_artwork$ref;
@@ -22,6 +24,13 @@ export type ArtworkSidebarAuctionPartnerInfo_artwork = {
 
 const node: ConcreteFragment = (function(){
 var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "_id",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
@@ -35,13 +44,7 @@ return {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_biddable",
-      "args": null,
-      "storageKey": null
-    },
+    v0,
     {
       "kind": "LinkedField",
       "alias": null,
@@ -58,7 +61,8 @@ return {
           "name": "name",
           "args": null,
           "storageKey": null
-        }
+        },
+        v1
       ]
     },
     {
@@ -77,7 +81,7 @@ return {
           "args": null,
           "storageKey": null
         },
-        v0
+        v1
       ]
     },
     {
@@ -89,6 +93,14 @@ return {
       "concreteType": "Sale",
       "plural": false,
       "selections": [
+        v0,
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "is_closed",
+          "args": null,
+          "storageKey": null
+        },
         {
           "kind": "ScalarField",
           "alias": null,
@@ -96,12 +108,12 @@ return {
           "args": null,
           "storageKey": null
         },
-        v0
+        v1
       ]
     },
-    v0
+    v1
   ]
 };
 })();
-(node as any).hash = '6bd15df43a0432c47130b031be2830e1';
+(node as any).hash = 'e1fe54df68d7f574fbcb85149c14f99e';
 export default node;

--- a/src/__generated__/ArtworkSidebarQuery.graphql.ts
+++ b/src/__generated__/ArtworkSidebarQuery.graphql.ts
@@ -67,16 +67,19 @@ fragment ArtworkSidebarMetadata_artwork on Artwork {
 }
 
 fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
-  is_biddable
+  _id
   partner {
-    __id
+    _id
     name
+    __id
   }
   sale_artwork {
     estimate
     __id
   }
   sale {
+    _id
+    is_closed
     is_with_buyers_premium
     __id
   }
@@ -347,7 +350,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkSidebarQuery",
   "id": null,
-  "text": "query ArtworkSidebarQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkSidebar_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
+  "text": "query ArtworkSidebarQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkSidebar_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -702,6 +705,7 @@ return {
               }
             ]
           },
+          v9,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -711,8 +715,9 @@ return {
             "concreteType": "Partner",
             "plural": false,
             "selections": [
-              v2,
+              v9,
               v7,
+              v2,
               v8,
               {
                 "kind": "LinkedField",
@@ -744,6 +749,14 @@ return {
             "concreteType": "Sale",
             "plural": false,
             "selections": [
+              v9,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_closed",
+                "args": null,
+                "storageKey": null
+              },
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -756,13 +769,6 @@ return {
                 "kind": "ScalarField",
                 "alias": null,
                 "name": "is_open",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_closed",
                 "args": null,
                 "storageKey": null
               },
@@ -805,8 +811,7 @@ return {
                 "name": "is_registration_closed",
                 "args": null,
                 "storageKey": null
-              },
-              v9
+              }
             ]
           },
           {
@@ -870,7 +875,6 @@ return {
             "args": null,
             "storageKey": null
           },
-          v9,
           {
             "kind": "ScalarField",
             "alias": null,

--- a/src/__generated__/ArtworkSidebar_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebar_Test_Query.graphql.ts
@@ -63,16 +63,19 @@ fragment ArtworkSidebarMetadata_artwork on Artwork {
 }
 
 fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
-  is_biddable
+  _id
   partner {
-    __id
+    _id
     name
+    __id
   }
   sale_artwork {
     estimate
     __id
   }
   sale {
+    _id
+    is_closed
     is_with_buyers_premium
     __id
   }
@@ -335,7 +338,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkSidebar_Test_Query",
   "id": null,
-  "text": "query ArtworkSidebar_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebar_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
+  "text": "query ArtworkSidebar_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebar_artwork\n    __id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -690,6 +693,7 @@ return {
               }
             ]
           },
+          v8,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -699,8 +703,9 @@ return {
             "concreteType": "Partner",
             "plural": false,
             "selections": [
-              v1,
+              v8,
               v6,
+              v1,
               v7,
               {
                 "kind": "LinkedField",
@@ -732,6 +737,14 @@ return {
             "concreteType": "Sale",
             "plural": false,
             "selections": [
+              v8,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_closed",
+                "args": null,
+                "storageKey": null
+              },
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -744,13 +757,6 @@ return {
                 "kind": "ScalarField",
                 "alias": null,
                 "name": "is_open",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_closed",
                 "args": null,
                 "storageKey": null
               },
@@ -793,8 +799,7 @@ return {
                 "name": "is_registration_closed",
                 "args": null,
                 "storageKey": null
-              },
-              v8
+              }
             ]
           },
           {
@@ -858,7 +863,6 @@ return {
             "args": null,
             "storageKey": null
           },
-          v8,
           {
             "kind": "ScalarField",
             "alias": null,

--- a/src/__generated__/routes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/routes_ArtworkQuery.graphql.ts
@@ -287,16 +287,19 @@ fragment ArtworkSidebarMetadata_artwork on Artwork {
 }
 
 fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
-  is_biddable
+  _id
   partner {
-    __id
+    _id
     name
+    __id
   }
   sale_artwork {
     estimate
     __id
   }
   sale {
+    _id
+    is_closed
     is_with_buyers_premium
     __id
   }
@@ -493,45 +496,47 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = {
+v3 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "display",
+    "args": null,
+    "storageKey": null
+  }
+],
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "initials",
   "args": null,
   "storageKey": null
 },
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_followed",
-  "args": null,
-  "storageKey": null
-},
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "is_followed",
   "args": null,
   "storageKey": null
 },
@@ -545,25 +550,32 @@ v9 = {
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "href",
   "args": null,
   "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "is_closed",
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
 v12 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "is_closed",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "is_open",
   "args": null,
   "storageKey": null
 },
-v13 = [
+v14 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -572,7 +584,7 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v15 = [
   {
     "kind": "LinkedField",
     "alias": "img",
@@ -600,10 +612,10 @@ v14 = [
     ],
     "concreteType": "ResizedImageUrl",
     "plural": false,
-    "selections": v13
+    "selections": v14
   }
 ],
-v15 = {
+v16 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "dimensions",
@@ -628,22 +640,13 @@ v15 = {
     }
   ]
 },
-v16 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "edition_of",
   "args": null,
   "storageKey": null
 },
-v17 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "display",
-    "args": null,
-    "storageKey": null
-  }
-],
 v18 = [
   {
     "kind": "Literal",
@@ -673,7 +676,7 @@ return {
   "operationKind": "query",
   "name": "routes_ArtworkQuery",
   "id": null,
-  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  artist {\n    id\n    __id\n  }\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImages_artwork\n  __id\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsChecklist_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkImages_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  images {\n    id\n    uri: url(version: [\"larger\", \"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information(format: HTML)\n  partner {\n    _id\n    id\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    is_default_profile_public\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsChecklist_artwork on Artwork {\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  is_biddable\n  partner {\n    __id\n    name\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
+  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  artist {\n    id\n    __id\n  }\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImages_artwork\n  __id\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsChecklist_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkImages_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  images {\n    id\n    uri: url(version: [\"larger\", \"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information(format: HTML)\n  partner {\n    _id\n    id\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    is_default_profile_public\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsChecklist_artwork on Artwork {\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  artists {\n    __id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  sale {\n    is_open\n    is_closed\n    __id\n  }\n  sale_artwork {\n    lot_label\n    estimate\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    active_bid {\n      __id\n    }\n  }\n  sale {\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  __id\n  sale_message\n  is_inquireable\n  edition_sets {\n    __id\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -716,13 +719,53 @@ return {
         "plural": false,
         "selections": [
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "sale_message",
-            "args": null,
-            "storageKey": null
+            "name": "myLotStanding",
+            "storageKey": "myLotStanding(live:true)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "live",
+                "value": true,
+                "type": "Boolean"
+              }
+            ],
+            "concreteType": "LotStanding",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "active_bid",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "BidderPosition",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "is_winning",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "max_bid",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "BidderPositionMaxBid",
+                    "plural": false,
+                    "selections": v3
+                  },
+                  v2
+                ]
+              }
+            ]
           },
-          v3,
+          v4,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -732,9 +775,9 @@ return {
             "concreteType": "Partner",
             "plural": false,
             "selections": [
-              v4,
               v5,
               v6,
+              v7,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -770,12 +813,13 @@ return {
                     ]
                   },
                   v2,
-                  v3,
-                  v7
+                  v4,
+                  v8
                 ]
               },
               v2,
-              v8,
+              v9,
+              v10,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -795,8 +839,7 @@ return {
                   v2
                 ]
               },
-              v9,
-              v3,
+              v4,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -815,14 +858,14 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v10,
+              v11,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextAuction",
                 "selections": [
-                  v5,
-                  v8,
+                  v6,
+                  v10,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -830,8 +873,8 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v11,
                   v12,
+                  v13,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -859,14 +902,14 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v10,
+              v11,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextFair",
                 "selections": [
-                  v5,
-                  v8,
+                  v6,
+                  v10,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -897,7 +940,7 @@ return {
                     "concreteType": "Profile",
                     "plural": false,
                     "selections": [
-                      v6,
+                      v7,
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -906,7 +949,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": false,
-                        "selections": v14
+                        "selections": v15
                       },
                       v2
                     ]
@@ -924,15 +967,15 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v10,
+              v11,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextPartnerShow",
                 "selections": [
+                  v6,
+                  v10,
                   v5,
-                  v8,
-                  v4,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -948,7 +991,7 @@ return {
                     "args": null,
                     "concreteType": "Image",
                     "plural": false,
-                    "selections": v14
+                    "selections": v15
                   }
                 ]
               }
@@ -972,10 +1015,10 @@ return {
             "plural": true,
             "selections": [
               v2,
-              v3,
-              v5,
+              v4,
+              v6,
+              v10,
               v8,
-              v7,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1044,9 +1087,9 @@ return {
                             "plural": false,
                             "selections": [
                               v2,
-                              v3,
+                              v4,
                               v9,
-                              v5,
+                              v6,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -1077,7 +1120,7 @@ return {
                                     ],
                                     "concreteType": "CroppedImageUrl",
                                     "plural": false,
-                                    "selections": v13
+                                    "selections": v14
                                   }
                                 ]
                               }
@@ -1116,8 +1159,8 @@ return {
             "plural": true,
             "selections": [
               v2,
-              v15,
-              v16
+              v16,
+              v17
             ]
           },
           {
@@ -1173,7 +1216,7 @@ return {
                 "args": null,
                 "concreteType": "SaleArtworkCurrentBid",
                 "plural": false,
-                "selections": v17
+                "selections": v3
               },
               {
                 "kind": "LinkedField",
@@ -1201,7 +1244,7 @@ return {
                 "args": null,
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
-                "selections": v17
+                "selections": v3
               }
             ]
           },
@@ -1226,8 +1269,8 @@ return {
             "args": null,
             "storageKey": null
           },
-          v15,
           v16,
+          v17,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -1253,6 +1296,7 @@ return {
               }
             ]
           },
+          v9,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1262,6 +1306,8 @@ return {
             "concreteType": "Sale",
             "plural": false,
             "selections": [
+              v9,
+              v12,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1270,8 +1316,7 @@ return {
                 "storageKey": null
               },
               v2,
-              v12,
-              v11,
+              v13,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1311,54 +1356,6 @@ return {
                 "name": "is_registration_closed",
                 "args": null,
                 "storageKey": null
-              },
-              v9
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "myLotStanding",
-            "storageKey": "myLotStanding(live:true)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "live",
-                "value": true,
-                "type": "Boolean"
-              }
-            ],
-            "concreteType": "LotStanding",
-            "plural": true,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "active_bid",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "BidderPosition",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "is_winning",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "max_bid",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "BidderPositionMaxBid",
-                    "plural": false,
-                    "selections": v17
-                  },
-                  v2
-                ]
               }
             ]
           },
@@ -1371,9 +1368,16 @@ return {
             "concreteType": "Artist",
             "plural": false,
             "selections": [
-              v3,
+              v4,
               v2
             ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "sale_message",
+            "args": null,
+            "storageKey": null
           },
           {
             "kind": "ScalarField",
@@ -1382,7 +1386,6 @@ return {
             "args": null,
             "storageKey": null
           },
-          v9,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -1504,11 +1507,11 @@ return {
                 "concreteType": "Author",
                 "plural": false,
                 "selections": [
-                  v5,
+                  v6,
                   v2
                 ]
               },
-              v8,
+              v10,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1547,7 +1550,7 @@ return {
                     ],
                     "concreteType": "ResizedImageUrl",
                     "plural": false,
-                    "selections": v13
+                    "selections": v14
                   }
                 ]
               },
@@ -1559,7 +1562,7 @@ return {
                 "storageKey": null
               },
               v2,
-              v3
+              v4
             ]
           },
           {
@@ -1599,7 +1602,7 @@ return {
             "concreteType": "Image",
             "plural": true,
             "selections": [
-              v3,
+              v4,
               {
                 "kind": "ScalarField",
                 "alias": "uri",
@@ -1644,7 +1647,7 @@ return {
                 ],
                 "concreteType": "ResizedImageUrl",
                 "plural": false,
-                "selections": v13
+                "selections": v14
               },
               {
                 "kind": "ScalarField",


### PR DESCRIPTION
This still needs a mediator event in Force for auction Buyer's premium.

Or it might be worth to just rebuild this modal here in reaction. But seems like eigen is also still using Force html page for that, so I figured - I'll go with a mediator call for now.

@cavvia - also adding analytics call for the 'buyer's premium' click. Figured it's not going to hurt to track it.