### PR TITLE
/review/counter page UI

### DIFF
--- a/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
+++ b/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
@@ -1,0 +1,13 @@
+import { Link, Sans, SansProps } from "@artsy/palette"
+import React from "react"
+
+export const ConditionsOfSaleDisclaimer: React.SFC<
+  Partial<SansProps>
+> = props => (
+  <Sans size="2" color="black60" {...props}>
+    By clicking Submit, I agree to Artsy’s{" "}
+    <Link href="/conditions-of-sale" target="_blank">
+      Conditions of Sale.
+    </Link>
+  </Sans>
+)

--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -2,28 +2,27 @@ import { TransactionDetailsSummaryItem_order } from "__generated__/TransactionDe
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
-import {
-  Flex,
-  FlexProps,
-  Sans,
-  Serif,
-  Spacer,
-  StackableBorderBox,
-} from "@artsy/palette"
+import { Flex, Sans, Serif, Spacer } from "@artsy/palette"
+import { StepSummaryItem, StepSummaryItemProps } from "Styleguide/Components"
 
-export interface TransactionDetailsSummaryItemProps extends FlexProps {
+export interface TransactionDetailsSummaryItemProps
+  extends StepSummaryItemProps {
   order: TransactionDetailsSummaryItem_order
   offerOverride?: string | null
   useLastSubmittedOffer?: boolean
+  offerContextPrice?: "LIST_PRICE" | "LAST_OFFER"
 }
 
 export class TransactionDetailsSummaryItem extends React.Component<
   TransactionDetailsSummaryItemProps
 > {
+  static defaultProps: Partial<TransactionDetailsSummaryItemProps> = {
+    offerContextPrice: "LIST_PRICE",
+  }
   render() {
     const { offerOverride, order, ...others } = this.props
     return (
-      <StackableBorderBox flexDirection="column" {...others}>
+      <StepSummaryItem {...others}>
         {this.renderPriceEntry()}
         <Spacer mb={2} />
         <Entry label="Shipping" value={this.shippingDisplayAmount()} />
@@ -31,7 +30,7 @@ export class TransactionDetailsSummaryItem extends React.Component<
         <Entry label="Tax" value={this.taxDisplayAmount()} />
         <Spacer mb={2} />
         <Entry label="Total" value={this.buyerTotalDisplayAmount()} final />
-      </StackableBorderBox>
+      </StepSummaryItem>
     )
   }
 
@@ -85,7 +84,7 @@ export class TransactionDetailsSummaryItem extends React.Component<
   }
 
   renderPriceEntry = () => {
-    const { order, offerOverride } = this.props
+    const { order, offerOverride, offerContextPrice } = this.props
     if (order.mode === "BUY") {
       return <Entry label="Price" value={order.itemsTotal} />
     }
@@ -99,7 +98,19 @@ export class TransactionDetailsSummaryItem extends React.Component<
           label={isBuyerOffer ? "Your offer" : "Seller's offer"}
           value={offerOverride || (offer && offer.amount) || "—"}
         />
-        <SecondaryEntry label="List price" value={order.totalListPrice} />
+        {offerContextPrice === "LIST_PRICE" ? (
+          <SecondaryEntry label="List price" value={order.totalListPrice} />
+        ) : (
+          // show last offer
+          <SecondaryEntry
+            label={
+              order.lastOffer.fromParticipant === "SELLER"
+                ? "Seller's offer"
+                : "Your offer"
+            }
+            value={order.lastOffer.amount}
+          />
+        )}
       </>
     )
   }

--- a/src/Apps/Order/Components/__stories__/TransactionDetailsSummaryItem.story.tsx
+++ b/src/Apps/Order/Components/__stories__/TransactionDetailsSummaryItem.story.tsx
@@ -153,6 +153,43 @@ storiesOf("Apps/Order Page/Components", module).add(
             )}
           </Flex>
         </Section>
+        <Section title="Transaction Summary (last offer context)">
+          <Flex width={280} flexDirection="column">
+            {render(
+              {
+                __typename: "OfferOrder",
+                mode: "OFFER",
+                lastOffer: {
+                  id: "2345",
+                  amount: "$102",
+                  amountCents: 102489,
+                  shippingTotal: "$200",
+                  shippingTotalCents: 20000,
+                  taxTotal: "$100",
+                  taxTotalCents: 10000,
+                  buyerTotal: "$102789",
+                  buyerTotalCents: 10278900,
+                  fromParticipant: "SELLER",
+                },
+                myLastOffer: {
+                  id: "23456",
+                  amount: "$100",
+                  amountCents: 102489,
+                  shippingTotal: "$200",
+                  shippingTotalCents: 20000,
+                  taxTotal: "$100",
+                  taxTotalCents: 10000,
+                  buyerTotal: "$102789",
+                  buyerTotalCents: 10278900,
+                  fromParticipant: "BUYER",
+                },
+              },
+              {
+                offerContextPrice: "LAST_OFFER",
+              }
+            )}
+          </Flex>
+        </Section>
       </>
     )
   }

--- a/src/Apps/Order/Components/__tests__/TransactionDetailsSummary.test.tsx
+++ b/src/Apps/Order/Components/__tests__/TransactionDetailsSummary.test.tsx
@@ -237,5 +237,30 @@ describe("TransactionDetailsSummaryItem", () => {
 
       expect(text).toMatch("Your offer$1billion")
     })
