### PR TITLE
Added checks for version mismatch errors when making an initial offer.

### DIFF
--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/initialOffer.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/initialOffer.ts
@@ -26,3 +26,14 @@ export const initialOfferFailedCannotOffer = {
     },
   },
 }
+
+export const initialOfferFailedVersionMismatch = {
+  ecommerceAddInitialOfferToOrder: {
+    orderOrError: {
+      error: {
+        type: "processing",
+        code: "artwork_version_mismatch",
+      },
+    },
+  },
+}


### PR DESCRIPTION
This PR addresses [PURCHASE-723](https://artsyproduct.atlassian.net/browse/PURCHASE-723) in which a user is shown an informative error message if they make an initial offer on an artwork whose underlying data has changed since the page loaded.

This situation would arise if an administrator is updating an artwork in the CMS while a visitor is viewing that artwork's page. If the administrator saves that artwork before the visitor has a chance to click the Make Offer button, then this error message should be triggered to prevent them from making an offer on the altered artwork.