### PR TITLE
Show error modal on accept offer review page if charge capture fails

### DIFF
--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -92,22 +92,38 @@ export class Accept extends Component<AcceptProps, AcceptState> {
             const {
               ecommerceBuyerAcceptOffer: { orderOrError },
             } = data
-
-            if (orderOrError.error) {
-              this.onMutationError(
-                new ErrorWithMetadata(
-                  orderOrError.error.code,
-                  orderOrError.error
-                )
-              )
-            } else {
-              this.props.router.push(`/orders/${this.props.order.id}/status`)
-            }
+            this.onSubmitCompleted(orderOrError)
           },
           onError: this.onMutationError.bind(this),
         })
       }
     })
+  }
+
+  onSubmitCompleted(orderOrError) {
+    const error = orderOrError.error
+    if (error) {
+      switch (error.code) {
+        case "capture_failed": {
+          this.onMutationError(
+            new ErrorWithMetadata(error.code, error),
+            "An error occurred",
+            "There was an error processing your payment. Please try again or contact orders@artsy.net."
+          )
+          break
+        }
+        default: {
+          this.onMutationError(new ErrorWithMetadata(error.code, error))
+          break
+        }
+      }
+    } else {
+      this.onSuccessfulSubmit()
+    }
+  }
+
+  onSuccessfulSubmit() {
+    this.props.router.push(`/orders/${this.props.order.id}/status`)
   }
 
   onMutationError(error, errorModalTitle?, errorModalMessage?) {

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/acceptOffer.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/acceptOffer.ts
@@ -18,3 +18,14 @@ export const acceptOfferFailed = {
     },
   },
 }
+export const AcceptOfferPaymentFailed = {
+  ecommerceBuyerAcceptOffer: {
+    orderOrError: {
+      error: {
+        type: "processing",
+        code: "capture_failed",
+        data: { some_details: "more details" },
+      },
+    },
+  },
+}

--- a/src/Apps/Order/Routes/__tests__/Accept.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Accept.test.tsx
@@ -20,6 +20,7 @@ import { Stepper } from "Styleguide/Components"
 import { CountdownTimer } from "Styleguide/Components/CountdownTimer"
 import {
   acceptOfferFailed,
+  AcceptOfferPaymentFailed,
   acceptOfferSuccess,
 } from "../__fixtures__/MutationResults"
 import { AcceptFragmentContainer as AcceptRoute } from "../Accept"
@@ -209,6 +210,29 @@ describe("Accept seller offer", () => {
       expect(errorComponent.text()).toContain("An error occurred")
       expect(errorComponent.text()).toContain(
         "Something went wrong. Please try again or contact orders@artsy.net."
+      )
+
+      component.find(ModalButton).simulate("click")
+      expect(component.find(ErrorModal).props().show).toBe(false)
+    })
+
+    it("shows an error modal if there is a capture_failed error", () => {
+      const component = getWrapper()
+      const mockCommitMutation = commitMutation as jest.Mock<any>
+      mockCommitMutation.mockImplementationOnce(
+        (_environment, { onCompleted }) => {
+          onCompleted(AcceptOfferPaymentFailed)
+        }
+      )
+
+      const submitButton = component.find(Button).last()
+      submitButton.simulate("click")
+
+      const errorComponent = component.find(ErrorModal)
+      expect(errorComponent.props().show).toBe(true)
+      expect(errorComponent.text()).toContain("An error occurred")
+      expect(errorComponent.text()).toContain(
+        "There was an error processing your payment. Please try again or contact orders@artsy.net."
       )
 
       component.find(ModalButton).simulate("click")


### PR DESCRIPTION
Displays an error modal with the correct title and message if charge capture fails when accepting an offer on `/orders/$orderId/review/accept`.

Addresses [PURCHASE-715](https://artsyproduct.atlassian.net/browse/PURCHASE-715).

<img width="1403" alt="screen shot 2018-12-13 at 5 59 17 pm" src="https://user-images.githubusercontent.com/4432348/49972836-ddbc7b00-ff00-11e8-8a65-d9273f22d0c1.png">

<img width="399" alt="screen shot 2018-12-13 at 5 59 26 pm" src="https://user-images.githubusercontent.com/4432348/49972835-ddbc7b00-ff00-11e8-92ee-95ab3212fc48.png">