### PR TITLE
Fix/offer history button

### DIFF
--- a/src/Apps/Order/Components/OfferHistoryItem.tsx
+++ b/src/Apps/Order/Components/OfferHistoryItem.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, FlexProps, Sans, Serif } from "@artsy/palette"
 import { OfferHistoryItem_order } from "__generated__/OfferHistoryItem_order.graphql"
 import { StaticCollapse } from "Components/StaticCollapse"
-import React from "react"
+import React, { HTMLProps } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import {
   StepSummaryItem,
@@ -43,7 +43,31 @@ class OfferHistoryItem extends React.Component<
           </Sans>
         </Row>
         {previousOffers.length > 0 && (
-          <>
+          <Flex
+            flexDirection="column"
+            position="relative"
+            style={{ minHeight: "26px" }}
+          >
+            <Row
+              position="absolute"
+              style={{
+                right: "0",
+                transition: "opacity 0.24s ease",
+                opacity: showingFullHistory ? 0 : 1,
+                pointerEvents: showingFullHistory ? "none" : "all",
+              }}
+            >
+              <div />
+              <Button
+                variant="secondaryGray"
+                size="small"
+                onClick={() => {
+                  this.setState({ showingFullHistory: true })
+                }}
+              >
+                Show offer history
+              </Button>
+            </Row>
             <StaticCollapse open={showingFullHistory}>
               <Flex m={0} flexDirection="column">
                 {previousOffers.map(({ node: offer }) => (
@@ -59,28 +83,17 @@ class OfferHistoryItem extends React.Component<
                 ))}
               </Flex>
             </StaticCollapse>
-            <StaticCollapse open={!showingFullHistory}>
-              <Row>
-                <div />
-                <Button
-                  variant="secondaryGray"
-                  size="small"
-                  onClick={() => {
-                    this.setState({ showingFullHistory: true })
-                  }}
-                >
-                  Show offer history
-                </Button>
-              </Row>
-            </StaticCollapse>
-          </>
+          </Flex>
         )}
       </StepSummaryItem>
     )
   }
 }
 
-const Row: React.SFC<FlexProps> = ({ children, ...others }) => (
+const Row: React.SFC<
+  // TODO: look into why a separate style prop is necessary here
+  FlexProps & { style?: HTMLProps<HTMLDivElement>["style"] }
+> = ({ children, ...others }) => (
   <Flex justifyContent="space-between" alignItems="baseline" {...others}>
     {children}
   </Flex>

--- a/src/Apps/Order/Components/OfferHistoryItem.tsx
+++ b/src/Apps/Order/Components/OfferHistoryItem.tsx
@@ -44,20 +44,6 @@ class OfferHistoryItem extends React.Component<
         </Row>
         {previousOffers.length > 0 && (
           <>
-            <StaticCollapse open={!showingFullHistory}>
-              <Row>
-                <div />
-                <Button
-                  variant="secondaryGray"
-                  size="small"
-                  onClick={() => {
-                    this.setState({ showingFullHistory: true })
-                  }}
-                >
-                  Show offer history
-                </Button>
-              </Row>
-            </StaticCollapse>
             <StaticCollapse open={showingFullHistory}>
               <Flex m={0} flexDirection="column">
                 {previousOffers.map(({ node: offer }) => (
@@ -72,6 +58,20 @@ class OfferHistoryItem extends React.Component<
                   </Row>
                 ))}
               </Flex>
+            </StaticCollapse>
+            <StaticCollapse open={!showingFullHistory}>
+              <Row>
+                <div />
+                <Button
+                  variant="secondaryGray"
+                  size="small"
+                  onClick={() => {
+                    this.setState({ showingFullHistory: true })
+                  }}
+                >
+                  Show offer history
+                </Button>
+              </Row>
             </StaticCollapse>
           </>
         )}

--- a/src/Apps/Order/Components/__tests__/OfferHistoryItem.test.tsx
+++ b/src/Apps/Order/Components/__tests__/OfferHistoryItem.test.tsx
@@ -67,17 +67,13 @@ describe("OfferHistoryItem", () => {
     const button = offerHistory.find(Button)
     expect(button).toHaveLength(1)
 
-    const collapses = offerHistory.find(StaticCollapse)
+    const collapse = offerHistory.find(StaticCollapse)
 
-    expect(collapses).toHaveLength(2)
-
-    expect(collapses.get(0).props.open).toBeFalsy()
-    expect(collapses.get(1).props.open).toBeTruthy()
+    expect(collapse.props().open).toBeFalsy()
 
     button.simulate("click")
 
-    expect(offerHistory.find(StaticCollapse).get(0).props.open).toBeTruthy()
-    expect(offerHistory.find(StaticCollapse).get(1).props.open).toBeFalsy()
+    expect(offerHistory.find(StaticCollapse).props().open).toBeTruthy()
 
     const text = offerHistory.text()
     expect(text).toMatch("You (May 21)$1,200.00")

--- a/src/Apps/Order/Components/__tests__/OfferHistoryItem.test.tsx
+++ b/src/Apps/Order/Components/__tests__/OfferHistoryItem.test.tsx
@@ -71,13 +71,13 @@ describe("OfferHistoryItem", () => {
 
     expect(collapses).toHaveLength(2)
 
-    expect(collapses.get(0).props.open).toBeTruthy()
-    expect(collapses.get(1).props.open).toBeFalsy()
+    expect(collapses.get(0).props.open).toBeFalsy()
+    expect(collapses.get(1).props.open).toBeTruthy()
 
     button.simulate("click")
 
-    expect(offerHistory.find(StaticCollapse).get(0).props.open).toBeFalsy()
-    expect(offerHistory.find(StaticCollapse).get(1).props.open).toBeTruthy()
+    expect(offerHistory.find(StaticCollapse).get(0).props.open).toBeTruthy()
+    expect(offerHistory.find(StaticCollapse).get(1).props.open).toBeFalsy()
 
     const text = offerHistory.text()
     expect(text).toMatch("You (May 21)$1,200.00")

--- a/src/Apps/Order/Routes/__tests__/Counter.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.test.tsx
@@ -167,7 +167,6 @@ describe("Submit Pending Counter Offer", () => {
           onCompleted(submitPendingOfferSuccess)
         }
       )
-      console.log(component)
       const submitButton = component.find(Button).last()
       submitButton.simulate("click")
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-751
https://artsyproduct.atlassian.net/browse/PURCHASE-755

- Make the StaticCollapse capable of rendering closed offline
- Improve the 'show offer history' button interaction

## Before:
![bad-interaction](https://user-images.githubusercontent.com/1242537/50223490-3ec9d000-0393-11e9-84f2-670b5231bb2a.gif)

## After:
![better-transition](https://user-images.githubusercontent.com/1242537/50226839-290cd880-039c-11e9-9b5a-a8a57d2efa3c.gif)


