### PR TITLE
Track edition set option selection in RAP sidebar for BNMO

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarSizeInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarSizeInfo.tsx
@@ -23,11 +23,8 @@ export class ArtworkSidebarSizeInfo extends React.Component<
     }
     return (
       <Box color="black60">
-        <Serif size="2">
-          {dimensions &&
-            (dimensions.in || dimensions.cm) &&
-            [dimensions.in, dimensions.cm].join("; ")}
-        </Serif>
+        {dimensions.in && <Serif size="2">{dimensions.in}</Serif>}
+        {dimensions.cm && <Serif size="2">{dimensions.cm}</Serif>}
         {edition_of && <Serif size="2">{edition_of}</Serif>}
       </Box>
     )

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarMetadata.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarMetadata.test.tsx
@@ -49,7 +49,10 @@ describe("ArtworkSidebarMetadata", () => {
     })
 
     it("displays dimentions", () => {
-      expect(wrapper.html()).toContain("97 × 15 in; 246.4 × 38.1 cm")
+      const html = wrapper.html()
+
+      expect(html).toContain("97 × 15 in")
+      expect(html).toContain("246.4 × 38.1 cm")
     })
 
     it("displays classification", () => {
@@ -71,7 +74,9 @@ describe("ArtworkSidebarMetadata", () => {
     })
 
     it("displays edition dimentions", () => {
-      expect(wrapper.html()).toContain("14 × 18 in; 35.6 × 45.7 cm")
+      const html = wrapper.html()
+      expect(html).toContain("14 × 18 in")
+      expect(html).toContain("35.6 × 45.7 cm")
     })
 
     it("displays edition details", () => {
@@ -99,7 +104,8 @@ describe("ArtworkSidebarMetadata", () => {
     it("does not render edition dimentions or details", () => {
       expect(wrapper.find(ArtworkSidebarSizeInfo).length).toBe(0)
       const html = wrapper.html()
-      expect(html).not.toContain("40 × 42 in; cm: 101.6 × 106.7 cm")
+      expect(html).not.toContain("40 × 42 in")
+      expect(html).not.toContain("101.6 × 106.7 cm")
       expect(html).not.toContain("Edition of 3000")
     })
 
@@ -146,7 +152,10 @@ describe("ArtworkSidebarMetadata", () => {
     })
 
     it("displays edition dimentions", () => {
-      expect(wrapper.html()).toContain("17 × 13 in; 43.2 × 33 cm")
+      const html = wrapper.html()
+
+      expect(html).toContain("17 × 13 in")
+      expect(html).toContain("43.2 × 33 cm")
     })
 
     it("displays classification", () => {


### PR DESCRIPTION
Render radio buttons for each edition set option within the Responsive Artwork Page sidebar for works that are enrolled in either of both of the Buy Now / Make Offer e-commerce programs.

![2018-12-07-123512_871x673_scrot](https://user-images.githubusercontent.com/123595/49663843-ec48f500-fa1d-11e8-8720-fb9ee9fb19bd.png)
