### PR TITLE
 [PATCH publishing] CanvasFooter does not render if article is super or in series

### DIFF
--- a/src/Components/Publishing/Layouts/FeatureLayout.tsx
+++ b/src/Components/Publishing/Layouts/FeatureLayout.tsx
@@ -40,7 +40,7 @@ export const FeatureLayout: React.SFC<ArticleProps> = props => {
     article.hero_section &&
     article.hero_section.type === "fullscreen"
   const sponsor = (seriesArticle && seriesArticle.sponsor) || article.sponsor
-  const hasRelated = relatedArticlesForCanvas && !isSuper && !seriesArticle
+  const seriesOrSuper = isSuper || seriesArticle
 
   return (
     <FeatureLayoutContainer>
@@ -64,7 +64,8 @@ export const FeatureLayout: React.SFC<ArticleProps> = props => {
 
       {seriesArticle && <ArticleCardsBlock {...props} />}
 
-      {(hasRelated || display) &&
+      {(relatedArticlesForCanvas || display) &&
+        !seriesOrSuper &&
         !customEditorial && (
           <CanvasFooter
             article={article}

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -72,9 +72,12 @@ export class StandardLayout extends React.Component<
       relatedArticlesForPanel,
       renderTime,
       showTooltips,
+      isSuper,
     } = this.props
     const { isTruncated } = this.state
+    const { seriesArticle } = article
     const campaign = omit(display, "panel", "canvas")
+    const seriesOrSuper = isSuper || seriesArticle
 
     return (
       <Responsive>
@@ -127,14 +130,15 @@ export class StandardLayout extends React.Component<
                 />
               )}
 
-              {(relatedArticlesForCanvas || display) && (
-                <CanvasFooter
-                  article={article}
-                  display={display}
-                  relatedArticles={relatedArticlesForCanvas}
-                  renderTime={renderTime}
-                />
-              )}
+              {(relatedArticlesForCanvas || display) &&
+                !seriesOrSuper && (
+                  <CanvasFooter
+                    article={article}
+                    display={display}
+                    relatedArticles={relatedArticlesForCanvas}
+                    renderTime={renderTime}
+                  />
+                )}
             </ArticleWrapper>
           )
         }}

--- a/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
@@ -1,9 +1,13 @@
+import { DisplayCanvas } from "Components/Publishing/Display/Canvas"
 import {
   FeatureArticle,
   SeriesArticle,
   SeriesArticleSponsored,
 } from "Components/Publishing/Fixtures/Articles"
-import { RelatedCanvas } from "Components/Publishing/Fixtures/Components"
+import {
+  Display,
+  RelatedCanvas,
+} from "Components/Publishing/Fixtures/Components"
 import { Nav } from "Components/Publishing/Nav/Nav"
 import { ArticleCardsBlock } from "Components/Publishing/RelatedArticles/ArticleCards/Block"
 import { RelatedArticlesCanvas } from "Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas"
@@ -21,7 +25,7 @@ jest.mock(
   })
 )
 
