### PR TITLE
Adds empty review/reject component and route

### DIFF
--- a/src/Apps/Order/Routes/Reject/index.tsx
+++ b/src/Apps/Order/Routes/Reject/index.tsx
@@ -17,7 +17,6 @@ export class Reject extends Component<RejectProps, RejectState> {
   }
 
   render() {
-    console.log("Hello!")
     return <Serif size="2">"Hello world"</Serif>
   }
 }

--- a/src/Apps/Order/Routes/Reject/index.tsx
+++ b/src/Apps/Order/Routes/Reject/index.tsx
@@ -1,0 +1,33 @@
+import { Serif } from "@artsy/palette"
+import { Reject_order } from "__generated__/Reject_order.graphql"
+import React, { Component } from "react"
+import { createFragmentContainer, graphql, RelayProp } from "react-relay"
+
+interface RejectProps {
+  relay?: RelayProp
+  order: Reject_order
+}
+interface RejectState {
+  isCommittingMutation: boolean
+}
+
+export class Reject extends Component<RejectProps, RejectState> {
+  state = {
+    isCommittingMutation: false,
+  }
+
+  render() {
+    console.log("Hello!")
+    return <Serif size="2">"Hello world"</Serif>
+  }
+}
+
+export const RejectFragmentContainer = createFragmentContainer(
+  Reject,
+  graphql`
+    fragment Reject_order on Order {
+      id
+      stateExpiresAt
+    }
+  `
+)

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -71,7 +71,9 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
           this.props.router.push(`/orders/${this.props.order.id}/accept`)
           break
         case "DECLINE":
-          this.props.router.push(`/orders/${this.props.order.id}/review/reject`)
+          this.props.router.push(
+            `/orders/${this.props.order.id}/review/decline`
+          )
           break
         default:
           window.alert(`You decided to ${responseOption}.`)

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -70,6 +70,9 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
         case "ACCEPT":
           this.props.router.push(`/orders/${this.props.order.id}/accept`)
           break
+        case "DECLINE":
+          this.props.router.push(`/orders/${this.props.order.id}/review/reject`)
+          break
         default:
           window.alert(`You decided to ${responseOption}.`)
           break

--- a/src/Apps/Order/Routes/__tests__/Respond.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Respond.test.tsx
@@ -206,7 +206,7 @@ describe("Offer InitialMutation", () => {
         .onClick({})
 
       expect(mockPushRoute).toHaveBeenCalledWith(
-        `/orders/${testOrder.id}/review/reject` // TODO: Change to /review/decline
+        `/orders/${testOrder.id}/review/decline`
       )
     })
 

