### PR TITLE
adding key to the avatar used in follow artist popover after following an artist

### DIFF
--- a/src/Styleguide/Components/FollowArtistPopover/FollowArtistPopoverRow.tsx
+++ b/src/Styleguide/Components/FollowArtistPopover/FollowArtistPopoverRow.tsx
@@ -69,9 +69,10 @@ class FollowArtistPopoverRow extends React.Component<Props, State> {
     const artist = swappedArtist || originalArtist
     const imageUrl = get(artist, a => a.image.cropped.url)
     const { _id: artistID } = artist
+    const key = `avatar-${artistID}`
     return (
       <Flex alignItems="center" mb={1} mt={1}>
-        <Avatar size="xs" src={imageUrl} />
+        <Avatar size="xs" src={imageUrl} key={key} />
         <ArtistName size="3t" color="black100" ml={1} mr={1}>
           {artist.name}
         </ArtistName>


### PR DESCRIPTION
#minor.

Also not sure it looks much better without having a loader in there or something. This blank space looks like jittering as well...

![follow](https://user-images.githubusercontent.com/437156/49833909-00b42700-fd69-11e8-88f9-cc1cf6628ce2.gif)
