### PR TITLE
[PATCH Artwork] Update image sizing

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -65,7 +65,7 @@ export class LargeArtworkImageBrowser extends React.Component<
                   <Flex
                     flexDirection="column"
                     justifyContent="center"
-                    px={3}
+                    px={hasMultipleImages ? 3 : 0}
                     key={image.id}
                   >
                     <Lightbox
@@ -213,7 +213,7 @@ const Container = styled(Box)`
 `
 
 const DesktopImage = styled(ResponsiveImage)`
-  padding-bottom: 660px; /* Responsive max height */
+  padding-bottom: 60vh; /* Responsive max height */
 `
 
 const PageIndicator = styled.span`

--- a/src/Apps/Artwork/routes.tsx
+++ b/src/Apps/Artwork/routes.tsx
@@ -4,6 +4,8 @@ import { ArtworkAppFragmentContainer as ArtworkApp } from "./ArtworkApp"
 // @ts-ignore
 import { ComponentClass, StatelessComponent } from "react"
 
+// TODO: Investigate better error boundaries for runtime errors
+
 export const routes = [
   {
     path: "/artwork2/:artworkID",

--- a/src/Apps/__stories__/ArtworkApp.story.tsx
+++ b/src/Apps/__stories__/ArtworkApp.story.tsx
@@ -72,7 +72,7 @@ storiesOf("Apps/Artwork Page", module)
     return (
       <MockRouter
         routes={artworkRoutes}
-        initialRoute="/artwork2/thelma-appel-sea-garden-iv"
+        initialRoute="/artwork2/josef-albers-interlinear-n-65"
       />
     )
   })


### PR DESCRIPTION
Updates overall height of image to be dynamic to viewers screen size (60%) and removes padding when arrows are not present. 

<img width="1438" alt="screen shot 2018-12-20 at 10 55 07 am" src="https://user-images.githubusercontent.com/236943/50295881-17343f80-0447-11e9-9f8f-f989c3482aea.png">

<img width="1437" alt="screen shot 2018-12-20 at 10 55 43 am" src="https://user-images.githubusercontent.com/236943/50295891-1a2f3000-0447-11e9-8347-0b7bb16256bd.png">
