### PR TITLE
Don't show radio buttons if artwork is not e-commerce enabled

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -53,7 +53,11 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
   }
 
   renderEdition(edition) {
-    const isEcommerceEnrolled = edition.is_acquireable || edition.is_inquireable
+    const { artwork } = this.props
+    const isEcommerceEnrolled =
+      (artwork.is_acquireable || artwork.is_offerable) &&
+      (edition.is_acquireable || edition.is_offerable)
+
     const editionFragment = (
       <>
         <SizeInfo piece={edition} />
@@ -62,20 +66,23 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         </Serif>
       </>
     )
-
-    return (
-      <Row>
-        <Radio
-          mr="1"
-          onSelect={e => {
-            this.setState({ selectedEditionId: edition.__id } as any)
-          }}
-          selected={this.state.selectedEditionId === edition.__id}
-          disabled={!isEcommerceEnrolled}
-        />
-        {editionFragment}
-      </Row>
-    )
+    if (isEcommerceEnrolled) {
+      return (
+        <Row>
+          <Radio
+            mr="1"
+            onSelect={e => {
+              this.setState({ selectedEditionId: edition.__id } as any)
+            }}
+            selected={this.state.selectedEditionId === edition.__id}
+            disabled={!isEcommerceEnrolled}
+          />
+          {editionFragment}
+        </Row>
+      )
+    } else {
+      return <Row>{editionFragment}</Row>
+    }
   }
   renderEditions() {
     const editions = this.props.artwork.edition_sets


### PR DESCRIPTION
Follow-up to #1651 

Don't show the radio buttons at all if the artwork is not enrolled in either Buy Now or Make Offer programs.

![2018-12-07-134105_759x654_scrot](https://user-images.githubusercontent.com/123595/49666321-b90a6400-fa25-11e8-94f0-80e460292814.png)
