### PR TITLE
[PATCH artwork] Constrain image area

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -1,4 +1,4 @@
-import { Box, Separator } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { ArtworkApp_artwork } from "__generated__/ArtworkApp_artwork.graphql"
 import React from "react"
 import { LazyLoadComponent } from "react-lazy-load-image-component"
@@ -28,6 +28,7 @@ export const ArtworkApp: React.SFC<Props> = props => {
       <Row>
         <Col sm={8}>
           <ArtworkBanner artwork={props.artwork} />
+          <Spacer mb={4} />
         </Col>
       </Row>
       <Row>

--- a/src/Apps/Artwork/Components/ImageCarousel.tsx
+++ b/src/Apps/Artwork/Components/ImageCarousel.tsx
@@ -1,3 +1,4 @@
+import { space } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 
@@ -36,8 +37,9 @@ const SmallImageArea = styled(BaseImageArea)`
 `
 
 const LargeImageArea = styled(BaseImageArea)`
-  min-height: 450px;
-  height: calc(100vh - 160px);
+  /* FIXME: Is this still needed? */
+  /* min-height: 450px;
+  height: calc(100vh - 160px); */
 `
 
 const ImageContainer = styled.div`
@@ -58,7 +60,9 @@ const SmallImage = styled(BaseImage)`
 `
 
 const LargeImage = styled(BaseImage)`
-  max-height: 100%;
+  max-height: 550px;
+  height: 65vh;
+  padding: 0 ${space(2)}px;
 `
 
 // TODO: Should Icon have this styling by default?
@@ -199,10 +203,11 @@ export class ImageCarousel extends React.Component<
   renderImage(breakpoint?: string) {
     const xs = breakpoint === "xs"
     const Image = xs ? SmallImage : LargeImage
+    const key = `image-${this.state.currentImage}` // update reconciler to show download on image change
 
     return (
       <Lightbox deepZoom={this.image.deepZoom} enabled={this.image.is_zoomable}>
-        <Image src={this.image.uri} />
+        <Image src={this.image.uri} key={key} />
       </Lightbox>
     )
   }

--- a/src/Apps/__stories__/ArtworkApp.story.tsx
+++ b/src/Apps/__stories__/ArtworkApp.story.tsx
@@ -60,3 +60,11 @@ storiesOf("Apps/Artwork Page", module)
       />
     )
   })
+  .add("Tall image", () => {
+    return (
+      <MockRouter
+        routes={artworkRoutes}
+        initialRoute="/artwork2/nissa-kauppila-wu-ti-35-degrees-45-35-dot-5-n-81-degrees-21-16-dot-2-w"
+      />
+    )
+  })


### PR DESCRIPTION
Updates carousel to constrain image sizes similar to old artwork page: 

![images](https://user-images.githubusercontent.com/236943/49763769-95e8ea00-fc9b-11e8-874a-f80c0f7ff991.gif)