-it("renders RelatedArticlesCanvas", () => {
+it("renders RelatedArticlesCanvas if article is not super or in a series", () => {
   const article = mount(
     <FeatureLayout
       article={FeatureArticle}
@@ -31,10 +35,36 @@ it("renders RelatedArticlesCanvas", () => {
   expect(article.find(RelatedArticlesCanvas).length).toBe(1)
 })
 
-it("Does not render RelatedArticlesCanvas if isSuper", () => {
+it("Does not render RelatedArticlesCanvas if article is super", () => {
   const article = mount(
     <FeatureLayout
       article={FeatureArticle}
+      relatedArticlesForCanvas={RelatedCanvas}
+      isSuper
+    />
+  )
+  expect(article.find(RelatedArticlesCanvas).length).toBe(0)
+})
+
+it("Does not render RelatedArticlesCanvas if article is super and display is not undefined", () => {
+  const article = mount(
+    <FeatureLayout
+      article={FeatureArticle}
+      relatedArticlesForCanvas={RelatedCanvas}
+      display={Display("feature")}
+      isSuper
+    />
+  )
+  expect(article.find(RelatedArticlesCanvas).length).toBe(0)
+})
+
+it("Does not render RelatedArticlesCanvas if article is in a series", () => {
+  const Article = extend(cloneDeep(FeatureArticle), {
+    seriesArticle: SeriesArticle,
+  })
+  const article = mount(
+    <FeatureLayout
+      article={Article}
       relatedArticlesForCanvas={RelatedCanvas}
       isSuper
     />
@@ -50,6 +80,43 @@ it("renders a nav if article is in a series", () => {
     <FeatureLayout article={Article} relatedArticlesForCanvas={RelatedCanvas} />
   )
   expect(article.find(Nav).length).toBe(1)
+})
+
+it("renders display if article is not super or in a series", () => {
+  const article = mount(
+    <FeatureLayout
+      article={FeatureArticle}
+      relatedArticlesForCanvas={RelatedCanvas}
+      display={Display("feature")}
+    />
+  )
+  expect(article.find(DisplayCanvas).length).toBe(1)
+})
+
+it("does not render display if article is in a series", () => {
+  const Article = extend(cloneDeep(FeatureArticle), {
+    seriesArticle: SeriesArticle,
+  })
+  const article = mount(
+    <FeatureLayout
+      article={Article}
+      relatedArticlesForCanvas={RelatedCanvas}
+      display={Display("feature")}
+    />
+  )
+  expect(article.find(DisplayCanvas).length).toBe(0)
+})
+
+it("does not render display if article is super", () => {
+  const article = mount(
+    <FeatureLayout
+      article={FeatureArticle}
+      relatedArticlesForCanvas={RelatedCanvas}
+      display={Display("feature")}
+      isSuper
+    />
+  )
+  expect(article.find(DisplayCanvas).length).toBe(0)
 })
 
 it("does not render a nav if article has a non-fullscreen header", () => {

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -1,6 +1,9 @@
 import { DisplayCanvas } from "Components/Publishing/Display/Canvas"
 import { DisplayPanel } from "Components/Publishing/Display/DisplayPanel"
-import { StandardArticle } from "Components/Publishing/Fixtures/Articles"
+import {
+  SeriesArticle,
+  StandardArticle,
+} from "Components/Publishing/Fixtures/Articles"
 import {
   Display,
   RelatedCanvas,
@@ -11,6 +14,7 @@ import { RelatedArticlesCanvas } from "Components/Publishing/RelatedArticles/Can
 import { RelatedArticlesPanel } from "Components/Publishing/RelatedArticles/Panel/RelatedArticlesPanel"
 import { mount } from "enzyme"
 import "jest-styled-components"
+import { cloneDeep, extend } from "lodash"
 import React from "react"
 import { Sidebar } from "../Components/Sidebar"
 import { StandardLayout } from "../StandardLayout"
@@ -49,10 +53,38 @@ describe("Standard Article", () => {
     expect(article.find(RelatedArticlesCanvas).length).toBe(1)
   })
 
+  it("Does not render RelatedArticlesCanvas if article is super", () => {
+    props.isSuper = true
+    const article = getWrapper(props)
+    expect(article.find(RelatedArticlesCanvas).length).toBe(0)
+  })
+
+  it("Does not render RelatedArticlesCanvas if article is in a series", () => {
+    props.article = extend(cloneDeep(StandardArticle), {
+      seriesArticle: SeriesArticle,
+    })
+    const article = getWrapper(props)
+    expect(article.find(RelatedArticlesCanvas).length).toBe(0)
+  })
+
   it("renders display", () => {
     const article = getWrapper(props)
     expect(article.find(DisplayPanel).length).toBe(1)
     expect(article.find(DisplayCanvas).length).toBe(1)
+  })
+
+  it("Does not render display if article is in a series", () => {
+    props.article = extend(cloneDeep(StandardArticle), {
+      seriesArticle: SeriesArticle,
+    })
+    const article = getWrapper(props)
+    expect(article.find(DisplayCanvas).length).toBe(0)
+  })
+
+  it("Does not render display if article is super", () => {
+    props.isSuper = true
+    const article = getWrapper(props)
+    expect(article.find(DisplayCanvas).length).toBe(0)
   })
 
   it("shows read more if truncated", () => {

--- a/src/Components/Publishing/__stories__/ArticleStandard.story.tsx
+++ b/src/Components/Publishing/__stories__/ArticleStandard.story.tsx
@@ -13,7 +13,12 @@ import {
 } from "../Fixtures/Articles"
 
 import { ContextProvider } from "Artsy"
-import { Display, RelatedCanvas, RelatedPanel } from "../Fixtures/Components"
+import {
+  Display,
+  HeroSections,
+  RelatedCanvas,
+  RelatedPanel,
+} from "../Fixtures/Components"
 import { ArticleData } from "../Typings"
 
 const story = storiesOf("Publishing/Articles/Standard", module)
@@ -29,10 +34,11 @@ const story = storiesOf("Publishing/Articles/Standard", module)
     )
   })
   .add("Super Article", () => {
+    const article = extend({}, SuperArticle, { hero_section: HeroSections[2] })
     return (
       <ContextProvider>
         <Article
-          article={StandardArticle}
+          article={article}
           relatedArticlesForPanel={RelatedPanel}
           relatedArticlesForCanvas={RelatedCanvas}
           isSuper

--- a/src/Components/Publishing/__stories__/ArticleStandard.story.tsx
+++ b/src/Components/Publishing/__stories__/ArticleStandard.story.tsx
@@ -1,11 +1,15 @@
 import { storiesOf } from "@storybook/react"
 import { Article } from "Components/Publishing/Article"
+import { clone, extend } from "lodash"
 import React from "react"
 
 import {
+  BasicArticle,
   ImageHeavyStandardArticle,
   MissingVerticalStandardArticle,
+  SeriesArticle,
   StandardArticle,
+  SuperArticle,
 } from "../Fixtures/Articles"
 
 import { ContextProvider } from "Artsy"
@@ -21,6 +25,31 @@ const story = storiesOf("Publishing/Articles/Standard", module)
           relatedArticlesForPanel={RelatedPanel}
           relatedArticlesForCanvas={RelatedCanvas}
         />
+      </ContextProvider>
+    )
+  })
+  .add("Super Article", () => {
+    return (
+      <ContextProvider>
+        <Article
+          article={StandardArticle}
+          relatedArticlesForPanel={RelatedPanel}
+          relatedArticlesForCanvas={RelatedCanvas}
+          isSuper
+        />
+      </ContextProvider>
+    )
+  })
+  .add("In series", () => {
+    const article = clone({
+      ...StandardArticle,
+      seriesArticle: SeriesArticle,
+      relatedArticles: [BasicArticle, SuperArticle],
+    } as ArticleData)
+
+    return (
+      <ContextProvider>
+        <Article article={article} />
       </ContextProvider>
     )
   })


### PR DESCRIPTION
CanvasFooter is hidden unless isSuper is false and article is not in a series