### PR TITLE
Use totalListPrice for list price in /offer

### DIFF
--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -64,7 +64,6 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                     order {
                       id
                       mode
-                      itemsTotal
                       totalListPrice
                       ... on OfferOrder {
                         myLastOffer {
@@ -155,6 +154,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
               <Flex
                 flexDirection="column"
                 style={isCommittingMutation ? { pointerEvents: "none" } : {}}
+                id="offer-page-left-column"
               >
                 <Flex flexDirection="column">
                   <Input
@@ -172,9 +172,9 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                     block
                   />
                 </Flex>
-                {Boolean(order.itemsTotal) && (
+                {Boolean(order.totalListPrice) && (
                   <Sans size="2" color="black60">
-                    List price: {order.itemsTotal}
+                    List price: {order.totalListPrice}
                   </Sans>
                 )}
                 <Spacer mb={[2, 3]} />
@@ -258,7 +258,6 @@ export const OfferFragmentContainer = createFragmentContainer(
       id
       mode
       state
-      itemsTotal(precision: 2)
       totalListPrice(precision: 2)
       lineItems {
         edges {

--- a/src/Apps/Order/Routes/__tests__/Offer.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Offer.test.tsx
@@ -46,6 +46,12 @@ describe("Offer InitialMutation", () => {
     expect(input.text()).toContain("Your offer")
   })
 
+  it("shows the list price just below the input", () => {
+    const component = getWrapper(testProps)
+    const container = component.find("div#offer-page-left-column")
+    expect(container.text()).toContain("List price: $16,000")
+  })
+
   it("can receive input, which updates the transaction summary", () => {
     const component = getWrapper(testProps)
     const input = component.find(Input)

--- a/src/__generated__/OfferMutation.graphql.ts
+++ b/src/__generated__/OfferMutation.graphql.ts
@@ -21,7 +21,6 @@ export type OfferMutationResponse = {
             readonly order?: ({
                 readonly id: string | null;
                 readonly mode: OrderModeEnum | null;
-                readonly itemsTotal: string | null;
                 readonly totalListPrice: string | null;
                 readonly myLastOffer?: ({
                     readonly id: string | null;
@@ -56,7 +55,6 @@ mutation OfferMutation(
           __typename
           id
           mode
-          itemsTotal
           totalListPrice
           ... on OfferOrder {
             myLastOffer {
@@ -159,25 +157,18 @@ v5 = {
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "itemsTotal",
-  "args": null,
-  "storageKey": null
-},
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "totalListPrice",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v8 = {
   "kind": "InlineFragment",
   "type": "OfferOrder",
   "selections": [
@@ -198,7 +189,7 @@ v9 = {
           "args": null,
           "storageKey": null
         },
-        v8
+        v7
       ]
     }
   ]
@@ -208,7 +199,7 @@ return {
   "operationKind": "mutation",
   "name": "OfferMutation",
   "id": null,
-  "text": "mutation OfferMutation(\n  $input: AddInitialOfferToOrderInput!\n) {\n  ecommerceAddInitialOfferToOrder(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          id\n          mode\n          itemsTotal\n          totalListPrice\n          ... on OfferOrder {\n            myLastOffer {\n              id\n              amountCents\n              __id: id\n            }\n          }\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
+  "text": "mutation OfferMutation(\n  $input: AddInitialOfferToOrderInput!\n) {\n  ecommerceAddInitialOfferToOrder(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          id\n          mode\n          totalListPrice\n          ... on OfferOrder {\n            myLastOffer {\n              id\n              amountCents\n              __id: id\n            }\n          }\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -254,8 +245,7 @@ return {
                       v5,
                       v6,
                       v7,
-                      v8,
-                      v9
+                      v8
                     ]
                   }
                 ]
@@ -310,8 +300,7 @@ return {
                       v5,
                       v6,
                       v7,
-                      v8,
-                      v9
+                      v8
                     ]
                   }
                 ]
@@ -324,5 +313,5 @@ return {
   }
 };
 })();
-(node as any).hash = '1552f4300994d6916797385dc4bbef83';
+(node as any).hash = '8508c485628923f3ffe4d5226a7fbb8d';
 export default node;

--- a/src/__generated__/Offer_order.graphql.ts
+++ b/src/__generated__/Offer_order.graphql.ts
@@ -10,7 +10,6 @@ export type Offer_order = {
     readonly id: string | null;
     readonly mode: OrderModeEnum | null;
     readonly state: string | null;
-    readonly itemsTotal: string | null;
     readonly totalListPrice: string | null;
     readonly lineItems: ({
         readonly edges: ReadonlyArray<({
@@ -35,15 +34,7 @@ var v0 = {
   "args": null,
   "storageKey": null
 },
-v1 = [
-  {
-    "kind": "Literal",
-    "name": "precision",
-    "value": 2,
-    "type": "Int"
-  }
-],
-v2 = {
+v1 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
@@ -75,15 +66,15 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "itemsTotal",
-      "args": v1,
-      "storageKey": "itemsTotal(precision:2)"
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
       "name": "totalListPrice",
-      "args": v1,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "precision",
+          "value": 2,
+          "type": "Int"
+        }
+      ],
       "storageKey": "totalListPrice(precision:2)"
     },
     {
@@ -132,7 +123,7 @@ return {
                     }
                   ]
                 },
-                v2
+                v1
               ]
             }
           ]
@@ -149,9 +140,9 @@ return {
       "name": "TransactionDetailsSummaryItem_order",
       "args": null
     },
-    v2
+    v1
   ]
 };
 })();
-(node as any).hash = '867d9554eda7c1e15e9e9785acaf4db4';
+(node as any).hash = '3850326a36d217a9f606d88caa3b66e0';
 export default node;

--- a/src/__generated__/routes_OfferQuery.graphql.ts
+++ b/src/__generated__/routes_OfferQuery.graphql.ts
@@ -32,7 +32,6 @@ fragment Offer_order on Order {
   id
   mode
   state
-  itemsTotal(precision: 2)
   totalListPrice(precision: 2)
   lineItems {
     edges {
@@ -154,11 +153,18 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v4 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -166,17 +172,10 @@ v4 = [
     "type": "Int"
   }
 ],
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "__id",
   "args": null,
   "storageKey": null
 },
@@ -184,7 +183,7 @@ v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v4,
+  "args": v5,
   "storageKey": "shippingTotal(precision:2)"
 },
 v8 = {
@@ -198,7 +197,7 @@ v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v4,
+  "args": v5,
   "storageKey": "taxTotal(precision:2)"
 },
 v10 = {
@@ -212,12 +211,12 @@ v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v4,
+  "args": v5,
   "storageKey": "buyerTotal(precision:2)"
 },
 v12 = [
   v9,
-  v3,
+  v4,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -231,7 +230,7 @@ v12 = [
     "kind": "ScalarField",
     "alias": null,
     "name": "amount",
-    "args": v4,
+    "args": v5,
     "storageKey": "amount(precision:2)"
   },
   v10,
@@ -257,7 +256,7 @@ return {
   "operationKind": "query",
   "name": "routes_OfferQuery",
   "id": null,
-  "text": "query routes_OfferQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Offer_order\n    __id: id\n  }\n}\n\nfragment Offer_order on Order {\n  id\n  mode\n  state\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_OfferQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Offer_order\n    __id: id\n  }\n}\n\nfragment Offer_order on Order {\n  id\n  mode\n  state\n  totalListPrice(precision: 2)\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -299,8 +298,8 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v2,
           v3,
+          v4,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -311,15 +310,8 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "itemsTotal",
-            "args": v4,
-            "storageKey": "itemsTotal(precision:2)"
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "totalListPrice",
-            "args": v4,
+            "args": v5,
             "storageKey": "totalListPrice(precision:2)"
           },
           {
@@ -358,8 +350,8 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v3,
-                          v5,
+                          v4,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -442,8 +434,8 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
+              v3,
               v6,
-              v5,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
@@ -459,6 +451,7 @@ return {
               }
             ]
           },
+          v2,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -466,11 +459,17 @@ return {
             "args": null,
             "storageKey": null
           },
-          v6,
           v7,
           v8,
           v9,
           v10,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "itemsTotal",
+            "args": v5,
+            "storageKey": "itemsTotal(precision:2)"
+          },
           v11,
           {
             "kind": "InlineFragment",


### PR DESCRIPTION
Quick bug fix for https://artsyproduct.atlassian.net/browse/PURCHASE-702

Problem: the list price underneath the input on the offer page disappeared

Cause: `itemsTotal` was originally being used as the list price, but we refactored at some point and it became the offer price for offer orders (once an offer has been made, hence it was resolving to `null` on the initial `/offer` page) and `totalListPrice` became the list price field.

Solution: switch to using `totalListPrice`.