### PR TITLE
Adjust design spec implementation for artwork BNMO sidebar

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -67,7 +67,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
 
   renderSaleMessage(saleMessage: string) {
     return (
-      <Box pb={2} pt={1}>
+      <Box mb={1} mt={1}>
         <Serif size="5t" weight="semibold">
           {saleMessage}
         </Serif>
@@ -232,7 +232,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
           )}
         {artworkEcommerceAvailable &&
           artwork.shippingOrigin && (
-            <Serif size="2" color="black60">
+            <Serif mb={2} size="2" color="black60">
               Ships from {artwork.shippingOrigin}
             </Serif>
           )}

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -254,7 +254,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             loading={isCommittingCreateOrderMutation}
             onClick={this.handleCreateOrder}
           >
-            Buy Now
+            Buy now
           </Button>
         )}
         {artwork.is_offerable && (
@@ -266,7 +266,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             size="medium"
             mt={1}
           >
-            Make Offer
+            Make offer
           </Button>
         )}
 

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarCommercial.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebar/ArtworkSidebarCommercial.test.tsx
@@ -34,7 +34,7 @@ describe("ArtworkSidebarCommercial", () => {
 
     const wrapper = await getWrapper(artwork)
 
-    expect(wrapper.text()).toContain(artwork.sale_message)
+    expect(wrapper.text()).toContain("Buy now")
   })
 
   it("displays sold acquireable artwork", async () => {
@@ -50,7 +50,7 @@ describe("ArtworkSidebarCommercial", () => {
 
     const wrapper = await getWrapper(artwork)
 
-    expect(wrapper.text()).toContain("Make Offer")
+    expect(wrapper.text()).toContain("Make offer")
   })
 
   it("displays artwork enrolled in both Buy Now and Make Offer", async () => {
@@ -58,7 +58,7 @@ describe("ArtworkSidebarCommercial", () => {
 
     const wrapper = await getWrapper(artwork)
 
-    expect(wrapper.text()).toContain("Buy Now")
-    expect(wrapper.text()).toContain("Make Offer")
+    expect(wrapper.text()).toContain("Buy now")
+    expect(wrapper.text()).toContain("Make offer")
   })
 })


### PR DESCRIPTION
- Adjust spacing between sale message, shipping info, and CTA button
- Update Buy Now / Make Offer commercial action button labels within the Responsive Artwork Page component

Addresses https://github.com/artsy/reaction/pull/1683#issuecomment-446747684

---

**Before**

![2018-12-13-171149_815x328_scrot](https://user-images.githubusercontent.com/123595/49970883-bcf12700-fefa-11e8-82fd-13a356c41391.png)

---

**After**

![2018-12-13-172210_832x349_scrot](https://user-images.githubusercontent.com/123595/49971188-98e21580-fefb-11e8-9807-1779c7e75876.png)
