### PR TITLE
[FIX ssr] Fix circular refs in SSR

### DIFF
--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -96,14 +96,6 @@ export function buildServerApp(
           })()
         )
 
-        const scripts = []
-        loadableState && scripts.push(loadableState.getScriptTag())
-        scripts.push(`
-          <script>
-            var __RELAY_BOOTSTRAP__ = ${serializeRelayData(relayData)};
-          </script>
-        `)
-
         /**
          * FIXME: Relay SSR middleware is passing a _res object across which
          * has circular references, leading to issues *ONLY* on staging / prod
@@ -122,6 +114,14 @@ export function buildServerApp(
             error
           )
         }
+
+        const scripts = []
+        loadableState && scripts.push(loadableState.getScriptTag())
+        scripts.push(`
+          <script>
+            var __RELAY_BOOTSTRAP__ = ${serializeRelayData(relayData)};
+          </script>
+        `)
 
         resolve({
           ServerApp,


### PR DESCRIPTION
Noticed this was being run _after_ data was serialized, leading to locally unreproducible errors in staging and prod logs. 

```sh
reaction/Router/buildServerApp Error serializing data: TypeError: Converting circular structure to JSON
Dec 13 16:29:22 force-web-57597c545f-xt7mp k8s_force-web_force-web-57597c545f-xt7mp_default_6e266681-ff14-11e8-a5ad-0a7e8548888c_0:     at JSON.stringify (<anonymous>)
Dec 13 16:29:22 force-web-57597c545f-xt7mp k8s_force-web_force-web-57597c545f-xt7mp_default_6e266681-ff14-11e8-a5ad-0a7e8548888c_0:     at serialize (/app/node_modules/serialize-javascript/index.js:76:20)
Dec 13 16:29:22 force-web-57597c545f-xt7mp k8s_force-web_force-web-57597c545f-xt7mp_default_6e266681-ff14-11e8-a5ad-0a7e8548888c_0:     at serializeRelayData (/app/node_modules/@artsy/reaction/src/Artsy/Router/buildServerApp.tsx:143:21)
Dec 13 16:29:22 force-web-57597c545f-xt7mp k8s_force-web_force-web-57597c545f-xt7mp_default_6e266681-ff14-11e8-a5ad-0a7e8548888c_0:     at serializeRelayData (/app/node_modules/@artsy/reaction/src/Artsy/Router/buildServerApp.tsx:103:41)
Dec 13 16:29:22 force-web-57597c545f-xt7mp k8s_force-web_force-web-57597c545f-xt7mp_default_6e266681-ff14-11e8-a5ad-0a7e8548888c_0:     at tryCatch (/app/node_modules/regenerator-runtime/runtime.js:62:40)
Dec 13 16:29:22 force-web-57597c545f-xt7mp k8s_force-web_force-web-57597c545f-xt7mp_default_6e266681-ff14-11e8-a5ad-0a7e8548888c_0:     at Generator.invoke [as _invoke] (/app/node_modules/regenerator-runtime/runtime.js:296:22)
```