### PR TITLE
Update Buy Now / Make Offer shipping info components

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -5,6 +5,7 @@ import {
   FlexProps,
   Radio,
   RadioGroup,
+  Sans,
   Separator,
   Serif,
 } from "@artsy/palette"
@@ -226,15 +227,15 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         )}
         {artworkEcommerceAvailable &&
           artwork.shippingInfo && (
-            <Serif size="2" color="black60">
+            <Sans mb={2} size="2" color="black60">
               {artwork.shippingInfo}
-            </Serif>
+            </Sans>
           )}
         {artworkEcommerceAvailable &&
           artwork.shippingOrigin && (
-            <Serif mb={2} size="2" color="black60">
+            <Sans size="2" color="black60">
               Ships from {artwork.shippingOrigin}
-            </Serif>
+            </Sans>
           )}
         {artwork.is_inquireable && (
           <Button

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -226,15 +226,15 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
           </>
         )}
         {artworkEcommerceAvailable &&
-          artwork.shippingInfo && (
-            <Sans mb={2} size="2" color="black60">
-              {artwork.shippingInfo}
-            </Sans>
-          )}
-        {artworkEcommerceAvailable &&
           artwork.shippingOrigin && (
             <Sans size="2" color="black60">
               Ships from {artwork.shippingOrigin}
+            </Sans>
+          )}
+        {artworkEcommerceAvailable &&
+          artwork.shippingInfo && (
+            <Sans mb={2} size="2" color="black60">
+              {artwork.shippingInfo}
             </Sans>
           )}
         {artwork.is_inquireable && (


### PR DESCRIPTION
- Update font style for Buy Now / Make Offer artwork page shipping info components
- Swap order of `shippingInfo` and `shippingoOrigin`

---

**Before**

![2018-12-14-150022_610x373_scrot](https://user-images.githubusercontent.com/123595/50024651-14ea6500-ffb1-11e8-8f8e-66a5a9c9d2d7.png)


**After**

![2018-12-14-145958_640x335_scrot](https://user-images.githubusercontent.com/123595/50024655-17e55580-ffb1-11e8-87c2-b0710109365b.png)