+
+    it("lets you specify whether to use list price or last offer as context price", async () => {
+      const transactionSummary = await render(
+        {
+          ...transactionSummaryOfferOrder,
+          lastOffer: {
+            ...OfferWithTotals,
+            amount: "£405.00",
+            id: "last-offer",
+            fromParticipant: "SELLER",
+          },
+          myLastOffer: {
+            ...OfferWithTotals,
+            id: "my-last-offer",
+            amount: "£400.00",
+            fromParticipant: "BUYER",
+          },
+        },
+        { offerContextPrice: "LAST_OFFER" }
+      )
+
+      const text = transactionSummary.text()
+
+      expect(text).toContain("Your offer£400.00Seller's offer£405.00")
+    })
   })
 })

--- a/src/Apps/Order/Routes/Counter/index.tsx
+++ b/src/Apps/Order/Routes/Counter/index.tsx
@@ -1,0 +1,207 @@
+import { Button, Flex, Link, Sans, Spacer } from "@artsy/palette"
+import { Counter_order } from "__generated__/Counter_order.graphql"
+import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "Apps/Order/Components/ArtworkSummaryItem"
+import { CreditCardSummaryItemFragmentContainer as CreditCardSummaryItem } from "Apps/Order/Components/CreditCardSummaryItem"
+import {
+  counterofferFlowSteps,
+  OrderStepper,
+} from "Apps/Order/Components/OrderStepper"
+import { ShippingSummaryItemFragmentContainer as ShippingSummaryItem } from "Apps/Order/Components/ShippingSummaryItem"
+import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "Apps/Order/Components/TransactionDetailsSummaryItem"
+import { TwoColumnLayout } from "Apps/Order/Components/TwoColumnLayout"
+import { ContextConsumer, Mediator } from "Artsy/SystemContext"
+import { ErrorModal } from "Components/Modal/ErrorModal"
+import { Router } from "found"
+import React, { Component } from "react"
+import { createFragmentContainer, graphql, RelayProp } from "react-relay"
+import { CountdownTimer } from "Styleguide/Components/CountdownTimer"
+import { Col, Row } from "Styleguide/Elements/Grid"
+import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
+import createLogger from "Utils/logger"
+import { Media } from "Utils/Responsive"
+
+export interface CounterProps {
+  order: Counter_order
+  mediator: Mediator
+  relay?: RelayProp
+  router: Router
+}
+
+export interface CounterState {
+  isCommittingMutation: boolean
+  isErrorModalOpen: boolean
+  errorModalTitle: string
+  errorModalMessage: string
+}
+
+const logger = createLogger("Order/Routes/Counter/index.tsx")
+
+export class CounterRoute extends Component<CounterProps, CounterState> {
+  state = {
+    isCommittingMutation: false,
+    isErrorModalOpen: false,
+    errorModalTitle: null,
+    errorModalMessage: null,
+  } as CounterState
+
+  onSubmitButtonPressed: () => void = () => {
+    this.setState({ isCommittingMutation: true }, () => {
+      window.alert("You clicked submit.")
+      this.setState({ isCommittingMutation: false })
+    })
+  }
+
+  onMutationError(errors, errorModalTitle?, errorModalMessage?) {
+    logger.error(errors)
+    this.setState({
+      isCommittingMutation: false,
+      isErrorModalOpen: true,
+      errorModalTitle,
+      errorModalMessage,
+    })
+  }
+
+  onCloseModal = () => {
+    this.setState({ isErrorModalOpen: false })
+  }
+
+  onChangeResponse = () => {
+    const { order } = this.props
+    this.props.router.push(`/orders/${order.id}/respond`)
+  }
+
+  render() {
+    const { order } = this.props
+    const { isCommittingMutation } = this.state
+
+    return (
+      <>
+        <HorizontalPadding px={[0, 4]}>
+          <Row>
+            <Col>
+              <OrderStepper
+                currentStep="Review"
+                steps={counterofferFlowSteps}
+              />
+            </Col>
+          </Row>
+        </HorizontalPadding>
+
+        <HorizontalPadding>
+          <TwoColumnLayout
+            Content={
+              <Flex
+                flexDirection="column"
+                style={isCommittingMutation ? { pointerEvents: "none" } : {}}
+              >
+                <Flex flexDirection="column">
+                  <CountdownTimer
+                    action="Respond"
+                    note="Expired offers end the negotiation process permanently."
+                    countdownStart={order.lastOffer.createdAt}
+                    countdownEnd={order.stateExpiresAt}
+                  />
+                  <TransactionDetailsSummaryItem
+                    order={order}
+                    title="Your counteroffer"
+                    onChange={this.onChangeResponse}
+                    offerContextPrice="LAST_OFFER"
+                  />
+                </Flex>
+                <Spacer mb={3} />
+                <Flex flexDirection="column" />
+                <Media greaterThan="xs">
+                  <Button
+                    onClick={this.onSubmitButtonPressed}
+                    loading={isCommittingMutation}
+                    size="large"
+                    width="100%"
+                  >
+                    Submit
+                  </Button>
+                  <ConditionsOfSaleDisclaimer />
+                </Media>
+              </Flex>
+            }
+            Sidebar={
+              <Flex flexDirection="column">
+                <Flex flexDirection="column">
+                  <ArtworkSummaryItem order={order} />
+                  <ShippingSummaryItem order={order} locked />
+                  <CreditCardSummaryItem order={order} locked />
+                </Flex>
+                <Spacer mb={[2, 3]} />
+                <Media at="xs">
+                  <>
+                    <Button
+                      onClick={this.onSubmitButtonPressed}
+                      loading={isCommittingMutation}
+                      size="large"
+                      width="100%"
+                    >
+                      Submit
+                    </Button>
+                    <ConditionsOfSaleDisclaimer />
+                    <Spacer mb={[2, 3]} />
+                  </>
+                </Media>
+              </Flex>
+            }
+          />
+        </HorizontalPadding>
+
+        <ErrorModal
+          onClose={this.onCloseModal}
+          show={this.state.isErrorModalOpen}
+          contactEmail="orders@artsy.net"
+          detailText={this.state.errorModalMessage}
+          headerText={this.state.errorModalTitle}
+        />
+      </>
+    )
+  }
+}
+
+const ConditionsOfSaleDisclaimer = () => (
+  <>
+    <Spacer mb={2} />
+    <Sans size="2" color="black60">
+      By clicking Submit, I agree to Artsy’s{" "}
+      <Link href="https://www.artsy.net/conditions-of-sale">
+        Conditions of Sale.
+      </Link>
+    </Sans>
+  </>
+)
+
+const CounterRouteWrapper = props => (
+  <ContextConsumer>
+    {({ mediator }) => {
+      return <CounterRoute {...props} mediator={mediator} />
+    }}
+  </ContextConsumer>
+)
+
+export const CounterFragmentContainer = createFragmentContainer(
+  CounterRouteWrapper,
+  graphql`
+    fragment Counter_order on Order {
+      id
+      mode
+      state
+      itemsTotal(precision: 2)
+      totalListPrice(precision: 2)
+      stateExpiresAt
+      ... on OfferOrder {
+        lastOffer {
+          createdAt
+        }
+      }
+      ...TransactionDetailsSummaryItem_order
+      ...ArtworkSummaryItem_order
+      ...ShippingSummaryItem_order
+      ...CreditCardSummaryItem_order
+      ...OfferHistoryItem_order
+    }
+  `
+)

