### PR TITLE
[FIX tracking] Fix tracking on artwork pages

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -36,6 +36,7 @@ export class ArtworkDetails extends Component<ArtworkDetailsProps> {
       flow: Schema.Flow.ArtworkAboutTheArtist,
       type: Schema.Type.Tab,
       label: data.trackingLabel,
+      action_type: Schema.ActionType.Click,
     }
   })
   trackTabChange() {

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -8,6 +8,9 @@ import { slugify } from "underscore.string"
 import { resize } from "Utils/resizer"
 import { Responsive } from "Utils/Responsive"
 
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
+
 interface Props {
   collection: {
     artist_ids?: string[]
@@ -51,7 +54,19 @@ const imageWidthSizes = {
   xl: 1112,
 }
 
+@track({
+  context_module: Schema.ContextModule.CollectionDescription,
+})
 export class CollectionHeader extends Component<Props> {
+  @track({
+    subject: Schema.Subject.ReadMore,
+    type: Schema.Type.Button,
+    action_type: Schema.ActionType.Click,
+  })
+  trackReadMoreClick() {
+    // noop
+  }
+
   render() {
     const { collection } = this.props
     return (
@@ -100,7 +115,9 @@ export class CollectionHeader extends Component<Props> {
                         <Col xl="8" lg="8" md="10" sm="12" xs="12">
                           <ExtendedSerif size="5" px={[0, 1]}>
                             <ReadMore
-                              onReadMoreClicked={() => false}
+                              onReadMoreClicked={this.trackReadMoreClick.bind(
+                                this
+                              )}
                               maxChars={chars}
                               content={getReadMoreContent(
                                 collection.description,

--- a/src/Styleguide/Components/ReadMore.tsx
+++ b/src/Styleguide/Components/ReadMore.tsx
@@ -1,5 +1,4 @@
 import { track } from "Artsy/Analytics"
-import * as Schema from "Artsy/Analytics/Schema"
 import { isString } from "lodash"
 import React, { Component } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
@@ -47,11 +46,6 @@ export class ReadMore extends Component<ReadMoreProps, ReadMoreState> {
     }
   }
 
-  @track({
-    action_type: Schema.ActionType.Click,
-    subject: "Read more",
-    type: "button",
-  })
   expandText() {
     this.setState(
       {


### PR DESCRIPTION
Fixes a few issue we were seeing on the artwork page

- Double tracking on read more
- Tabs not firing
- Also updates Collect read more button to track from call-site since this button is shared across a few locations

Updates: https://artsyproduct.atlassian.net/browse/GROW-983
Fixes: https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-324&quickFilter=110