--- a/src/Apps/Order/Routes/__tests__/Respond.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Respond.test.tsx
@@ -205,8 +205,9 @@ describe("Offer InitialMutation", () => {
         .props()
         .onClick({})
 
-      // TODO: get rid of window.alert
-      expect(window.alert).toHaveBeenCalledWith(`You decided to DECLINE.`)
+      expect(mockPushRoute).toHaveBeenCalledWith(
+        `/orders/${testOrder.id}/review/reject` // TODO: Change to /review/decline
+      )
     })
 
     it("Countering the seller's offer works", () => {

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -171,7 +171,7 @@ const redirects: RedirectRecord = {
       ],
     },
     {
-      path: "review/reject",
+      path: "review/decline",
       rules: [
         goToStatusIfNotOfferOrder,
         goToStatusIfNotAwaitingBuyerResponse,

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -171,6 +171,14 @@ const redirects: RedirectRecord = {
       ],
     },
     {
+      path: "review/reject",
+      rules: [
+        goToStatusIfNotOfferOrder,
+        goToStatusIfNotAwaitingBuyerResponse,
+        goToStatusIfOrderIsNotSubmitted,
+      ],
+    },
+    {
       path: "status",
       rules: [
         goToReviewIfOrderIsPending,

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -7,6 +7,7 @@ import { OrderApp } from "./OrderApp"
 import { AcceptFragmentContainer as AcceptRoute } from "Apps/Order/Routes/Accept"
 import { OfferFragmentContainer as OfferRoute } from "Apps/Order/Routes/Offer"
 import { PaymentFragmentContainer as PaymentRoute } from "Apps/Order/Routes/Payment"
+import { RejectFragmentContainer as RejectRoute } from "Apps/Order/Routes/Reject"
 import { RespondFragmentContainer as RespondRoute } from "Apps/Order/Routes/Respond"
 import { ReviewFragmentContainer as ReviewRoute } from "Apps/Order/Routes/Review"
 import { ShippingFragmentContainer as ShippingRoute } from "Apps/Order/Routes/Shipping"
@@ -179,6 +180,17 @@ export const routes: RouteConfig[] = [
           query routes_AcceptQuery($orderID: String!) {
             order: ecommerceOrder(id: $orderID) {
               ...Accept_order
+            }
+          }
+        `,
+      },
+      {
+        path: "review/reject",
+        Component: RejectRoute,
+        query: graphql`
+          query routes_RejectQuery($orderID: String!) {
+            order: ecommerceOrder(id: $orderID) {
+              ...Reject_order
             }
           }
         `,

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -185,7 +185,7 @@ export const routes: RouteConfig[] = [
         `,
       },
       {
-        path: "review/reject",
+        path: "review/decline",
         Component: RejectRoute,
         query: graphql`
           query routes_RejectQuery($orderID: String!) {

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -251,6 +251,30 @@ storiesOf("Apps/Order Page/Accept Offer", module).add("Review (accept)", () => (
   />
 ))
 
+storiesOf("Apps/Order Page/Reject Offer", module).add("Review (reject)", () => (
+  // Steve was going to look into sharing these stubbed data sets, check with him before merging.
+  <Router
+    initialRoute="/orders/123/review/reject"
+    mockResolvers={mockResolver({
+      // ...OfferOrderWithShippingDetails,
+      // state: "SUBMITTED",
+      // stateExpiresAt: moment()
+      //   .add(1, "day")
+      //   .toISOString(),
+      // lastOffer: {
+      //   ...OfferWithTotals,
+      //   id: "last-offer",
+      //   createdAt: moment()
+      //     .subtract(1, "day")
+      //     .toISOString(),
+      // },
+      // awaitingResponseFrom: "BUYER",
+      // offers: { edges: Offers },
+      // buyer: Buyer,
+    })}
+  />
+))
+
 storiesOf("Apps/Order Page/Make Offer/Status", module)
   .add("submitted (ship)", () => (
     <Router

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -256,21 +256,21 @@ storiesOf("Apps/Order Page/Reject Offer", module).add("Review (reject)", () => (
   <Router
     initialRoute="/orders/123/review/reject"
     mockResolvers={mockResolver({
-      // ...OfferOrderWithShippingDetails,
-      // state: "SUBMITTED",
-      // stateExpiresAt: moment()
-      //   .add(1, "day")
-      //   .toISOString(),
-      // lastOffer: {
-      //   ...OfferWithTotals,
-      //   id: "last-offer",
-      //   createdAt: moment()
-      //     .subtract(1, "day")
-      //     .toISOString(),
-      // },
-      // awaitingResponseFrom: "BUYER",
-      // offers: { edges: Offers },
-      // buyer: Buyer,
+      ...OfferOrderWithShippingDetails,
+      state: "SUBMITTED",
+      stateExpiresAt: moment()
+        .add(1, "day")
+        .toISOString(),
+      lastOffer: {
+        ...OfferWithTotals,
+        id: "last-offer",
+        createdAt: moment()
+          .subtract(1, "day")
+          .toISOString(),
+      },
+      awaitingResponseFrom: "BUYER",
+      offers: { edges: Offers },
+      buyer: Buyer,
     })}
   />
 ))

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -254,7 +254,7 @@ storiesOf("Apps/Order Page/Accept Offer", module).add("Review (accept)", () => (
 storiesOf("Apps/Order Page/Reject Offer", module).add("Review (reject)", () => (
   // Steve was going to look into sharing these stubbed data sets, check with him before merging.
   <Router
-    initialRoute="/orders/123/review/reject"
+    initialRoute="/orders/123/review/decline"
     mockResolvers={mockResolver({
       ...OfferOrderWithShippingDetails,
       state: "SUBMITTED",

--- a/src/__generated__/Reject_order.graphql.ts
+++ b/src/__generated__/Reject_order.graphql.ts
@@ -1,0 +1,45 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+declare const _Reject_order$ref: unique symbol;
+export type Reject_order$ref = typeof _Reject_order$ref;
+export type Reject_order = {
+    readonly id: string | null;
+    readonly stateExpiresAt: string | null;
+    readonly " $refType": Reject_order$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "Reject_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "stateExpiresAt",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "__id",
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '8c6f00be05dfc79a6272149506646a01';
+export default node;

--- a/src/__generated__/routes_RejectQuery.graphql.ts
+++ b/src/__generated__/routes_RejectQuery.graphql.ts
@@ -1,0 +1,138 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { Reject_order$ref } from "./Reject_order.graphql";
+export type routes_RejectQueryVariables = {
+    readonly orderID: string;
+};
+export type routes_RejectQueryResponse = {
+    readonly order: ({
+        readonly " $fragmentRefs": Reject_order$ref;
+    }) | null;
+};
+export type routes_RejectQuery = {
+    readonly response: routes_RejectQueryResponse;
+    readonly variables: routes_RejectQueryVariables;
+};
+
+
+
+/*
+query routes_RejectQuery(
+  $orderID: String!
+) {
+  order: ecommerceOrder(id: $orderID) {
+    __typename
+    ...Reject_order
+    __id: id
+  }
+}
+
+fragment Reject_order on Order {
+  id
+  stateExpiresAt
+  __id: id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "orderID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "orderID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_RejectQuery",
+  "id": null,
+  "text": "query routes_RejectQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Reject_order\n    __id: id\n  }\n}\n\nfragment Reject_order on Order {\n  id\n  stateExpiresAt\n  __id: id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_RejectQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "order",
+        "name": "ecommerceOrder",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": null,
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Reject_order",
+            "args": null
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_RejectQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "order",
+        "name": "ecommerceOrder",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": null,
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "__typename",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "stateExpiresAt",
+            "args": null,
+            "storageKey": null
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'f0e10c469c90e7ba99db6a4fd97ec72f';
+export default node;


### PR DESCRIPTION
This PR fixes [PURCHASE-659](https://artsyproduct.atlassian.net/browse/PURCHASE-659) by adding the ability to select "Decline" and get routed to a(n empty) component. 

This is a work-in-progress because we're seeing the following error get thrown silently in this code:

https://github.com/artsy/reaction/blob/7e1dc1ced96681e46d23dec0c1ed18bac6289843/src/Artsy/Router/buildClientApp.tsx#L68-L72

Here's the error:

```
Error: loadable-components state not found. You have a problem server-side. Please verify that you have called `loadableState.getScriptTag()` server-side.
    at loadComponents (loadable-components.es.js?c034:118)
    at _callee$ (VM2659 buildClientApp.tsx:110)
    at tryCatch (runtime.js?96cf:62)
    at Generator.invoke [as _invoke] (runtime.js?96cf:288)
    at Generator.prototype.(:9001/anonymous function) [as next] (webpack-internal:///./node_modules/regenerator-runtime/runtime.js:114:21)
    at asyncGeneratorStep (VM2659 buildClientApp.tsx:32)
    at _next (VM2659 buildClientApp.tsx:34)
```

Unsure how to immediately proceed, we can take a look later unless someone else knows?

FYI I'm seeing this on our staging deploy as well. Routes show up empty: https://artsy-reaction.netlify.com/?selectedKind=Apps%2FOrder%20Page%2FBuy%20Now%2FPayment&selectedStory=With%20%27Pickup%27&full=0&addons=0&stories=1&panelRight=0