--- a/src/Apps/Order/Routes/Counter/index.tsx
+++ b/src/Apps/Order/Routes/Counter/index.tsx
@@ -1,6 +1,7 @@
-import { Button, Flex, Link, Sans, Spacer } from "@artsy/palette"
+import { Button, Flex, Spacer } from "@artsy/palette"
 import { Counter_order } from "__generated__/Counter_order.graphql"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "Apps/Order/Components/ArtworkSummaryItem"
+import { ConditionsOfSaleDisclaimer } from "Apps/Order/Components/ConditionsOfSaleDisclaimer"
 import { CreditCardSummaryItemFragmentContainer as CreditCardSummaryItem } from "Apps/Order/Components/CreditCardSummaryItem"
 import {
   counterofferFlowSteps,
@@ -119,7 +120,7 @@ export class CounterRoute extends Component<CounterProps, CounterState> {
                   >
                     Submit
                   </Button>
-                  <ConditionsOfSaleDisclaimer />
+                  <ConditionsOfSaleDisclaimer textAlign="center" />
                 </Media>
               </Flex>
             }
@@ -141,6 +142,7 @@ export class CounterRoute extends Component<CounterProps, CounterState> {
                     >
                       Submit
                     </Button>
+                    <Spacer mb={2} />
                     <ConditionsOfSaleDisclaimer />
                     <Spacer mb={[2, 3]} />
                   </>
@@ -161,18 +163,6 @@ export class CounterRoute extends Component<CounterProps, CounterState> {
     )
   }
 }
