### PR TITLE
Patch graphql .mjs file to fix storybooks no-load error

### DIFF
--- a/patches/graphql+0.13.2.patch
+++ b/patches/graphql+0.13.2.patch
@@ -16,3 +16,19 @@ patch-package
    }
 +
  }
+\ No newline at end of file
+--- a/node_modules/graphql/utilities/assertValidName.mjs
++++ b/node_modules/graphql/utilities/assertValidName.mjs
+@@ -29,9 +29,9 @@ export function assertValidName(name) {
+  */
+ export function isValidNameError(name, node) {
+   !(typeof name === 'string') ? invariant(0, 'Expected string') : void 0;
+-  if (name.length > 1 && name[0] === '_' && name[1] === '_') {
+-    return new GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
+-  }
++  // if (name.length > 1 && name[0] === '_' && name[1] === '_') {
++  //   return new GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
++  // }
+   if (!NAME_RX.test(name)) {
+     return new GraphQLError('Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "' + name + '" does not.', node);
+   }

--- a/src/Apps/Order/Components/__stories__/ArtworkSummaryItem.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ArtworkSummaryItem.story.tsx
@@ -1,11 +1,11 @@
 import { Flex } from "@artsy/palette"
 import { ArtworkSummaryItem_order } from "__generated__/ArtworkSummaryItem_order.graphql"
+import { mockResolver, UntouchedBuyOrder } from "Apps/__tests__/Fixtures/Order"
 import { MockRelayRenderer } from "DevTools"
 import React from "react"
 import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Styleguide/Utils/Section"
-import { mockResolver } from "../../../__tests__/Fixtures/Order"
 import { ArtworkSummaryItemFragmentContainer } from "../ArtworkSummaryItem"
 
 const makeLineItems = ({ artistName, artworkTitle }) => ({
@@ -29,17 +29,6 @@ const makeLineItems = ({ artistName, artworkTitle }) => ({
   ],
 })
 
-const order: ArtworkSummaryItem_order = {
-  " $refType": null,
-  lineItems: makeLineItems({
-    artistName: "Francesca DiMattio",
-    artworkTitle: "The Fox",
-  }) as any,
-  seller: {
-    name: "Salon 94",
-  },
-}
-
 const orderQuery = graphql`
   query ArtworkSummaryItemStoryQuery {
     order: ecommerceOrder(id: "foo") {
@@ -52,17 +41,10 @@ const render = (extraOrderProps?: Partial<ArtworkSummaryItem_order>) => {
   return (
     <MockRelayRenderer
       Component={ArtworkSummaryItemFragmentContainer}
-      mockResolvers={{
-        ...mockResolver({
-          ...order,
-          ...extraOrderProps,
-          seller: undefined,
-        }),
-        OrderParty: () => ({
-          ...order.seller,
-          __typename: "User",
-        }),
-      }}
+      mockResolvers={mockResolver({
+        ...UntouchedBuyOrder,
+        ...extraOrderProps,
+      })}
       query={orderQuery}
     />
   )
@@ -86,8 +68,9 @@ storiesOf("Apps/Order Page/Components", module)
             artworkTitle: "Some quite long title you know how artists can be",
           }) as any,
           seller: {
+            __typename: "Partner",
             name: "Salon Nineteen Eighty Four and Three Quarters",
-          },
+          } as any,
         })}
       </Flex>
     </Section>


### PR DESCRIPTION
context: https://artsy.slack.com/archives/C2TQ4PT8R/p1544560372121700

This bug first appeared in https://github.com/artsy/reaction/commit/2334f3006a414b1bab8ee7bb17af03d55172e887

That commit introduced quite a few dependency updates. One of them (I’m guessing the webpack update) caused storybook’s webpack to resolve `.mjs` files in preference of `.js` files if both are present for the same filename, which is fine.

The problem was that we are using a patched version of `graphql` which specifically disabled the ‘__id’ error message shown above. This patch was applied to a `.js` file but I discovered that there is also a `.mjs` version of that file which was now the version being loaded. So I patched that file too and the problem went away.

edit: also fixed the ArtworkSummaryItem story, which had an unrelated data mocking issue.