### PR TITLE
[PATCH publishing] adds social embed to sections

### DIFF
--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -9,6 +9,7 @@ import { Embed } from "./Embed"
 import { ImageCollection } from "./ImageCollection"
 import { ImageSetPreview } from "./ImageSetPreview"
 import { SectionContainer } from "./SectionContainer"
+import { SocialEmbed } from "./SocialEmbed"
 import { Text } from "./Text"
 import { Video } from "./Video"
 
@@ -156,6 +157,7 @@ export class Sections extends Component<Props, State> {
       image_set: <ImageSetPreview section={section} />,
       video: <Video section={section} />,
       embed: <Embed section={section} />,
+      social_embed: <SocialEmbed section={section} />,
       text: (
         <Text
           html={section.body}

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sections snapshots renders properly 1`] = `
+exports[`Sections snapshots tests renders properly 1`] = `
 .c31 {
   display: -webkit-box;
   display: -webkit-flex;


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-793

This is the second part of work that adds social embeds to standard and feature articles. It is dependent on https://github.com/artsy/positron/pull/1825

![screen shot 2018-12-17 at 8 08 01 pm](https://user-images.githubusercontent.com/5201004/50125573-80ddff00-0237-11e9-8163-8a26497c5863.png)