-
-const ConditionsOfSaleDisclaimer = () => (
-  <>
-    <Spacer mb={2} />
-    <Sans size="2" color="black60">
-      By clicking Submit, I agree to Artsy’s{" "}
-      <Link href="https://www.artsy.net/conditions-of-sale">
-        Conditions of Sale.
-      </Link>
-    </Sans>
-  </>
-)
 
 const CounterRouteWrapper = props => (
   <ContextConsumer>

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -1,8 +1,9 @@
-import { Button, Flex, Join, Sans, Spacer } from "@artsy/palette"
+import { Button, Flex, Join, Spacer } from "@artsy/palette"
 import { Review_order } from "__generated__/Review_order.graphql"
 import { ReviewSubmitOfferOrderMutation } from "__generated__/ReviewSubmitOfferOrderMutation.graphql"
 import { ReviewSubmitOrderMutation } from "__generated__/ReviewSubmitOrderMutation.graphql"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "Apps/Order/Components/ArtworkSummaryItem"
+import { ConditionsOfSaleDisclaimer } from "Apps/Order/Components/ConditionsOfSaleDisclaimer"
 import { ItemReviewFragmentContainer as ItemReview } from "Apps/Order/Components/ItemReview"
 import {
   buyNowFlowSteps,
@@ -329,16 +330,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                       Submit
                     </Button>
                     <Spacer mb={2} />
-                    <Sans textAlign="center" size="2" color="black60">
-                      By clicking Submit, I agree to Artsy’s{" "}
-                      <a
-                        href="https://www.artsy.net/conditions-of-sale"
-                        target="_blank"
-                      >
-                        Conditions of Sale
-                      </a>
-                      .
-                    </Sans>
+                    <ConditionsOfSaleDisclaimer textAlign="center" />
                   </Media>
                 </Join>
                 <Spacer mb={3} />
@@ -366,16 +358,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                     Submit
                   </Button>
                   <Spacer mb={2} />
-                  <Sans size="2" color="black60">
-                    By clicking Submit, I agree to Artsy’s{" "}
-                    <a
-                      href="https://www.artsy.net/conditions-of-sale"
-                      target="_blank"
-                    >
-                      Conditions of Sale
-                    </a>
-                    .
-                  </Sans>
+                  <ConditionsOfSaleDisclaimer />
                   <Spacer mb={2} />
                   <Helper
                     artworkId={order.lineItems.edges[0].node.artwork.id}

--- a/src/Apps/Order/Routes/__tests__/Counter.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.test.tsx
@@ -1,0 +1,153 @@
+import { Button } from "@artsy/palette"
+import {
+  Buyer,
+  OfferOrderWithShippingDetails,
+  Offers,
+  OfferWithTotals,
+} from "Apps/__tests__/Fixtures/Order"
+import { ArtworkSummaryItemFragmentContainer } from "Apps/Order/Components/ArtworkSummaryItem"
+import { CreditCardSummaryItemFragmentContainer } from "Apps/Order/Components/CreditCardSummaryItem"
+import { OrderStepper } from "Apps/Order/Components/OrderStepper"
+import { ShippingSummaryItemFragmentContainer } from "Apps/Order/Components/ShippingSummaryItem"
+import { TransactionDetailsSummaryItemFragmentContainer } from "Apps/Order/Components/TransactionDetailsSummaryItem"
+import { MockBoot } from "DevTools"
+import { mount } from "enzyme"
+import moment from "moment"
+import React from "react"
+import { commitMutation as _commitMutation } from "react-relay"
+import { Stepper } from "Styleguide/Components"
+import { CountdownTimer } from "Styleguide/Components/CountdownTimer"
+import { CounterFragmentContainer as CounterRoute } from "../Counter"
+
+jest.mock("Utils/getCurrentTimeAsIsoString")
+
+const NOW = "2018-12-05T13:47:16.446Z"
+
+require("Utils/getCurrentTimeAsIsoString").__setCurrentTime(NOW)
+
+jest.mock("react-relay", () => ({
+  commitMutation: jest.fn(),
+  createFragmentContainer: component => component,
+}))
+
+const testOrder = {
+  ...OfferOrderWithShippingDetails,
+  stateExpiresAt: moment(NOW)
+    .add(1, "day")
+    .toISOString(),
+  lastOffer: {
+    ...OfferWithTotals,
+    createdAt: moment(NOW)
+      .subtract(1, "day")
+      .toISOString(),
+    amount: "$sellers.offer",
+  },
+  myLastOffer: {
+    ...OfferWithTotals,
+    createdAt: moment(NOW)
+      .subtract(1, "seconds")
+      .toISOString(),
+    amount: "$your.offer",
+    fromParticipant: "BUYER",
+  },
+  offers: { edges: Offers },
+  buyer: Buyer,
+}
+
+let mockPushRoute: jest.Mock<string>
+let mockMediatorTrigger: jest.Mock<string>
+
+describe("Offer InitialMutation", () => {
+  const getWrapper = (extraOrderProps?) => {
+    return mount(
+      <MockBoot>
+        <CounterRoute
+          relay={{ environment: {} }}
+          router={{ push: mockPushRoute }}
+          mediator={{ trigger: mockMediatorTrigger }}
+          order={{
+            ...testOrder,
+            ...extraOrderProps,
+          }}
+        />
+      </MockBoot>
+    )
+  }
+
+  beforeEach(() => {
+    mockPushRoute = jest.fn()
+    mockMediatorTrigger = jest.fn()
+  })
+
+  it("Shows the stepper", () => {
+    const component = getWrapper()
+    const stepper = component.find(OrderStepper)
+    expect(stepper.text()).toMatchInlineSnapshot(`"Respond Review"`)
+
+    const index = component.find(Stepper).props().currentStepIndex
+    expect(index).toBe(1)
+  })
+
+  it("shows the countdown timer", () => {
+    const component = getWrapper({
+      stateExpiresAt: moment(NOW)
+        .add(1, "day")
+        .add(4, "hours")
+        .add(22, "minutes")
+        .add(59, "seconds"),
+    })
+    const timer = component.find(CountdownTimer)
+    expect(timer.text()).toContain("01d 04h 22m 59s left")
+  })
+
+  it("shows the transaction summary", () => {
+    const component = getWrapper()
+    const transactionSummary = component.find(
+      TransactionDetailsSummaryItemFragmentContainer
+    )
+    expect(transactionSummary).toHaveLength(1)
+
+    expect(transactionSummary.text()).toMatch("Your counterofferChange")
+    expect(transactionSummary.text()).toMatch("Your offer$your.offer")
+    expect(transactionSummary.text()).toMatch("Seller's offer$sellers.offer")
+  })
+
+  it("shows the artwork summary", () => {
+    const component = getWrapper()
+    const artworkSummary = component.find(ArtworkSummaryItemFragmentContainer)
+    expect(artworkSummary).toHaveLength(1)
+
+    expect(artworkSummary.text()).toMatch("Lisa BreslowGramercy Park South")
+  })
+
+  it("shows the shipping details", () => {
+    const component = getWrapper()
+    const shippingSummary = component.find(ShippingSummaryItemFragmentContainer)
+    expect(shippingSummary).toHaveLength(1)
+
+    expect(shippingSummary.text()).toMatch("Ship toJoelle Van Dyne401 Broadway")
+  })
+
+  it("shows the payment details", () => {
+    const component = getWrapper()
+    const paymentSummary = component.find(
+      CreditCardSummaryItemFragmentContainer
+    )
+    expect(paymentSummary).toHaveLength(1)
+
+    expect(paymentSummary.text()).toMatchInlineSnapshot(`"•••• 4444  Exp 3/21"`)
+  })
+
+  it("shows the submit button", () => {
+    const component = getWrapper()
+    const continueButton = component.find(Button).last()
+    expect(continueButton.text()).toBe("Submit")
+  })
+
+  it("Shows the conditions of sale disclaimer.", () => {
+    const component = getWrapper()
+    expect(component.text()).toMatch(
+      "By clicking Submit, I agree to Artsy’s Conditions of Sale."
+    )
+  })
+})

--- a/src/Apps/Order/Routes/__tests__/Review.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.test.tsx
@@ -6,6 +6,8 @@ import {
   OfferOrderWithShippingDetails,
   UntouchedBuyOrder,
 } from "Apps/__tests__/Fixtures/Order"
+import { CreditCardSummaryItemFragmentContainer } from "Apps/Order/Components/CreditCardSummaryItem"
+import { ShippingSummaryItemFragmentContainer } from "Apps/Order/Components/ShippingSummaryItem"
 import { ErrorModal, ModalButton } from "Components/Modal/ErrorModal"
 import { MockBoot } from "DevTools"
 import { commitMutation } from "react-relay"
@@ -75,8 +77,7 @@ describe("Review", () => {
     it("takes the user back to the /shipping view", () => {
       const component = getWrapper(defaultProps)
       component
-        .find(StepSummaryItem)
-        .first()
+        .find(ShippingSummaryItemFragmentContainer)
         .find("a")
         .simulate("click")
       expect(pushMock).toBeCalledWith("/orders/1234/shipping")
@@ -85,8 +86,7 @@ describe("Review", () => {
     it("takes the user back to the /payment view", () => {
       const component = getWrapper(defaultProps)
       component
-        .find(StepSummaryItem)
-        .last()
+        .find(CreditCardSummaryItemFragmentContainer)
         .find("a")
         .simulate("click")
       expect(pushMock).toBeCalledWith("/orders/1234/payment")
@@ -185,7 +185,7 @@ describe("Review", () => {
     it("shows an offer section in the shipping and payment review", () => {
       const component = getWrapper(offerOrderProps)
 
-      expect(component.find(StepSummaryItem).length).toEqual(3)
+      expect(component.find(StepSummaryItem).length).toEqual(4)
 
       expect(
         component

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -10,6 +10,7 @@ import { RespondFragmentContainer as RespondRoute } from "Apps/Order/Routes/Resp
 import { ReviewFragmentContainer as ReviewRoute } from "Apps/Order/Routes/Review"
 import { ShippingFragmentContainer as ShippingRoute } from "Apps/Order/Routes/Shipping"
 import { StatusFragmentContainer as StatusRoute } from "Apps/Order/Routes/Status"
+import { CounterFragmentContainer as CounterRoute } from "./Routes/Counter"
 
 // @ts-ignore
 import { ComponentClass, StatelessComponent } from "react"
@@ -44,6 +45,11 @@ export const routes: RouteConfig[] = [
           ... on OfferOrder {
             myLastOffer {
               id
+              createdAt
+            }
+            lastOffer {
+              id
+              createdAt
             }
           }
           requestedFulfillment {
@@ -128,6 +134,21 @@ export const routes: RouteConfig[] = [
           query routes_PaymentQuery($orderID: String!) {
             order: ecommerceOrder(id: $orderID) {
               ...Payment_order
+            }
+          }
+        `,
+        cacheConfig: {
+          force: true,
+        },
+      },
+      {
+        path: "review/counter",
+        Component: CounterRoute,
+        onTransition: confirmRouteExit,
+        query: graphql`
+          query routes_CounterQuery($orderID: String!) {
+            order: ecommerceOrder(id: $orderID) {
+              ...Counter_order
             }
           }
         `,

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -174,27 +174,59 @@ storiesOf("Apps/Order Page/Make Offer/Review", module).add("Review", () => (
   />
 ))
 
-storiesOf("Apps/Order Page/Counter Offer", module).add("Respond", () => (
-  <Router
-    initialRoute="/orders/123/respond"
-    mockResolvers={mockResolver({
-      ...OfferOrderWithShippingDetails,
-      state: "SUBMITTED",
-      stateExpiresAt: moment()
-        .add(1, "day")
-        .toISOString(),
-      lastOffer: {
-        ...OfferWithTotals,
-        createdAt: moment()
-          .subtract(1, "day")
+storiesOf("Apps/Order Page/Counter Offer", module)
+  .add("Respond", () => (
+    <Router
+      initialRoute="/orders/123/respond"
+      mockResolvers={mockResolver({
+        ...OfferOrderWithShippingDetails,
+        state: "SUBMITTED",
+        stateExpiresAt: moment()
+          .add(1, "day")
           .toISOString(),
-      },
-      awaitingResponseFrom: "BUYER",
-      offers: { edges: Offers },
-      buyer: Buyer,
-    })}
-  />
-))
+        lastOffer: {
+          ...OfferWithTotals,
+          createdAt: moment()
+            .subtract(1, "day")
+            .toISOString(),
+        },
+        awaitingResponseFrom: "BUYER",
+        offers: { edges: Offers },
+        buyer: Buyer,
+      })}
+    />
+  ))
+
+  .add("Review (counter)", () => (
+    <Router
+      initialRoute="/orders/123/review/counter"
+      mockResolvers={mockResolver({
+        ...OfferOrderWithShippingDetails,
+        state: "SUBMITTED",
+        stateExpiresAt: moment()
+          .add(1, "day")
+          .toISOString(),
+        lastOffer: {
+          ...OfferWithTotals,
+          id: "last-offer",
+          createdAt: moment()
+            .subtract(1, "day")
+            .toISOString(),
+        },
+        myLastOffer: {
+          ...OfferWithTotals,
+          id: "my-last-offer",
+          fromParticipant: "BUYER",
+          createdAt: moment()
+            .subtract(1, "minute")
+            .toISOString(),
+        },
+        awaitingResponseFrom: "BUYER",
+        offers: { edges: Offers },
+        buyer: Buyer,
+      })}
+    />
+  ))
 
 storiesOf("Apps/Order Page/Make Offer/Status", module)
   .add("submitted (ship)", () => (

--- a/src/__generated__/Counter_order.graphql.ts
+++ b/src/__generated__/Counter_order.graphql.ts
@@ -1,0 +1,148 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+import { ArtworkSummaryItem_order$ref } from "./ArtworkSummaryItem_order.graphql";
+import { CreditCardSummaryItem_order$ref } from "./CreditCardSummaryItem_order.graphql";
+import { OfferHistoryItem_order$ref } from "./OfferHistoryItem_order.graphql";
+import { ShippingSummaryItem_order$ref } from "./ShippingSummaryItem_order.graphql";
+import { TransactionDetailsSummaryItem_order$ref } from "./TransactionDetailsSummaryItem_order.graphql";
+export type OrderModeEnum = "BUY" | "OFFER" | "%future added value";
+declare const _Counter_order$ref: unique symbol;
+export type Counter_order$ref = typeof _Counter_order$ref;
+export type Counter_order = {
+    readonly id: string | null;
+    readonly mode: OrderModeEnum | null;
+    readonly state: string | null;
+    readonly itemsTotal: string | null;
+    readonly totalListPrice: string | null;
+    readonly stateExpiresAt: string | null;
+    readonly lastOffer?: ({
+        readonly createdAt: string | null;
+    }) | null;
+    readonly " $fragmentRefs": TransactionDetailsSummaryItem_order$ref & ArtworkSummaryItem_order$ref & ShippingSummaryItem_order$ref & CreditCardSummaryItem_order$ref & OfferHistoryItem_order$ref;
+    readonly " $refType": Counter_order$ref;
+};
+
+
+
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "precision",
+    "value": 2,
+    "type": "Int"
+  }
+];
+return {
+  "kind": "Fragment",
+  "name": "Counter_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    v0,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "state",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "itemsTotal",
+      "args": v1,
+      "storageKey": "itemsTotal(precision:2)"
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "totalListPrice",
+      "args": v1,
+      "storageKey": "totalListPrice(precision:2)"
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "stateExpiresAt",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "mode",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "TransactionDetailsSummaryItem_order",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ArtworkSummaryItem_order",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ShippingSummaryItem_order",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "CreditCardSummaryItem_order",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "OfferHistoryItem_order",
+      "args": null
+    },
+    {
+      "kind": "InlineFragment",
+      "type": "OfferOrder",
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "lastOffer",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Offer",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "createdAt",
+              "args": null,
+              "storageKey": null
+            },
+            v0
+          ]
+        }
+      ]
+    }
+  ]
+};
+})();
+(node as any).hash = '53059a64667f6767a97fbacce52642d3';
+export default node;

--- a/src/__generated__/routes_CounterQuery.graphql.ts
+++ b/src/__generated__/routes_CounterQuery.graphql.ts
@@ -1,0 +1,763 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { Counter_order$ref } from "./Counter_order.graphql";
+export type routes_CounterQueryVariables = {
+    readonly orderID: string;
+};
+export type routes_CounterQueryResponse = {
+    readonly order: ({
+        readonly " $fragmentRefs": Counter_order$ref;
+    }) | null;
+};
+export type routes_CounterQuery = {
+    readonly response: routes_CounterQueryResponse;
+    readonly variables: routes_CounterQueryVariables;
+};
+
+
+
+/*
+query routes_CounterQuery(
+  $orderID: String!
+) {
+  order: ecommerceOrder(id: $orderID) {
+    __typename
+    ...Counter_order
+    __id: id
+  }
+}
+
+fragment Counter_order on Order {
+  id
+  mode
+  state
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  stateExpiresAt
+  ... on OfferOrder {
+    lastOffer {
+      createdAt
+      __id: id
+    }
+  }
+  ...TransactionDetailsSummaryItem_order
+  ...ArtworkSummaryItem_order
+  ...ShippingSummaryItem_order
+  ...CreditCardSummaryItem_order
+  ...OfferHistoryItem_order
+  __id: id
+}
+
+fragment TransactionDetailsSummaryItem_order on Order {
+  __typename
+  mode
+  shippingTotal(precision: 2)
+  shippingTotalCents
+  taxTotal(precision: 2)
+  taxTotalCents
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  buyerTotal(precision: 2)
+  ... on OfferOrder {
+    lastOffer {
+      id
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      __id: id
+    }
+    myLastOffer {
+      id
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      __id: id
+    }
+  }
+  __id: id
+}
+
+fragment ArtworkSummaryItem_order on Order {
+  seller {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      __id
+    }
+    ... on User {
+      __id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          __id
+        }
+        __id: id
+      }
+    }
+  }
+  __id: id
+}
+
+fragment ShippingSummaryItem_order on Order {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          __id
+        }
+        __id: id
+      }
+    }
+  }
+  __id: id
+}
+
+fragment CreditCardSummaryItem_order on Order {
+  creditCard {
+    brand
+    last_digits
+    expiration_year
+    expiration_month
+    __id
+  }
+  __id: id
+}
+
+fragment OfferHistoryItem_order on Order {
+  ... on OfferOrder {
+    offers {
+      edges {
+        node {
+          id
+          amount(precision: 2)
+          createdAt(format: "MMM D")
+          fromParticipant
+          __id: id
+        }
+      }
+    }
+    lastOffer {
+      id
+      fromParticipant
+      amount(precision: 2)
+      shippingTotal(precision: 2)
+      taxTotal(precision: 2)
+      __id: id
+    }
+  }
+  totalListPrice(precision: 2)
+  __id: id
+}
+
+fragment ShippingAddress_ship on Ship {
+  name
+  addressLine1
+  addressLine2
+  city
+  postalCode
+  region
+  country
+  phoneNumber
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "orderID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "orderID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "shippingTotalCents",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "precision",
+    "value": 2,
+    "type": "Int"
+  }
+],
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "shippingTotal",
+  "args": v5,
+  "storageKey": "shippingTotal(precision:2)"
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "taxTotal",
+  "args": v5,
+  "storageKey": "taxTotal(precision:2)"
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "taxTotalCents",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "buyerTotal",
+  "args": v5,
+  "storageKey": "buyerTotal(precision:2)"
+},
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "amount",
+  "args": v5,
+  "storageKey": "amount(precision:2)"
+},
+v14 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "amountCents",
+  "args": null,
+  "storageKey": null
+},
+v15 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "buyerTotalCents",
+  "args": null,
+  "storageKey": null
+},
+v16 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "fromParticipant",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_CounterQuery",
+  "id": null,
+  "text": "query routes_CounterQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Counter_order\n    __id: id\n  }\n}\n\nfragment Counter_order on Order {\n  id\n  mode\n  state\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  stateExpiresAt\n  ... on OfferOrder {\n    lastOffer {\n      createdAt\n      __id: id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment OfferHistoryItem_order on Order {\n  ... on OfferOrder {\n    offers {\n      edges {\n        node {\n          id\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          __id: id\n        }\n      }\n    }\n    lastOffer {\n      id\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      __id: id\n    }\n  }\n  totalListPrice(precision: 2)\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_CounterQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "order",
+        "name": "ecommerceOrder",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": null,
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Counter_order",
+            "args": null
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_CounterQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "order",
+        "name": "ecommerceOrder",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": null,
+        "plural": false,
+        "selections": [
+          v3,
+          v4,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "state",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "itemsTotal",
+            "args": v5,
+            "storageKey": "itemsTotal(precision:2)"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "totalListPrice",
+            "args": v5,
+            "storageKey": "totalListPrice(precision:2)"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "stateExpiresAt",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "requestedFulfillment",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v6,
+              {
+                "kind": "InlineFragment",
+                "type": "Ship",
+                "selections": [
+                  v7,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "addressLine1",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "addressLine2",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "city",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "postalCode",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "region",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "country",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "phoneNumber",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          v6,
+          v8,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
+          v9,
+          v10,
+          v11,
+          v2,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "seller",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v6,
+              v12,
+              {
+                "kind": "InlineFragment",
+                "type": "Partner",
+                "selections": [
+                  v7
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "lineItems",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "OrderLineItemConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "OrderLineItemEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "OrderLineItem",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "artist_names",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "title",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "date",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "shippingOrigin",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": "resized_ArtworkSummaryItem",
+                                "name": "resized",
+                                "storageKey": "resized(width:55)",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 55,
+                                    "type": "Int"
+                                  }
+                                ],
+                                "concreteType": "ResizedImageUrl",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "url",
+                                    "args": null,
+                                    "storageKey": null
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          v12
+                        ]
+                      },
+                      v2
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCard",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CreditCard",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "brand",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "last_digits",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_year",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_month",
+                "args": null,
+                "storageKey": null
+              },
+              v12
+            ]
+          },
+          {
+            "kind": "InlineFragment",
+            "type": "OfferOrder",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "lastOffer",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Offer",
+                "plural": false,
+                "selections": [
+                  v3,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "createdAt",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v4,
+                  v13,
+                  v14,
+                  v8,
+                  v2,
+                  v9,
+                  v10,
+                  v11,
+                  v15,
+                  v16
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "myLastOffer",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Offer",
+                "plural": false,
+                "selections": [
+                  v9,
+                  v4,
+                  v14,
+                  v8,
+                  v3,
+                  v13,
+                  v10,
+                  v11,
+                  v15,
+                  v16,
+                  v2
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "offers",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "OfferConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "OfferEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Offer",
+                        "plural": false,
+                        "selections": [
+                          v4,
+                          v13,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "createdAt",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "format",
+                                "value": "MMM D",
+                                "type": "String"
+                              }
+                            ],
+                            "storageKey": "createdAt(format:\"MMM D\")"
+                          },
+                          v16,
+                          v2
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'c372f34248ca76c22e5b41d54085bebd';
+export default node;

--- a/src/__generated__/routes_OrderQuery.graphql.ts
+++ b/src/__generated__/routes_OrderQuery.graphql.ts
@@ -31,6 +31,11 @@ export type routes_OrderQueryResponse = {
         }) | null;
         readonly myLastOffer?: ({
             readonly id: string | null;
+            readonly createdAt: string | null;
+        }) | null;
+        readonly lastOffer?: ({
+            readonly id: string | null;
+            readonly createdAt: string | null;
         }) | null;
         readonly awaitingResponseFrom?: OrderParticipantEnum | null;
     }) | null;
@@ -58,6 +63,12 @@ query routes_OrderQuery(
     ... on OfferOrder {
       myLastOffer {
         id
+        createdAt
+        __id: id
+      }
+      lastOffer {
+        id
+        createdAt
         __id: id
       }
       awaitingResponseFrom
@@ -233,7 +244,18 @@ v12 = {
   "plural": false,
   "selections": v9
 },
-v13 = {
+v13 = [
+  v4,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "createdAt",
+    "args": null,
+    "storageKey": null
+  },
+  v10
+],
+v14 = {
   "kind": "InlineFragment",
   "type": "OfferOrder",
   "selections": [
@@ -245,10 +267,17 @@ v13 = {
       "args": null,
       "concreteType": "Offer",
       "plural": false,
-      "selections": [
-        v4,
-        v10
-      ]
+      "selections": v13
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "lastOffer",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Offer",
+      "plural": false,
+      "selections": v13
     },
     {
       "kind": "ScalarField",
@@ -264,7 +293,7 @@ return {
   "operationKind": "query",
   "name": "routes_OrderQuery",
   "id": null,
-  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    id\n    mode\n    state\n    ... on OfferOrder {\n      myLastOffer {\n        id\n        __id: id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
+  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    id\n    mode\n    state\n    ... on OfferOrder {\n      myLastOffer {\n        id\n        createdAt\n        __id: id\n      }\n      lastOffer {\n        id\n        createdAt\n        __id: id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -290,7 +319,7 @@ return {
           v11,
           v12,
           v10,
-          v13
+          v14
         ]
       }
     ]
@@ -318,12 +347,12 @@ return {
           v11,
           v12,
           v10,
-          v13
+          v14
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = '3108a4804a568117e7648269beeac008';
+(node as any).hash = '980157379498cf9019d77ed1e2e06bbf';
 export default node;


### PR DESCRIPTION
Hello friends!

This implements the initial UI for the counter offer review page. It also does a couple of other things:

- Expands on the the redirect logic refactor from a few days ago to allow decoupling the route hierarchy from the redirect rules hierarchy. e.g. this route and a few others fall under `/review/*` but should not share the same logic as the main `/review` page.
- Builds the `TransactionDetailsSummary` on top of `StepSummaryItem` rather than `StackableBorderBox`, to allow us to specify the `title` and `onChange` props that make this happen:  
   ![image](https://user-images.githubusercontent.com/1242537/49653526-1950d400-fa2d-11e8-8d23-2b2260f5feb8.png)
- Also updates the `TransactionDetailsSummaryItem` to allow us to specify which 'context' price appears below the main price. e.g. 
   ![image](https://user-images.githubusercontent.com/1242537/49653583-5026ea00-fa2d-11e8-9327-45f025fac134.png)
   vs
   ![image](https://user-images.githubusercontent.com/1242537/49653671-95e3b280-fa2d-11e8-8625-1d68f13f6941.png)



 
Desktop

![image](https://user-images.githubusercontent.com/1242537/49653307-713b0b00-fa2c-11e8-8682-58acdf720da6.png)

Mobile

![image](https://user-images.githubusercontent.com/1242537/49653370-9d568c00-fa2c-11e8-918d-11e4d6b2e713.png)


We are still working on the mutation side of things so that will come in a follow-up PR.