### PR TITLE
Use Palette components for Series & Video

### DIFF
--- a/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/StandardHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/StandardHeader.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 24px;
   color: #C2C2C2;
 }
 
@@ -301,14 +301,22 @@ exports[`Standard Header Snapshots renders properly 1`] = `
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 24px;
+  color: #000;
 }
 
 .c7 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c8 {
   margin: 10px 20px 0 0;
 }
 
-.c7::before {
+.c8::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -318,12 +326,12 @@ exports[`Standard Header Snapshots renders properly 1`] = `
   background-color: black;
 }
 
-.c8 {
+.c9 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -337,18 +345,18 @@ exports[`Standard Header Snapshots renders properly 1`] = `
   margin-top: 5px;
 }
 
-.c10 {
+.c11 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c10:hover {
+.c11:hover {
   opacity: 0.6;
 }
 
-.c10:first-child {
+.c11:first-child {
   padding-left: 0;
 }
 
@@ -368,7 +376,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
 }
 
 .c3 a {
-  color: black;
+  color: #000;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -435,6 +443,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
     >
       <div
         className="c3 c4"
+        color="#000"
         fontFamily={
           Object {
             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -458,7 +467,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
       color="black"
     >
       <div
-        className="c4"
+        className="c7"
         fontFamily={
           Object {
             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -468,17 +477,17 @@ exports[`Standard Header Snapshots renders properly 1`] = `
         fontSize="14px"
       >
         <div
-          className="c7"
+          className="c8"
           color="black"
         >
           Casey Lesser
         </div>
       </div>
       <div
-        className="c8"
+        className="c9"
       >
         <div
-          className="c4"
+          className="c7"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -491,10 +500,10 @@ exports[`Standard Header Snapshots renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c9"
+        className="c10"
       >
         <a
-          className="c10"
+          className="c11"
           href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
           onClick={[Function]}
           target="_blank"
@@ -520,7 +529,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
           </svg>
         </a>
         <a
-          className="c10"
+          className="c11"
           href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
           onClick={[Function]}
           target="_blank"
@@ -546,7 +555,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
           </svg>
         </a>
         <a
-          className="c10"
+          className="c11"
           href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
           onClick={[Function]}
           target="_blank"

--- a/src/Components/Publishing/Layouts/SeriesLayout.tsx
+++ b/src/Components/Publishing/Layouts/SeriesLayout.tsx
@@ -1,12 +1,16 @@
+import { Box, color } from "@artsy/palette"
 import React, { Component } from "react"
-import styled, { StyledFunction } from "styled-components"
-import { pMedia } from "../../Helpers"
-import { Nav } from "../Nav/Nav"
-import { ArticleCards } from "../RelatedArticles/ArticleCards/ArticleCards"
-import { FixedBackground } from "../Series/FixedBackground"
-import { SeriesAbout, SeriesAboutContainer } from "../Series/SeriesAbout"
-import { SeriesTitle, SeriesTitleContainer } from "../Series/SeriesTitle"
-import { ArticleData } from "../Typings"
+import styled from "styled-components"
+
+import { Nav } from "Components/Publishing/Nav/Nav"
+import { ArticleCards } from "Components/Publishing/RelatedArticles/ArticleCards/ArticleCards"
+import { FixedBackground } from "Components/Publishing/Series/FixedBackground"
+import { SeriesAbout } from "Components/Publishing/Series/SeriesAbout"
+import {
+  SeriesTitle,
+  SeriesTitleContainer,
+} from "Components/Publishing/Series/SeriesTitle"
+import { ArticleData } from "Components/Publishing/Typings"
 
 interface Props {
   article?: ArticleData
@@ -19,13 +23,16 @@ export class SeriesLayout extends Component<Props, null> {
   public static defaultProps: Partial<Props>
 
   render() {
-    const { article, backgroundColor, color, relatedArticles } = this.props
+    const { article, backgroundColor, relatedArticles } = this.props
     const { hero_section, sponsor } = article
     const backgroundUrl =
       hero_section && hero_section.url ? hero_section.url : ""
 
     return (
-      <SeriesContainer color={color} backgroundColor={backgroundColor}>
+      <SeriesContainer
+        color={this.props.color}
+        backgroundColor={backgroundColor}
+      >
         <Nav transparent sponsor={sponsor} canFix={false} />
 
         <FixedBackground
@@ -34,17 +41,18 @@ export class SeriesLayout extends Component<Props, null> {
         />
 
         <SeriesContent sponsor={sponsor}>
-          <SeriesTitle article={article} color={color} />
+          <SeriesTitle article={article} color={this.props.color} />
 
           {relatedArticles && (
             <ArticleCards
               relatedArticles={relatedArticles}
               series={article}
-              color={color}
+              color={this.props.color}
             />
           )}
-
-          <SeriesAbout article={article} color={color} />
+          <Box maxWidth={1200} mx="auto" pt={[40, 40, 60]}>
+            <SeriesAbout article={article} color={this.props.color} />
+          </Box>
         </SeriesContent>
       </SeriesContainer>
     )
@@ -52,7 +60,7 @@ export class SeriesLayout extends Component<Props, null> {
 }
 
 SeriesLayout.defaultProps = {
-  backgroundColor: "black",
+  backgroundColor: color("black100"),
   color: "white",
 }
 
@@ -61,12 +69,7 @@ interface ContainerProps {
   sponsor?: any
 }
 
-const Div: StyledFunction<
-  Props & ContainerProps & React.HTMLProps<HTMLDivElement>
-> =
-  styled.div
-
-export const SeriesContent = Div`
+export const SeriesContent = styled.div<Props & ContainerProps>`
   max-width: 1200px;
   min-height: 100vh;
   margin: 0 auto;
@@ -74,18 +77,8 @@ export const SeriesContent = Div`
   ${SeriesTitleContainer} {
     margin-bottom: ${props => (props.sponsor ? "60px" : "90px")};
   }
-
-  ${SeriesAboutContainer} {
-    padding-top: 60px;
-  }
-
-  ${pMedia.md`
-    ${SeriesAboutContainer} {
-      padding-top: 60px;
-    }
-  `}
 `
-export const SeriesContainer = Div`
+export const SeriesContainer = styled.div<Props & ContainerProps>`
   color: ${props => props.color};
 
   ${SeriesContent} {

--- a/src/Components/Publishing/Layouts/VideoLayout.tsx
+++ b/src/Components/Publishing/Layouts/VideoLayout.tsx
@@ -1,15 +1,19 @@
+import { Box } from "@artsy/palette"
 import React, { Component } from "react"
 import track from "react-tracking"
 import styled from "styled-components"
-import Events from "../../../Utils/Events"
-import { media as mediaQueries } from "../../Helpers"
-import { getEditorialHref } from "../Constants"
-import { Nav, NavContainer } from "../Nav/Nav"
-import { ArticleCardsBlock } from "../RelatedArticles/ArticleCards/Block"
-import { ArticleData } from "../Typings"
-import { VideoContainer, VideoPlayer } from "../Video/Player/VideoPlayer"
-import { VideoAbout, VideoAboutContainer } from "../Video/VideoAbout"
-import { VideoCover } from "../Video/VideoCover"
+
+import { getEditorialHref } from "Components/Publishing/Constants"
+import { Nav, NavContainer } from "Components/Publishing/Nav/Nav"
+import { ArticleCardsBlock } from "Components/Publishing/RelatedArticles/ArticleCards/Block"
+import { ArticleData } from "Components/Publishing/Typings"
+import {
+  VideoContainer,
+  VideoPlayer,
+} from "Components/Publishing/Video/Player/VideoPlayer"
+import { VideoAbout } from "Components/Publishing/Video/VideoAbout"
+import { VideoCover } from "Components/Publishing/Video/VideoCover"
+import Events from "Utils/Events"
 
 interface Props {
   article: ArticleData
@@ -94,11 +98,15 @@ export class VideoLayout extends Component<Props, State> {
             hideCover={this.state.hideCover}
           />
         </VideoPlayerContainer>
-        <VideoAbout article={article} color="white" />
 
-        {(relatedArticles || seriesArticle) && (
-          <ArticleCardsBlock {...this.props} color="white" />
-        )}
+        <Box px={20} maxWidth={1200} mx="auto">
+          <Box pt={[40, 40, 60]}>
+            <VideoAbout article={article} color="white" />
+          </Box>
+          {(relatedArticles || seriesArticle) && (
+            <ArticleCardsBlock {...this.props} color="white" />
+          )}
+        </Box>
       </VideoLayoutContainer>
     )
   }
@@ -113,16 +121,6 @@ const VideoLayoutContainer = styled.div`
     position: absolute;
     top: 0;
   }
-
-  ${VideoAboutContainer} {
-    margin: 60px auto 100px auto;
-  }
-
-  ${mediaQueries.sm`
-    ${VideoAboutContainer} {
-      margin: 40px auto 100px auto;
-    }
-  `};
 `
 
 const VideoPlayerContainer = styled.div`

--- a/src/Components/Publishing/Layouts/VideoLayout.tsx
+++ b/src/Components/Publishing/Layouts/VideoLayout.tsx
@@ -103,8 +103,11 @@ export class VideoLayout extends Component<Props, State> {
           <Box pt={[40, 40, 60]}>
             <VideoAbout article={article} color="white" />
           </Box>
+
           {(relatedArticles || seriesArticle) && (
-            <ArticleCardsBlock {...this.props} color="white" />
+            <Box pt={[60, 60, 100]}>
+              <ArticleCardsBlock {...this.props} color="white" />
+            </Box>
           )}
         </Box>
       </VideoLayoutContainer>

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1977,7 +1977,7 @@ exports[`renders a sponsored series properly 1`] = `
   margin-bottom: 30px;
 }
 
-.ikXwHe .c15 {
+.bhMdnS .c15 {
   margin-bottom: 90px;
 }
 

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -8,6 +8,88 @@ exports[`renders a series properly 1`] = `
   display: flex;
 }
 
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  padding: 20px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c31 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c37 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.c38 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.c40 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+}
+
 .c7 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-weight: 600;
@@ -22,6 +104,42 @@ exports[`renders a series properly 1`] = `
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 4px;
+}
+
+.c22 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c23 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 20px;
+}
+
+.c25 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c33 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1em;
+}
+
+.c39 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
 }
 
 .c16 {
@@ -30,6 +148,19 @@ exports[`renders a series properly 1`] = `
 
 .c17 {
   margin-bottom: 40px;
+}
+
+.c27 {
+  margin-bottom: 10px;
+  margin-left: 0px;
+  width: 100%;
+}
+
+.c36 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 40px;
 }
 
 .c5 {
@@ -113,11 +244,11 @@ exports[`renders a series properly 1`] = `
   z-index: 10;
 }
 
-.c33 {
+.c35 {
   margin: 10px 20px 0 0;
 }
 
-.c33::before {
+.c35::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -132,7 +263,7 @@ exports[`renders a series properly 1`] = `
   white-space: nowrap;
 }
 
-.c32 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -147,12 +278,12 @@ exports[`renders a series properly 1`] = `
   color: white;
 }
 
-.c31 {
+.c32 {
   width: 32px;
   height: 32px;
 }
 
-.c28 {
+.c29 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -164,9 +295,8 @@ exports[`renders a series properly 1`] = `
 
 .c26 {
   position: relative;
-  width: 50%;
   height: inherit;
-  margin-left: 30px;
+  background: white;
 }
 
 .c18 {
@@ -176,85 +306,30 @@ exports[`renders a series properly 1`] = `
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  padding: 30px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: block;
 }
 
-.c18 .c27 {
+.c18 .c28 {
   opacity: 1;
 }
 
-.c18:hover .c27 {
+.c18:hover .c28 {
   opacity: 0.7;
-}
-
-.c18 .c25 {
-  background: black;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
-}
-
-.c22 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
-  margin-bottom: 30px;
-}
-
-.c20 {
-  margin-bottom: 10px;
-}
-
-.c23 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
 }
 
 .c30 {
   position: absolute;
   left: 20px;
-  bottom: 20px;
   right: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  bottom: 20px;
 }
 
-.c29 svg {
-  width: 40px;
+.c30 svg {
+  height: 40px;
 }
 
 .c8 {
-  background-color: black;
+  background-color: #000;
   position: fixed;
   top: 0;
   left: 0;
@@ -283,43 +358,6 @@ exports[`renders a series properly 1`] = `
   right: 0;
   bottom: 0;
   z-index: -1;
-}
-
-.c36 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
-}
-
-.c38 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c40 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
 }
 
 .c41 {
@@ -508,42 +546,6 @@ exports[`renders a series properly 1`] = `
   text-transform: none;
 }
 
-.c35 {
-  color: white;
-  max-width: 1200px;
-  width: 100%;
-}
-
-.c37 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: none;
-}
-
-.c37:first-of-type {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c37:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: block;
-  margin-bottom: 10px;
-}
-
-.c39 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
-}
-
 .c14 {
   color: white;
   text-align: center;
@@ -577,10 +579,6 @@ exports[`renders a series properly 1`] = `
   margin-bottom: 90px;
 }
 
-.c12 .c34 {
-  padding-top: 60px;
-}
-
 .c0 {
   color: white;
 }
@@ -590,8 +588,287 @@ exports[`renders a series properly 1`] = `
 }
 
 @media screen and (min-width:40em) {
+  .c19 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c19 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c19 {
+    padding: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c19 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c20 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c20 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c20 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c20 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c20 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c20 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c37 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c37 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c37 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c38 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c38 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c38 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c40 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c40 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c40 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c22 {
+    font-size: 28px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c22 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c22 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c22 {
+    line-height: 36px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c22 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c22 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c23 {
+    font-size: 18px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c23 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c23 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c23 {
+    line-height: 26px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c23 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c23 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c39 {
+    margin-bottom: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c39 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c39 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c17 {
     margin-bottom: 60px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c27 {
+    margin-bottom: 10px;
+    margin-left: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c27 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c27 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c27 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c27 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c27 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c36 {
+    padding-top: 40px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c36 {
+    padding-top: 60px;
   }
 }
 
@@ -610,91 +887,8 @@ exports[`renders a series properly 1`] = `
 }
 
 @media (max-width:900px) {
-  .c26 {
-    width: 100%;
-    margin-left: 0;
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width:900px) {
-  .c18 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-    padding: 20px;
-  }
-}
-
-@media (max-width:900px) {
-  .c19 {
-    width: 100%;
-    margin-bottom: 0;
-  }
-}
-
-@media (max-width:900px) {
-  .c22 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-}
-
-@media (max-width:900px) {
-  .c23 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-    margin-bottom: 20px;
-  }
-}
-
-@media (max-width:900px) {
-  .c29 svg {
-    width: 30px;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c38 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c38 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c40 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c40 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
+  .c30 svg {
+    height: 30px;
   }
 }
 
@@ -758,23 +952,6 @@ exports[`renders a series properly 1`] = `
   }
 }
 
-@media (max-width:768px) {
-  .c37:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    display: none;
-  }
-
-  .c37 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    margin-top: 60px;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c39 {
-    margin-bottom: 20px;
-  }
-}
-
 @media (max-width:900px) {
   .c14 .PartnerBlock__ImageContainer-ydgi2-1 {
     padding-bottom: 0;
@@ -788,12 +965,6 @@ exports[`renders a series properly 1`] = `
     font-size: 65px;
     line-height: 1em;
     margin-bottom: 20px;
-  }
-}
-
-@media (max-width:900px) {
-  .c12 .c34 {
-    padding-top: 60px;
   }
 }
 
@@ -889,88 +1060,126 @@ exports[`renders a series properly 1`] = `
           <div
             className="c19"
           >
-            <div>
-              <div
-                className="c20 c21"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
-                The Future of Art
-              </div>
-              <div
-                className="c22"
-              >
-                New Study Shows the Gender Pay Gap for Artists Is Not So Simple
-              </div>
-              <div
-                className="c23"
-              >
-                The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
-              </div>
-            </div>
             <div
-              className="c24"
+              className="c20"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
             >
-              <div
-                className="c21"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
+              <div>
+                <div
+                  className="c21"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
                   }
-                }
-                fontSize="14px"
-              >
-                Aug 28, 2017
-              </div>
-            </div>
-          </div>
-          <div
-            className="c25 c26"
-          >
-            <img
-              className="c27 c28"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
-            />
-            <div
-              className="c29 c30"
-            >
-              <svg
-                className="c31"
-                version="1.1"
-                viewBox="0 0 40 56"
-                x="0px"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0px"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
+                  fontSize="14px"
                 >
-                  <polygon
-                    fill="white"
-                    points="0 0 0 56 39.3600006 28"
-                  />
-                </g>
-              </svg>
-              <div
-                className="c21"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
+                  The Future of Art
+                </div>
+                <div
+                  className="c22"
+                  fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                  fontSize={
+                    Array [
+                      "28px",
+                      "28px",
+                      "42px",
+                      "42px",
+                    ]
                   }
-                }
-                fontSize="14px"
+                >
+                  New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+                </div>
+                <div
+                  className="c23"
+                  fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                  fontSize={
+                    Array [
+                      "18px",
+                      "18px",
+                      "22px",
+                      "22px",
+                    ]
+                  }
+                >
+                  The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
+                </div>
+              </div>
+              <div
+                className="c24"
               >
-                02:28
+                <div
+                  className="c25"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  Aug 28, 2017
+                </div>
+              </div>
+            </div>
+            <div
+              className="c26 c27"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
+            >
+              <img
+                className="c28 c29"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+              />
+              <div
+                className="c30 c31"
+              >
+                <svg
+                  className="c32"
+                  version="1.1"
+                  viewBox="0 0 40 56"
+                  x="0px"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0px"
+                >
+                  <g
+                    fill="none"
+                    fillRule="evenodd"
+                    stroke="none"
+                    strokeWidth="1"
+                  >
+                    <polygon
+                      fill="white"
+                      points="0 0 0 56 39.3600006 28"
+                    />
+                  </g>
+                </svg>
+                <div
+                  className="c33"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  02:28
+                </div>
               </div>
             </div>
           </div>
@@ -988,54 +1197,18 @@ exports[`renders a series properly 1`] = `
           <div
             className="c19"
           >
-            <div>
-              <div
-                className="c20 c21"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
-                The Future of Art
-              </div>
-              <div
-                className="c22"
-              >
-                New York's Next Art District
-              </div>
-              <div
-                className="c23"
-              >
-                Land exhibitions, make influential contacts, and gain valuable feedback about your work.
-              </div>
-            </div>
             <div
-              className="Byline c32"
-              color="white"
+              className="c20"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
             >
-              <div
-                className="c21"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
-                <div
-                  className="c33"
-                  color="white"
-                >
-                  Casey Lesser
-                </div>
-              </div>
-              <div
-                className="c24"
-              >
+              <div>
                 <div
                   className="c21"
                   fontFamily={
@@ -1046,53 +1219,156 @@ exports[`renders a series properly 1`] = `
                   }
                   fontSize="14px"
                 >
-                  May 19, 2017
+                  The Future of Art
+                </div>
+                <div
+                  className="c22"
+                  fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                  fontSize={
+                    Array [
+                      "28px",
+                      "28px",
+                      "42px",
+                      "42px",
+                    ]
+                  }
+                >
+                  New York's Next Art District
+                </div>
+                <div
+                  className="c23"
+                  fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                  fontSize={
+                    Array [
+                      "18px",
+                      "18px",
+                      "22px",
+                      "22px",
+                    ]
+                  }
+                >
+                  Land exhibitions, make influential contacts, and gain valuable feedback about your work.
+                </div>
+              </div>
+              <div
+                className="Byline c34"
+                color="white"
+              >
+                <div
+                  className="c25"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  <div
+                    className="c35"
+                    color="white"
+                  >
+                    Casey Lesser
+                  </div>
+                </div>
+                <div
+                  className="c24"
+                >
+                  <div
+                    className="c25"
+                    fontFamily={
+                      Object {
+                        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                        "fontWeight": 500,
+                      }
+                    }
+                    fontSize="14px"
+                  >
+                    May 19, 2017
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="c25 c26"
-          >
-            <img
-              className="c27 c28"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
-            />
+            <div
+              className="c26 c27"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
+            >
+              <img
+                className="c28 c29"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+              />
+            </div>
           </div>
         </a>
       </div>
     </div>
     <div
-      className="c34 c35 c36"
-      color="white"
+      className="c36"
     >
       <div
-        className="c37 c38"
+        className="c37"
+        color="white"
+        width="100%"
       >
         <div
-          className="c39"
-        >
-          About the Series
-        </div>
-      </div>
-      <div
-        className="c37 c40"
-      >
-        <div
-          className="SeriesAbout__description"
+          className="c38"
+          width={
+            Array [
+              1,
+              1,
+              0.3333333333333333,
+              0.3333333333333333,
+            ]
+          }
         >
           <div
-            className="article__text-section c41"
-            color="white"
+            className="c39"
+            fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+            fontSize="28px"
+          >
+            About the Series
+          </div>
+          <div
+            className="rrm-container rrm-greaterThanOrEqual-md"
+          />
+        </div>
+        <div
+          className="c40"
+          width={
+            Array [
+              1,
+              1,
+              0.6666666666666666,
+              0.6666666666666666,
+            ]
+          }
+        >
+          <div
+            className="SeriesAbout__description"
           >
             <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+              className="article__text-section c41"
+              color="white"
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+                  }
                 }
-              }
-            />
+              />
+            </div>
           </div>
+          <div
+            className="rrm-container rrm-lessThan-md"
+          />
         </div>
       </div>
     </div>
@@ -1108,6 +1384,88 @@ exports[`renders a sponsored series properly 1`] = `
   display: flex;
 }
 
+.c25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  padding: 20px;
+}
+
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c37 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c43 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.c44 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.c47 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+}
+
 .c9 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-weight: 600;
@@ -1117,19 +1475,76 @@ exports[`renders a sponsored series properly 1`] = `
   text-align: center;
 }
 
+.c27 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 4px;
+}
+
 .c28 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c29 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 20px;
+}
+
+.c31 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c23 {
+.c39 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1em;
+}
+
+.c45 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c22 {
   color: white;
 }
 
-.c24 {
+.c23 {
   margin-bottom: 40px;
+}
+
+.c33 {
+  margin-bottom: 10px;
+  margin-left: 0px;
+  width: 100%;
+}
+
+.c42 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 40px;
+}
+
+.c46 {
+  margin-bottom: 4px;
+}
+
+.c49 {
+  margin-top: 60px;
 }
 
 .c5 {
@@ -1218,11 +1633,11 @@ exports[`renders a sponsored series properly 1`] = `
   z-index: 10;
 }
 
-.c40 {
+.c41 {
   margin: 10px 20px 0 0;
 }
 
-.c40::before {
+.c41::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -1232,12 +1647,12 @@ exports[`renders a sponsored series properly 1`] = `
   background-color: white;
 }
 
-.c31 {
+.c30 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c39 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1267,99 +1682,43 @@ exports[`renders a sponsored series properly 1`] = `
   display: block;
 }
 
-.c33 {
+.c32 {
   position: relative;
-  width: 50%;
   height: inherit;
-  margin-left: 30px;
+  background: white;
 }
 
-.c25 {
+.c24 {
   border: 1px solid;
   border-radius: 2px;
   color: white;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  padding: 30px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: block;
 }
 
-.c25 .c34 {
+.c24 .c34 {
   opacity: 1;
 }
 
-.c25:hover .c34 {
+.c24:hover .c34 {
   opacity: 0.7;
 }
 
-.c25 .c32 {
-  background: black;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
-}
-
-.c29 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
-  margin-bottom: 30px;
-}
-
-.c27 {
-  margin-bottom: 10px;
-}
-
-.c30 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c37 {
+.c36 {
   position: absolute;
   left: 20px;
-  bottom: 20px;
   right: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  bottom: 20px;
 }
 
 .c36 svg {
-  width: 40px;
+  height: 40px;
 }
 
 .c10 {
-  background-color: black;
+  background-color: #000;
   position: fixed;
   top: 0;
   left: 0;
@@ -1390,55 +1749,18 @@ exports[`renders a sponsored series properly 1`] = `
   z-index: -1;
 }
 
-.c43 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
-}
-
-.c45 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c47 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c19 {
+.c18 {
   display: block;
 }
 
-.c22 img {
+.c21 img {
   max-width: 240px;
   max-height: 40px;
   object-fit: contain;
   object-position: left;
 }
 
-.c20 {
+.c19 {
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
@@ -1632,53 +1954,17 @@ exports[`renders a sponsored series properly 1`] = `
   text-transform: none;
 }
 
-.c42 {
-  color: white;
-  max-width: 1200px;
-  width: 100%;
-}
-
-.c44 .c18 {
-  display: none;
-}
-
-.c44:first-of-type {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c44:first-of-type .c18 {
-  display: block;
-  margin-bottom: 10px;
-}
-
-.c46 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
-}
-
 .c16 {
   color: white;
   text-align: center;
 }
 
-.c16 .c21 {
+.c16 .c20 {
   padding-top: 5px;
   padding-bottom: 40px;
 }
 
-.c16 .c21 img {
+.c16 .c20 img {
   margin-left: auto;
   margin-right: auto;
 }
@@ -1691,12 +1977,8 @@ exports[`renders a sponsored series properly 1`] = `
   margin-bottom: 30px;
 }
 
-.eMbNCF .c15 {
+.ikXwHe .c15 {
   margin-bottom: 90px;
-}
-
-.eMbNCF .c41 {
-  padding-top: 60px;
 }
 
 .c14 {
@@ -1709,10 +1991,6 @@ exports[`renders a sponsored series properly 1`] = `
   margin-bottom: 60px;
 }
 
-.c14 .c41 {
-  padding-top: 60px;
-}
-
 .c0 {
   color: white;
 }
@@ -1722,8 +2000,287 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c24 {
+  .c25 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c25 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c25 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c25 {
+    padding: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c25 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c25 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c26 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c26 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c26 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c26 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c26 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c26 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c43 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c43 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c43 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c44 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c44 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c44 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c47 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c47 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c47 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c28 {
+    font-size: 28px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c28 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c28 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c28 {
+    line-height: 36px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c28 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c28 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c29 {
+    font-size: 18px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c29 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c29 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c29 {
+    line-height: 26px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c29 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c29 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c45 {
+    margin-bottom: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c45 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c45 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c23 {
     margin-bottom: 60px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c33 {
+    margin-bottom: 10px;
+    margin-left: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c33 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c33 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c33 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c33 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c33 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c42 {
+    padding-top: 40px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c42 {
+    padding-top: 60px;
   }
 }
 
@@ -1749,96 +2306,13 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media (max-width:900px) {
-  .c33 {
-    width: 100%;
-    margin-left: 0;
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width:900px) {
-  .c25 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-    padding: 20px;
-  }
-}
-
-@media (max-width:900px) {
-  .c26 {
-    width: 100%;
-    margin-bottom: 0;
-  }
-}
-
-@media (max-width:900px) {
-  .c29 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-}
-
-@media (max-width:900px) {
-  .c30 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-    margin-bottom: 20px;
-  }
-}
-
-@media (max-width:900px) {
   .c36 svg {
-    width: 30px;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c45 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c45 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c47 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c47 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
+    height: 30px;
   }
 }
 
 @media (max-width:720px) {
-  .c20 {
+  .c19 {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -1906,25 +2380,8 @@ exports[`renders a sponsored series properly 1`] = `
   }
 }
 
-@media (max-width:768px) {
-  .c44:first-of-type .c18 {
-    display: none;
-  }
-
-  .c44 .c18 {
-    margin-top: 60px;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c46 {
-    margin-bottom: 20px;
-  }
-}
-
 @media (max-width:900px) {
-  .c16 .c21 {
+  .c16 .c20 {
     padding-bottom: 0;
   }
 }
@@ -1936,18 +2393,6 @@ exports[`renders a sponsored series properly 1`] = `
     font-size: 65px;
     line-height: 1em;
     margin-bottom: 20px;
-  }
-}
-
-@media (max-width:900px) {
-  .eMbNCF .c41 {
-    padding-top: 60px;
-  }
-}
-
-@media (max-width:900px) {
-  .c14 .c41 {
-    padding-top: 60px;
   }
 }
 
@@ -2071,15 +2516,15 @@ exports[`renders a sponsored series properly 1`] = `
         The Future of Art
       </div>
       <div
-        className="PartnerBlock c18 c19"
+        className="PartnerBlock c18"
       >
         <div
-          className="c20"
+          className="c19"
         >
           Presented in Partnership with
         </div>
         <div
-          className="c21 c22"
+          className="c20 c21"
         >
           <a
             href="http://artsy.net"
@@ -2094,170 +2539,35 @@ exports[`renders a sponsored series properly 1`] = `
       </div>
     </div>
     <div
-      className="c23"
+      className="c22"
       color="white"
     >
       <div
-        className="c24"
+        className="c23"
       >
         <a
-          className="ArticleCard c25"
+          className="ArticleCard c24"
           color="white"
           href="joanne-artman-gallery-poetry-naturerefinement-form"
           onClick={[Function]}
         >
           <div
-            className="c26"
+            className="c25"
           >
-            <div>
-              <div
-                className="c27 c28"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
-                The Future of Art
-              </div>
-              <div
-                className="c29"
-              >
-                New Study Shows the Gender Pay Gap for Artists Is Not So Simple
-              </div>
-              <div
-                className="c30"
-              >
-                The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
-              </div>
-            </div>
             <div
-              className="c31"
+              className="c26"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
             >
-              <div
-                className="c28"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
-                Aug 28, 2017
-              </div>
-            </div>
-          </div>
-          <div
-            className="c32 c33"
-          >
-            <img
-              className="c34 c35"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
-            />
-            <div
-              className="c36 c37"
-            >
-              <svg
-                className="c38"
-                version="1.1"
-                viewBox="0 0 40 56"
-                x="0px"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0px"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
-                >
-                  <polygon
-                    fill="white"
-                    points="0 0 0 56 39.3600006 28"
-                  />
-                </g>
-              </svg>
-              <div
-                className="c28"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
-                02:28
-              </div>
-            </div>
-          </div>
-        </a>
-      </div>
-      <div
-        className="c24"
-      >
-        <a
-          className="ArticleCard c25"
-          color="white"
-          href="new-yorks-next-art-district"
-          onClick={[Function]}
-        >
-          <div
-            className="c26"
-          >
-            <div>
-              <div
-                className="c27 c28"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
-                The Future of Art
-              </div>
-              <div
-                className="c29"
-              >
-                New York's Next Art District
-              </div>
-              <div
-                className="c30"
-              >
-                Land exhibitions, make influential contacts, and gain valuable feedback about your work.
-              </div>
-            </div>
-            <div
-              className="Byline c39"
-              color="white"
-            >
-              <div
-                className="c28"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
+              <div>
                 <div
-                  className="c40"
-                  color="white"
-                >
-                  Casey Lesser
-                </div>
-              </div>
-              <div
-                className="c31"
-              >
-                <div
-                  className="c28"
+                  className="c27"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2266,96 +2576,346 @@ exports[`renders a sponsored series properly 1`] = `
                   }
                   fontSize="14px"
                 >
-                  May 19, 2017
+                  The Future of Art
+                </div>
+                <div
+                  className="c28"
+                  fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                  fontSize={
+                    Array [
+                      "28px",
+                      "28px",
+                      "42px",
+                      "42px",
+                    ]
+                  }
+                >
+                  New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+                </div>
+                <div
+                  className="c29"
+                  fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                  fontSize={
+                    Array [
+                      "18px",
+                      "18px",
+                      "22px",
+                      "22px",
+                    ]
+                  }
+                >
+                  The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
+                </div>
+              </div>
+              <div
+                className="c30"
+              >
+                <div
+                  className="c31"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  Aug 28, 2017
+                </div>
+              </div>
+            </div>
+            <div
+              className="c32 c33"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
+            >
+              <img
+                className="c34 c35"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+              />
+              <div
+                className="c36 c37"
+              >
+                <svg
+                  className="c38"
+                  version="1.1"
+                  viewBox="0 0 40 56"
+                  x="0px"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0px"
+                >
+                  <g
+                    fill="none"
+                    fillRule="evenodd"
+                    stroke="none"
+                    strokeWidth="1"
+                  >
+                    <polygon
+                      fill="white"
+                      points="0 0 0 56 39.3600006 28"
+                    />
+                  </g>
+                </svg>
+                <div
+                  className="c39"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  02:28
                 </div>
               </div>
             </div>
           </div>
+        </a>
+      </div>
+      <div
+        className="c23"
+      >
+        <a
+          className="ArticleCard c24"
+          color="white"
+          href="new-yorks-next-art-district"
+          onClick={[Function]}
+        >
           <div
-            className="c32 c33"
+            className="c25"
           >
-            <img
-              className="c34 c35"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
-            />
+            <div
+              className="c26"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
+            >
+              <div>
+                <div
+                  className="c27"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  The Future of Art
+                </div>
+                <div
+                  className="c28"
+                  fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                  fontSize={
+                    Array [
+                      "28px",
+                      "28px",
+                      "42px",
+                      "42px",
+                    ]
+                  }
+                >
+                  New York's Next Art District
+                </div>
+                <div
+                  className="c29"
+                  fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                  fontSize={
+                    Array [
+                      "18px",
+                      "18px",
+                      "22px",
+                      "22px",
+                    ]
+                  }
+                >
+                  Land exhibitions, make influential contacts, and gain valuable feedback about your work.
+                </div>
+              </div>
+              <div
+                className="Byline c40"
+                color="white"
+              >
+                <div
+                  className="c31"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  <div
+                    className="c41"
+                    color="white"
+                  >
+                    Casey Lesser
+                  </div>
+                </div>
+                <div
+                  className="c30"
+                >
+                  <div
+                    className="c31"
+                    fontFamily={
+                      Object {
+                        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                        "fontWeight": 500,
+                      }
+                    }
+                    fontSize="14px"
+                  >
+                    May 19, 2017
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="c32 c33"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
+            >
+              <img
+                className="c34 c35"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+              />
+            </div>
           </div>
         </a>
       </div>
     </div>
     <div
-      className="c41 c42 c43"
-      color="white"
+      className="c42"
     >
       <div
-        className="c44 c45"
+        className="c43"
+        color="white"
+        width="100%"
       >
         <div
-          className="c46"
-        >
-          About the Series
-        </div>
-        <div
-          className="PartnerBlock c18 c19"
+          className="c44"
+          width={
+            Array [
+              1,
+              1,
+              0.3333333333333333,
+              0.3333333333333333,
+            ]
+          }
         >
           <div
-            className="c20"
+            className="c45"
+            fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+            fontSize="28px"
           >
-            Presented in Partnership with
+            About the Series
           </div>
           <div
-            className="c21 c22"
-          >
-            <a
-              href="http://artsy.net"
-              onClick={[Function]}
-              target="_blank"
-            >
-              <img
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGEu3iYW6CQhbVxsjpOYwZQ%252FGKL_Wort-Bildmarke_negative_rgb%2B2.png&width=240&quality=80"
-              />
-            </a>
-          </div>
-        </div>
-      </div>
-      <div
-        className="c44 c47"
-      >
-        <div
-          className="SeriesAbout__description"
-        >
-          <div
-            className="article__text-section c48"
-            color="white"
+            className="rrm-container rrm-greaterThanOrEqual-md"
           >
             <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-                }
-              }
-            />
+              className="c46"
+            >
+              <div
+                className="PartnerBlock c18"
+              >
+                <div
+                  className="c19"
+                >
+                  Presented in Partnership with
+                </div>
+                <div
+                  className="c20 c21"
+                >
+                  <a
+                    href="http://artsy.net"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <img
+                      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGEu3iYW6CQhbVxsjpOYwZQ%252FGKL_Wort-Bildmarke_negative_rgb%2B2.png&width=240&quality=80"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
-          className="PartnerBlock c18 c19"
+          className="c47"
+          width={
+            Array [
+              1,
+              1,
+              0.6666666666666666,
+              0.6666666666666666,
+            ]
+          }
         >
           <div
-            className="c20"
+            className="SeriesAbout__description"
           >
-            Presented in Partnership with
+            <div
+              className="article__text-section c48"
+              color="white"
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+                  }
+                }
+              />
+            </div>
           </div>
           <div
-            className="c21 c22"
+            className="rrm-container rrm-lessThan-md"
           >
-            <a
-              href="http://artsy.net"
-              onClick={[Function]}
-              target="_blank"
+            <div
+              className="c49"
             >
-              <img
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGEu3iYW6CQhbVxsjpOYwZQ%252FGKL_Wort-Bildmarke_negative_rgb%2B2.png&width=240&quality=80"
-              />
-            </a>
+              <div
+                className="PartnerBlock c18"
+              >
+                <div
+                  className="c19"
+                >
+                  Presented in Partnership with
+                </div>
+                <div
+                  className="c20 c21"
+                >
+                  <a
+                    href="http://artsy.net"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <img
+                      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGEu3iYW6CQhbVxsjpOYwZQ%252FGKL_Wort-Bildmarke_negative_rgb%2B2.png&width=240&quality=80"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -8,14 +8,125 @@ exports[`Video Layout matches the snapshot 1`] = `
   display: flex;
 }
 
+.c35 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  padding-bottom: 40px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 .c47 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
   margin-left: auto;
   margin-right: auto;
   max-width: 1200px;
+}
+
+.c49 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 80px;
+  width: 100%;
+}
+
+.c71 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  padding: 20px;
+}
+
+.c72 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c81 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c86 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.c87 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.c89 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
 }
 
 .c8 {
@@ -27,46 +138,146 @@ exports[`Video Layout matches the snapshot 1`] = `
   text-align: center;
 }
 
-.c41 {
+.c39 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 24px;
+  margin-right: 20px;
 }
 
-.c57 {
+.c40 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.c41 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 42px;
+  line-height: 50px;
+}
+
+.c44 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  padding-top: 30px;
+}
+
+.c50 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  color: white;
+  padding-bottom: 10px;
+}
+
+.c56 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c70 {
+.c67 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 24px;
   color: white;
 }
 
-.c35 {
+.c73 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 4px;
+}
+
+.c74 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c75 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 20px;
+}
+
+.c82 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1em;
+}
+
+.c88 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c36 {
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
   padding-bottom: 12px;
 }
 
-.c67 {
+.c37 {
+  padding-right: 20px;
+  width: 60px;
+}
+
+.c42 {
+  max-width: 100%;
+}
+
+.c45 {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c53 {
+  margin-top: 40px;
+}
+
+.c61 {
+  width: 100%;
+}
+
+.c64 {
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
 }
 
-.c71 {
+.c68 {
   color: white;
 }
 
-.c72 {
+.c69 {
   margin-bottom: 40px;
+}
+
+.c77 {
+  margin-bottom: 10px;
+  margin-left: 0px;
+  width: 100%;
+}
+
+.c85 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-bottom: 100px;
+  padding-top: 40px;
 }
 
 .c6 {
@@ -150,11 +361,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   z-index: 10;
 }
 
-.c85 {
+.c84 {
   margin: 10px 20px 0 0;
 }
 
-.c85::before {
+.c84::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -164,12 +375,12 @@ exports[`Video Layout matches the snapshot 1`] = `
   background-color: white;
 }
 
-.c56 {
+.c55 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c59 {
+.c58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -183,26 +394,26 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c61 {
+.c60 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c61:hover {
+.c60:hover {
   opacity: 0.6;
 }
 
-.c61:first-child {
+.c60:first-child {
   padding-left: 0;
 }
 
-.c60 {
+.c59 {
   margin: 5px 10px 5px 0;
 }
 
-.c84 {
+.c83 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -222,7 +433,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   height: 32px;
 }
 
-.c81 {
+.c79 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -232,186 +443,39 @@ exports[`Video Layout matches the snapshot 1`] = `
   display: block;
 }
 
-.c79 {
+.c76 {
   position: relative;
-  width: 50%;
   height: inherit;
-  margin-left: 30px;
+  background: white;
 }
 
-.c73 {
+.c70 {
   border: 1px solid;
   border-radius: 2px;
   color: white;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  padding: 30px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: block;
 }
 
-.c73 .c80 {
+.c70 .c78 {
   opacity: 1;
 }
 
-.c73:hover .c80 {
+.c70:hover .c78 {
   opacity: 0.7;
 }
 
-.c73 .c78 {
-  background: black;
-}
-
-.c74 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
-}
-
-.c76 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
-  margin-bottom: 30px;
-}
-
-.c75 {
-  margin-bottom: 10px;
-}
-
-.c77 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c83 {
+.c80 {
   position: absolute;
   left: 20px;
-  bottom: 20px;
   right: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  bottom: 20px;
 }
 
-.c82 svg {
-  width: 40px;
-}
-
-.c39 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
-}
-
-.c37 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c38 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c43 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c49 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c50 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c53 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c63 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c65 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c80 svg {
+  height: 40px;
 }
 
 .c52 {
@@ -600,12 +664,12 @@ exports[`Video Layout matches the snapshot 1`] = `
   text-transform: none;
 }
 
-.c64 {
+.c62 {
   position: relative;
   width: 100%;
 }
 
-.c64 a {
+.c62 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -615,22 +679,22 @@ exports[`Video Layout matches the snapshot 1`] = `
   background-position: bottom;
 }
 
-.c64 a:hover {
+.c62 a:hover {
   color: white;
   opacity: .65;
 }
 
-.c64 div[class*='ToolTip'] a {
+.c62 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c64 p,
-.c64 ul,
-.c64 ol,
-.c64 .paragraph,
-.c64 div[data-block=true] .public-DraftStyleDefault-block {
+.c62 p,
+.c62 ul,
+.c62 ol,
+.c62 .paragraph,
+.c62 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -641,32 +705,32 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-style: inherit;
 }
 
-.c64 p:first-child,
-.c64 .paragraph:first-child,
-.c64 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c62 p:first-child,
+.c62 .paragraph:first-child,
+.c62 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c64 p:last-child,
-.c64 .paragraph:last-child,
-.c64 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c62 p:last-child,
+.c62 .paragraph:last-child,
+.c62 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c64 ul,
-.c64 ol {
+.c62 ul,
+.c62 ol {
   padding-left: 1em;
 }
 
-.c64 ul {
+.c62 ul {
   list-style: disc;
 }
 
-.c64 ol {
+.c62 ol {
   list-style: decimal;
 }
 
-.c64 li {
+.c62 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -675,7 +739,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   padding-bottom: .5em;
 }
 
-.c64 h1 {
+.c62 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -688,7 +752,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   text-align: center;
 }
 
-.c64 h1::before {
+.c62 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -699,7 +763,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   right: calc(50% - 4px);
 }
 
-.c64 h2 {
+.c62 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -708,15 +772,15 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c64 h2 a {
+.c62 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c64 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+.c62 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
   background-position: bottom !important;
 }
 
-.c64 h3 {
+.c62 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -726,7 +790,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c64 h3 strong {
+.c62 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -734,11 +798,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   line-height: 1.5em;
 }
 
-.c64 h3 a {
+.c62 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c64 blockquote {
+.c62 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -751,7 +815,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   word-break: break-word;
 }
 
-.c64 .content-end {
+.c62 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -762,14 +826,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-bottom: 1px;
 }
 
-.c64 .artist-follow {
+.c62 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c64 .artist-follow::before {
+.c62 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -777,49 +841,13 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-size: 32px;
 }
 
-.c64 .artist-follow::after {
+.c62 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
   line-height: 1.1em;
   -webkit-font-smoothing: antialiased;
   text-transform: none;
-}
-
-.c87 {
-  color: white;
-  max-width: 1200px;
-  width: 100%;
-}
-
-.c88 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: none;
-}
-
-.c88:first-of-type {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c88:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: block;
-  margin-bottom: 10px;
-}
-
-.c89 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
 }
 
 .c26 {
@@ -1040,50 +1068,25 @@ exports[`Video Layout matches the snapshot 1`] = `
   opacity: 1;
 }
 
-.c55 {
+.c54 {
   color: white;
 }
 
-.c51 {
-  color: white;
-  margin-bottom: 15px;
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 34px;
-  line-height: 1.1em;
-}
-
-.c48 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c48 p {
+.c48 .c51 p {
   padding: 0;
 }
 
-.c62 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c46 .c54 {
-  margin-top: 40px;
-}
-
-.c69 a {
+.c66 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c66 {
+.c63 {
   color: white;
 }
 
-.c66 .c68 {
+.c63 .c65 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -1092,30 +1095,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-bottom: 40px;
 }
 
-.c66 .c68 a {
+.c63 .c65 a {
   border-bottom: 2px solid;
 }
 
-.c66 .c86 {
-  margin: 60px auto 100px auto;
-}
-
-.c40 {
-  margin-right: 20px;
-}
-
-.c40 a {
+.c38 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c42 {
-  position: relative;
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
 }
 
 .c30 {
@@ -1129,23 +1116,13 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 .c34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
   box-sizing: border-box;
-  padding-bottom: 60px;
   z-index: 1;
 }
 
 .c34 .c18 {
   height: 60px;
   width: 44px;
-  margin-right: 15px;
   cursor: pointer;
 }
 
@@ -1170,13 +1147,8 @@ exports[`Video Layout matches the snapshot 1`] = `
   height: 100%;
 }
 
-.c44 {
+.c43 {
   position: relative;
-  margin-top: 30px;
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
 }
 
 .c0 {
@@ -1190,7 +1162,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   top: 0;
 }
 
-.c0 .c45 {
+.c0 .c46 {
   margin: 60px auto 100px auto;
 }
 
@@ -1206,8 +1178,413 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
+  .c35 {
+    padding-bottom: 60px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c47 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c47 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c47 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c49 {
+    padding-top: 80px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c49 {
+    padding-top: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c49 {
+    padding-top: 0px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c49 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c49 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c49 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c71 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c71 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c71 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c71 {
+    padding: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c71 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c71 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c72 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c72 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c72 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c72 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c72 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c72 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c86 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c86 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c86 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c87 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c87 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c87 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c89 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c89 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c89 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c44 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c44 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c44 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c44 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c44 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c44 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c74 {
+    font-size: 28px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c74 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c74 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c74 {
+    line-height: 36px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c74 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c74 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c75 {
+    font-size: 18px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c75 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c75 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c75 {
+    line-height: 26px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c75 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c75 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c88 {
+    margin-bottom: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c88 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c88 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c42 {
+    max-width: 60%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c61 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c61 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c61 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c69 {
     margin-bottom: 60px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c77 {
+    margin-bottom: 10px;
+    margin-left: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c77 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c77 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c77 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c77 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c77 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c85 {
+    padding-top: 40px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c85 {
+    padding-top: 60px;
   }
 }
 
@@ -1226,193 +1603,8 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media (max-width:900px) {
-  .c79 {
-    width: 100%;
-    margin-left: 0;
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width:900px) {
-  .c73 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-    padding: 20px;
-  }
-}
-
-@media (max-width:900px) {
-  .c74 {
-    width: 100%;
-    margin-bottom: 0;
-  }
-}
-
-@media (max-width:900px) {
-  .c76 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-}
-
-@media (max-width:900px) {
-  .c77 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-    margin-bottom: 20px;
-  }
-}
-
-@media (max-width:900px) {
-  .c82 svg {
-    width: 30px;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c37 {
-    -webkit-flex-basis: 16.666666666666668%;
-    -ms-flex-preferred-size: 16.666666666666668%;
-    flex-basis: 16.666666666666668%;
-    max-width: 16.666666666666668%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c37 {
-    -webkit-flex-basis: 8.333333333333334%;
-    -ms-flex-preferred-size: 8.333333333333334%;
-    flex-basis: 8.333333333333334%;
-    max-width: 8.333333333333334%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c38 {
-    -webkit-flex-basis: 83.33333333333334%;
-    -ms-flex-preferred-size: 83.33333333333334%;
-    flex-basis: 83.33333333333334%;
-    max-width: 83.33333333333334%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c38 {
-    -webkit-flex-basis: 50%;
-    -ms-flex-preferred-size: 50%;
-    flex-basis: 50%;
-    max-width: 50%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c43 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c43 {
-    -webkit-flex-basis: 58.333333333333336%;
-    -ms-flex-preferred-size: 58.333333333333336%;
-    flex-basis: 58.333333333333336%;
-    max-width: 58.333333333333336%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c49 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c49 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c50 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c53 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c53 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c63 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c63 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c65 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c65 {
-    display: none;
+  .c80 svg {
+    height: 30px;
   }
 }
 
@@ -1477,38 +1669,38 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media (max-width:600px) {
-  .c64 p,
-  .c64 ul,
-  .c64 ol,
-  .c64 div[data-block=true] .public-DraftStyleDefault-block {
+  .c62 p,
+  .c62 ul,
+  .c62 ol,
+  .c62 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c64 li {
+  .c62 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c64 h1 {
+  .c62 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c64 h2 {
+  .c62 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c64 h3 {
+  .c62 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1516,14 +1708,14 @@ exports[`Video Layout matches the snapshot 1`] = `
     line-height: 1.5em;
   }
 
-  .c64 h3 strong {
+  .c62 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c64 blockquote {
+  .c62 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -1531,100 +1723,19 @@ exports[`Video Layout matches the snapshot 1`] = `
     margin: 0;
   }
 
-  .c64 .content-start {
+  .c62 .content-start {
     font-size: 55px;
   }
 }
 
 @media (max-width:768px) {
-  .c88:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    display: none;
-  }
-
-  .c88 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    margin-top: 60px;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c89 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (max-width:768px) {
-  .c55 .c58 {
+  .c54 .c57 {
     margin-top: 0px;
   }
 }
 
-@media (max-width:720px) {
-  .c51 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-}
-
-@media (max-width:720px) {
-  .c48 {
-    margin-top: 80px;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (max-width:720px) {
-  .c46 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
 @media (max-width:768px) {
-  .c66 .c68 a {
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c66 .c86 {
-    margin: 40px auto 100px auto;
-  }
-}
-
-@media (max-width:768px) {
-  .c36 {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-  }
-}
-
-@media (max-width:768px) {
-  .c34 {
-    padding-bottom: 40px;
-  }
-}
-
-@media (max-width:768px) {
-  .c44 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-  }
-}
-
-@media (max-width:768px) {
-  .c0 .c45 {
+  .c0 .c46 {
     margin: 40px auto 100px auto;
   }
 }
@@ -1844,17 +1955,18 @@ exports[`Video Layout matches the snapshot 1`] = `
         className="c31 c32"
       />
       <div
-        className="c33 c34"
+        className="c33 c34 c35"
       >
         <div
-          className="c35"
+          className="c36"
         >
           <div
             className="c3"
           >
             <div
-              className="c36 c37"
+              className="c37"
               onClick={[Function]}
+              width="60px"
             >
               <svg
                 className="c18 c19"
@@ -1878,14 +1990,14 @@ exports[`Video Layout matches the snapshot 1`] = `
               </svg>
             </div>
             <div
-              className="c36 c38"
+              className=""
             >
               <div>
                 <div
-                  className="c39"
+                  className="c3"
                 >
                   <div
-                    className="c40 c41"
+                    className="c38 c39"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize="14px"
                   >
@@ -1896,7 +2008,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     </a>
                   </div>
                   <div
-                    className="c41"
+                    className="c40"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize="14px"
                   >
@@ -1904,22 +2016,29 @@ exports[`Video Layout matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  className="c39"
+                  className="c41"
+                  fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                  fontSize="42px"
                 >
-                  <span
-                    className="c42"
-                  >
-                    Trevor Paglan
-                  </span>
+                  Trevor Paglan
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="c36 c43"
+            className="c42"
           >
             <div
-              className="c44"
+              className="c43 c44"
+              fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+              fontSize={
+                Array [
+                  "18px",
+                  "22px",
+                  "22px",
+                  "22px",
+                ]
+              }
             >
               The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
             </div>
@@ -1929,22 +2048,32 @@ exports[`Video Layout matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c45 c46 c47"
+    className="c45"
   >
     <div
-      className="c48 c49"
+      className="c46 c47"
     >
       <div
-        className="c50"
+        className="c48 c49"
+        width={
+          Array [
+            1,
+            1,
+            0.3333333333333333,
+            0.3333333333333333,
+          ]
+        }
       >
         <div
-          className="c51"
+          className="c50"
           color="white"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="28px"
         >
           Credits
         </div>
         <div
-          className="article__text-section c52"
+          className="article__text-section c51 c52"
           color="black"
         >
           <div
@@ -1955,140 +2084,150 @@ exports[`Video Layout matches the snapshot 1`] = `
             }
           />
         </div>
-      </div>
-      <div
-        className="c53"
-      >
         <div
-          className="c54 c55"
+          className="rrm-container rrm-greaterThanOrEqual-md"
         >
           <div
-            className="c56"
+            className="c53"
           >
             <div
-              className="c57"
-              fontFamily={
-                Object {
-                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                  "fontWeight": 500,
-                }
-              }
-              fontSize="14px"
+              className="c54"
             >
-              Jul 28, 2017 4:38 pm
+              <div
+                className="c55"
+              >
+                <div
+                  className="c56"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  Jul 28, 2017 4:38 pm
+                </div>
+              </div>
+              <div
+                className="c57 c58"
+              >
+                <div
+                  className="c59 c56"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  Share
+                </div>
+                <a
+                  className="c60"
+                  href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+                  onClick={[Function]}
+                  target="_blank"
+                >
+                  <svg
+                    height="14px"
+                    version="1.1"
+                    viewBox="0 0 14 14"
+                    width="14px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <path
+                        d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                        fill="white"
+                      />
+                    </g>
+                  </svg>
+                </a>
+                <a
+                  className="c60"
+                  href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+                  onClick={[Function]}
+                  target="_blank"
+                >
+                  <svg
+                    height="14px"
+                    version="1.1"
+                    viewBox="0 0 16 14"
+                    width="16px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <path
+                        d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                        fill="white"
+                      />
+                    </g>
+                  </svg>
+                </a>
+                <a
+                  className="c60"
+                  href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
+                  onClick={[Function]}
+                  target="_blank"
+                >
+                  <svg
+                    height="14px"
+                    version="1.1"
+                    viewBox="0 0 17 14"
+                    width="17px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <path
+                        d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                        fill="white"
+                      />
+                    </g>
+                  </svg>
+                </a>
+              </div>
             </div>
-          </div>
-          <div
-            className="c58 c59"
-          >
-            <div
-              className="c60 c57"
-              fontFamily={
-                Object {
-                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                  "fontWeight": 500,
-                }
-              }
-              fontSize="14px"
-            >
-              Share
-            </div>
-            <a
-              className="c61"
-              href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
-              onClick={[Function]}
-              target="_blank"
-            >
-              <svg
-                height="14px"
-                version="1.1"
-                viewBox="0 0 14 14"
-                width="14px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
-                >
-                  <path
-                    d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-                    fill="white"
-                  />
-                </g>
-              </svg>
-            </a>
-            <a
-              className="c61"
-              href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
-              onClick={[Function]}
-              target="_blank"
-            >
-              <svg
-                height="14px"
-                version="1.1"
-                viewBox="0 0 16 14"
-                width="16px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
-                >
-                  <path
-                    d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-                    fill="white"
-                  />
-                </g>
-              </svg>
-            </a>
-            <a
-              className="c61"
-              href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
-              onClick={[Function]}
-              target="_blank"
-            >
-              <svg
-                height="14px"
-                version="1.1"
-                viewBox="0 0 17 14"
-                width="17px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
-                >
-                  <path
-                    d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-                    fill="white"
-                  />
-                </g>
-              </svg>
-            </a>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="c62 c63"
-    >
       <div
-        className="c50"
+        className="c61"
+        width={
+          Array [
+            1,
+            1,
+            0.6666666666666666,
+            0.6666666666666666,
+          ]
+        }
       >
         <div
-          className="c51"
+          className="c50"
           color="white"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="28px"
         >
           About the Film
         </div>
         <div
-          className="article__text-section c64"
+          className="article__text-section c51 c62"
           color="white"
         >
           <div
@@ -2099,376 +2238,481 @@ exports[`Video Layout matches the snapshot 1`] = `
             }
           />
         </div>
-      </div>
-      <div
-        className="c65"
-      >
         <div
-          className="c54 c55"
+          className="rrm-container rrm-lessThan-md"
         >
           <div
-            className="c56"
+            className="c53"
           >
             <div
-              className="c57"
-              fontFamily={
-                Object {
-                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                  "fontWeight": 500,
-                }
-              }
-              fontSize="14px"
+              className="c54"
             >
-              Jul 28, 2017 4:38 pm
+              <div
+                className="c55"
+              >
+                <div
+                  className="c56"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  Jul 28, 2017 4:38 pm
+                </div>
+              </div>
+              <div
+                className="c57 c58"
+              >
+                <div
+                  className="c59 c56"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  Share
+                </div>
+                <a
+                  className="c60"
+                  href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+                  onClick={[Function]}
+                  target="_blank"
+                >
+                  <svg
+                    height="14px"
+                    version="1.1"
+                    viewBox="0 0 14 14"
+                    width="14px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <path
+                        d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                        fill="white"
+                      />
+                    </g>
+                  </svg>
+                </a>
+                <a
+                  className="c60"
+                  href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+                  onClick={[Function]}
+                  target="_blank"
+                >
+                  <svg
+                    height="14px"
+                    version="1.1"
+                    viewBox="0 0 16 14"
+                    width="16px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <path
+                        d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                        fill="white"
+                      />
+                    </g>
+                  </svg>
+                </a>
+                <a
+                  className="c60"
+                  href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
+                  onClick={[Function]}
+                  target="_blank"
+                >
+                  <svg
+                    height="14px"
+                    version="1.1"
+                    viewBox="0 0 17 14"
+                    width="17px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fillRule="evenodd"
+                      stroke="none"
+                      strokeWidth="1"
+                    >
+                      <path
+                        d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                        fill="white"
+                      />
+                    </g>
+                  </svg>
+                </a>
+              </div>
             </div>
-          </div>
-          <div
-            className="c58 c59"
-          >
-            <div
-              className="c60 c57"
-              fontFamily={
-                Object {
-                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                  "fontWeight": 500,
-                }
-              }
-              fontSize="14px"
-            >
-              Share
-            </div>
-            <a
-              className="c61"
-              href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
-              onClick={[Function]}
-              target="_blank"
-            >
-              <svg
-                height="14px"
-                version="1.1"
-                viewBox="0 0 14 14"
-                width="14px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
-                >
-                  <path
-                    d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-                    fill="white"
-                  />
-                </g>
-              </svg>
-            </a>
-            <a
-              className="c61"
-              href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
-              onClick={[Function]}
-              target="_blank"
-            >
-              <svg
-                height="14px"
-                version="1.1"
-                viewBox="0 0 16 14"
-                width="16px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
-                >
-                  <path
-                    d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-                    fill="white"
-                  />
-                </g>
-              </svg>
-            </a>
-            <a
-              className="c61"
-              href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
-              onClick={[Function]}
-              target="_blank"
-            >
-              <svg
-                height="14px"
-                version="1.1"
-                viewBox="0 0 17 14"
-                width="17px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
-                >
-                  <path
-                    d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-                    fill="white"
-                  />
-                </g>
-              </svg>
-            </a>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="c66"
-    color="white"
-  >
     <div
-      className="c67"
+      className="c63"
+      color="white"
     >
       <div
-        className="c68 c69 c70"
-        color="white"
-        fontFamily={
-          Object {
-            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-            "fontWeight": 500,
-          }
-        }
-        fontSize="14px"
-      >
-        More in 
-        <a
-          href="/series/future-of-art"
-        >
-          The Future of Art
-        </a>
-      </div>
-      <div
-        className="c71"
-        color="white"
+        className="c64"
       >
         <div
-          className="c72"
+          className="c65 c66 c67"
+          color="white"
+          fontFamily={
+            Object {
+              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+              "fontWeight": 500,
+            }
+          }
+          fontSize="14px"
         >
+          More in 
           <a
-            className="ArticleCard c73"
-            color="white"
-            href="joanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
+            href="/series/future-of-art"
           >
-            <div
-              className="c74"
-            >
-              <div>
-                <div
-                  className="c75 c57"
-                  fontFamily={
-                    Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
-                    }
-                  }
-                  fontSize="14px"
-                >
-                  The Future of Art
-                </div>
-                <div
-                  className="c76"
-                >
-                  New Study Shows the Gender Pay Gap for Artists Is Not So Simple
-                </div>
-                <div
-                  className="c77"
-                >
-                  The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
-                </div>
-              </div>
-              <div
-                className="c56"
-              >
-                <div
-                  className="c57"
-                  fontFamily={
-                    Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
-                    }
-                  }
-                  fontSize="14px"
-                >
-                  Aug 28, 2017
-                </div>
-              </div>
-            </div>
-            <div
-              className="c78 c79"
-            >
-              <img
-                className="c80 c81"
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
-              />
-              <div
-                className="c82 c83"
-              >
-                <svg
-                  className="c18 c19"
-                  version="1.1"
-                  viewBox="0 0 40 56"
-                  x="0px"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0px"
-                >
-                  <g
-                    fill="none"
-                    fillRule="evenodd"
-                    stroke="none"
-                    strokeWidth="1"
-                  >
-                    <polygon
-                      fill="white"
-                      points="0 0 0 56 39.3600006 28"
-                    />
-                  </g>
-                </svg>
-                <div
-                  className="c57"
-                  fontFamily={
-                    Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
-                    }
-                  }
-                  fontSize="14px"
-                >
-                  02:28
-                </div>
-              </div>
-            </div>
+            The Future of Art
           </a>
         </div>
         <div
-          className="c72"
+          className="c68"
+          color="white"
         >
-          <a
-            className="ArticleCard c73"
-            color="white"
-            href="new-yorks-next-art-district"
-            onClick={[Function]}
+          <div
+            className="c69"
           >
-            <div
-              className="c74"
+            <a
+              className="ArticleCard c70"
+              color="white"
+              href="joanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
             >
-              <div>
+              <div
+                className="c71"
+              >
                 <div
-                  className="c75 c57"
-                  fontFamily={
-                    Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
-                    }
+                  className="c72"
+                  width={
+                    Array [
+                      "100%",
+                      "100%",
+                      "50%",
+                      "50%",
+                    ]
                   }
-                  fontSize="14px"
                 >
-                  The Future of Art
+                  <div>
+                    <div
+                      className="c73"
+                      fontFamily={
+                        Object {
+                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                          "fontWeight": 500,
+                        }
+                      }
+                      fontSize="14px"
+                    >
+                      The Future of Art
+                    </div>
+                    <div
+                      className="c74"
+                      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                      fontSize={
+                        Array [
+                          "28px",
+                          "28px",
+                          "42px",
+                          "42px",
+                        ]
+                      }
+                    >
+                      New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+                    </div>
+                    <div
+                      className="c75"
+                      fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                      fontSize={
+                        Array [
+                          "18px",
+                          "18px",
+                          "22px",
+                          "22px",
+                        ]
+                      }
+                    >
+                      The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
+                    </div>
+                  </div>
+                  <div
+                    className="c55"
+                  >
+                    <div
+                      className="c56"
+                      fontFamily={
+                        Object {
+                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                          "fontWeight": 500,
+                        }
+                      }
+                      fontSize="14px"
+                    >
+                      Aug 28, 2017
+                    </div>
+                  </div>
                 </div>
                 <div
-                  className="c76"
+                  className="c76 c77"
+                  width={
+                    Array [
+                      "100%",
+                      "100%",
+                      "50%",
+                      "50%",
+                    ]
+                  }
                 >
-                  New York's Next Art District
-                </div>
-                <div
-                  className="c77"
-                >
-                  Land exhibitions, make influential contacts, and gain valuable feedback about your work.
+                  <img
+                    className="c78 c79"
+                    src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+                  />
+                  <div
+                    className="c80 c81"
+                  >
+                    <svg
+                      className="c18 c19"
+                      version="1.1"
+                      viewBox="0 0 40 56"
+                      x="0px"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0px"
+                    >
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                        stroke="none"
+                        strokeWidth="1"
+                      >
+                        <polygon
+                          fill="white"
+                          points="0 0 0 56 39.3600006 28"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      className="c82"
+                      fontFamily={
+                        Object {
+                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                          "fontWeight": 500,
+                        }
+                      }
+                      fontSize="14px"
+                    >
+                      02:28
+                    </div>
+                  </div>
                 </div>
               </div>
+            </a>
+          </div>
+          <div
+            className="c69"
+          >
+            <a
+              className="ArticleCard c70"
+              color="white"
+              href="new-yorks-next-art-district"
+              onClick={[Function]}
+            >
               <div
-                className="Byline c84"
+                className="c71"
+              >
+                <div
+                  className="c72"
+                  width={
+                    Array [
+                      "100%",
+                      "100%",
+                      "50%",
+                      "50%",
+                    ]
+                  }
+                >
+                  <div>
+                    <div
+                      className="c73"
+                      fontFamily={
+                        Object {
+                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                          "fontWeight": 500,
+                        }
+                      }
+                      fontSize="14px"
+                    >
+                      The Future of Art
+                    </div>
+                    <div
+                      className="c74"
+                      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                      fontSize={
+                        Array [
+                          "28px",
+                          "28px",
+                          "42px",
+                          "42px",
+                        ]
+                      }
+                    >
+                      New York's Next Art District
+                    </div>
+                    <div
+                      className="c75"
+                      fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                      fontSize={
+                        Array [
+                          "18px",
+                          "18px",
+                          "22px",
+                          "22px",
+                        ]
+                      }
+                    >
+                      Land exhibitions, make influential contacts, and gain valuable feedback about your work.
+                    </div>
+                  </div>
+                  <div
+                    className="Byline c83"
+                    color="white"
+                  >
+                    <div
+                      className="c56"
+                      fontFamily={
+                        Object {
+                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                          "fontWeight": 500,
+                        }
+                      }
+                      fontSize="14px"
+                    >
+                      <div
+                        className="c84"
+                        color="white"
+                      >
+                        Casey Lesser
+                      </div>
+                    </div>
+                    <div
+                      className="c55"
+                    >
+                      <div
+                        className="c56"
+                        fontFamily={
+                          Object {
+                            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                            "fontWeight": 500,
+                          }
+                        }
+                        fontSize="14px"
+                      >
+                        May 19, 2017
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="c76 c77"
+                  width={
+                    Array [
+                      "100%",
+                      "100%",
+                      "50%",
+                      "50%",
+                    ]
+                  }
+                >
+                  <img
+                    className="c78 c79"
+                    src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+                  />
+                </div>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        className="c85"
+      >
+        <div
+          className="c86"
+          color="white"
+          width="100%"
+        >
+          <div
+            className="c87"
+            width={
+              Array [
+                1,
+                1,
+                0.3333333333333333,
+                0.3333333333333333,
+              ]
+            }
+          >
+            <div
+              className="c88"
+              fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+              fontSize="28px"
+            >
+              About the Series
+            </div>
+            <div
+              className="rrm-container rrm-greaterThanOrEqual-md"
+            />
+          </div>
+          <div
+            className="c89"
+            width={
+              Array [
+                1,
+                1,
+                0.6666666666666666,
+                0.6666666666666666,
+              ]
+            }
+          >
+            <div
+              className="SeriesAbout__description"
+            >
+              <div
+                className="article__text-section c51 c62"
                 color="white"
               >
                 <div
-                  className="c57"
-                  fontFamily={
+                  dangerouslySetInnerHTML={
                     Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
+                      "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
                     }
                   }
-                  fontSize="14px"
-                >
-                  <div
-                    className="c85"
-                    color="white"
-                  >
-                    Casey Lesser
-                  </div>
-                </div>
-                <div
-                  className="c56"
-                >
-                  <div
-                    className="c57"
-                    fontFamily={
-                      Object {
-                        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                        "fontWeight": 500,
-                      }
-                    }
-                    fontSize="14px"
-                  >
-                    May 19, 2017
-                  </div>
-                </div>
+                />
               </div>
             </div>
             <div
-              className="c78 c79"
-            >
-              <img
-                className="c80 c81"
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
-              />
-            </div>
-          </a>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c67"
-    >
-      <div
-        className="c86 c87 c39"
-        color="white"
-      >
-        <div
-          className="c88 c49"
-        >
-          <div
-            className="c89"
-          >
-            About the Series
-          </div>
-        </div>
-        <div
-          className="c88 c63"
-        >
-          <div
-            className="SeriesAbout__description"
-          >
-            <div
-              className="article__text-section c64"
-              color="white"
-            >
-              <div
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-                  }
-                }
-              />
-            </div>
+              className="rrm-container rrm-lessThan-md"
+            />
           </div>
         </div>
       </div>

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   padding-right: 20px;
 }
 
-.c47 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -35,7 +35,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   max-width: 1200px;
 }
 
-.c49 {
+.c48 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -157,14 +157,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   line-height: 50px;
 }
 
-.c44 {
+.c43 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 18px;
   line-height: 26px;
   padding-top: 30px;
 }
 
-.c50 {
+.c49 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-size: 28px;
   line-height: 36px;
@@ -172,7 +172,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   padding-bottom: 10px;
 }
 
-.c56 {
+.c55 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
@@ -239,17 +239,28 @@ exports[`Video Layout matches the snapshot 1`] = `
   max-width: 100%;
 }
 
-.c45 {
+.c44 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
   padding-left: 20px;
   padding-right: 20px;
 }
 
-.c53 {
+.c45 {
+  padding-top: 40px;
+}
+
+.c52 {
   margin-top: 40px;
 }
 
-.c61 {
+.c60 {
   width: 100%;
+}
+
+.c62 {
+  padding-top: 60px;
 }
 
 .c64 {
@@ -375,12 +386,12 @@ exports[`Video Layout matches the snapshot 1`] = `
   background-color: white;
 }
 
-.c55 {
+.c54 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c58 {
+.c57 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -394,22 +405,22 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c60 {
+.c59 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c60:hover {
+.c59:hover {
   opacity: 0.6;
 }
 
-.c60:first-child {
+.c59:first-child {
   padding-left: 0;
 }
 
-.c59 {
+.c58 {
   margin: 5px 10px 5px 0;
 }
 
@@ -478,12 +489,12 @@ exports[`Video Layout matches the snapshot 1`] = `
   height: 40px;
 }
 
-.c52 {
+.c51 {
   position: relative;
   width: 100%;
 }
 
-.c52 a {
+.c51 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -493,22 +504,22 @@ exports[`Video Layout matches the snapshot 1`] = `
   background-position: bottom;
 }
 
-.c52 a:hover {
+.c51 a:hover {
   color: #999999;
   opacity: 1;
 }
 
-.c52 div[class*='ToolTip'] a {
+.c51 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c52 p,
-.c52 ul,
-.c52 ol,
-.c52 .paragraph,
-.c52 div[data-block=true] .public-DraftStyleDefault-block {
+.c51 p,
+.c51 ul,
+.c51 ol,
+.c51 .paragraph,
+.c51 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -519,32 +530,32 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-style: inherit;
 }
 
-.c52 p:first-child,
-.c52 .paragraph:first-child,
-.c52 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c51 p:first-child,
+.c51 .paragraph:first-child,
+.c51 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c52 p:last-child,
-.c52 .paragraph:last-child,
-.c52 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c51 p:last-child,
+.c51 .paragraph:last-child,
+.c51 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c52 ul,
-.c52 ol {
+.c51 ul,
+.c51 ol {
   padding-left: 1em;
 }
 
-.c52 ul {
+.c51 ul {
   list-style: disc;
 }
 
-.c52 ol {
+.c51 ol {
   list-style: decimal;
 }
 
-.c52 li {
+.c51 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -553,7 +564,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   padding-bottom: .5em;
 }
 
-.c52 h1 {
+.c51 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -566,7 +577,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   text-align: center;
 }
 
-.c52 h1::before {
+.c51 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -577,7 +588,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   right: calc(50% - 4px);
 }
 
-.c52 h2 {
+.c51 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -586,15 +597,15 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c52 h2 a {
+.c51 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c52 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+.c51 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
   background-position: bottom !important;
 }
 
-.c52 h3 {
+.c51 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -604,7 +615,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c52 h3 strong {
+.c51 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -612,11 +623,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   line-height: 1.5em;
 }
 
-.c52 h3 a {
+.c51 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c52 blockquote {
+.c51 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -629,7 +640,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   word-break: break-word;
 }
 
-.c52 .content-end {
+.c51 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -640,14 +651,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-bottom: 1px;
 }
 
-.c52 .artist-follow {
+.c51 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c52 .artist-follow::before {
+.c51 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -655,7 +666,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-size: 32px;
 }
 
-.c52 .artist-follow::after {
+.c51 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -664,12 +675,12 @@ exports[`Video Layout matches the snapshot 1`] = `
   text-transform: none;
 }
 
-.c62 {
+.c61 {
   position: relative;
   width: 100%;
 }
 
-.c62 a {
+.c61 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -679,22 +690,22 @@ exports[`Video Layout matches the snapshot 1`] = `
   background-position: bottom;
 }
 
-.c62 a:hover {
+.c61 a:hover {
   color: white;
   opacity: .65;
 }
 
-.c62 div[class*='ToolTip'] a {
+.c61 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c62 p,
-.c62 ul,
-.c62 ol,
-.c62 .paragraph,
-.c62 div[data-block=true] .public-DraftStyleDefault-block {
+.c61 p,
+.c61 ul,
+.c61 ol,
+.c61 .paragraph,
+.c61 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -705,32 +716,32 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-style: inherit;
 }
 
-.c62 p:first-child,
-.c62 .paragraph:first-child,
-.c62 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c61 p:first-child,
+.c61 .paragraph:first-child,
+.c61 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c62 p:last-child,
-.c62 .paragraph:last-child,
-.c62 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c61 p:last-child,
+.c61 .paragraph:last-child,
+.c61 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c62 ul,
-.c62 ol {
+.c61 ul,
+.c61 ol {
   padding-left: 1em;
 }
 
-.c62 ul {
+.c61 ul {
   list-style: disc;
 }
 
-.c62 ol {
+.c61 ol {
   list-style: decimal;
 }
 
-.c62 li {
+.c61 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -739,7 +750,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   padding-bottom: .5em;
 }
 
-.c62 h1 {
+.c61 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -752,7 +763,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   text-align: center;
 }
 
-.c62 h1::before {
+.c61 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -763,7 +774,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   right: calc(50% - 4px);
 }
 
-.c62 h2 {
+.c61 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -772,15 +783,15 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c62 h2 a {
+.c61 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c62 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+.c61 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
   background-position: bottom !important;
 }
 
-.c62 h3 {
+.c61 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -790,7 +801,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c62 h3 strong {
+.c61 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -798,11 +809,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   line-height: 1.5em;
 }
 
-.c62 h3 a {
+.c61 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c62 blockquote {
+.c61 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -815,7 +826,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   word-break: break-word;
 }
 
-.c62 .content-end {
+.c61 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -826,14 +837,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-bottom: 1px;
 }
 
-.c62 .artist-follow {
+.c61 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c62 .artist-follow::before {
+.c61 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -841,7 +852,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-size: 32px;
 }
 
-.c62 .artist-follow::after {
+.c61 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -1068,11 +1079,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   opacity: 1;
 }
 
-.c54 {
+.c53 {
   color: white;
 }
 
-.c48 .c51 p {
+.c47 .c50 p {
   padding: 0;
 }
 
@@ -1147,10 +1158,6 @@ exports[`Video Layout matches the snapshot 1`] = `
   height: 100%;
 }
 
-.c43 {
-  position: relative;
-}
-
 .c0 {
   background: black;
   color: white;
@@ -1160,10 +1167,6 @@ exports[`Video Layout matches the snapshot 1`] = `
 .c0 .c1 {
   position: absolute;
   top: 0;
-}
-
-.c0 .c46 {
-  margin: 60px auto 100px auto;
 }
 
 .c9 {
@@ -1184,7 +1187,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c47 {
+  .c46 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
@@ -1192,7 +1195,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c47 {
+  .c46 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1200,7 +1203,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:64em) {
-  .c47 {
+  .c46 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1208,37 +1211,37 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c49 {
+  .c48 {
     padding-top: 80px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c49 {
+  .c48 {
     padding-top: 0px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c49 {
+  .c48 {
     padding-top: 0px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c49 {
+  .c48 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c49 {
+  .c48 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c49 {
+  .c48 {
     width: 33.33333333333333%;
   }
 }
@@ -1382,37 +1385,37 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c44 {
+  .c43 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c44 {
+  .c43 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c44 {
+  .c43 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c44 {
+  .c43 {
     line-height: 32px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c44 {
+  .c43 {
     line-height: 32px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c44 {
+  .c43 {
     line-height: 32px;
   }
 }
@@ -1514,20 +1517,44 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c61 {
+  .c45 {
+    padding-top: 40px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c45 {
+    padding-top: 60px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c60 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c61 {
+  .c60 {
     width: 66.66666666666666%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c61 {
+  .c60 {
     width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c62 {
+    padding-top: 60px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c62 {
+    padding-top: 100px;
   }
 }
 
@@ -1609,38 +1636,38 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media (max-width:600px) {
-  .c52 p,
-  .c52 ul,
-  .c52 ol,
-  .c52 div[data-block=true] .public-DraftStyleDefault-block {
+  .c51 p,
+  .c51 ul,
+  .c51 ol,
+  .c51 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c52 li {
+  .c51 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c52 h1 {
+  .c51 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c52 h2 {
+  .c51 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c52 h3 {
+  .c51 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1648,14 +1675,14 @@ exports[`Video Layout matches the snapshot 1`] = `
     line-height: 1.5em;
   }
 
-  .c52 h3 strong {
+  .c51 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c52 blockquote {
+  .c51 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -1663,44 +1690,44 @@ exports[`Video Layout matches the snapshot 1`] = `
     margin: 0;
   }
 
-  .c52 .content-start {
+  .c51 .content-start {
     font-size: 55px;
   }
 }
 
 @media (max-width:600px) {
-  .c62 p,
-  .c62 ul,
-  .c62 ol,
-  .c62 div[data-block=true] .public-DraftStyleDefault-block {
+  .c61 p,
+  .c61 ul,
+  .c61 ol,
+  .c61 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c62 li {
+  .c61 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c62 h1 {
+  .c61 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c62 h2 {
+  .c61 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c62 h3 {
+  .c61 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1708,14 +1735,14 @@ exports[`Video Layout matches the snapshot 1`] = `
     line-height: 1.5em;
   }
 
-  .c62 h3 strong {
+  .c61 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c62 blockquote {
+  .c61 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -1723,20 +1750,14 @@ exports[`Video Layout matches the snapshot 1`] = `
     margin: 0;
   }
 
-  .c62 .content-start {
+  .c61 .content-start {
     font-size: 55px;
   }
 }
 
 @media (max-width:768px) {
-  .c54 .c57 {
+  .c53 .c56 {
     margin-top: 0px;
-  }
-}
-
-@media (max-width:768px) {
-  .c0 .c46 {
-    margin: 40px auto 100px auto;
   }
 }
 
@@ -2029,7 +2050,7 @@ exports[`Video Layout matches the snapshot 1`] = `
             className="c42"
           >
             <div
-              className="c43 c44"
+              className="c43"
               fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
               fontSize={
                 Array [
@@ -2048,456 +2069,97 @@ exports[`Video Layout matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c45"
+    className="c44"
   >
     <div
-      className="c46 c47"
+      className="c45"
     >
       <div
-        className="c48 c49"
-        width={
-          Array [
-            1,
-            1,
-            0.3333333333333333,
-            0.3333333333333333,
-          ]
-        }
+        className="c46"
       >
         <div
-          className="c50"
-          color="white"
-          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
-          fontSize="28px"
-        >
-          Credits
-        </div>
-        <div
-          className="article__text-section c51 c52"
-          color="black"
-        >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p><b>Director</b></p><p>Marina Cashdan</p><p><b>Featuring</b></p><p>Trevor Paglan</p>",
-              }
-            }
-          />
-        </div>
-        <div
-          className="rrm-container rrm-greaterThanOrEqual-md"
-        >
-          <div
-            className="c53"
-          >
-            <div
-              className="c54"
-            >
-              <div
-                className="c55"
-              >
-                <div
-                  className="c56"
-                  fontFamily={
-                    Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
-                    }
-                  }
-                  fontSize="14px"
-                >
-                  Jul 28, 2017 4:38 pm
-                </div>
-              </div>
-              <div
-                className="c57 c58"
-              >
-                <div
-                  className="c59 c56"
-                  fontFamily={
-                    Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
-                    }
-                  }
-                  fontSize="14px"
-                >
-                  Share
-                </div>
-                <a
-                  className="c60"
-                  href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
-                  onClick={[Function]}
-                  target="_blank"
-                >
-                  <svg
-                    height="14px"
-                    version="1.1"
-                    viewBox="0 0 14 14"
-                    width="14px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      fill="none"
-                      fillRule="evenodd"
-                      stroke="none"
-                      strokeWidth="1"
-                    >
-                      <path
-                        d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-                        fill="white"
-                      />
-                    </g>
-                  </svg>
-                </a>
-                <a
-                  className="c60"
-                  href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
-                  onClick={[Function]}
-                  target="_blank"
-                >
-                  <svg
-                    height="14px"
-                    version="1.1"
-                    viewBox="0 0 16 14"
-                    width="16px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      fill="none"
-                      fillRule="evenodd"
-                      stroke="none"
-                      strokeWidth="1"
-                    >
-                      <path
-                        d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-                        fill="white"
-                      />
-                    </g>
-                  </svg>
-                </a>
-                <a
-                  className="c60"
-                  href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
-                  onClick={[Function]}
-                  target="_blank"
-                >
-                  <svg
-                    height="14px"
-                    version="1.1"
-                    viewBox="0 0 17 14"
-                    width="17px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      fill="none"
-                      fillRule="evenodd"
-                      stroke="none"
-                      strokeWidth="1"
-                    >
-                      <path
-                        d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-                        fill="white"
-                      />
-                    </g>
-                  </svg>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="c61"
-        width={
-          Array [
-            1,
-            1,
-            0.6666666666666666,
-            0.6666666666666666,
-          ]
-        }
-      >
-        <div
-          className="c50"
-          color="white"
-          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
-          fontSize="28px"
-        >
-          About the Film
-        </div>
-        <div
-          className="article__text-section c51 c62"
-          color="white"
-        >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p>Integer posuere erat a ante venenatis <a href='artsy.net'>dapibus posuere velit</a> aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-              }
-            }
-          />
-        </div>
-        <div
-          className="rrm-container rrm-lessThan-md"
-        >
-          <div
-            className="c53"
-          >
-            <div
-              className="c54"
-            >
-              <div
-                className="c55"
-              >
-                <div
-                  className="c56"
-                  fontFamily={
-                    Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
-                    }
-                  }
-                  fontSize="14px"
-                >
-                  Jul 28, 2017 4:38 pm
-                </div>
-              </div>
-              <div
-                className="c57 c58"
-              >
-                <div
-                  className="c59 c56"
-                  fontFamily={
-                    Object {
-                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                      "fontWeight": 500,
-                    }
-                  }
-                  fontSize="14px"
-                >
-                  Share
-                </div>
-                <a
-                  className="c60"
-                  href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
-                  onClick={[Function]}
-                  target="_blank"
-                >
-                  <svg
-                    height="14px"
-                    version="1.1"
-                    viewBox="0 0 14 14"
-                    width="14px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      fill="none"
-                      fillRule="evenodd"
-                      stroke="none"
-                      strokeWidth="1"
-                    >
-                      <path
-                        d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-                        fill="white"
-                      />
-                    </g>
-                  </svg>
-                </a>
-                <a
-                  className="c60"
-                  href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
-                  onClick={[Function]}
-                  target="_blank"
-                >
-                  <svg
-                    height="14px"
-                    version="1.1"
-                    viewBox="0 0 16 14"
-                    width="16px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      fill="none"
-                      fillRule="evenodd"
-                      stroke="none"
-                      strokeWidth="1"
-                    >
-                      <path
-                        d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-                        fill="white"
-                      />
-                    </g>
-                  </svg>
-                </a>
-                <a
-                  className="c60"
-                  href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
-                  onClick={[Function]}
-                  target="_blank"
-                >
-                  <svg
-                    height="14px"
-                    version="1.1"
-                    viewBox="0 0 17 14"
-                    width="17px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      fill="none"
-                      fillRule="evenodd"
-                      stroke="none"
-                      strokeWidth="1"
-                    >
-                      <path
-                        d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-                        fill="white"
-                      />
-                    </g>
-                  </svg>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c63"
-      color="white"
-    >
-      <div
-        className="c64"
-      >
-        <div
-          className="c65 c66 c67"
-          color="white"
-          fontFamily={
-            Object {
-              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-              "fontWeight": 500,
-            }
+          className="c47 c48"
+          width={
+            Array [
+              1,
+              1,
+              0.3333333333333333,
+              0.3333333333333333,
+            ]
           }
-          fontSize="14px"
-        >
-          More in 
-          <a
-            href="/series/future-of-art"
-          >
-            The Future of Art
-          </a>
-        </div>
-        <div
-          className="c68"
-          color="white"
         >
           <div
-            className="c69"
+            className="c49"
+            color="white"
+            fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+            fontSize="28px"
           >
-            <a
-              className="ArticleCard c70"
-              color="white"
-              href="joanne-artman-gallery-poetry-naturerefinement-form"
-              onClick={[Function]}
+            Credits
+          </div>
+          <div
+            className="article__text-section c50 c51"
+            color="black"
+          >
+            <div
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "<p><b>Director</b></p><p>Marina Cashdan</p><p><b>Featuring</b></p><p>Trevor Paglan</p>",
+                }
+              }
+            />
+          </div>
+          <div
+            className="rrm-container rrm-greaterThanOrEqual-md"
+          >
+            <div
+              className="c52"
             >
               <div
-                className="c71"
+                className="c53"
               >
                 <div
-                  className="c72"
-                  width={
-                    Array [
-                      "100%",
-                      "100%",
-                      "50%",
-                      "50%",
-                    ]
-                  }
+                  className="c54"
                 >
-                  <div>
-                    <div
-                      className="c73"
-                      fontFamily={
-                        Object {
-                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                          "fontWeight": 500,
-                        }
-                      }
-                      fontSize="14px"
-                    >
-                      The Future of Art
-                    </div>
-                    <div
-                      className="c74"
-                      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
-                      fontSize={
-                        Array [
-                          "28px",
-                          "28px",
-                          "42px",
-                          "42px",
-                        ]
-                      }
-                    >
-                      New Study Shows the Gender Pay Gap for Artists Is Not So Simple
-                    </div>
-                    <div
-                      className="c75"
-                      fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
-                      fontSize={
-                        Array [
-                          "18px",
-                          "18px",
-                          "22px",
-                          "22px",
-                        ]
-                      }
-                    >
-                      The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
-                    </div>
-                  </div>
                   <div
                     className="c55"
-                  >
-                    <div
-                      className="c56"
-                      fontFamily={
-                        Object {
-                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                          "fontWeight": 500,
-                        }
+                    fontFamily={
+                      Object {
+                        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                        "fontWeight": 500,
                       }
-                      fontSize="14px"
-                    >
-                      Aug 28, 2017
-                    </div>
+                    }
+                    fontSize="14px"
+                  >
+                    Jul 28, 2017 4:38 pm
                   </div>
                 </div>
                 <div
-                  className="c76 c77"
-                  width={
-                    Array [
-                      "100%",
-                      "100%",
-                      "50%",
-                      "50%",
-                    ]
-                  }
+                  className="c56 c57"
                 >
-                  <img
-                    className="c78 c79"
-                    src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
-                  />
                   <div
-                    className="c80 c81"
+                    className="c58 c55"
+                    fontFamily={
+                      Object {
+                        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                        "fontWeight": 500,
+                      }
+                    }
+                    fontSize="14px"
+                  >
+                    Share
+                  </div>
+                  <a
+                    className="c59"
+                    href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+                    onClick={[Function]}
+                    target="_blank"
                   >
                     <svg
-                      className="c18 c19"
+                      height="14px"
                       version="1.1"
-                      viewBox="0 0 40 56"
-                      x="0px"
+                      viewBox="0 0 14 14"
+                      width="14px"
                       xmlns="http://www.w3.org/2000/svg"
-                      y="0px"
                     >
                       <g
                         fill="none"
@@ -2505,120 +2167,284 @@ exports[`Video Layout matches the snapshot 1`] = `
                         stroke="none"
                         strokeWidth="1"
                       >
-                        <polygon
+                        <path
+                          d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
                           fill="white"
-                          points="0 0 0 56 39.3600006 28"
                         />
                       </g>
                     </svg>
-                    <div
-                      className="c82"
-                      fontFamily={
-                        Object {
-                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                          "fontWeight": 500,
-                        }
-                      }
-                      fontSize="14px"
+                  </a>
+                  <a
+                    className="c59"
+                    href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <svg
+                      height="14px"
+                      version="1.1"
+                      viewBox="0 0 16 14"
+                      width="16px"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      02:28
-                    </div>
-                  </div>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                        stroke="none"
+                        strokeWidth="1"
+                      >
+                        <path
+                          d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                          fill="white"
+                        />
+                      </g>
+                    </svg>
+                  </a>
+                  <a
+                    className="c59"
+                    href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <svg
+                      height="14px"
+                      version="1.1"
+                      viewBox="0 0 17 14"
+                      width="17px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                        stroke="none"
+                        strokeWidth="1"
+                      >
+                        <path
+                          d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                          fill="white"
+                        />
+                      </g>
+                    </svg>
+                  </a>
                 </div>
               </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c60"
+          width={
+            Array [
+              1,
+              1,
+              0.6666666666666666,
+              0.6666666666666666,
+            ]
+          }
+        >
+          <div
+            className="c49"
+            color="white"
+            fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+            fontSize="28px"
+          >
+            About the Film
+          </div>
+          <div
+            className="article__text-section c50 c61"
+            color="white"
+          >
+            <div
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "<p>Integer posuere erat a ante venenatis <a href='artsy.net'>dapibus posuere velit</a> aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+                }
+              }
+            />
+          </div>
+          <div
+            className="rrm-container rrm-lessThan-md"
+          >
+            <div
+              className="c52"
+            >
+              <div
+                className="c53"
+              >
+                <div
+                  className="c54"
+                >
+                  <div
+                    className="c55"
+                    fontFamily={
+                      Object {
+                        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                        "fontWeight": 500,
+                      }
+                    }
+                    fontSize="14px"
+                  >
+                    Jul 28, 2017 4:38 pm
+                  </div>
+                </div>
+                <div
+                  className="c56 c57"
+                >
+                  <div
+                    className="c58 c55"
+                    fontFamily={
+                      Object {
+                        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                        "fontWeight": 500,
+                      }
+                    }
+                    fontSize="14px"
+                  >
+                    Share
+                  </div>
+                  <a
+                    className="c59"
+                    href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <svg
+                      height="14px"
+                      version="1.1"
+                      viewBox="0 0 14 14"
+                      width="14px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                        stroke="none"
+                        strokeWidth="1"
+                      >
+                        <path
+                          d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                          fill="white"
+                        />
+                      </g>
+                    </svg>
+                  </a>
+                  <a
+                    className="c59"
+                    href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <svg
+                      height="14px"
+                      version="1.1"
+                      viewBox="0 0 16 14"
+                      width="16px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                        stroke="none"
+                        strokeWidth="1"
+                      >
+                        <path
+                          d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                          fill="white"
+                        />
+                      </g>
+                    </svg>
+                  </a>
+                  <a
+                    className="c59"
+                    href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <svg
+                      height="14px"
+                      version="1.1"
+                      viewBox="0 0 17 14"
+                      width="17px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                        stroke="none"
+                        strokeWidth="1"
+                      >
+                        <path
+                          d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                          fill="white"
+                        />
+                      </g>
+                    </svg>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c62"
+    >
+      <div
+        className="c63"
+        color="white"
+      >
+        <div
+          className="c64"
+        >
+          <div
+            className="c65 c66 c67"
+            color="white"
+            fontFamily={
+              Object {
+                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                "fontWeight": 500,
+              }
+            }
+            fontSize="14px"
+          >
+            More in 
+            <a
+              href="/series/future-of-art"
+            >
+              The Future of Art
             </a>
           </div>
           <div
-            className="c69"
+            className="c68"
+            color="white"
           >
-            <a
-              className="ArticleCard c70"
-              color="white"
-              href="new-yorks-next-art-district"
-              onClick={[Function]}
+            <div
+              className="c69"
             >
-              <div
-                className="c71"
+              <a
+                className="ArticleCard c70"
+                color="white"
+                href="joanne-artman-gallery-poetry-naturerefinement-form"
+                onClick={[Function]}
               >
                 <div
-                  className="c72"
-                  width={
-                    Array [
-                      "100%",
-                      "100%",
-                      "50%",
-                      "50%",
-                    ]
-                  }
+                  className="c71"
                 >
-                  <div>
-                    <div
-                      className="c73"
-                      fontFamily={
-                        Object {
-                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                          "fontWeight": 500,
-                        }
-                      }
-                      fontSize="14px"
-                    >
-                      The Future of Art
-                    </div>
-                    <div
-                      className="c74"
-                      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
-                      fontSize={
-                        Array [
-                          "28px",
-                          "28px",
-                          "42px",
-                          "42px",
-                        ]
-                      }
-                    >
-                      New York's Next Art District
-                    </div>
-                    <div
-                      className="c75"
-                      fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
-                      fontSize={
-                        Array [
-                          "18px",
-                          "18px",
-                          "22px",
-                          "22px",
-                        ]
-                      }
-                    >
-                      Land exhibitions, make influential contacts, and gain valuable feedback about your work.
-                    </div>
-                  </div>
                   <div
-                    className="Byline c83"
-                    color="white"
+                    className="c72"
+                    width={
+                      Array [
+                        "100%",
+                        "100%",
+                        "50%",
+                        "50%",
+                      ]
+                    }
                   >
-                    <div
-                      className="c56"
-                      fontFamily={
-                        Object {
-                          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                          "fontWeight": 500,
-                        }
-                      }
-                      fontSize="14px"
-                    >
+                    <div>
                       <div
-                        className="c84"
-                        color="white"
-                      >
-                        Casey Lesser
-                      </div>
-                    </div>
-                    <div
-                      className="c55"
-                    >
-                      <div
-                        className="c56"
+                        className="c73"
                         fontFamily={
                           Object {
                             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2627,92 +2453,295 @@ exports[`Video Layout matches the snapshot 1`] = `
                         }
                         fontSize="14px"
                       >
-                        May 19, 2017
+                        The Future of Art
+                      </div>
+                      <div
+                        className="c74"
+                        fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                        fontSize={
+                          Array [
+                            "28px",
+                            "28px",
+                            "42px",
+                            "42px",
+                          ]
+                        }
+                      >
+                        New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+                      </div>
+                      <div
+                        className="c75"
+                        fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                        fontSize={
+                          Array [
+                            "18px",
+                            "18px",
+                            "22px",
+                            "22px",
+                          ]
+                        }
+                      >
+                        The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
+                      </div>
+                    </div>
+                    <div
+                      className="c54"
+                    >
+                      <div
+                        className="c55"
+                        fontFamily={
+                          Object {
+                            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                            "fontWeight": 500,
+                          }
+                        }
+                        fontSize="14px"
+                      >
+                        Aug 28, 2017
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="c76 c77"
+                    width={
+                      Array [
+                        "100%",
+                        "100%",
+                        "50%",
+                        "50%",
+                      ]
+                    }
+                  >
+                    <img
+                      className="c78 c79"
+                      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+                    />
+                    <div
+                      className="c80 c81"
+                    >
+                      <svg
+                        className="c18 c19"
+                        version="1.1"
+                        viewBox="0 0 40 56"
+                        x="0px"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0px"
+                      >
+                        <g
+                          fill="none"
+                          fillRule="evenodd"
+                          stroke="none"
+                          strokeWidth="1"
+                        >
+                          <polygon
+                            fill="white"
+                            points="0 0 0 56 39.3600006 28"
+                          />
+                        </g>
+                      </svg>
+                      <div
+                        className="c82"
+                        fontFamily={
+                          Object {
+                            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                            "fontWeight": 500,
+                          }
+                        }
+                        fontSize="14px"
+                      >
+                        02:28
                       </div>
                     </div>
                   </div>
                 </div>
+              </a>
+            </div>
+            <div
+              className="c69"
+            >
+              <a
+                className="ArticleCard c70"
+                color="white"
+                href="new-yorks-next-art-district"
+                onClick={[Function]}
+              >
                 <div
-                  className="c76 c77"
-                  width={
-                    Array [
-                      "100%",
-                      "100%",
-                      "50%",
-                      "50%",
-                    ]
-                  }
+                  className="c71"
                 >
-                  <img
-                    className="c78 c79"
-                    src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+                  <div
+                    className="c72"
+                    width={
+                      Array [
+                        "100%",
+                        "100%",
+                        "50%",
+                        "50%",
+                      ]
+                    }
+                  >
+                    <div>
+                      <div
+                        className="c73"
+                        fontFamily={
+                          Object {
+                            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                            "fontWeight": 500,
+                          }
+                        }
+                        fontSize="14px"
+                      >
+                        The Future of Art
+                      </div>
+                      <div
+                        className="c74"
+                        fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                        fontSize={
+                          Array [
+                            "28px",
+                            "28px",
+                            "42px",
+                            "42px",
+                          ]
+                        }
+                      >
+                        New York's Next Art District
+                      </div>
+                      <div
+                        className="c75"
+                        fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                        fontSize={
+                          Array [
+                            "18px",
+                            "18px",
+                            "22px",
+                            "22px",
+                          ]
+                        }
+                      >
+                        Land exhibitions, make influential contacts, and gain valuable feedback about your work.
+                      </div>
+                    </div>
+                    <div
+                      className="Byline c83"
+                      color="white"
+                    >
+                      <div
+                        className="c55"
+                        fontFamily={
+                          Object {
+                            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                            "fontWeight": 500,
+                          }
+                        }
+                        fontSize="14px"
+                      >
+                        <div
+                          className="c84"
+                          color="white"
+                        >
+                          Casey Lesser
+                        </div>
+                      </div>
+                      <div
+                        className="c54"
+                      >
+                        <div
+                          className="c55"
+                          fontFamily={
+                            Object {
+                              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                              "fontWeight": 500,
+                            }
+                          }
+                          fontSize="14px"
+                        >
+                          May 19, 2017
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="c76 c77"
+                    width={
+                      Array [
+                        "100%",
+                        "100%",
+                        "50%",
+                        "50%",
+                      ]
+                    }
+                  >
+                    <img
+                      className="c78 c79"
+                      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+                    />
+                  </div>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c85"
+        >
+          <div
+            className="c86"
+            color="white"
+            width="100%"
+          >
+            <div
+              className="c87"
+              width={
+                Array [
+                  1,
+                  1,
+                  0.3333333333333333,
+                  0.3333333333333333,
+                ]
+              }
+            >
+              <div
+                className="c88"
+                fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                fontSize="28px"
+              >
+                About the Series
+              </div>
+              <div
+                className="rrm-container rrm-greaterThanOrEqual-md"
+              />
+            </div>
+            <div
+              className="c89"
+              width={
+                Array [
+                  1,
+                  1,
+                  0.6666666666666666,
+                  0.6666666666666666,
+                ]
+              }
+            >
+              <div
+                className="SeriesAbout__description"
+              >
+                <div
+                  className="article__text-section c50 c61"
+                  color="white"
+                >
+                  <div
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+                      }
+                    }
                   />
                 </div>
               </div>
-            </a>
-          </div>
-        </div>
-      </div>
-      <div
-        className="c85"
-      >
-        <div
-          className="c86"
-          color="white"
-          width="100%"
-        >
-          <div
-            className="c87"
-            width={
-              Array [
-                1,
-                1,
-                0.3333333333333333,
-                0.3333333333333333,
-              ]
-            }
-          >
-            <div
-              className="c88"
-              fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
-              fontSize="28px"
-            >
-              About the Series
-            </div>
-            <div
-              className="rrm-container rrm-greaterThanOrEqual-md"
-            />
-          </div>
-          <div
-            className="c89"
-            width={
-              Array [
-                1,
-                1,
-                0.6666666666666666,
-                0.6666666666666666,
-              ]
-            }
-          >
-            <div
-              className="SeriesAbout__description"
-            >
               <div
-                className="article__text-section c51 c62"
-                color="white"
-              >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-                    }
-                  }
-                />
-              </div>
+                className="rrm-container rrm-lessThan-md"
+              />
             </div>
-            <div
-              className="rrm-container rrm-lessThan-md"
-            />
           </div>
         </div>
       </div>

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCard.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCard.tsx
@@ -1,12 +1,13 @@
 import { Box, color, Flex, Sans, Serif } from "@artsy/palette"
+import React, { Component } from "react"
+import track, { TrackingProp } from "react-tracking"
+import styled from "styled-components"
+
 import { media } from "Components/Helpers"
 import { Byline } from "Components/Publishing/Byline/Byline"
 import { Date } from "Components/Publishing/Byline/Date"
 import { formatTime, getMediaDate } from "Components/Publishing/Constants"
 import { IconVideoPlay } from "Components/Publishing/Icon/IconVideoPlay"
-import React, { Component } from "react"
-import track, { TrackingProp } from "react-tracking"
-import styled from "styled-components"
 import { crop } from "Utils/resizer"
 
 interface Props {
@@ -92,7 +93,7 @@ export class ArticleCard extends Component<Props> {
     if (this.isUnpublishedMedia()) {
       return (
         <MediaContainer>
-          <Sans size={["8", "8", "8", "10"]}>Coming Soon</Sans>
+          <Sans size={["8", "8", "10", "10"]}>Coming Soon</Sans>
         </MediaContainer>
       )
     } else {
@@ -146,17 +147,12 @@ export class ArticleCard extends Component<Props> {
         onClick={this.openLink}
       >
         <Flex
-          flexDirection={[
-            "column-reverse",
-            "column-reverse",
-            "column-reverse",
-            "row",
-          ]}
-          p={[20, 20, 20, 30]}
+          flexDirection={["column-reverse", "column-reverse", "row", "row"]}
+          p={[20, 20, 30, 30]}
         >
           <Flex
-            width={["100%", "100%", "100%", "50%"]}
-            mb={[0, 0, 0, "5px"]}
+            width={["100%", "100%", "50%", "50%"]}
+            mb={[0, 0, "5px", "5px"]}
             flexDirection="column"
             justifyContent="space-between"
           >
@@ -166,11 +162,11 @@ export class ArticleCard extends Component<Props> {
                   {series.title}
                 </Sans>
               )}
-              <Sans size={["8", "8", "8", "10"]} mb={20}>
+              <Sans size={["8", "8", "10", "10"]} mb={20}>
                 {title}
               </Sans>
 
-              <Serif size={["4", "4", "4", "5"]} mb={20}>
+              <Serif size={["4", "4", "5", "5"]} mb={20}>
                 {description}
               </Serif>
             </div>
@@ -178,9 +174,9 @@ export class ArticleCard extends Component<Props> {
           </Flex>
 
           <ImageContainer
-            width={["100%", "100%", "100%", "50%"]}
-            ml={[0, 0, 0, 30]}
-            mb={[10, 10, 10, 0]}
+            width={["100%", "100%", "50%", "50%"]}
+            ml={[0, 0, 30, 30]}
+            mb={[10, 10, 0, 0]}
           >
             {editImage ? (
               editImage

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCard.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCard.tsx
@@ -1,6 +1,5 @@
-import { Sans } from "@artsy/palette"
-import { garamond, unica } from "Assets/Fonts"
-import { pMedia } from "Components/Helpers"
+import { Box, color, Flex, Sans, Serif } from "@artsy/palette"
+import { media } from "Components/Helpers"
 import { Byline } from "Components/Publishing/Byline/Byline"
 import { Date } from "Components/Publishing/Byline/Date"
 import { formatTime, getMediaDate } from "Components/Publishing/Constants"
@@ -22,17 +21,15 @@ interface Props {
   tracking?: TrackingProp
 }
 
-interface LinkProps extends Props, React.HTMLProps<HTMLLinkElement> {
-  published: boolean
-}
-
 @track()
-export class ArticleCard extends Component<Props, null> {
+export class ArticleCard extends Component<Props> {
   public static defaultProps: Partial<Props>
 
-  isUnpublishedMedia() {
-    const { media, layout } = this.props.article
-    return layout === "video" && media && !media.published
+  isUnpublishedMedia = () => {
+    const { article } = this.props
+    return (
+      article.layout === "video" && article.media && !article.media.published
+    )
   }
 
   isEditing = () => {
@@ -48,20 +45,24 @@ export class ArticleCard extends Component<Props, null> {
   }
 
   renderDate = () => {
-    const { article, color, editDate } = this.props
-    const { media } = article
+    const { article, editDate } = this.props
 
     if (editDate) {
       return (
-        <MediaDate size="3t" weight="medium">
+        <Sans size="3t" weight="medium">
           {editDate}
-        </MediaDate>
+        </Sans>
       )
-    } else if (media) {
+    } else if (article.media) {
       return this.renderMediaDate()
     } else {
       return (
-        <Byline article={article} color={color} size="3t" layout="condensed" />
+        <Byline
+          article={article}
+          color={this.props.color}
+          size="3t"
+          layout="condensed"
+        />
       )
     }
   }
@@ -73,10 +74,12 @@ export class ArticleCard extends Component<Props, null> {
 
     if (this.isUnpublishedMedia()) {
       return (
-        <MediaDate size="3t" weight="medium">
-          <span>Available </span>
-          <Date format="monthYear" date={mediaDate} />
-        </MediaDate>
+        <Sans size="3t" weight="medium">
+          <Flex alignItems="flex-end">
+            <Box mr="5px">Available</Box>
+            <Date format="monthYear" date={mediaDate} />
+          </Flex>
+        </Sans>
       )
     } else {
       return <Date layout="condensed" size="3t" date={date} />
@@ -84,18 +87,22 @@ export class ArticleCard extends Component<Props, null> {
   }
 
   renderMediaCoverInfo = () => {
-    const { article, color } = this.props
+    const { article } = this.props
 
     if (this.isUnpublishedMedia()) {
-      return <MediaComingSoon>Coming Soon</MediaComingSoon>
+      return (
+        <MediaContainer>
+          <Sans size={["8", "8", "8", "10"]}>Coming Soon</Sans>
+        </MediaContainer>
+      )
     } else {
       return (
-        <MediaPlay>
-          <IconVideoPlay color={color} />
-          <Sans size="3t" weight="medium">
+        <MediaContainer justifyContent="space-between" alignItems="flex-end">
+          <IconVideoPlay color={this.props.color} />
+          <Sans size="3t" weight="medium" lineHeight="1em">
             {formatTime(article.media.duration)}
           </Sans>
-        </MediaPlay>
+        </MediaContainer>
       )
     }
   }
@@ -116,13 +123,12 @@ export class ArticleCard extends Component<Props, null> {
   render() {
     const {
       article,
-      color,
       editDescription,
       editImage,
       editTitle,
       series,
     } = this.props
-    const { layout, media } = article
+    const { layout } = article
     const isUnpublishedMedia = this.isUnpublishedMedia()
 
     const description = editDescription ? editDescription : article.description
@@ -134,42 +140,65 @@ export class ArticleCard extends Component<Props, null> {
     return (
       <ArticleCardContainer
         href={isUnpublishedMedia ? "" : article.slug}
-        color={color}
+        color={this.props.color}
         className="ArticleCard"
         published={!isUnpublishedMedia}
         onClick={this.openLink}
       >
-        <TextContainer>
-          <div>
-            {series && (
-              <SeriesTitle size="3t" weight="medium">
-                {series.title}
-              </SeriesTitle>
+        <Flex
+          flexDirection={[
+            "column-reverse",
+            "column-reverse",
+            "column-reverse",
+            "row",
+          ]}
+          p={[20, 20, 20, 30]}
+        >
+          <Flex
+            width={["100%", "100%", "100%", "50%"]}
+            mb={[0, 0, 0, "5px"]}
+            flexDirection="column"
+            justifyContent="space-between"
+          >
+            <div>
+              {series && (
+                <Sans size="3t" weight="medium" mb={1}>
+                  {series.title}
+                </Sans>
+              )}
+              <Sans size={["8", "8", "8", "10"]} mb={20}>
+                {title}
+              </Sans>
+
+              <Serif size={["4", "4", "4", "5"]} mb={20}>
+                {description}
+              </Serif>
+            </div>
+            {this.renderDate()}
+          </Flex>
+
+          <ImageContainer
+            width={["100%", "100%", "100%", "50%"]}
+            ml={[0, 0, 0, 30]}
+            mb={[10, 10, 10, 0]}
+          >
+            {editImage ? (
+              editImage
+            ) : (
+              <Image
+                src={crop(article.thumbnail_image, { width: 680, height: 450 })}
+              />
             )}
-            <Title>{title}</Title>
-
-            <Description>{description}</Description>
-          </div>
-          {this.renderDate()}
-        </TextContainer>
-
-        <ImageContainer>
-          {editImage ? (
-            editImage
-          ) : (
-            <Image
-              src={crop(article.thumbnail_image, { width: 680, height: 450 })}
-            />
-          )}
-          {media && layout === "video" && this.renderMediaCoverInfo()}
-        </ImageContainer>
+            {article.media && layout === "video" && this.renderMediaCoverInfo()}
+          </ImageContainer>
+        </Flex>
       </ArticleCardContainer>
     )
   }
 }
 
 ArticleCard.defaultProps = {
-  color: "black",
+  color: color("black100"),
 }
 
 const Image = styled.img`
@@ -181,29 +210,22 @@ const Image = styled.img`
   display: block;
 `
 
-const ImageContainer = styled.div`
+const ImageContainer = styled(Box)`
   position: relative;
-  width: 50%;
   height: inherit;
-  margin-left: 30px;
-  ${pMedia.md`
-    width: 100%;
-    margin-left: 0;
-    margin-bottom: 10px;
-  `};
+  background: white;
 `
 
-export const ArticleCardContainer = styled.a`
+export const ArticleCardContainer = styled.a<{ published: boolean }>`
   border: 1px solid;
   border-radius: 2px;
-  color: ${(props: LinkProps) => props.color};
-  cursor: ${(props: LinkProps) => (props.published ? "pointer" : "default")};
+  color: ${props => props.color};
+  cursor: ${props => (props.published ? "pointer" : "default")};
   text-decoration: none;
-  padding: 30px;
-  display: flex;
+  display: block;
 
   ${Image} {
-    opacity: ${(props: LinkProps) => (props.published ? "1" : "0.7")};
+    opacity: ${props => (props.published ? "1" : "0.7")};
   }
 
   &:hover {
@@ -211,82 +233,20 @@ export const ArticleCardContainer = styled.a`
       opacity: 0.7;
     }
   }
-
-  ${ImageContainer} {
-    background: ${(props: LinkProps) =>
-      props.color === "white" ? "black" : "white"};
-  }
-  ${pMedia.md`
-    flex-direction: column-reverse;
-    padding: 20px;
-  `};
 `
 
-const TextContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
-  ${pMedia.md`
-    width: 100%;
-    margin-bottom: 0;
-  `};
-`
-
-const Title = styled.div`
-  ${unica("s45")};
-  margin-bottom: 30px;
-  ${pMedia.md`
-    ${unica("s32")}
-  `};
-`
-
-const SeriesTitle = styled(Sans)`
-  margin-bottom: 10px;
-`
-
-const Description = styled.div`
-  ${garamond("s23")};
-  ${pMedia.md`
-    ${garamond("s19")}
-    margin-bottom: 20px;
-  `};
-`
-
-const MediaDate = styled(Sans)`
-  display: flex;
-  align-items: flex-end;
-
-  span {
-    margin-right: 5px;
-  }
-`
-
-const Media = styled.div`
+const MediaContainer = styled(Flex)`
   position: absolute;
   left: 20px;
-  bottom: 20px;
   right: 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-`
+  bottom: 20px;
 
-const MediaPlay = styled(Media)`
   svg {
-    width: 40px;
+    height: 40px;
   }
-  ${pMedia.md`
+  ${media.md`
     svg {
-      width: 30px;
+      height: 30px;
     }
-  `};
-`
-
-const MediaComingSoon = styled(Media)`
-  ${unica("s45")};
-  ${pMedia.md`
-    ${unica("s32")}
   `};
 `

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCards.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCards.tsx
@@ -32,7 +32,3 @@ export const ArticleCards: React.SFC<Props> = props => {
 
 // Used to target wrapper in other components
 export const ArticlesWrapper = styled(Box)``
-
-ArticleCards.defaultProps = {
-  color: "black",
-}

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCards.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCards.tsx
@@ -1,7 +1,8 @@
 import { Box } from "@artsy/palette"
-import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
+
+import { ArticleData } from "Components/Publishing/Typings"
 import { ArticleCard } from "./ArticleCard"
 
 interface Props {

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/Block.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/Block.tsx
@@ -1,14 +1,14 @@
 import { Box, color } from "@artsy/palette"
+import React from "react"
+import styled from "styled-components"
+
 import { unica } from "Assets/Fonts"
-import { media } from "Components/Helpers"
 import {
   Vertical,
   VerticalOrSeriesTitle,
 } from "Components/Publishing/Sections/VerticalOrSeriesTitle"
 import { SeriesAbout } from "Components/Publishing/Series/SeriesAbout"
 import { ArticleData } from "Components/Publishing/Typings"
-import React from "react"
-import styled from "styled-components"
 import { ArticleCards } from "./ArticleCards"
 
 interface Props {
@@ -60,9 +60,6 @@ export const ArticleCardsContainer = styled.div`
 
     a {
       border-bottom: 2px solid;
-      ${media.sm`
-        display: block;
-      `};
     }
   }
 `

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/Block.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/Block.tsx
@@ -1,14 +1,11 @@
-import { Box } from "@artsy/palette"
+import { Box, color } from "@artsy/palette"
 import { unica } from "Assets/Fonts"
 import { media } from "Components/Helpers"
 import {
   Vertical,
   VerticalOrSeriesTitle,
 } from "Components/Publishing/Sections/VerticalOrSeriesTitle"
-import {
-  SeriesAbout,
-  SeriesAboutContainer,
-} from "Components/Publishing/Series/SeriesAbout"
+import { SeriesAbout } from "Components/Publishing/Series/SeriesAbout"
 import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
@@ -21,28 +18,28 @@ interface Props {
 }
 
 export const ArticleCardsBlock: React.SFC<Props> = props => {
-  const { article, color, relatedArticles } = props
+  const { article, relatedArticles } = props
   const { seriesArticle } = article
 
   return (
-    <ArticleCardsContainer color={color}>
+    <ArticleCardsContainer color={props.color}>
       {(relatedArticles || article.relatedArticles) && (
         <Box maxWidth={1200} mx="auto">
           <VerticalOrSeriesTitle
             article={article}
-            color={color}
+            color={props.color}
             prefix="More in "
           />
           <ArticleCards
             relatedArticles={relatedArticles || article.relatedArticles}
             series={seriesArticle}
-            color={color}
+            color={props.color}
           />
         </Box>
       )}
       {seriesArticle && (
-        <Box maxWidth={1200} mx="auto">
-          <SeriesAbout article={seriesArticle} color={color} />
+        <Box maxWidth={1200} mx="auto" pt={[40, 40, 60]} pb={100}>
+          <SeriesAbout article={seriesArticle} color={props.color} />
         </Box>
       )}
     </ArticleCardsContainer>
@@ -50,7 +47,7 @@ export const ArticleCardsBlock: React.SFC<Props> = props => {
 }
 
 ArticleCardsBlock.defaultProps = {
-  color: "black",
+  color: color("black100"),
 }
 
 export const ArticleCardsContainer = styled.div`
@@ -68,14 +65,4 @@ export const ArticleCardsContainer = styled.div`
       `};
     }
   }
-
-  ${SeriesAboutContainer} {
-    margin: 60px auto 100px auto;
-  }
-
-  ${media.sm`
-    ${SeriesAboutContainer} {
-      margin: 40px auto 100px auto;
-    }
-  `};
 `

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/ArticleCard.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/ArticleCard.test.tsx
@@ -74,7 +74,7 @@ describe("ArticleCard", () => {
     expect(component.find(IconVideoPlay).length).toBe(0)
     expect(component.text()).not.toMatch("03:12")
     expect(component.text()).toMatch("Coming Soon")
-    expect(component.text()).toMatch("Available ")
+    expect(component.text()).toMatch("Available")
   })
 
   it("Renders publish date if layout does not have media", () => {

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCard.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCard.test.tsx.snap
@@ -1,30 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArticleCard renders an article properly 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  padding: 20px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
 .c3 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 4px;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c5 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 20px;
+}
+
+.c7 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c8 {
+.c11 {
+  margin-bottom: 10px;
+  margin-left: 0px;
+  width: 100%;
+}
+
+.c9 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c7 {
+.c8 {
   margin: 10px 20px 0 0;
 }
 
-.c7::before {
+.c8::before {
   content: "";
   display: inline-block;
   width: 8px;
   height: 8px;
   border-radius: 50%;
   margin: 0 5px 1px 0;
-  background-color: black;
+  background-color: #000;
 }
 
 .c6 {
@@ -39,10 +94,10 @@ exports[`ArticleCard renders an article properly 1`] = `
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-  color: black;
+  color: #000;
 }
 
-.c12 {
+.c13 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -54,172 +109,238 @@ exports[`ArticleCard renders an article properly 1`] = `
 
 .c10 {
   position: relative;
-  width: 50%;
   height: inherit;
-  margin-left: 30px;
+  background: white;
 }
 
 .c0 {
   border: 1px solid;
   border-radius: 2px;
-  color: black;
+  color: #000;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  padding: 30px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: block;
 }
 
-.c0 .c11 {
+.c0 .c12 {
   opacity: 1;
 }
 
-.c0:hover .c11 {
+.c0:hover .c12 {
   opacity: 0.7;
 }
 
-.c0 .c9 {
-  background: white;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
-  margin-bottom: 30px;
-}
-
-.c2 {
-  margin-bottom: 10px;
-}
-
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media (max-width:900px) {
-  .c10 {
-    width: 100%;
-    margin-left: 0;
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width:900px) {
-  .c0 {
+@media screen and (min-width:40em) {
+  .c1 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c1 {
     padding: 20px;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
   .c1 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c1 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
     width: 100%;
-    margin-bottom: 0;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c2 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c4 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
+    font-size: 28px;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c4 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c4 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c4 {
+    line-height: 36px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c4 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c4 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c5 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-    margin-bottom: 20px;
+    font-size: 18px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c5 {
+    line-height: 26px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c11 {
+    margin-bottom: 10px;
+    margin-left: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c11 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c11 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c11 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c11 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c11 {
+    width: 50%;
   }
 }
 
 <a
   className="ArticleCard c0"
-  color="black"
+  color="#000"
   href="new-yorks-next-art-district"
   onClick={[Function]}
 >
   <div
     className="c1"
   >
-    <div>
-      <div
-        className="c2 c3"
-        fontFamily={
-          Object {
-            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-            "fontWeight": 500,
-          }
-        }
-        fontSize="14px"
-      >
-        The Future of Art
-      </div>
-      <div
-        className="c4"
-      >
-        New York's Next Art District
-      </div>
-      <div
-        className="c5"
-      >
-        Land exhibitions, make influential contacts, and gain valuable feedback about your work.
-      </div>
-    </div>
     <div
-      className="Byline c6"
-      color="black"
+      className="c2"
+      width={
+        Array [
+          "100%",
+          "100%",
+          "50%",
+          "50%",
+        ]
+      }
     >
-      <div
-        className="c3"
-        fontFamily={
-          Object {
-            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-            "fontWeight": 500,
-          }
-        }
-        fontSize="14px"
-      >
-        <div
-          className="c7"
-          color="black"
-        >
-          Casey Lesser
-        </div>
-      </div>
-      <div
-        className="c8"
-      >
+      <div>
         <div
           className="c3"
           fontFamily={
@@ -230,69 +351,109 @@ exports[`ArticleCard renders an article properly 1`] = `
           }
           fontSize="14px"
         >
-          May 19, 2017
+          The Future of Art
+        </div>
+        <div
+          className="c4"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize={
+            Array [
+              "28px",
+              "28px",
+              "42px",
+              "42px",
+            ]
+          }
+        >
+          New York's Next Art District
+        </div>
+        <div
+          className="c5"
+          fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+          fontSize={
+            Array [
+              "18px",
+              "18px",
+              "22px",
+              "22px",
+            ]
+          }
+        >
+          Land exhibitions, make influential contacts, and gain valuable feedback about your work.
+        </div>
+      </div>
+      <div
+        className="Byline c6"
+        color="#000"
+      >
+        <div
+          className="c7"
+          fontFamily={
+            Object {
+              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+              "fontWeight": 500,
+            }
+          }
+          fontSize="14px"
+        >
+          <div
+            className="c8"
+            color="#000"
+          >
+            Casey Lesser
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div
+            className="c7"
+            fontFamily={
+              Object {
+                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                "fontWeight": 500,
+              }
+            }
+            fontSize="14px"
+          >
+            May 19, 2017
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="c9 c10"
-  >
-    <img
-      className="c11 c12"
-      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
-    />
+    <div
+      className="c10 c11"
+      width={
+        Array [
+          "100%",
+          "100%",
+          "50%",
+          "50%",
+        ]
+      }
+    >
+      <img
+        className="c12 c13"
+        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+      />
+    </div>
   </div>
 </a>
 `;
 
 exports[`ArticleCard renders an article with children properly 1`] = `
-.c3 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c11 {
-  width: 32px;
-  height: 32px;
-}
-
-.c8 {
-  position: relative;
-  width: 50%;
-  height: inherit;
-  margin-left: 30px;
-}
-
-.c0 {
-  border: 1px solid;
-  border-radius: 2px;
-  color: black;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  padding: 30px;
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  padding: 20px;
 }
 
-.c0 .ArticleCard__Image-nqsvxw-0 {
-  opacity: 1;
-}
-
-.c0:hover .ArticleCard__Image-nqsvxw-0 {
-  opacity: 0.7;
-}
-
-.c0 .c7 {
-  background: white;
-}
-
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -304,30 +465,11 @@ exports[`ArticleCard renders an article with children properly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
+  width: 100%;
 }
 
-.c4 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
-  margin-bottom: 30px;
-}
-
-.c2 {
-  margin-bottom: 10px;
-}
-
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c6 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -336,96 +478,359 @@ exports[`ArticleCard renders an article with children properly 1`] = `
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-}
-
-.c6 span {
-  margin-right: 5px;
-}
-
-.c10 {
-  position: absolute;
-  left: 20px;
-  bottom: 20px;
-  right: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+}
+
+.c3 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 4px;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c5 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 20px;
+}
+
+.c6 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c12 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1em;
+}
+
+.c8 {
+  margin-bottom: 10px;
+  margin-left: 0px;
+  width: 100%;
+}
+
+.c11 {
+  width: 32px;
+  height: 32px;
+}
+
+.c7 {
+  position: relative;
+  height: inherit;
+  background: white;
+}
+
+.c0 {
+  border: 1px solid;
+  border-radius: 2px;
+  color: #000;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+}
+
+.c0 .ArticleCard__Image-nqsvxw-0 {
+  opacity: 1;
+}
+
+.c0:hover .ArticleCard__Image-nqsvxw-0 {
+  opacity: 0.7;
+}
+
+.c9 {
+  position: absolute;
+  left: 20px;
+  right: 20px;
+  bottom: 20px;
 }
 
 .c9 svg {
-  width: 40px;
+  height: 40px;
 }
 
-@media (max-width:900px) {
-  .c8 {
-    width: 100%;
-    margin-left: 0;
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width:900px) {
-  .c0 {
+@media screen and (min-width:40em) {
+  .c1 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c1 {
     padding: 20px;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
   .c1 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c1 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
     width: 100%;
-    margin-bottom: 0;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c2 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c4 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
+    font-size: 28px;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c4 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c4 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c4 {
+    line-height: 36px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c4 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c4 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c5 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-    margin-bottom: 20px;
+    font-size: 18px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c5 {
+    line-height: 26px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c8 {
+    margin-bottom: 10px;
+    margin-left: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c8 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c8 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c8 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c8 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c8 {
+    width: 50%;
   }
 }
 
 @media (max-width:900px) {
   .c9 svg {
-    width: 30px;
+    height: 30px;
   }
 }
 
 <a
   className="ArticleCard c0"
-  color="black"
+  color="#000"
   href="joanne-artman-gallery-poetry-naturerefinement-form"
   onClick={[Function]}
 >
   <div
     className="c1"
   >
-    <div>
+    <div
+      className="c2"
+      width={
+        Array [
+          "100%",
+          "100%",
+          "50%",
+          "50%",
+        ]
+      }
+    >
+      <div>
+        <div
+          className="c3"
+          fontFamily={
+            Object {
+              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+              "fontWeight": 500,
+            }
+          }
+          fontSize="14px"
+        >
+          The Future of Art
+        </div>
+        <div
+          className="c4"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize={
+            Array [
+              "28px",
+              "28px",
+              "42px",
+              "42px",
+            ]
+          }
+        >
+          <div>
+            Child 
+            title
+          </div>
+        </div>
+        <div
+          className="c5"
+          fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+          fontSize={
+            Array [
+              "18px",
+              "18px",
+              "22px",
+              "22px",
+            ]
+          }
+        >
+          <div>
+            Child 
+            description
+          </div>
+        </div>
+      </div>
       <div
-        className="c2 c3"
+        className="c6"
         fontFamily={
           Object {
             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -434,82 +839,62 @@ exports[`ArticleCard renders an article with children properly 1`] = `
         }
         fontSize="14px"
       >
-        The Future of Art
-      </div>
-      <div
-        className="c4"
-      >
         <div>
           Child 
-          title
-        </div>
-      </div>
-      <div
-        className="c5"
-      >
-        <div>
-          Child 
-          description
+          date
         </div>
       </div>
     </div>
     <div
-      className="c6 c3"
-      fontFamily={
-        Object {
-          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-          "fontWeight": 500,
-        }
+      className="c7 c8"
+      width={
+        Array [
+          "100%",
+          "100%",
+          "50%",
+          "50%",
+        ]
       }
-      fontSize="14px"
     >
       <div>
         Child 
-        date
+        image
       </div>
-    </div>
-  </div>
-  <div
-    className="c7 c8"
-  >
-    <div>
-      Child 
-      image
-    </div>
-    <div
-      className="c9 c10"
-    >
-      <svg
-        className="c11"
-        version="1.1"
-        viewBox="0 0 40 56"
-        x="0px"
-        xmlns="http://www.w3.org/2000/svg"
-        y="0px"
-      >
-        <g
-          fill="none"
-          fillRule="evenodd"
-          stroke="none"
-          strokeWidth="1"
-        >
-          <polygon
-            fill="black"
-            points="0 0 0 56 39.3600006 28"
-          />
-        </g>
-      </svg>
       <div
-        className="c3"
-        fontFamily={
-          Object {
-            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-            "fontWeight": 500,
-          }
-        }
-        fontSize="14px"
+        className="c9 c10"
       >
-        02:28
+        <svg
+          className="c11"
+          version="1.1"
+          viewBox="0 0 40 56"
+          x="0px"
+          xmlns="http://www.w3.org/2000/svg"
+          y="0px"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <polygon
+              fill="#000"
+              points="0 0 0 56 39.3600006 28"
+            />
+          </g>
+        </svg>
+        <div
+          className="c12"
+          fontFamily={
+            Object {
+              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+              "fontWeight": 500,
+            }
+          }
+          fontSize="14px"
+        >
+          02:28
+        </div>
       </div>
     </div>
   </div>
@@ -517,11 +902,88 @@ exports[`ArticleCard renders an article with children properly 1`] = `
 `;
 
 exports[`ArticleCard renders an article with unpublished media properly 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  padding: 20px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
 .c3 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 4px;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c5 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 20px;
+}
+
+.c7 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c15 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1em;
+}
+
+.c9 {
+  margin-bottom: 10px;
+  margin-left: 0px;
+  width: 100%;
 }
 
 .c6 {
@@ -529,12 +991,12 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
   white-space: nowrap;
 }
 
-.c13 {
+.c14 {
   width: 32px;
   height: 32px;
 }
 
-.c10 {
+.c11 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -546,235 +1008,363 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
 
 .c8 {
   position: relative;
-  width: 50%;
   height: inherit;
-  margin-left: 30px;
+  background: white;
 }
 
 .c0 {
   border: 1px solid;
   border-radius: 2px;
-  color: black;
+  color: #000;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  padding: 30px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: block;
 }
 
-.c0 .c9 {
+.c0 .c10 {
   opacity: 1;
 }
 
-.c0:hover .c9 {
+.c0:hover .c10 {
   opacity: 0.7;
-}
-
-.c0 .c7 {
-  background: white;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
-  margin-bottom: 30px;
-}
-
-.c2 {
-  margin-bottom: 10px;
-}
-
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
 }
 
 .c12 {
   position: absolute;
   left: 20px;
-  bottom: 20px;
   right: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  bottom: 20px;
 }
 
-.c11 svg {
-  width: 40px;
+.c12 svg {
+  height: 40px;
 }
 
-@media (max-width:900px) {
-  .c8 {
-    width: 100%;
-    margin-left: 0;
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width:900px) {
-  .c0 {
+@media screen and (min-width:40em) {
+  .c1 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c1 {
     padding: 20px;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
   .c1 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c1 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
     width: 100%;
-    margin-bottom: 0;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c2 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c4 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
+    font-size: 28px;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c4 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c4 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c4 {
+    line-height: 36px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c4 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c4 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c5 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-    margin-bottom: 20px;
+    font-size: 18px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c5 {
+    line-height: 26px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c9 {
+    margin-bottom: 10px;
+    margin-left: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c9 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c9 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c9 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c9 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c9 {
+    width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c11 svg {
-    width: 30px;
+  .c12 svg {
+    height: 30px;
   }
 }
 
 <a
   className="ArticleCard c0"
-  color="black"
+  color="#000"
   href="joanne-artman-gallery-poetry-naturerefinement-form"
   onClick={[Function]}
 >
   <div
     className="c1"
   >
-    <div>
-      <div
-        className="c2 c3"
-        fontFamily={
-          Object {
-            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-            "fontWeight": 500,
-          }
-        }
-        fontSize="14px"
-      >
-        The Future of Art
-      </div>
-      <div
-        className="c4"
-      >
-        New Study Shows the Gender Pay Gap for Artists Is Not So Simple
-      </div>
-      <div
-        className="c5"
-      >
-        The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
-      </div>
-    </div>
     <div
-      className="c6"
+      className="c2"
+      width={
+        Array [
+          "100%",
+          "100%",
+          "50%",
+          "50%",
+        ]
+      }
     >
-      <div
-        className="c3"
-        fontFamily={
-          Object {
-            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-            "fontWeight": 500,
+      <div>
+        <div
+          className="c3"
+          fontFamily={
+            Object {
+              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+              "fontWeight": 500,
+            }
           }
-        }
-        fontSize="14px"
-      >
-        Aug 28, 2017
-      </div>
-    </div>
-  </div>
-  <div
-    className="c7 c8"
-  >
-    <img
-      className="c9 c10"
-      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
-    />
-    <div
-      className="c11 c12"
-    >
-      <svg
-        className="c13"
-        version="1.1"
-        viewBox="0 0 40 56"
-        x="0px"
-        xmlns="http://www.w3.org/2000/svg"
-        y="0px"
-      >
-        <g
-          fill="none"
-          fillRule="evenodd"
-          stroke="none"
-          strokeWidth="1"
+          fontSize="14px"
         >
-          <polygon
-            fill="black"
-            points="0 0 0 56 39.3600006 28"
-          />
-        </g>
-      </svg>
-      <div
-        className="c3"
-        fontFamily={
-          Object {
-            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-            "fontWeight": 500,
+          The Future of Art
+        </div>
+        <div
+          className="c4"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize={
+            Array [
+              "28px",
+              "28px",
+              "42px",
+              "42px",
+            ]
           }
-        }
-        fontSize="14px"
+        >
+          New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+        </div>
+        <div
+          className="c5"
+          fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+          fontSize={
+            Array [
+              "18px",
+              "18px",
+              "22px",
+              "22px",
+            ]
+          }
+        >
+          The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
+        </div>
+      </div>
+      <div
+        className="c6"
       >
-        02:28
+        <div
+          className="c7"
+          fontFamily={
+            Object {
+              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+              "fontWeight": 500,
+            }
+          }
+          fontSize="14px"
+        >
+          Aug 28, 2017
+        </div>
+      </div>
+    </div>
+    <div
+      className="c8 c9"
+      width={
+        Array [
+          "100%",
+          "100%",
+          "50%",
+          "50%",
+        ]
+      }
+    >
+      <img
+        className="c10 c11"
+        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+      />
+      <div
+        className="c12 c13"
+      >
+        <svg
+          className="c14"
+          version="1.1"
+          viewBox="0 0 40 56"
+          x="0px"
+          xmlns="http://www.w3.org/2000/svg"
+          y="0px"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <polygon
+              fill="#000"
+              points="0 0 0 56 39.3600006 28"
+            />
+          </g>
+        </svg>
+        <div
+          className="c15"
+          fontFamily={
+            Object {
+              "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+              "fontWeight": 500,
+            }
+          }
+          fontSize="14px"
+        >
+          02:28
+        </div>
       </div>
     </div>
   </div>

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCards.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCards.test.tsx.snap
@@ -1,6 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArticleCard renders properly 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  padding: 20px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c5 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 20px;
+}
+
 .c7 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
@@ -8,12 +64,21 @@ exports[`ArticleCard renders properly 1`] = `
   line-height: 20px;
 }
 
-.c0 {
-  color: black;
+.c17 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1em;
 }
 
-.c1 {
+.c0 {
   margin-bottom: 40px;
+}
+
+.c11 {
+  margin-bottom: 10px;
+  margin-left: 0px;
+  width: 100%;
 }
 
 .c8 {
@@ -27,7 +92,7 @@ exports[`ArticleCard renders properly 1`] = `
   height: 8px;
   border-radius: 50%;
   margin: 0 5px 1px 0;
-  background-color: black;
+  background-color: #000;
 }
 
 .c9 {
@@ -47,7 +112,7 @@ exports[`ArticleCard renders properly 1`] = `
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-  color: black;
+  color: #000;
 }
 
 .c16 {
@@ -65,195 +130,407 @@ exports[`ArticleCard renders properly 1`] = `
   display: block;
 }
 
-.c11 {
+.c10 {
   position: relative;
-  width: 50%;
   height: inherit;
-  margin-left: 30px;
-}
-
-.c2 {
-  border: 1px solid;
-  border-radius: 2px;
-  color: black;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  padding: 30px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 .c12 {
-  opacity: 1;
-}
-
-.c2:hover .c12 {
-  opacity: 0.7;
-}
-
-.c2 .c10 {
   background: white;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
+.c1 {
+  border: 1px solid;
+  border-radius: 2px;
+  color: #000;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
 }
 
-.c4 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
-  margin-bottom: 30px;
+.c1 .c12 {
+  opacity: 1;
 }
 
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
+.c1:hover .c12 {
+  opacity: 0.7;
 }
 
-.c15 {
+.c14 {
   position: absolute;
   left: 20px;
-  bottom: 20px;
   right: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  bottom: 20px;
 }
 
 .c14 svg {
-  width: 40px;
+  height: 40px;
 }
 
 @media screen and (min-width:40em) {
-  .c1 {
-    margin-bottom: 60px;
-  }
-}
-
-@media (max-width:900px) {
-  .c11 {
-    width: 100%;
-    margin-left: 0;
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width:900px) {
   .c2 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
     padding: 20px;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c2 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c3 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c3 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c3 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c3 {
     width: 100%;
-    margin-bottom: 0;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c3 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c3 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c4 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
+    font-size: 28px;
   }
 }
 
-@media (max-width:900px) {
+@media screen and (min-width:52em) {
+  .c4 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c4 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c4 {
+    line-height: 36px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c4 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c4 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c5 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-    margin-bottom: 20px;
+    font-size: 18px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c5 {
+    line-height: 26px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c5 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    margin-bottom: 60px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c11 {
+    margin-bottom: 10px;
+    margin-left: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c11 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c11 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c11 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c11 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c11 {
+    width: 50%;
   }
 }
 
 @media (max-width:900px) {
   .c14 svg {
-    width: 30px;
+    height: 30px;
   }
 }
 
 <div
-  className="c0"
-  color="black"
+  className=""
 >
   <div
-    className="c1"
+    className="c0"
   >
     <a
-      className="ArticleCard c2"
-      color="black"
+      className="ArticleCard c1"
+      color="#000"
       href="new-yorks-next-art-district"
       onClick={[Function]}
     >
       <div
-        className="c3"
+        className="c2"
       >
-        <div>
-          <div
-            className="c4"
-          >
-            New York's Next Art District
+        <div
+          className="c3"
+          width={
+            Array [
+              "100%",
+              "100%",
+              "50%",
+              "50%",
+            ]
+          }
+        >
+          <div>
+            <div
+              className="c4"
+              fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+              fontSize={
+                Array [
+                  "28px",
+                  "28px",
+                  "42px",
+                  "42px",
+                ]
+              }
+            >
+              New York's Next Art District
+            </div>
+            <div
+              className="c5"
+              fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+              fontSize={
+                Array [
+                  "18px",
+                  "18px",
+                  "22px",
+                  "22px",
+                ]
+              }
+            >
+              Land exhibitions, make influential contacts, and gain valuable feedback about your work.
+            </div>
           </div>
           <div
-            className="c5"
+            className="Byline c6"
+            color="#000"
           >
-            Land exhibitions, make influential contacts, and gain valuable feedback about your work.
+            <div
+              className="c7"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
+              }
+              fontSize="14px"
+            >
+              <div
+                className="c8"
+                color="#000"
+              >
+                Casey Lesser
+              </div>
+            </div>
+            <div
+              className="c9"
+            >
+              <div
+                className="c7"
+                fontFamily={
+                  Object {
+                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                    "fontWeight": 500,
+                  }
+                }
+                fontSize="14px"
+              >
+                May 19, 2017
+              </div>
+            </div>
           </div>
         </div>
         <div
-          className="Byline c6"
-          color="black"
+          className="c10 c11"
+          width={
+            Array [
+              "100%",
+              "100%",
+              "50%",
+              "50%",
+            ]
+          }
         >
-          <div
-            className="c7"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
-              }
-            }
-            fontSize="14px"
-          >
+          <img
+            className="c12 c13"
+            src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+          />
+        </div>
+      </div>
+    </a>
+  </div>
+  <div
+    className="c0"
+  >
+    <a
+      className="ArticleCard c1"
+      color="#000"
+      href="joanne-artman-gallery-poetry-naturerefinement-form"
+      onClick={[Function]}
+    >
+      <div
+        className="c2"
+      >
+        <div
+          className="c3"
+          width={
+            Array [
+              "100%",
+              "100%",
+              "50%",
+              "50%",
+            ]
+          }
+        >
+          <div>
             <div
-              className="c8"
-              color="black"
+              className="c4"
+              fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+              fontSize={
+                Array [
+                  "28px",
+                  "28px",
+                  "42px",
+                  "42px",
+                ]
+              }
             >
-              Casey Lesser
+              New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+            </div>
+            <div
+              className="c5"
+              fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+              fontSize={
+                Array [
+                  "18px",
+                  "18px",
+                  "22px",
+                  "22px",
+                ]
+              }
+            >
+              The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
             </div>
           </div>
           <div
@@ -269,103 +546,60 @@ exports[`ArticleCard renders properly 1`] = `
               }
               fontSize="14px"
             >
-              May 19, 2017
+              Aug 28, 2017
             </div>
           </div>
         </div>
-      </div>
-      <div
-        className="c10 c11"
-      >
-        <img
-          className="c12 c13"
-          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
-        />
-      </div>
-    </a>
-  </div>
-  <div
-    className="c1"
-  >
-    <a
-      className="ArticleCard c2"
-      color="black"
-      href="joanne-artman-gallery-poetry-naturerefinement-form"
-      onClick={[Function]}
-    >
-      <div
-        className="c3"
-      >
-        <div>
-          <div
-            className="c4"
-          >
-            New Study Shows the Gender Pay Gap for Artists Is Not So Simple
-          </div>
-          <div
-            className="c5"
-          >
-            The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
-          </div>
-        </div>
         <div
-          className="c9"
+          className="c10 c11"
+          width={
+            Array [
+              "100%",
+              "100%",
+              "50%",
+              "50%",
+            ]
+          }
         >
+          <img
+            className="c12 c13"
+            src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+          />
           <div
-            className="c7"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
-              }
-            }
-            fontSize="14px"
+            className="c14 c15"
           >
-            Aug 28, 2017
-          </div>
-        </div>
-      </div>
-      <div
-        className="c10 c11"
-      >
-        <img
-          className="c12 c13"
-          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
-        />
-        <div
-          className="c14 c15"
-        >
-          <svg
-            className="c16"
-            version="1.1"
-            viewBox="0 0 40 56"
-            x="0px"
-            xmlns="http://www.w3.org/2000/svg"
-            y="0px"
-          >
-            <g
-              fill="none"
-              fillRule="evenodd"
-              stroke="none"
-              strokeWidth="1"
+            <svg
+              className="c16"
+              version="1.1"
+              viewBox="0 0 40 56"
+              x="0px"
+              xmlns="http://www.w3.org/2000/svg"
+              y="0px"
             >
-              <polygon
-                fill="black"
-                points="0 0 0 56 39.3600006 28"
-              />
-            </g>
-          </svg>
-          <div
-            className="c7"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
+              <g
+                fill="none"
+                fillRule="evenodd"
+                stroke="none"
+                strokeWidth="1"
+              >
+                <polygon
+                  fill="#000"
+                  points="0 0 0 56 39.3600006 28"
+                />
+              </g>
+            </svg>
+            <div
+              className="c17"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
               }
-            }
-            fontSize="14px"
-          >
-            02:28
+              fontSize="14px"
+            >
+              02:28
+            </div>
           </div>
         </div>
       </div>

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/Block.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/Block.test.tsx.snap
@@ -1,124 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArticleCard renders properly 1`] = `
-.c4 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-  color: black;
-}
-
-.c12 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c1 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c5 {
-  color: black;
-}
-
-.c6 {
-  margin-bottom: 40px;
-}
-
-.c3 a {
-  color: black;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c13 {
-  margin: 10px 20px 0 0;
-}
-
-.c13::before {
-  content: "";
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin: 0 5px 1px 0;
-  background-color: black;
-}
-
-.c14 {
-  margin: 5px 20px 0 0;
-  white-space: nowrap;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  color: black;
-}
-
-.c21 {
-  width: 32px;
-  height: 32px;
-}
-
-.c18 {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
-  -webkit-transition: opacity 0.15s;
-  transition: opacity 0.15s;
-  display: block;
-}
-
-.c16 {
-  position: relative;
-  width: 50%;
-  height: inherit;
-  margin-left: 30px;
-}
-
-.c7 {
-  border: 1px solid;
-  border-radius: 2px;
-  color: black;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  padding: 30px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c7 .c17 {
-  opacity: 1;
-}
-
-.c7:hover .c17 {
-  opacity: 0.7;
-}
-
-.c7 .c15 {
-  background: white;
-}
-
 .c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  padding: 20px;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -130,50 +24,173 @@ exports[`ArticleCard renders properly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 50%;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
+  width: 100%;
 }
 
-.c9 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
-  margin-bottom: 30px;
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
+  color: #000;
 }
 
 .c10 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
+}
+
+.c11 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
+  font-size: 18px;
+  line-height: 26px;
+  margin-bottom: 20px;
+}
+
+.c13 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c23 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1em;
+}
+
+.c1 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c5 {
+  color: #000;
+}
+
+.c6 {
+  margin-bottom: 40px;
+}
+
+.c17 {
+  margin-bottom: 10px;
+  margin-left: 0px;
+  width: 100%;
+}
+
+.c3 a {
+  color: #000;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14 {
+  margin: 10px 20px 0 0;
+}
+
+.c14::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin: 0 5px 1px 0;
+  background-color: #000;
+}
+
+.c15 {
+  margin: 5px 20px 0 0;
+  white-space: nowrap;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  color: #000;
+}
+
+.c22 {
+  width: 32px;
+  height: 32px;
+}
+
+.c19 {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  -webkit-transition: opacity 0.15s;
+  transition: opacity 0.15s;
+  display: block;
+}
+
+.c16 {
+  position: relative;
+  height: inherit;
+  background: white;
+}
+
+.c7 {
+  border: 1px solid;
+  border-radius: 2px;
+  color: #000;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+}
+
+.c7 .c18 {
+  opacity: 1;
+}
+
+.c7:hover .c18 {
+  opacity: 0.7;
 }
 
 .c20 {
   position: absolute;
   left: 20px;
-  bottom: 20px;
   right: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  bottom: 20px;
 }
 
-.c19 svg {
-  width: 40px;
+.c20 svg {
+  height: 40px;
 }
 
 .c0 {
-  color: black;
+  color: #000;
 }
 
 .c0 .c2 {
@@ -189,8 +206,154 @@ exports[`ArticleCard renders properly 1`] = `
   border-bottom: 2px solid;
 }
 
-.c0 .SeriesAbout__SeriesAboutContainer-s1xh0wwc-0 {
-  margin: 60px auto 100px auto;
+@media screen and (min-width:40em) {
+  .c8 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c8 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c8 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c8 {
+    padding: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c8 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c8 {
+    padding: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c9 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c9 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c9 {
+    margin-bottom: 5px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c9 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c9 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c9 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c10 {
+    font-size: 28px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c10 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c10 {
+    font-size: 42px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c10 {
+    line-height: 36px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c10 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c10 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c11 {
+    font-size: 18px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c11 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c11 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c11 {
+    line-height: 26px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c11 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c11 {
+    line-height: 32px;
+  }
 }
 
 @media screen and (min-width:40em) {
@@ -199,77 +362,61 @@ exports[`ArticleCard renders properly 1`] = `
   }
 }
 
-@media (max-width:900px) {
-  .c16 {
-    width: 100%;
-    margin-left: 0;
+@media screen and (min-width:40em) {
+  .c17 {
     margin-bottom: 10px;
+    margin-left: 0px;
   }
 }
 
-@media (max-width:900px) {
-  .c7 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-    padding: 20px;
+@media screen and (min-width:52em) {
+  .c17 {
+    margin-bottom: 0px;
+    margin-left: 30px;
   }
 }
 
-@media (max-width:900px) {
-  .c8 {
+@media screen and (min-width:64em) {
+  .c17 {
+    margin-bottom: 0px;
+    margin-left: 30px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c17 {
     width: 100%;
-    margin-bottom: 0;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c17 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c17 {
+    width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c9 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-}
-
-@media (max-width:900px) {
-  .c10 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-    margin-bottom: 20px;
-  }
-}
-
-@media (max-width:900px) {
-  .c19 svg {
-    width: 30px;
-  }
-}
-
-@media (max-width:768px) {
-  .c0 .c2 a {
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c0 .SeriesAbout__SeriesAboutContainer-s1xh0wwc-0 {
-    margin: 40px auto 100px auto;
+  .c20 svg {
+    height: 30px;
   }
 }
 
 <div
   className="c0"
-  color="black"
+  color="#000"
 >
   <div
     className="c1"
   >
     <div
       className="c2 c3 c4"
-      color="black"
+      color="#000"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -285,58 +432,67 @@ exports[`ArticleCard renders properly 1`] = `
     </div>
     <div
       className="c5"
-      color="black"
+      color="#000"
     >
       <div
         className="c6"
       >
         <a
           className="ArticleCard c7"
-          color="black"
+          color="#000"
           href="new-yorks-next-art-district"
           onClick={[Function]}
         >
           <div
             className="c8"
           >
-            <div>
-              <div
-                className="c9"
-              >
-                New York's Next Art District
-              </div>
-              <div
-                className="c10"
-              >
-                Land exhibitions, make influential contacts, and gain valuable feedback about your work.
-              </div>
-            </div>
             <div
-              className="Byline c11"
-              color="black"
+              className="c9"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
             >
-              <div
-                className="c12"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
-                  }
-                }
-                fontSize="14px"
-              >
+              <div>
                 <div
-                  className="c13"
-                  color="black"
+                  className="c10"
+                  fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                  fontSize={
+                    Array [
+                      "28px",
+                      "28px",
+                      "42px",
+                      "42px",
+                    ]
+                  }
                 >
-                  Casey Lesser
+                  New York's Next Art District
+                </div>
+                <div
+                  className="c11"
+                  fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                  fontSize={
+                    Array [
+                      "18px",
+                      "18px",
+                      "22px",
+                      "22px",
+                    ]
+                  }
+                >
+                  Land exhibitions, make influential contacts, and gain valuable feedback about your work.
                 </div>
               </div>
               <div
-                className="c14"
+                className="Byline c12"
+                color="#000"
               >
                 <div
-                  className="c12"
+                  className="c13"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -345,18 +501,47 @@ exports[`ArticleCard renders properly 1`] = `
                   }
                   fontSize="14px"
                 >
-                  May 19, 2017
+                  <div
+                    className="c14"
+                    color="#000"
+                  >
+                    Casey Lesser
+                  </div>
+                </div>
+                <div
+                  className="c15"
+                >
+                  <div
+                    className="c13"
+                    fontFamily={
+                      Object {
+                        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                        "fontWeight": 500,
+                      }
+                    }
+                    fontSize="14px"
+                  >
+                    May 19, 2017
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="c15 c16"
-          >
-            <img
-              className="c17 c18"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
-            />
+            <div
+              className="c16 c17"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
+            >
+              <img
+                className="c18 c19"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+              />
+            </div>
           </div>
         </a>
       </div>
@@ -365,83 +550,121 @@ exports[`ArticleCard renders properly 1`] = `
       >
         <a
           className="ArticleCard c7"
-          color="black"
+          color="#000"
           href="joanne-artman-gallery-poetry-naturerefinement-form"
           onClick={[Function]}
         >
           <div
             className="c8"
           >
-            <div>
-              <div
-                className="c9"
-              >
-                New Study Shows the Gender Pay Gap for Artists Is Not So Simple
-              </div>
-              <div
-                className="c10"
-              >
-                The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
-              </div>
-            </div>
             <div
-              className="c14"
+              className="c9"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
             >
-              <div
-                className="c12"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
+              <div>
+                <div
+                  className="c10"
+                  fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+                  fontSize={
+                    Array [
+                      "28px",
+                      "28px",
+                      "42px",
+                      "42px",
+                    ]
                   }
-                }
-                fontSize="14px"
-              >
-                Aug 28, 2017
-              </div>
-            </div>
-          </div>
-          <div
-            className="c15 c16"
-          >
-            <img
-              className="c17 c18"
-              src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
-            />
-            <div
-              className="c19 c20"
-            >
-              <svg
-                className="c21"
-                version="1.1"
-                viewBox="0 0 40 56"
-                x="0px"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0px"
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  stroke="none"
-                  strokeWidth="1"
                 >
-                  <polygon
-                    fill="black"
-                    points="0 0 0 56 39.3600006 28"
-                  />
-                </g>
-              </svg>
-              <div
-                className="c12"
-                fontFamily={
-                  Object {
-                    "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                    "fontWeight": 500,
+                  New Study Shows the Gender Pay Gap for Artists Is Not So Simple
+                </div>
+                <div
+                  className="c11"
+                  fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+                  fontSize={
+                    Array [
+                      "18px",
+                      "18px",
+                      "22px",
+                      "22px",
+                    ]
                   }
-                }
-                fontSize="14px"
+                >
+                  The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
+                </div>
+              </div>
+              <div
+                className="c15"
               >
-                02:28
+                <div
+                  className="c13"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  Aug 28, 2017
+                </div>
+              </div>
+            </div>
+            <div
+              className="c16 c17"
+              width={
+                Array [
+                  "100%",
+                  "100%",
+                  "50%",
+                  "50%",
+                ]
+              }
+            >
+              <img
+                className="c18 c19"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+              />
+              <div
+                className="c20 c21"
+              >
+                <svg
+                  className="c22"
+                  version="1.1"
+                  viewBox="0 0 40 56"
+                  x="0px"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0px"
+                >
+                  <g
+                    fill="none"
+                    fillRule="evenodd"
+                    stroke="none"
+                    strokeWidth="1"
+                  >
+                    <polygon
+                      fill="#000"
+                      points="0 0 0 56 39.3600006 28"
+                    />
+                  </g>
+                </svg>
+                <div
+                  className="c23"
+                  fontFamily={
+                    Object {
+                      "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                      "fontWeight": 500,
+                    }
+                  }
+                  fontSize="14px"
+                >
+                  02:28
+                </div>
               </div>
             </div>
           </div>

--- a/src/Components/Publishing/Sections/VerticalOrSeriesTitle.tsx
+++ b/src/Components/Publishing/Sections/VerticalOrSeriesTitle.tsx
@@ -1,8 +1,8 @@
-import { Sans } from "@artsy/palette"
+import { color, Sans } from "@artsy/palette"
+import { getEditorialHref } from "Components/Publishing/Constants"
+import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
-import { getEditorialHref } from "../Constants"
-import { ArticleData } from "../Typings"
 
 interface Props {
   article?: ArticleData
@@ -12,24 +12,19 @@ interface Props {
 }
 
 export const VerticalOrSeriesTitle: React.SFC<Props> = props => {
-  const { article, color, prefix } = props
-  const { layout, hero_section, seriesArticle } = article
+  const { article, prefix } = props
+  const { seriesArticle } = article
   const vertical = props.vertical
     ? props.vertical
     : article.vertical && article.vertical.name
-  const hasSeries =
-    (layout === "feature" &&
-      hero_section &&
-      hero_section.type === "fullscreen") ||
-    layout === "video"
 
   const seriesLink =
     seriesArticle && getEditorialHref("series", seriesArticle.slug)
 
   return (
-    <Vertical size="3t" weight="medium" color={color}>
+    <Vertical size="3" weight="medium" color={props.color}>
       {prefix}
-      {seriesArticle && hasSeries ? (
+      {seriesArticle ? (
         <a href={seriesLink}>{seriesArticle.title}</a>
       ) : (
         <span>{vertical}</span>
@@ -40,7 +35,11 @@ export const VerticalOrSeriesTitle: React.SFC<Props> = props => {
 
 export const Vertical = styled(Sans)`
   a {
-    color: ${props => props.color || "black"};
+    color: ${props => props.color};
     text-decoration: none;
   }
 `
+
+VerticalOrSeriesTitle.defaultProps = {
+  color: color("black100"),
+}

--- a/src/Components/Publishing/Sections/VerticalOrSeriesTitle.tsx
+++ b/src/Components/Publishing/Sections/VerticalOrSeriesTitle.tsx
@@ -1,8 +1,9 @@
 import { color, Sans } from "@artsy/palette"
-import { getEditorialHref } from "Components/Publishing/Constants"
-import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
+
+import { getEditorialHref } from "Components/Publishing/Constants"
+import { ArticleData } from "Components/Publishing/Typings"
 
 interface Props {
   article?: ArticleData

--- a/src/Components/Publishing/Sections/__tests__/VerticalOrSeriesTitle.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/VerticalOrSeriesTitle.test.tsx
@@ -41,18 +41,6 @@ it("renders a series if feature and fullscreen", () => {
   expect(component.text()).toMatch(SeriesArticleSponsored.title)
 })
 
-it("renders a vertical if feature and not fullscreen", () => {
-  const FeatureSeriesArticle = clone({
-    ...FeatureArticle,
-    hero_section: { type: "basic" },
-    seriesArticle: SeriesArticleSponsored,
-  })
-  const component = mount(
-    <VerticalOrSeriesTitle article={FeatureSeriesArticle} />
-  )
-  expect(component.text()).toMatch(FeatureArticle.vertical.name)
-})
-
 it("renders with props vertical", () => {
   const component = mount(
     <VerticalOrSeriesTitle

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/VerticalOrSeriesTitle.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/VerticalOrSeriesTitle.test.tsx.snap
@@ -5,17 +5,19 @@ exports[`renders properly for a feature article 1`] = `
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 24px;
+  color: #000;
 }
 
 .c0 a {
-  color: black;
+  color: #000;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 <div
   className="c0 c1"
+  color="#000"
   fontFamily={
     Object {
       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -35,17 +37,19 @@ exports[`renders properly for a standard article 1`] = `
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 24px;
+  color: #000;
 }
 
 .c0 a {
-  color: black;
+  color: #000;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 <div
   className="c0 c1"
+  color="#000"
   fontFamily={
     Object {
       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",

--- a/src/Components/Publishing/Series/SeriesAbout.tsx
+++ b/src/Components/Publishing/Series/SeriesAbout.tsx
@@ -1,12 +1,12 @@
-import { unica } from "Assets/Fonts"
+import { Box, Flex, Sans } from "@artsy/palette"
 import React, { Component } from "react"
-import { Col, Row } from "react-styled-flexboxgrid"
 import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
-import { media } from "../../Helpers"
-import { PartnerBlock, PartnerBlockContainer } from "../Partner/PartnerBlock"
-import { Text } from "../Sections/Text"
-import { ArticleData } from "../Typings"
+
+import { PartnerBlock } from "Components/Publishing/Partner/PartnerBlock"
+import { Text } from "Components/Publishing/Sections/Text"
+import { ArticleData } from "Components/Publishing/Typings"
+import { Media } from "Utils/Responsive"
 
 interface Props {
   article?: ArticleData
@@ -36,6 +36,29 @@ export class SeriesAbout extends Component<Props, null> {
     })
   }
 
+  partnerBlock = () => {
+    const {
+      article: { sponsor },
+      color,
+    } = this.props
+    const sponsorLogo =
+      sponsor &&
+      (color === "white"
+        ? sponsor.partner_light_logo
+        : sponsor.partner_dark_logo)
+
+    return (
+      <PartnerBlock
+        logo={sponsorLogo}
+        url={sponsor.partner_logo_link}
+        trackingData={{
+          type: "external link",
+          destination_path: sponsor.partner_logo_link,
+        }}
+      />
+    )
+  }
+
   render() {
     const {
       article: { series, sponsor },
@@ -44,104 +67,51 @@ export class SeriesAbout extends Component<Props, null> {
       editSubTitle,
     } = this.props
 
-    const sponsorLogo =
-      sponsor &&
-      (color === "black"
-        ? sponsor.partner_dark_logo
-        : sponsor.partner_light_logo)
-
     return (
-      <SeriesAboutContainer color={color}>
-        <StyledCol xs={12} sm={4}>
-          <Title>
+      <SeriesAboutContainer
+        color={color || "black"}
+        maxWidth="1200px"
+        mx="auto"
+        width="100%"
+        flexDirection={["column", "column", "row", "row"]}
+      >
+        <Flex
+          width={[1, 1, 1 / 3, 1 / 3]}
+          justifyContent="space-between"
+          flexDirection="column"
+        >
+          <Sans size="8" mb={["20px", "20px", 0, 0]}>
             {editSubTitle
               ? editSubTitle
               : (series && series.sub_title) || "About the Series"}
-          </Title>
-          {sponsor && (
-            <PartnerBlock
-              logo={sponsorLogo}
-              url={sponsor.partner_logo_link}
-              trackingData={{
-                type: "external link",
-                destination_path: sponsor.partner_logo_link,
-              }}
-            />
-          )}
-        </StyledCol>
-        <StyledCol xs={12} sm={8}>
+          </Sans>
+
+          <Media greaterThanOrEqual="md">
+            {sponsor && <Box mb={1}>{this.partnerBlock()}</Box>}
+          </Media>
+        </Flex>
+
+        <Flex width={[1, 1, 2 / 3, 2 / 3]} flexDirection="column">
           {editDescription ? (
-            <Text layout="standard" color={color}>
+            <Text layout="standard" color={color || "black"}>
               {editDescription}
             </Text>
           ) : (
             <div className="SeriesAbout__description">
               <Text
                 layout="standard"
-                color={color}
+                color={color || "black"}
                 html={series && series.description}
               />
             </div>
           )}
-          {sponsor && (
-            <PartnerBlock
-              logo={sponsorLogo}
-              url={sponsor.partner_logo_link}
-              trackingData={{
-                type: "external link",
-                destination_path: sponsor.partner_logo_link,
-              }}
-            />
-          )}
-        </StyledCol>
+          <Media lessThan="md">
+            {sponsor && <Box mt={60}>{this.partnerBlock()}</Box>}
+          </Media>
+        </Flex>
       </SeriesAboutContainer>
     )
   }
 }
 
-SeriesAbout.defaultProps = {
-  color: "black",
-}
-
-export const SeriesAboutContainer = styled(Row)`
-  color: ${(props: Props) => props.color};
-  max-width: 1200px;
-  width: 100%;
-`
-
-const StyledCol = styled(Col)`
-  ${PartnerBlockContainer} {
-    display: none;
-  }
-
-  &:first-of-type {
-    display: flex;
-    justify-content: space-between;
-    flex-direction: column;
-
-    ${PartnerBlockContainer} {
-      display: block;
-      margin-bottom: 10px;
-    }
-  }
-
-  ${props => media.sm`
-    &:first-of-type {
-      ${PartnerBlockContainer} {
-        display: none;
-      }
-    }
-
-    ${PartnerBlockContainer} {
-      margin-top: 60px;
-      display: block;
-    }
-  `};
-`
-
-const Title = styled.div`
-  ${unica("s32")};
-  ${props => media.sm`
-    margin-bottom: 20px;
-  `};
-`
+export const SeriesAboutContainer = styled(Flex)``

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -1,49 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SeriesAbout snapshots Renders properly 1`] = `
-.c1 {
-  box-sizing: border-box;
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .c3 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
 }
 
-.c5 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c2 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
 }
 
-.c6 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 a {
+.c4 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -53,22 +63,22 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   background-position: bottom;
 }
 
-.c6 a:hover {
+.c4 a:hover {
   color: #999999;
   opacity: 1;
 }
 
-.c6 div[class*='ToolTip'] a {
+.c4 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c6 p,
-.c6 ul,
-.c6 ol,
-.c6 .paragraph,
-.c6 div[data-block=true] .public-DraftStyleDefault-block {
+.c4 p,
+.c4 ul,
+.c4 ol,
+.c4 .paragraph,
+.c4 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -79,32 +89,32 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   font-style: inherit;
 }
 
-.c6 p:first-child,
-.c6 .paragraph:first-child,
-.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c4 p:first-child,
+.c4 .paragraph:first-child,
+.c4 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c6 p:last-child,
-.c6 .paragraph:last-child,
-.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c4 p:last-child,
+.c4 .paragraph:last-child,
+.c4 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c6 ul,
-.c6 ol {
+.c4 ul,
+.c4 ol {
   padding-left: 1em;
 }
 
-.c6 ul {
+.c4 ul {
   list-style: disc;
 }
 
-.c6 ol {
+.c4 ol {
   list-style: decimal;
 }
 
-.c6 li {
+.c4 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -113,7 +123,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c6 h1 {
+.c4 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -126,7 +136,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   text-align: center;
 }
 
-.c6 h1::before {
+.c4 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -137,7 +147,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   right: calc(50% - 4px);
 }
 
-.c6 h2 {
+.c4 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -146,15 +156,15 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   margin: 0;
 }
 
-.c6 h2 a {
+.c4 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c6 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+.c4 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
   background-position: bottom !important;
 }
 
-.c6 h3 {
+.c4 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -164,7 +174,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   margin: 0;
 }
 
-.c6 h3 strong {
+.c4 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -172,11 +182,11 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   line-height: 1.5em;
 }
 
-.c6 h3 a {
+.c4 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c6 blockquote {
+.c4 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -189,7 +199,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   word-break: break-word;
 }
 
-.c6 .content-end {
+.c4 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -200,14 +210,14 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   margin-bottom: 1px;
 }
 
-.c6 .artist-follow {
+.c4 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c6 .artist-follow::before {
+.c4 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -215,7 +225,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   font-size: 32px;
 }
 
-.c6 .artist-follow::after {
+.c4 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -224,115 +234,117 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   text-transform: none;
 }
 
-.c0 {
-  color: black;
-  max-width: 1200px;
-  width: 100%;
+@media screen and (min-width:40em) {
+  .c0 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
 }
 
-.c2 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: none;
+@media screen and (min-width:52em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
 }
 
-.c2:first-of-type {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+@media screen and (min-width:64em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
 }
 
-.c2:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: block;
-  margin-bottom: 10px;
+@media screen and (min-width:40em) {
+  .c1 {
+    width: 100%;
+  }
 }
 
-.c4 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
+@media screen and (min-width:52em) {
+  .c1 {
+    width: 33.33333333333333%;
+  }
 }
 
-@media only screen and (min-width:0em) {
+@media screen and (min-width:64em) {
+  .c1 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
+    width: 100%;
   }
 }
 
-@media only screen and (min-width:48em) {
+@media screen and (min-width:52em) {
   .c3 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
+    width: 66.66666666666666%;
   }
 }
 
-@media only screen and (min-width:0em) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
+@media screen and (min-width:64em) {
+  .c3 {
+    width: 66.66666666666666%;
   }
 }
 
-@media only screen and (min-width:48em) {
-  .c5 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
+@media screen and (min-width:40em) {
+  .c2 {
+    margin-bottom: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    margin-bottom: 0px;
   }
 }
 
 @media (max-width:600px) {
-  .c6 p,
-  .c6 ul,
-  .c6 ol,
-  .c6 div[data-block=true] .public-DraftStyleDefault-block {
+  .c4 p,
+  .c4 ul,
+  .c4 ol,
+  .c4 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c6 li {
+  .c4 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c6 h1 {
+  .c4 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c6 h2 {
+  .c4 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c6 h3 {
+  .c4 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -340,14 +352,14 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c6 h3 strong {
+  .c4 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c6 blockquote {
+  .c4 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -355,49 +367,54 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
     margin: 0;
   }
 
-  .c6 .content-start {
+  .c4 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:768px) {
-  .c2:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    display: none;
-  }
-
-  .c2 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    margin-top: 60px;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c4 {
-    margin-bottom: 20px;
-  }
-}
-
 <div
-  className="c0 c1"
+  className="c0"
   color="black"
+  width="100%"
 >
   <div
-    className="c2 c3"
+    className="c1"
+    width={
+      Array [
+        1,
+        1,
+        0.3333333333333333,
+        0.3333333333333333,
+      ]
+    }
   >
     <div
-      className="c4"
+      className="c2"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="28px"
     >
       About the Series
     </div>
+    <div
+      className="rrm-container rrm-greaterThanOrEqual-md"
+    />
   </div>
   <div
-    className="c2 c5"
+    className="c3"
+    width={
+      Array [
+        1,
+        1,
+        0.6666666666666666,
+        0.6666666666666666,
+      ]
+    }
   >
     <div
       className="SeriesAbout__description"
     >
       <div
-        className="article__text-section c6"
+        className="article__text-section c4"
         color="black"
       >
         <div
@@ -409,54 +426,67 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
         />
       </div>
     </div>
+    <div
+      className="rrm-container rrm-lessThan-md"
+    />
   </div>
 </div>
 `;
 
 exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
-.c1 {
-  box-sizing: border-box;
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .c3 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
 }
 
-.c5 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c2 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
 }
 
-.c6 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 a {
+.c4 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -466,22 +496,22 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   background-position: bottom;
 }
 
-.c6 a:hover {
+.c4 a:hover {
   color: #999999;
   opacity: 1;
 }
 
-.c6 div[class*='ToolTip'] a {
+.c4 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c6 p,
-.c6 ul,
-.c6 ol,
-.c6 .paragraph,
-.c6 div[data-block=true] .public-DraftStyleDefault-block {
+.c4 p,
+.c4 ul,
+.c4 ol,
+.c4 .paragraph,
+.c4 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -492,32 +522,32 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   font-style: inherit;
 }
 
-.c6 p:first-child,
-.c6 .paragraph:first-child,
-.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c4 p:first-child,
+.c4 .paragraph:first-child,
+.c4 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c6 p:last-child,
-.c6 .paragraph:last-child,
-.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c4 p:last-child,
+.c4 .paragraph:last-child,
+.c4 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c6 ul,
-.c6 ol {
+.c4 ul,
+.c4 ol {
   padding-left: 1em;
 }
 
-.c6 ul {
+.c4 ul {
   list-style: disc;
 }
 
-.c6 ol {
+.c4 ol {
   list-style: decimal;
 }
 
-.c6 li {
+.c4 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -526,7 +556,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   padding-bottom: .5em;
 }
 
-.c6 h1 {
+.c4 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -539,7 +569,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   text-align: center;
 }
 
-.c6 h1::before {
+.c4 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -550,7 +580,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   right: calc(50% - 4px);
 }
 
-.c6 h2 {
+.c4 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -559,15 +589,15 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   margin: 0;
 }
 
-.c6 h2 a {
+.c4 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c6 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+.c4 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
   background-position: bottom !important;
 }
 
-.c6 h3 {
+.c4 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -577,7 +607,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   margin: 0;
 }
 
-.c6 h3 strong {
+.c4 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -585,11 +615,11 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   line-height: 1.5em;
 }
 
-.c6 h3 a {
+.c4 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c6 blockquote {
+.c4 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -602,7 +632,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   word-break: break-word;
 }
 
-.c6 .content-end {
+.c4 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -613,14 +643,14 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   margin-bottom: 1px;
 }
 
-.c6 .artist-follow {
+.c4 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c6 .artist-follow::before {
+.c4 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -628,7 +658,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   font-size: 32px;
 }
 
-.c6 .artist-follow::after {
+.c4 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -637,115 +667,117 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   text-transform: none;
 }
 
-.c0 {
-  color: black;
-  max-width: 1200px;
-  width: 100%;
+@media screen and (min-width:40em) {
+  .c0 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
 }
 
-.c2 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: none;
+@media screen and (min-width:52em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
 }
 
-.c2:first-of-type {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+@media screen and (min-width:64em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
 }
 
-.c2:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: block;
-  margin-bottom: 10px;
+@media screen and (min-width:40em) {
+  .c1 {
+    width: 100%;
+  }
 }
 
-.c4 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
+@media screen and (min-width:52em) {
+  .c1 {
+    width: 33.33333333333333%;
+  }
 }
 
-@media only screen and (min-width:0em) {
+@media screen and (min-width:64em) {
+  .c1 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
+    width: 100%;
   }
 }
 
-@media only screen and (min-width:48em) {
+@media screen and (min-width:52em) {
   .c3 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
+    width: 66.66666666666666%;
   }
 }
 
-@media only screen and (min-width:0em) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
+@media screen and (min-width:64em) {
+  .c3 {
+    width: 66.66666666666666%;
   }
 }
 
-@media only screen and (min-width:48em) {
-  .c5 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
+@media screen and (min-width:40em) {
+  .c2 {
+    margin-bottom: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    margin-bottom: 0px;
   }
 }
 
 @media (max-width:600px) {
-  .c6 p,
-  .c6 ul,
-  .c6 ol,
-  .c6 div[data-block=true] .public-DraftStyleDefault-block {
+  .c4 p,
+  .c4 ul,
+  .c4 ol,
+  .c4 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c6 li {
+  .c4 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c6 h1 {
+  .c4 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c6 h2 {
+  .c4 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c6 h3 {
+  .c4 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -753,14 +785,14 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
     line-height: 1.5em;
   }
 
-  .c6 h3 strong {
+  .c4 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c6 blockquote {
+  .c4 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -768,46 +800,51 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
     margin: 0;
   }
 
-  .c6 .content-start {
+  .c4 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:768px) {
-  .c2:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    display: none;
-  }
-
-  .c2 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    margin-top: 60px;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c4 {
-    margin-bottom: 20px;
-  }
-}
-
 <div
-  className="c0 c1"
+  className="c0"
   color="black"
+  width="100%"
 >
   <div
-    className="c2 c3"
+    className="c1"
+    width={
+      Array [
+        1,
+        1,
+        0.3333333333333333,
+        0.3333333333333333,
+      ]
+    }
   >
     <div
-      className="c4"
+      className="c2"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="28px"
     >
       About the Series
     </div>
+    <div
+      className="rrm-container rrm-greaterThanOrEqual-md"
+    />
   </div>
   <div
-    className="c2 c5"
+    className="c3"
+    width={
+      Array [
+        1,
+        1,
+        0.6666666666666666,
+        0.6666666666666666,
+      ]
+    }
   >
     <div
-      className="article__text-section c6"
+      className="article__text-section c4"
       color="black"
     >
       <div>
@@ -815,54 +852,67 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
         description
       </div>
     </div>
+    <div
+      className="rrm-container rrm-lessThan-md"
+    />
   </div>
 </div>
 `;
 
 exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
-.c1 {
-  box-sizing: border-box;
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .c3 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
 }
 
-.c5 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c2 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
 }
 
-.c6 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 a {
+.c4 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -872,22 +922,22 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   background-position: bottom;
 }
 
-.c6 a:hover {
+.c4 a:hover {
   color: #999999;
   opacity: 1;
 }
 
-.c6 div[class*='ToolTip'] a {
+.c4 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c6 p,
-.c6 ul,
-.c6 ol,
-.c6 .paragraph,
-.c6 div[data-block=true] .public-DraftStyleDefault-block {
+.c4 p,
+.c4 ul,
+.c4 ol,
+.c4 .paragraph,
+.c4 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -898,32 +948,32 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   font-style: inherit;
 }
 
-.c6 p:first-child,
-.c6 .paragraph:first-child,
-.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c4 p:first-child,
+.c4 .paragraph:first-child,
+.c4 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c6 p:last-child,
-.c6 .paragraph:last-child,
-.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c4 p:last-child,
+.c4 .paragraph:last-child,
+.c4 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c6 ul,
-.c6 ol {
+.c4 ul,
+.c4 ol {
   padding-left: 1em;
 }
 
-.c6 ul {
+.c4 ul {
   list-style: disc;
 }
 
-.c6 ol {
+.c4 ol {
   list-style: decimal;
 }
 
-.c6 li {
+.c4 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -932,7 +982,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   padding-bottom: .5em;
 }
 
-.c6 h1 {
+.c4 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -945,7 +995,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   text-align: center;
 }
 
-.c6 h1::before {
+.c4 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -956,7 +1006,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   right: calc(50% - 4px);
 }
 
-.c6 h2 {
+.c4 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -965,15 +1015,15 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   margin: 0;
 }
 
-.c6 h2 a {
+.c4 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c6 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+.c4 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
   background-position: bottom !important;
 }
 
-.c6 h3 {
+.c4 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -983,7 +1033,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   margin: 0;
 }
 
-.c6 h3 strong {
+.c4 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -991,11 +1041,11 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   line-height: 1.5em;
 }
 
-.c6 h3 a {
+.c4 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c6 blockquote {
+.c4 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -1008,7 +1058,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   word-break: break-word;
 }
 
-.c6 .content-end {
+.c4 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -1019,14 +1069,14 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   margin-bottom: 1px;
 }
 
-.c6 .artist-follow {
+.c4 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c6 .artist-follow::before {
+.c4 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -1034,7 +1084,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   font-size: 32px;
 }
 
-.c6 .artist-follow::after {
+.c4 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -1043,115 +1093,117 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   text-transform: none;
 }
 
-.c0 {
-  color: black;
-  max-width: 1200px;
-  width: 100%;
+@media screen and (min-width:40em) {
+  .c0 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
 }
 
-.c2 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: none;
+@media screen and (min-width:52em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
 }
 
-.c2:first-of-type {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+@media screen and (min-width:64em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
 }
 
-.c2:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-  display: block;
-  margin-bottom: 10px;
+@media screen and (min-width:40em) {
+  .c1 {
+    width: 100%;
+  }
 }
 
-.c4 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
+@media screen and (min-width:52em) {
+  .c1 {
+    width: 33.33333333333333%;
+  }
 }
 
-@media only screen and (min-width:0em) {
+@media screen and (min-width:64em) {
+  .c1 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
+    width: 100%;
   }
 }
 
-@media only screen and (min-width:48em) {
+@media screen and (min-width:52em) {
   .c3 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
+    width: 66.66666666666666%;
   }
 }
 
-@media only screen and (min-width:0em) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
+@media screen and (min-width:64em) {
+  .c3 {
+    width: 66.66666666666666%;
   }
 }
 
-@media only screen and (min-width:48em) {
-  .c5 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
+@media screen and (min-width:40em) {
+  .c2 {
+    margin-bottom: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    margin-bottom: 0px;
   }
 }
 
 @media (max-width:600px) {
-  .c6 p,
-  .c6 ul,
-  .c6 ol,
-  .c6 div[data-block=true] .public-DraftStyleDefault-block {
+  .c4 p,
+  .c4 ul,
+  .c4 ol,
+  .c4 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c6 li {
+  .c4 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c6 h1 {
+  .c4 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c6 h2 {
+  .c4 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c6 h3 {
+  .c4 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1159,14 +1211,14 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
     line-height: 1.5em;
   }
 
-  .c6 h3 strong {
+  .c4 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c6 blockquote {
+  .c4 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -1174,52 +1226,57 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
     margin: 0;
   }
 
-  .c6 .content-start {
+  .c4 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:768px) {
-  .c2:first-of-type .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    display: none;
-  }
-
-  .c2 .PartnerBlock__PartnerBlockContainer-ydgi2-0 {
-    margin-top: 60px;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c4 {
-    margin-bottom: 20px;
-  }
-}
-
 <div
-  className="c0 c1"
+  className="c0"
   color="black"
+  width="100%"
 >
   <div
-    className="c2 c3"
+    className="c1"
+    width={
+      Array [
+        1,
+        1,
+        0.3333333333333333,
+        0.3333333333333333,
+      ]
+    }
   >
     <div
-      className="c4"
+      className="c2"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="28px"
     >
       <div>
         Child 
         sub_title
       </div>
     </div>
+    <div
+      className="rrm-container rrm-greaterThanOrEqual-md"
+    />
   </div>
   <div
-    className="c2 c5"
+    className="c3"
+    width={
+      Array [
+        1,
+        1,
+        0.6666666666666666,
+        0.6666666666666666,
+      ]
+    }
   >
     <div
       className="SeriesAbout__description"
     >
       <div
-        className="article__text-section c6"
+        className="article__text-section c4"
         color="black"
       >
         <div
@@ -1231,60 +1288,81 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
         />
       </div>
     </div>
+    <div
+      className="rrm-container rrm-lessThan-md"
+    />
   </div>
 </div>
 `;
 
 exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
-.c1 {
-  box-sizing: border-box;
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+}
+
+.c2 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 20px;
 }
 
 .c3 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+  margin-bottom: 4px;
 }
 
 .c9 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+  margin-top: 60px;
 }
 
-.c6 {
+.c4 {
   display: block;
 }
 
-.c8 img {
+.c6 img {
   max-width: 240px;
   max-height: 40px;
   object-fit: contain;
   object-position: left;
 }
 
-.c7 {
+.c5 {
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
@@ -1292,12 +1370,12 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin-bottom: 20px;
 }
 
-.c10 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c10 a {
+.c8 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1307,22 +1385,22 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   background-position: bottom;
 }
 
-.c10 a:hover {
+.c8 a:hover {
   color: #999999;
   opacity: 1;
 }
 
-.c10 div[class*='ToolTip'] a {
+.c8 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c10 p,
-.c10 ul,
-.c10 ol,
-.c10 .paragraph,
-.c10 div[data-block=true] .public-DraftStyleDefault-block {
+.c8 p,
+.c8 ul,
+.c8 ol,
+.c8 .paragraph,
+.c8 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -1333,32 +1411,32 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   font-style: inherit;
 }
 
-.c10 p:first-child,
-.c10 .paragraph:first-child,
-.c10 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c8 p:first-child,
+.c8 .paragraph:first-child,
+.c8 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c10 p:last-child,
-.c10 .paragraph:last-child,
-.c10 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c8 p:last-child,
+.c8 .paragraph:last-child,
+.c8 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c10 ul,
-.c10 ol {
+.c8 ul,
+.c8 ol {
   padding-left: 1em;
 }
 
-.c10 ul {
+.c8 ul {
   list-style: disc;
 }
 
-.c10 ol {
+.c8 ol {
   list-style: decimal;
 }
 
-.c10 li {
+.c8 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -1367,7 +1445,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   padding-bottom: .5em;
 }
 
-.c10 h1 {
+.c8 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -1380,7 +1458,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   text-align: center;
 }
 
-.c10 h1::before {
+.c8 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -1391,7 +1469,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   right: calc(50% - 4px);
 }
 
-.c10 h2 {
+.c8 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -1400,15 +1478,15 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin: 0;
 }
 
-.c10 h2 a {
+.c8 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c10 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+.c8 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
   background-position: bottom !important;
 }
 
-.c10 h3 {
+.c8 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -1418,7 +1496,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin: 0;
 }
 
-.c10 h3 strong {
+.c8 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -1426,11 +1504,11 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   line-height: 1.5em;
 }
 
-.c10 h3 a {
+.c8 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c10 blockquote {
+.c8 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -1443,7 +1521,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   word-break: break-word;
 }
 
-.c10 .content-end {
+.c8 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -1454,14 +1532,14 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin-bottom: 1px;
 }
 
-.c10 .artist-follow {
+.c8 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c10 .artist-follow::before {
+.c8 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -1469,7 +1547,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   font-size: 32px;
 }
 
-.c10 .artist-follow::after {
+.c8 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -1478,84 +1556,86 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   text-transform: none;
 }
 
-.c0 {
-  color: black;
-  max-width: 1200px;
-  width: 100%;
-}
-
-.c2 .c5 {
-  display: none;
-}
-
-.c2:first-of-type {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2:first-of-type .c5 {
-  display: block;
-  margin-bottom: 10px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
-}
-
-@media only screen and (min-width:0em) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
+@media screen and (min-width:40em) {
+  .c0 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
   }
 }
 
-@media only screen and (min-width:48em) {
-  .c3 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
+@media screen and (min-width:52em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
   }
 }
 
-@media only screen and (min-width:0em) {
-  .c9 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
+@media screen and (min-width:64em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
   }
 }
 
-@media only screen and (min-width:48em) {
-  .c9 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
+@media screen and (min-width:40em) {
+  .c1 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c1 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c7 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c7 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c7 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    margin-bottom: 20px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    margin-bottom: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    margin-bottom: 0px;
   }
 }
 
 @media (max-width:720px) {
-  .c7 {
+  .c5 {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -1564,38 +1644,38 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
 }
 
 @media (max-width:600px) {
-  .c10 p,
-  .c10 ul,
-  .c10 ol,
-  .c10 div[data-block=true] .public-DraftStyleDefault-block {
+  .c8 p,
+  .c8 ul,
+  .c8 ol,
+  .c8 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c10 li {
+  .c8 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c10 h1 {
+  .c8 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c10 h2 {
+  .c8 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c10 h3 {
+  .c8 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1603,14 +1683,14 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
     line-height: 1.5em;
   }
 
-  .c10 h3 strong {
+  .c8 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c10 blockquote {
+  .c8 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -1618,71 +1698,81 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
     margin: 0;
   }
 
-  .c10 .content-start {
+  .c8 .content-start {
     font-size: 55px;
   }
 }
 
-@media (max-width:768px) {
-  .c2:first-of-type .c5 {
-    display: none;
-  }
-
-  .c2 .c5 {
-    margin-top: 60px;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c4 {
-    margin-bottom: 20px;
-  }
-}
-
 <div
-  className="c0 c1"
+  className="c0"
   color="black"
+  width="100%"
 >
   <div
-    className="c2 c3"
+    className="c1"
+    width={
+      Array [
+        1,
+        1,
+        0.3333333333333333,
+        0.3333333333333333,
+      ]
+    }
   >
     <div
-      className="c4"
+      className="c2"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="28px"
     >
       About the Series
     </div>
     <div
-      className="PartnerBlock c5 c6"
+      className="rrm-container rrm-greaterThanOrEqual-md"
     >
       <div
-        className="c7"
+        className="c3"
       >
-        Presented in Partnership with
-      </div>
-      <div
-        className="c8"
-      >
-        <a
-          href="http://artsy.net"
-          onClick={[Function]}
-          target="_blank"
+        <div
+          className="PartnerBlock c4"
         >
-          <img
-            src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAjncVmjZHFM4Z-0b6nPz8A%252FGUCCI.png&width=240&quality=80"
-          />
-        </a>
+          <div
+            className="c5"
+          >
+            Presented in Partnership with
+          </div>
+          <div
+            className="c6"
+          >
+            <a
+              href="http://artsy.net"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <img
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAjncVmjZHFM4Z-0b6nPz8A%252FGUCCI.png&width=240&quality=80"
+              />
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </div>
   <div
-    className="c2 c9"
+    className="c7"
+    width={
+      Array [
+        1,
+        1,
+        0.6666666666666666,
+        0.6666666666666666,
+      ]
+    }
   >
     <div
       className="SeriesAbout__description"
     >
       <div
-        className="article__text-section c10"
+        className="article__text-section c8"
         color="black"
       >
         <div
@@ -1695,25 +1785,33 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
       </div>
     </div>
     <div
-      className="PartnerBlock c5 c6"
+      className="rrm-container rrm-lessThan-md"
     >
       <div
-        className="c7"
+        className="c9"
       >
-        Presented in Partnership with
-      </div>
-      <div
-        className="c8"
-      >
-        <a
-          href="http://artsy.net"
-          onClick={[Function]}
-          target="_blank"
+        <div
+          className="PartnerBlock c4"
         >
-          <img
-            src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAjncVmjZHFM4Z-0b6nPz8A%252FGUCCI.png&width=240&quality=80"
-          />
-        </a>
+          <div
+            className="c5"
+          >
+            Presented in Partnership with
+          </div>
+          <div
+            className="c6"
+          >
+            <a
+              href="http://artsy.net"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <img
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAjncVmjZHFM4Z-0b6nPz8A%252FGUCCI.png&width=240&quality=80"
+              />
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/Components/Publishing/Video/VideoAbout.tsx
+++ b/src/Components/Publishing/Video/VideoAbout.tsx
@@ -1,11 +1,11 @@
-import { Flex } from "@artsy/palette"
-import { unica } from "Assets/Fonts"
+import { Box, color, Flex, Sans } from "@artsy/palette"
 import React, { Component } from "react"
-import { Col } from "react-styled-flexboxgrid"
 import styled from "styled-components"
-import { pMedia } from "../../Helpers"
-import { ShareDate } from "../Byline/ShareDate"
-import { Text } from "../Sections/Text"
+
+import { ShareDate } from "Components/Publishing/Byline/ShareDate"
+import { StyledText } from "Components/Publishing/Sections/StyledText"
+import { Text } from "Components/Publishing/Sections/Text"
+import { Media } from "Utils/Responsive"
 
 export interface VideoAboutProps {
   article: any
@@ -16,87 +16,77 @@ export interface VideoAboutProps {
 
 export class VideoAbout extends Component<VideoAboutProps, null> {
   static defaultProps = {
-    color: "black",
+    color: color("black100"),
   }
 
   render() {
-    const { article, color, editCredits, editDescription } = this.props
+    const { article, editCredits, editDescription } = this.props
     const {
       media: { credits, description },
     } = article
 
     return (
-      <VideoAboutContainer maxWidth={1200} mx="auto">
-        <Credits xs={12} sm={4}>
-          <Col xs={12}>
-            <Title color={color}>Credits</Title>
+      <VideoAboutContainer
+        maxWidth={1200}
+        mx="auto"
+        flexDirection={["column-reverse", "column-reverse", "row", "row"]}
+      >
+        <Credits
+          width={[1, 1, 1 / 3, 1 / 3]}
+          flexDirection="column"
+          pt={["80px", "80px", 0, 0]}
+        >
+          <Sans size="8" color={this.props.color} pb={10}>
+            Credits
+          </Sans>
 
-            {editCredits ? (
-              <Text layout="standard">{editCredits}</Text>
-            ) : (
-              <Text layout="standard" html={credits} />
-            )}
-          </Col>
-          <Col sm={12} xs={false}>
-            <ShareDate color={color} article={article} />
-          </Col>
+          {editCredits ? (
+            <Text layout="standard">{editCredits}</Text>
+          ) : (
+            <Text layout="standard" html={credits} />
+          )}
+
+          <Media greaterThanOrEqual="md">
+            <Box mt={40}>
+              <ShareDate color={this.props.color} article={article} />
+            </Box>
+          </Media>
         </Credits>
 
-        <About xs={12} sm={8}>
-          <Col xs={12}>
-            <Title color={color}>About the Film</Title>
+        <Box width={[1, 1, 2 / 3, 2 / 3]}>
+          <Sans size="8" color={this.props.color} pb={10}>
+            About the Film
+          </Sans>
 
-            {editDescription ? (
-              <Text color={color} layout="standard">
-                {editDescription}
-              </Text>
-            ) : (
-              <Text color={color} layout="standard" html={description} />
-            )}
-          </Col>
+          {editDescription ? (
+            <Text color={this.props.color} layout="standard">
+              {editDescription}
+            </Text>
+          ) : (
+            <Text
+              color={this.props.color}
+              layout="standard"
+              html={description}
+            />
+          )}
 
-          <Col sm={false} xs={12}>
-            <ShareDate color={color} article={article} />
-          </Col>
-        </About>
+          <Media lessThan="md">
+            <Box mt={40}>
+              <ShareDate color={this.props.color} article={article} />
+            </Box>
+          </Media>
+        </Box>
       </VideoAboutContainer>
     )
   }
 }
 
-const Title = styled.div.attrs<{ color: string }>({})`
-  color: ${props => props.color};
-  margin-bottom: 15px;
-  ${unica("s34")};
-  ${pMedia.sm`
-    ${unica("s32")}
-  `};
-`
-
-export const Credits = styled(Col)`
-  flex: 1;
-
-  p {
-    padding: 0;
+export const Credits = styled(Flex)`
+  ${StyledText} {
+    p {
+      padding: 0;
+    }
   }
-
-  ${pMedia.sm`
-    margin-top: 80px;
-    display: flex;
-    flex-direction: column;
-  `};
 `
 
-const About = styled(Col)`
-  flex: 1;
-`
-
-export const VideoAboutContainer = styled(Flex)`
-  ${ShareDate} {
-    margin-top: 40px;
-  }
-
-  ${pMedia.sm`
-    flex-direction: column-reverse;
-  `};
-`
+export const VideoAboutContainer = styled(Flex)``

--- a/src/Components/Publishing/Video/VideoCover.tsx
+++ b/src/Components/Publishing/Video/VideoCover.tsx
@@ -1,11 +1,9 @@
-import { Box, Flex } from "@artsy/palette"
-import { garamond } from "Assets/Fonts"
-import { Col } from "Components/Grid"
+import { Box, Flex, Serif } from "@artsy/palette"
 import React, { Component } from "react"
 import track, { TrackingProp } from "react-tracking"
-import styled, { StyledFunction } from "styled-components"
-import { media as mediaQueries } from "../../Helpers"
-import { IconVideoPlay } from "../Icon/IconVideoPlay"
+import styled from "styled-components"
+
+import { IconVideoPlay } from "Components/Publishing/Icon/IconVideoPlay"
 import { VideoInfoBlock } from "./VideoInfoBlock"
 
 interface Props {
@@ -56,13 +54,14 @@ export class VideoCover extends Component<Props, null> {
       <VideoCoverContainer hideCover={hideCover}>
         <VideoCoverAsset src={media.cover_image_url} />
         <VideoCoverOverlay />
-        <VideoCoverInfo>
+
+        <VideoCoverInfo alignItems="flex-end" pb={[40, 60]} px={20}>
           <Box maxWidth={1200} mx="auto" pb="12px">
             <Flex>
-              <Col xs={2} sm={1} onClick={this.onPlayClick}>
+              <Box width="60px" pr={20} onClick={this.onPlayClick}>
                 <IconVideoPlay color="white" />
-              </Col>
-              <Col xs={10} sm={6}>
+              </Box>
+              <Box>
                 <VideoInfoBlock
                   media={media}
                   subTitle={
@@ -72,13 +71,14 @@ export class VideoCover extends Component<Props, null> {
                   title={article.title}
                   editTitle={editTitle}
                 />
-              </Col>
+              </Box>
             </Flex>
-            <Col xs={12} sm={7}>
-              <MediaDescription>
+
+            <Box maxWidth={["100%", "60%"]}>
+              <Serif size={["4", "5", "5", "5"]} pt={30}>
                 {editDescription || article.description}
-              </MediaDescription>
-            </Col>
+              </Serif>
+            </Box>
           </Box>
         </VideoCoverInfo>
       </VideoCoverContainer>
@@ -86,8 +86,7 @@ export class VideoCover extends Component<Props, null> {
   }
 }
 
-const Div: StyledFunction<CoverAssetProps> = styled.div
-export const VideoCoverAsset = Div`
+export const VideoCoverAsset = styled.div<CoverAssetProps>`
   background: url(${props => props.src || ""}) no-repeat center center;
   background-size: cover;
   background-color: black;
@@ -97,26 +96,18 @@ const VideoCoverOverlay = styled.div`
   background: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.6));
 `
 
-const VideoCoverInfo = styled.div`
-  display: flex;
-  align-items: flex-end;
+const VideoCoverInfo = styled(Flex)`
   box-sizing: border-box;
-  padding-bottom: 60px;
   z-index: 1;
 
   ${IconVideoPlay} {
     height: 60px;
     width: 44px;
-    margin-right: 15px;
     cursor: pointer;
   }
-  ${mediaQueries.sm`
-    padding-bottom: 40px;
-  `};
 `
 
-const CoverDiv: StyledFunction<CoverProps> = styled.div
-export const VideoCoverContainer = CoverDiv`
+export const VideoCoverContainer = styled.div<CoverProps>`
   position: absolute;
   top: 0;
   left: 0;
@@ -126,18 +117,10 @@ export const VideoCoverContainer = CoverDiv`
   opacity: ${props => (props.hideCover ? "0" : "1")};
   visibility: ${props => (props.hideCover ? "hidden" : "visible")};
   transition: opacity 0.25s ease, visibility 0.25s ease;
+
   ${VideoCoverAsset}, ${VideoCoverOverlay}, ${VideoCoverInfo} {
     position: absolute;
     width: 100%;
     height: 100%;
   }
-`
-
-const MediaDescription = styled.div`
-  position: relative;
-  margin-top: 30px;
-  ${garamond("s23")};
-  ${mediaQueries.sm`
-    ${garamond("s19")}
-  `};
 `

--- a/src/Components/Publishing/Video/VideoInfoBlock.tsx
+++ b/src/Components/Publishing/Video/VideoInfoBlock.tsx
@@ -1,9 +1,8 @@
-import { Sans } from "@artsy/palette"
-import { unica } from "Assets/Fonts"
+import { Flex, Sans } from "@artsy/palette"
 import React, { Component } from "react"
-import { Row } from "react-styled-flexboxgrid"
 import styled from "styled-components"
-import { formatTime } from "../Constants"
+
+import { formatTime } from "Components/Publishing/Constants"
 
 interface Props {
   editTitle?: any
@@ -19,34 +18,24 @@ export class VideoInfoBlock extends Component<Props, null> {
 
     return (
       <div>
-        <Row>
+        <Flex>
           {subTitle && (
-            <SubTitle size="3t">
+            <SubTitle size="3" mr={20}>
               {subTitleLink ? <a href={subTitleLink}>{subTitle}</a> : subTitle}
             </SubTitle>
           )}
-          {media.duration && (
-            <Sans size="3t">{formatTime(media.duration)}</Sans>
-          )}
-        </Row>
-        <Row>
-          <MediaTitle>{editTitle || title}</MediaTitle>
-        </Row>
+          {media.duration && <Sans size="3">{formatTime(media.duration)}</Sans>}
+        </Flex>
+
+        <Sans size="10">{editTitle || title}</Sans>
       </div>
     )
   }
 }
 
 const SubTitle = styled(Sans)`
-  margin-right: 20px;
-
   a {
     color: white;
     text-decoration: none;
   }
-`
-
-const MediaTitle = styled.span`
-  position: relative;
-  ${unica("s45")};
 `

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
@@ -49,6 +49,48 @@ exports[`Video About matches the snapshot 1`] = `
   width: 100%;
 }
 
+.c8 {
+  margin: 5px 20px 0 0;
+  white-space: nowrap;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c13 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c13:hover {
+  opacity: 0.6;
+}
+
+.c13:first-child {
+  padding-left: 0;
+}
+
+.c12 {
+  margin: 5px 10px 5px 0;
+}
+
+.c7 {
+  color: #000;
+}
+
 .c5 {
   position: relative;
   width: 100%;
@@ -421,48 +463,6 @@ exports[`Video About matches the snapshot 1`] = `
   text-transform: none;
 }
 
-.c8 {
-  margin: 5px 20px 0 0;
-  white-space: nowrap;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  white-space: nowrap;
-  line-height: 1em;
-  margin-top: 5px;
-}
-
-.c13 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  padding-left: 7px;
-  padding-right: 7px;
-}
-
-.c13:hover {
-  opacity: 0.6;
-}
-
-.c13:first-child {
-  padding-left: 0;
-}
-
-.c12 {
-  margin: 5px 10px 5px 0;
-}
-
-.c7 {
-  color: #000;
-}
-
 .c1 .c4 p {
   padding: 0;
 }
@@ -542,6 +542,12 @@ exports[`Video About matches the snapshot 1`] = `
 @media screen and (min-width:64em) {
   .c14 {
     width: 66.66666666666666%;
+  }
+}
+
+@media (max-width:768px) {
+  .c7 .c10 {
+    margin-top: 0px;
   }
 }
 
@@ -662,12 +668,6 @@ exports[`Video About matches the snapshot 1`] = `
 
   .c15 .content-start {
     font-size: 55px;
-  }
-}
-
-@media (max-width:768px) {
-  .c7 .c10 {
-    margin-top: 0px;
   }
 }
 
@@ -1034,6 +1034,48 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   width: 100%;
 }
 
+.c8 {
+  margin: 5px 20px 0 0;
+  white-space: nowrap;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c13 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c13:hover {
+  opacity: 0.6;
+}
+
+.c13:first-child {
+  padding-left: 0;
+}
+
+.c12 {
+  margin: 5px 10px 5px 0;
+}
+
+.c7 {
+  color: #000;
+}
+
 .c5 {
   position: relative;
   width: 100%;
@@ -1406,48 +1448,6 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   text-transform: none;
 }
 
-.c8 {
-  margin: 5px 20px 0 0;
-  white-space: nowrap;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  white-space: nowrap;
-  line-height: 1em;
-  margin-top: 5px;
-}
-
-.c13 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  padding-left: 7px;
-  padding-right: 7px;
-}
-
-.c13:hover {
-  opacity: 0.6;
-}
-
-.c13:first-child {
-  padding-left: 0;
-}
-
-.c12 {
-  margin: 5px 10px 5px 0;
-}
-
-.c7 {
-  color: #000;
-}
-
 .c1 .c4 p {
   padding: 0;
 }
@@ -1527,6 +1527,12 @@ exports[`Video About matches the snapshot with editable props 1`] = `
 @media screen and (min-width:64em) {
   .c14 {
     width: 66.66666666666666%;
+  }
+}
+
+@media (max-width:768px) {
+  .c7 .c10 {
+    margin-top: 0px;
   }
 }
 
@@ -1647,12 +1653,6 @@ exports[`Video About matches the snapshot with editable props 1`] = `
 
   .c15 .content-start {
     font-size: 55px;
-  }
-}
-
-@media (max-width:768px) {
-  .c7 .c10 {
-    margin-top: 0px;
   }
 }
 

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
@@ -1,74 +1,432 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video About matches the snapshot 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
   margin-left: auto;
   margin-right: auto;
   max-width: 1200px;
 }
 
-.c11 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 80px;
+  width: 100%;
+}
+
+.c3 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  color: #000;
+  padding-bottom: 10px;
+}
+
+.c9 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c3 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c6 {
+  margin-top: 40px;
 }
 
-.c4 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c14 {
+  width: 100%;
 }
 
-.c7 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c5 {
+  position: relative;
+  width: 100%;
 }
 
-.c17 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c5 a {
+  color: black;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-image: linear-gradient( to bottom, transparent 0, #333333 1px, transparent 0 );
+  background-size: 1.25px 4px;
+  background-repeat: repeat-x;
+  background-position: bottom;
 }
 
-.c18 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c5 a:hover {
+  color: #999999;
+  opacity: 1;
 }
 
-.c10 {
+.c5 div[class*='ToolTip'] a {
+  background-image: none;
+  opacity: 1;
+  color: inherit;
+}
+
+.c5 p,
+.c5 ul,
+.c5 ol,
+.c5 .paragraph,
+.c5 div[data-block=true] .public-DraftStyleDefault-block {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 23px;
+  line-height: 1.5em;
+  -webkit-font-smoothing: antialiased;
+  padding-top: 1em;
+  padding-bottom: 1em;
+  margin: 0;
+  font-style: inherit;
+}
+
+.c5 p:first-child,
+.c5 .paragraph:first-child,
+.c5 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+  padding-top: 0;
+}
+
+.c5 p:last-child,
+.c5 .paragraph:last-child,
+.c5 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+  padding-bottom: 0;
+}
+
+.c5 ul,
+.c5 ol {
+  padding-left: 1em;
+}
+
+.c5 ul {
+  list-style: disc;
+}
+
+.c5 ol {
+  list-style: decimal;
+}
+
+.c5 li {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 23px;
+  line-height: 1.5em;
+  -webkit-font-smoothing: antialiased;
+  padding-top: .5em;
+  padding-bottom: .5em;
+}
+
+.c5 h1 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  font-weight: normal;
+  padding-top: 107px;
+  padding-bottom: 46px;
+  margin: 0;
+  position: relative;
+  text-align: center;
+}
+
+.c5 h1::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: black;
+  border-radius: 50%;
+  position: absolute;
+  top: 69px;
+  right: calc(50% - 4px);
+}
+
+.c5 h2 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+  font-weight: normal;
+  margin: 0;
+}
+
+.c5 h2 a {
+  background-size: 1.25px 1px;
+}
+
+.c5 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+  background-position: bottom !important;
+}
+
+.c5 h3 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+  font-weight: normal;
+  padding-top: 23px;
+  margin: 0;
+}
+
+.c5 h3 strong {
+  font-weight: normal;
+  font-family: Unica77LLWebMedium,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+}
+
+.c5 h3 a {
+  background-size: 1.25px 1px;
+}
+
+.c5 blockquote {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 40px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  text-align: left;
+  font-weight: normal;
+  padding-top: 46px;
+  padding-bottom: 46px;
+  margin: 0;
+  word-break: break-word;
+}
+
+.c5 .content-end {
+  display: inline-block;
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: black;
+  border-radius: 50%;
+  margin-left: 12px;
+  margin-bottom: 1px;
+}
+
+.c5 .artist-follow {
+  vertical-align: middle;
+  margin-left: 10px;
+  cursor: pointer;
+  background: none transparent;
+}
+
+.c5 .artist-follow::before {
+  font-family: "artsy-icons";
+  content: "";
+  vertical-align: -8.5px;
+  line-height: 32px;
+  font-size: 32px;
+}
+
+.c5 .artist-follow::after {
+  content: "Follow";
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  text-transform: none;
+}
+
+.c15 {
+  position: relative;
+  width: 100%;
+}
+
+.c15 a {
+  color: #000;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-image: linear-gradient( to bottom, transparent 0, #000 1px, transparent 0 );
+  background-size: 1.25px 4px;
+  background-repeat: repeat-x;
+  background-position: bottom;
+}
+
+.c15 a:hover {
+  color: #000;
+  opacity: .65;
+}
+
+.c15 div[class*='ToolTip'] a {
+  background-image: none;
+  opacity: 1;
+  color: inherit;
+}
+
+.c15 p,
+.c15 ul,
+.c15 ol,
+.c15 .paragraph,
+.c15 div[data-block=true] .public-DraftStyleDefault-block {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 23px;
+  line-height: 1.5em;
+  -webkit-font-smoothing: antialiased;
+  padding-top: 1em;
+  padding-bottom: 1em;
+  margin: 0;
+  font-style: inherit;
+}
+
+.c15 p:first-child,
+.c15 .paragraph:first-child,
+.c15 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+  padding-top: 0;
+}
+
+.c15 p:last-child,
+.c15 .paragraph:last-child,
+.c15 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+  padding-bottom: 0;
+}
+
+.c15 ul,
+.c15 ol {
+  padding-left: 1em;
+}
+
+.c15 ul {
+  list-style: disc;
+}
+
+.c15 ol {
+  list-style: decimal;
+}
+
+.c15 li {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 23px;
+  line-height: 1.5em;
+  -webkit-font-smoothing: antialiased;
+  padding-top: .5em;
+  padding-bottom: .5em;
+}
+
+.c15 h1 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  font-weight: normal;
+  padding-top: 107px;
+  padding-bottom: 46px;
+  margin: 0;
+  position: relative;
+  text-align: center;
+}
+
+.c15 h1::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: black;
+  border-radius: 50%;
+  position: absolute;
+  top: 69px;
+  right: calc(50% - 4px);
+}
+
+.c15 h2 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+  font-weight: normal;
+  margin: 0;
+}
+
+.c15 h2 a {
+  background-size: 1.25px 1px;
+}
+
+.c15 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+  background-position: bottom !important;
+}
+
+.c15 h3 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+  font-weight: normal;
+  padding-top: 23px;
+  margin: 0;
+}
+
+.c15 h3 strong {
+  font-weight: normal;
+  font-family: Unica77LLWebMedium,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+}
+
+.c15 h3 a {
+  background-size: 1.25px 1px;
+}
+
+.c15 blockquote {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 40px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  text-align: left;
+  font-weight: normal;
+  padding-top: 46px;
+  padding-bottom: 46px;
+  margin: 0;
+  word-break: break-word;
+}
+
+.c15 .content-end {
+  display: inline-block;
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: black;
+  border-radius: 50%;
+  margin-left: 12px;
+  margin-bottom: 1px;
+}
+
+.c15 .artist-follow {
+  vertical-align: middle;
+  margin-left: 10px;
+  cursor: pointer;
+  background: none transparent;
+}
+
+.c15 .artist-follow::before {
+  font-family: "artsy-icons";
+  content: "";
+  vertical-align: -8.5px;
+  line-height: 32px;
+  font-size: 32px;
+}
+
+.c15 .artist-follow::after {
+  content: "Follow";
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  text-transform: none;
+}
+
+.c8 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c13 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -82,415 +440,34 @@ exports[`Video About matches the snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c15 {
+.c13 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c15:hover {
+.c13:hover {
   opacity: 0.6;
 }
 
-.c15:first-child {
+.c13:first-child {
   padding-left: 0;
 }
 
-.c14 {
+.c12 {
   margin: 5px 10px 5px 0;
 }
 
-.c9 {
-  color: black;
+.c7 {
+  color: #000;
 }
 
-.c6 {
-  position: relative;
-  width: 100%;
-}
-
-.c6 a {
-  color: black;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  background-image: linear-gradient( to bottom, transparent 0, #333333 1px, transparent 0 );
-  background-size: 1.25px 4px;
-  background-repeat: repeat-x;
-  background-position: bottom;
-}
-
-.c6 a:hover {
-  color: #999999;
-  opacity: 1;
-}
-
-.c6 div[class*='ToolTip'] a {
-  background-image: none;
-  opacity: 1;
-  color: inherit;
-}
-
-.c6 p,
-.c6 ul,
-.c6 ol,
-.c6 .paragraph,
-.c6 div[data-block=true] .public-DraftStyleDefault-block {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-  padding-top: 1em;
-  padding-bottom: 1em;
-  margin: 0;
-  font-style: inherit;
-}
-
-.c6 p:first-child,
-.c6 .paragraph:first-child,
-.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
-  padding-top: 0;
-}
-
-.c6 p:last-child,
-.c6 .paragraph:last-child,
-.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
-  padding-bottom: 0;
-}
-
-.c6 ul,
-.c6 ol {
-  padding-left: 1em;
-}
-
-.c6 ul {
-  list-style: disc;
-}
-
-.c6 ol {
-  list-style: decimal;
-}
-
-.c6 li {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-  padding-top: .5em;
-  padding-bottom: .5em;
-}
-
-.c6 h1 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 40px;
-  line-height: 1.1em;
-  font-weight: normal;
-  padding-top: 107px;
-  padding-bottom: 46px;
-  margin: 0;
-  position: relative;
-  text-align: center;
-}
-
-.c6 h1::before {
-  content: "";
-  width: 8px;
-  height: 8px;
-  background: black;
-  border-radius: 50%;
-  position: absolute;
-  top: 69px;
-  right: calc(50% - 4px);
-}
-
-.c6 h2 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
-  font-weight: normal;
-  margin: 0;
-}
-
-.c6 h2 a {
-  background-size: 1.25px 1px;
-}
-
-.c6 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
-  background-position: bottom !important;
-}
-
-.c6 h3 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 19px;
-  line-height: 1.5em;
-  font-weight: normal;
-  padding-top: 23px;
-  margin: 0;
-}
-
-.c6 h3 strong {
-  font-weight: normal;
-  font-family: Unica77LLWebMedium,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 19px;
-  line-height: 1.5em;
-}
-
-.c6 h3 a {
-  background-size: 1.25px 1px;
-}
-
-.c6 blockquote {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 40px;
-  line-height: 1.1em;
-  -webkit-font-smoothing: antialiased;
-  text-align: left;
-  font-weight: normal;
-  padding-top: 46px;
-  padding-bottom: 46px;
-  margin: 0;
-  word-break: break-word;
-}
-
-.c6 .content-end {
-  display: inline-block;
-  content: "";
-  width: 8px;
-  height: 8px;
-  background: black;
-  border-radius: 50%;
-  margin-left: 12px;
-  margin-bottom: 1px;
-}
-
-.c6 .artist-follow {
-  vertical-align: middle;
-  margin-left: 10px;
-  cursor: pointer;
-  background: none transparent;
-}
-
-.c6 .artist-follow::before {
-  font-family: "artsy-icons";
-  content: "";
-  vertical-align: -8.5px;
-  line-height: 32px;
-  font-size: 32px;
-}
-
-.c6 .artist-follow::after {
-  content: "Follow";
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 17px;
-  line-height: 1.1em;
-  -webkit-font-smoothing: antialiased;
-  text-transform: none;
-}
-
-.c5 {
-  color: black;
-  margin-bottom: 15px;
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 34px;
-  line-height: 1.1em;
-}
-
-.c2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c2 p {
+.c1 .c4 p {
   padding: 0;
 }
 
-.c16 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c0 .c8 {
-  margin-top: 40px;
-}
-
-@media only screen and (min-width:0em) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c3 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c4 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c7 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c7 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c17 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c17 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c18 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c18 {
-    display: none;
-  }
-}
-
-@media (max-width:768px) {
-  .c9 .c12 {
-    margin-top: 0px;
-  }
-}
-
-@media (max-width:600px) {
-  .c6 p,
-  .c6 ul,
-  .c6 ol,
-  .c6 div[data-block=true] .public-DraftStyleDefault-block {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-  }
-
-  .c6 li {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-  }
-
-  .c6 h1 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 34px;
-    line-height: 1.1em;
-  }
-
-  .c6 h2 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-
-  .c6 h3 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 16px;
-    line-height: 1.1em;
-    line-height: 1.5em;
-  }
-
-  .c6 h3 strong {
-    font-family: Unica77LLWebMedium,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 16px;
-    line-height: 1.1em;
-  }
-
-  .c6 blockquote {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 34px;
-    line-height: 1.1em;
-    -webkit-font-smoothing: antialiased;
-    margin: 0;
-  }
-
-  .c6 .content-start {
-    font-size: 55px;
-  }
-}
-
-@media (max-width:720px) {
-  .c5 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-}
-
-@media (max-width:720px) {
-  .c2 {
-    margin-top: 80px;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (max-width:720px) {
+@media screen and (min-width:40em) {
   .c0 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
@@ -498,293 +475,509 @@ exports[`Video About matches the snapshot 1`] = `
   }
 }
 
+@media screen and (min-width:52em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    padding-top: 80px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    padding-top: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    padding-top: 0px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c14 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c14 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c14 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media (max-width:600px) {
+  .c5 p,
+  .c5 ul,
+  .c5 ol,
+  .c5 div[data-block=true] .public-DraftStyleDefault-block {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 19px;
+    line-height: 1.5em;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .c5 li {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 19px;
+    line-height: 1.5em;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .c5 h1 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+  }
+
+  .c5 h2 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 32px;
+    line-height: 1.1em;
+  }
+
+  .c5 h3 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+    line-height: 1.5em;
+  }
+
+  .c5 h3 strong {
+    font-family: Unica77LLWebMedium,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+
+  .c5 blockquote {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 34px;
+    line-height: 1.1em;
+    -webkit-font-smoothing: antialiased;
+    margin: 0;
+  }
+
+  .c5 .content-start {
+    font-size: 55px;
+  }
+}
+
+@media (max-width:600px) {
+  .c15 p,
+  .c15 ul,
+  .c15 ol,
+  .c15 div[data-block=true] .public-DraftStyleDefault-block {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 19px;
+    line-height: 1.5em;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .c15 li {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 19px;
+    line-height: 1.5em;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .c15 h1 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+  }
+
+  .c15 h2 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 32px;
+    line-height: 1.1em;
+  }
+
+  .c15 h3 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+    line-height: 1.5em;
+  }
+
+  .c15 h3 strong {
+    font-family: Unica77LLWebMedium,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+
+  .c15 blockquote {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 34px;
+    line-height: 1.1em;
+    -webkit-font-smoothing: antialiased;
+    margin: 0;
+  }
+
+  .c15 .content-start {
+    font-size: 55px;
+  }
+}
+
+@media (max-width:768px) {
+  .c7 .c10 {
+    margin-top: 0px;
+  }
+}
+
 <div
-  className="c0 c1"
+  className="c0"
 >
   <div
-    className="c2 c3"
+    className="c1 c2"
+    width={
+      Array [
+        1,
+        1,
+        0.3333333333333333,
+        0.3333333333333333,
+      ]
+    }
   >
     <div
-      className="c4"
+      className="c3"
+      color="#000"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="28px"
     >
-      <div
-        className="c5"
-        color="black"
-      >
-        Credits
-      </div>
-      <div
-        className="article__text-section c6"
-        color="black"
-      >
-        <div
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p><b>Director</b></p><p>Marina Cashdan</p><p><b>Featuring</b></p><p>Trevor Paglan</p>",
-            }
-          }
-        />
-      </div>
+      Credits
     </div>
     <div
-      className="c7"
+      className="article__text-section c4 c5"
+      color="black"
     >
       <div
-        className="c8 c9"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p><b>Director</b></p><p>Marina Cashdan</p><p><b>Featuring</b></p><p>Trevor Paglan</p>",
+          }
+        }
+      />
+    </div>
+    <div
+      className="rrm-container rrm-greaterThanOrEqual-md"
+    >
+      <div
+        className="c6"
       >
         <div
-          className="c10"
+          className="c7"
         >
           <div
-            className="c11"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
-              }
-            }
-            fontSize="14px"
+            className="c8"
           >
-            Jul 28, 2017 4:38 pm
+            <div
+              className="c9"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
+              }
+              fontSize="14px"
+            >
+              Jul 28, 2017 4:38 pm
+            </div>
           </div>
-        </div>
-        <div
-          className="c12 c13"
-        >
           <div
-            className="c14 c11"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
+            className="c10 c11"
+          >
+            <div
+              className="c12 c9"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
               }
-            }
-            fontSize="14px"
-          >
-            Share
+              fontSize="14px"
+            >
+              Share
+            </div>
+            <a
+              className="c13"
+              href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 14 14"
+                width="14px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
+            <a
+              className="c13"
+              href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 16 14"
+                width="16px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
+            <a
+              className="c13"
+              href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 17 14"
+                width="17px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
           </div>
-          <a
-            className="c15"
-            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 14 14"
-              width="14px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
-          <a
-            className="c15"
-            href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 16 14"
-              width="16px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
-          <a
-            className="c15"
-            href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 17 14"
-              width="17px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="c16 c17"
+    className="c14"
+    width={
+      Array [
+        1,
+        1,
+        0.6666666666666666,
+        0.6666666666666666,
+      ]
+    }
   >
     <div
-      className="c4"
+      className="c3"
+      color="#000"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="28px"
     >
-      <div
-        className="c5"
-        color="black"
-      >
-        About the Film
-      </div>
-      <div
-        className="article__text-section c6"
-        color="black"
-      >
-        <div
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>Integer posuere erat a ante venenatis <a href='artsy.net'>dapibus posuere velit</a> aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-            }
-          }
-        />
-      </div>
+      About the Film
     </div>
     <div
-      className="c18"
+      className="article__text-section c4 c15"
+      color="#000"
     >
       <div
-        className="c8 c9"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>Integer posuere erat a ante venenatis <a href='artsy.net'>dapibus posuere velit</a> aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
+          }
+        }
+      />
+    </div>
+    <div
+      className="rrm-container rrm-lessThan-md"
+    >
+      <div
+        className="c6"
       >
         <div
-          className="c10"
+          className="c7"
         >
           <div
-            className="c11"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
-              }
-            }
-            fontSize="14px"
+            className="c8"
           >
-            Jul 28, 2017 4:38 pm
+            <div
+              className="c9"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
+              }
+              fontSize="14px"
+            >
+              Jul 28, 2017 4:38 pm
+            </div>
           </div>
-        </div>
-        <div
-          className="c12 c13"
-        >
           <div
-            className="c14 c11"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
+            className="c10 c11"
+          >
+            <div
+              className="c12 c9"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
               }
-            }
-            fontSize="14px"
-          >
-            Share
+              fontSize="14px"
+            >
+              Share
+            </div>
+            <a
+              className="c13"
+              href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 14 14"
+                width="14px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
+            <a
+              className="c13"
+              href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 16 14"
+                width="16px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
+            <a
+              className="c13"
+              href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 17 14"
+                width="17px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
           </div>
-          <a
-            className="c15"
-            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 14 14"
-              width="14px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
-          <a
-            className="c15"
-            href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 16 14"
-              width="16px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
-          <a
-            className="c15"
-            href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 17 14"
-              width="17px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
         </div>
       </div>
     </div>
@@ -793,74 +986,432 @@ exports[`Video About matches the snapshot 1`] = `
 `;
 
 exports[`Video About matches the snapshot with editable props 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
   margin-left: auto;
   margin-right: auto;
   max-width: 1200px;
 }
 
-.c11 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 80px;
+  width: 100%;
+}
+
+.c3 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  color: #000;
+  padding-bottom: 10px;
+}
+
+.c9 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c3 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c6 {
+  margin-top: 40px;
 }
 
-.c4 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c14 {
+  width: 100%;
 }
 
-.c7 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c5 {
+  position: relative;
+  width: 100%;
 }
 
-.c17 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c5 a {
+  color: black;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-image: linear-gradient( to bottom, transparent 0, #333333 1px, transparent 0 );
+  background-size: 1.25px 4px;
+  background-repeat: repeat-x;
+  background-position: bottom;
 }
 
-.c18 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c5 a:hover {
+  color: #999999;
+  opacity: 1;
 }
 
-.c10 {
+.c5 div[class*='ToolTip'] a {
+  background-image: none;
+  opacity: 1;
+  color: inherit;
+}
+
+.c5 p,
+.c5 ul,
+.c5 ol,
+.c5 .paragraph,
+.c5 div[data-block=true] .public-DraftStyleDefault-block {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 23px;
+  line-height: 1.5em;
+  -webkit-font-smoothing: antialiased;
+  padding-top: 1em;
+  padding-bottom: 1em;
+  margin: 0;
+  font-style: inherit;
+}
+
+.c5 p:first-child,
+.c5 .paragraph:first-child,
+.c5 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+  padding-top: 0;
+}
+
+.c5 p:last-child,
+.c5 .paragraph:last-child,
+.c5 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+  padding-bottom: 0;
+}
+
+.c5 ul,
+.c5 ol {
+  padding-left: 1em;
+}
+
+.c5 ul {
+  list-style: disc;
+}
+
+.c5 ol {
+  list-style: decimal;
+}
+
+.c5 li {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 23px;
+  line-height: 1.5em;
+  -webkit-font-smoothing: antialiased;
+  padding-top: .5em;
+  padding-bottom: .5em;
+}
+
+.c5 h1 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  font-weight: normal;
+  padding-top: 107px;
+  padding-bottom: 46px;
+  margin: 0;
+  position: relative;
+  text-align: center;
+}
+
+.c5 h1::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: black;
+  border-radius: 50%;
+  position: absolute;
+  top: 69px;
+  right: calc(50% - 4px);
+}
+
+.c5 h2 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+  font-weight: normal;
+  margin: 0;
+}
+
+.c5 h2 a {
+  background-size: 1.25px 1px;
+}
+
+.c5 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+  background-position: bottom !important;
+}
+
+.c5 h3 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+  font-weight: normal;
+  padding-top: 23px;
+  margin: 0;
+}
+
+.c5 h3 strong {
+  font-weight: normal;
+  font-family: Unica77LLWebMedium,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+}
+
+.c5 h3 a {
+  background-size: 1.25px 1px;
+}
+
+.c5 blockquote {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 40px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  text-align: left;
+  font-weight: normal;
+  padding-top: 46px;
+  padding-bottom: 46px;
+  margin: 0;
+  word-break: break-word;
+}
+
+.c5 .content-end {
+  display: inline-block;
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: black;
+  border-radius: 50%;
+  margin-left: 12px;
+  margin-bottom: 1px;
+}
+
+.c5 .artist-follow {
+  vertical-align: middle;
+  margin-left: 10px;
+  cursor: pointer;
+  background: none transparent;
+}
+
+.c5 .artist-follow::before {
+  font-family: "artsy-icons";
+  content: "";
+  vertical-align: -8.5px;
+  line-height: 32px;
+  font-size: 32px;
+}
+
+.c5 .artist-follow::after {
+  content: "Follow";
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  text-transform: none;
+}
+
+.c15 {
+  position: relative;
+  width: 100%;
+}
+
+.c15 a {
+  color: #000;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-image: linear-gradient( to bottom, transparent 0, #000 1px, transparent 0 );
+  background-size: 1.25px 4px;
+  background-repeat: repeat-x;
+  background-position: bottom;
+}
+
+.c15 a:hover {
+  color: #000;
+  opacity: .65;
+}
+
+.c15 div[class*='ToolTip'] a {
+  background-image: none;
+  opacity: 1;
+  color: inherit;
+}
+
+.c15 p,
+.c15 ul,
+.c15 ol,
+.c15 .paragraph,
+.c15 div[data-block=true] .public-DraftStyleDefault-block {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 23px;
+  line-height: 1.5em;
+  -webkit-font-smoothing: antialiased;
+  padding-top: 1em;
+  padding-bottom: 1em;
+  margin: 0;
+  font-style: inherit;
+}
+
+.c15 p:first-child,
+.c15 .paragraph:first-child,
+.c15 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+  padding-top: 0;
+}
+
+.c15 p:last-child,
+.c15 .paragraph:last-child,
+.c15 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+  padding-bottom: 0;
+}
+
+.c15 ul,
+.c15 ol {
+  padding-left: 1em;
+}
+
+.c15 ul {
+  list-style: disc;
+}
+
+.c15 ol {
+  list-style: decimal;
+}
+
+.c15 li {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 23px;
+  line-height: 1.5em;
+  -webkit-font-smoothing: antialiased;
+  padding-top: .5em;
+  padding-bottom: .5em;
+}
+
+.c15 h1 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
+  line-height: 1.1em;
+  font-weight: normal;
+  padding-top: 107px;
+  padding-bottom: 46px;
+  margin: 0;
+  position: relative;
+  text-align: center;
+}
+
+.c15 h1::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: black;
+  border-radius: 50%;
+  position: absolute;
+  top: 69px;
+  right: calc(50% - 4px);
+}
+
+.c15 h2 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 1.1em;
+  font-weight: normal;
+  margin: 0;
+}
+
+.c15 h2 a {
+  background-size: 1.25px 1px;
+}
+
+.c15 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
+  background-position: bottom !important;
+}
+
+.c15 h3 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+  font-weight: normal;
+  padding-top: 23px;
+  margin: 0;
+}
+
+.c15 h3 strong {
+  font-weight: normal;
+  font-family: Unica77LLWebMedium,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 19px;
+  line-height: 1.5em;
+}
+
+.c15 h3 a {
+  background-size: 1.25px 1px;
+}
+
+.c15 blockquote {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 40px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  text-align: left;
+  font-weight: normal;
+  padding-top: 46px;
+  padding-bottom: 46px;
+  margin: 0;
+  word-break: break-word;
+}
+
+.c15 .content-end {
+  display: inline-block;
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: black;
+  border-radius: 50%;
+  margin-left: 12px;
+  margin-bottom: 1px;
+}
+
+.c15 .artist-follow {
+  vertical-align: middle;
+  margin-left: 10px;
+  cursor: pointer;
+  background: none transparent;
+}
+
+.c15 .artist-follow::before {
+  font-family: "artsy-icons";
+  content: "";
+  vertical-align: -8.5px;
+  line-height: 32px;
+  font-size: 32px;
+}
+
+.c15 .artist-follow::after {
+  content: "Follow";
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  text-transform: none;
+}
+
+.c8 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c13 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -874,415 +1425,34 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   margin-top: 5px;
 }
 
-.c15 {
+.c13 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c15:hover {
+.c13:hover {
   opacity: 0.6;
 }
 
-.c15:first-child {
+.c13:first-child {
   padding-left: 0;
 }
 
-.c14 {
+.c12 {
   margin: 5px 10px 5px 0;
 }
 
-.c9 {
-  color: black;
+.c7 {
+  color: #000;
 }
 
-.c6 {
-  position: relative;
-  width: 100%;
-}
-
-.c6 a {
-  color: black;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  background-image: linear-gradient( to bottom, transparent 0, #333333 1px, transparent 0 );
-  background-size: 1.25px 4px;
-  background-repeat: repeat-x;
-  background-position: bottom;
-}
-
-.c6 a:hover {
-  color: #999999;
-  opacity: 1;
-}
-
-.c6 div[class*='ToolTip'] a {
-  background-image: none;
-  opacity: 1;
-  color: inherit;
-}
-
-.c6 p,
-.c6 ul,
-.c6 ol,
-.c6 .paragraph,
-.c6 div[data-block=true] .public-DraftStyleDefault-block {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-  padding-top: 1em;
-  padding-bottom: 1em;
-  margin: 0;
-  font-style: inherit;
-}
-
-.c6 p:first-child,
-.c6 .paragraph:first-child,
-.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
-  padding-top: 0;
-}
-
-.c6 p:last-child,
-.c6 .paragraph:last-child,
-.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
-  padding-bottom: 0;
-}
-
-.c6 ul,
-.c6 ol {
-  padding-left: 1em;
-}
-
-.c6 ul {
-  list-style: disc;
-}
-
-.c6 ol {
-  list-style: decimal;
-}
-
-.c6 li {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-  padding-top: .5em;
-  padding-bottom: .5em;
-}
-
-.c6 h1 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 40px;
-  line-height: 1.1em;
-  font-weight: normal;
-  padding-top: 107px;
-  padding-bottom: 46px;
-  margin: 0;
-  position: relative;
-  text-align: center;
-}
-
-.c6 h1::before {
-  content: "";
-  width: 8px;
-  height: 8px;
-  background: black;
-  border-radius: 50%;
-  position: absolute;
-  top: 69px;
-  right: calc(50% - 4px);
-}
-
-.c6 h2 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 32px;
-  line-height: 1.1em;
-  font-weight: normal;
-  margin: 0;
-}
-
-.c6 h2 a {
-  background-size: 1.25px 1px;
-}
-
-.c6 h2 .LinkWithTooltip__PrimaryLink-s1omtxql-0 {
-  background-position: bottom !important;
-}
-
-.c6 h3 {
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 19px;
-  line-height: 1.5em;
-  font-weight: normal;
-  padding-top: 23px;
-  margin: 0;
-}
-
-.c6 h3 strong {
-  font-weight: normal;
-  font-family: Unica77LLWebMedium,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 19px;
-  line-height: 1.5em;
-}
-
-.c6 h3 a {
-  background-size: 1.25px 1px;
-}
-
-.c6 blockquote {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 40px;
-  line-height: 1.1em;
-  -webkit-font-smoothing: antialiased;
-  text-align: left;
-  font-weight: normal;
-  padding-top: 46px;
-  padding-bottom: 46px;
-  margin: 0;
-  word-break: break-word;
-}
-
-.c6 .content-end {
-  display: inline-block;
-  content: "";
-  width: 8px;
-  height: 8px;
-  background: black;
-  border-radius: 50%;
-  margin-left: 12px;
-  margin-bottom: 1px;
-}
-
-.c6 .artist-follow {
-  vertical-align: middle;
-  margin-left: 10px;
-  cursor: pointer;
-  background: none transparent;
-}
-
-.c6 .artist-follow::before {
-  font-family: "artsy-icons";
-  content: "";
-  vertical-align: -8.5px;
-  line-height: 32px;
-  font-size: 32px;
-}
-
-.c6 .artist-follow::after {
-  content: "Follow";
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 17px;
-  line-height: 1.1em;
-  -webkit-font-smoothing: antialiased;
-  text-transform: none;
-}
-
-.c5 {
-  color: black;
-  margin-bottom: 15px;
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 34px;
-  line-height: 1.1em;
-}
-
-.c2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c2 p {
+.c1 .c4 p {
   padding: 0;
 }
 
-.c16 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c0 .c8 {
-  margin-top: 40px;
-}
-
-@media only screen and (min-width:0em) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c3 {
-    -webkit-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-    flex-basis: 33.333333333333336%;
-    max-width: 33.333333333333336%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c4 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c7 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c7 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c17 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c17 {
-    -webkit-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-    flex-basis: 66.66666666666667%;
-    max-width: 66.66666666666667%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c18 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c18 {
-    display: none;
-  }
-}
-
-@media (max-width:768px) {
-  .c9 .c12 {
-    margin-top: 0px;
-  }
-}
-
-@media (max-width:600px) {
-  .c6 p,
-  .c6 ul,
-  .c6 ol,
-  .c6 div[data-block=true] .public-DraftStyleDefault-block {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-  }
-
-  .c6 li {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
-  }
-
-  .c6 h1 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 34px;
-    line-height: 1.1em;
-  }
-
-  .c6 h2 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-
-  .c6 h3 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 16px;
-    line-height: 1.1em;
-    line-height: 1.5em;
-  }
-
-  .c6 h3 strong {
-    font-family: Unica77LLWebMedium,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 16px;
-    line-height: 1.1em;
-  }
-
-  .c6 blockquote {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 34px;
-    line-height: 1.1em;
-    -webkit-font-smoothing: antialiased;
-    margin: 0;
-  }
-
-  .c6 .content-start {
-    font-size: 55px;
-  }
-}
-
-@media (max-width:720px) {
-  .c5 {
-    font-family: Unica77LLWebRegular,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 32px;
-    line-height: 1.1em;
-  }
-}
-
-@media (max-width:720px) {
-  .c2 {
-    margin-top: 80px;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (max-width:720px) {
+@media screen and (min-width:40em) {
   .c0 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
@@ -1290,287 +1460,503 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   }
 }
 
+@media screen and (min-width:52em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    padding-top: 80px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    padding-top: 0px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    padding-top: 0px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c2 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c14 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c14 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c14 {
+    width: 66.66666666666666%;
+  }
+}
+
+@media (max-width:600px) {
+  .c5 p,
+  .c5 ul,
+  .c5 ol,
+  .c5 div[data-block=true] .public-DraftStyleDefault-block {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 19px;
+    line-height: 1.5em;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .c5 li {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 19px;
+    line-height: 1.5em;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .c5 h1 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+  }
+
+  .c5 h2 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 32px;
+    line-height: 1.1em;
+  }
+
+  .c5 h3 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+    line-height: 1.5em;
+  }
+
+  .c5 h3 strong {
+    font-family: Unica77LLWebMedium,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+
+  .c5 blockquote {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 34px;
+    line-height: 1.1em;
+    -webkit-font-smoothing: antialiased;
+    margin: 0;
+  }
+
+  .c5 .content-start {
+    font-size: 55px;
+  }
+}
+
+@media (max-width:600px) {
+  .c15 p,
+  .c15 ul,
+  .c15 ol,
+  .c15 div[data-block=true] .public-DraftStyleDefault-block {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 19px;
+    line-height: 1.5em;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .c15 li {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 19px;
+    line-height: 1.5em;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .c15 h1 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 34px;
+    line-height: 1.1em;
+  }
+
+  .c15 h2 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 32px;
+    line-height: 1.1em;
+  }
+
+  .c15 h3 {
+    font-family: Unica77LLWebRegular,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+    line-height: 1.5em;
+  }
+
+  .c15 h3 strong {
+    font-family: Unica77LLWebMedium,Arial,serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 16px;
+    line-height: 1.1em;
+  }
+
+  .c15 blockquote {
+    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+    font-size: 34px;
+    line-height: 1.1em;
+    -webkit-font-smoothing: antialiased;
+    margin: 0;
+  }
+
+  .c15 .content-start {
+    font-size: 55px;
+  }
+}
+
+@media (max-width:768px) {
+  .c7 .c10 {
+    margin-top: 0px;
+  }
+}
+
 <div
-  className="c0 c1"
+  className="c0"
 >
   <div
-    className="c2 c3"
+    className="c1 c2"
+    width={
+      Array [
+        1,
+        1,
+        0.3333333333333333,
+        0.3333333333333333,
+      ]
+    }
   >
     <div
-      className="c4"
+      className="c3"
+      color="#000"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="28px"
     >
-      <div
-        className="c5"
-        color="black"
-      >
-        Credits
-      </div>
-      <div
-        className="article__text-section c6"
-        color="black"
-      >
-        <div>
-          Child 
-          media.credit
-        </div>
+      Credits
+    </div>
+    <div
+      className="article__text-section c4 c5"
+      color="black"
+    >
+      <div>
+        Child 
+        media.credit
       </div>
     </div>
     <div
-      className="c7"
+      className="rrm-container rrm-greaterThanOrEqual-md"
     >
       <div
-        className="c8 c9"
+        className="c6"
       >
         <div
-          className="c10"
+          className="c7"
         >
           <div
-            className="c11"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
-              }
-            }
-            fontSize="14px"
+            className="c8"
           >
-            Jul 28, 2017 4:38 pm
+            <div
+              className="c9"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
+              }
+              fontSize="14px"
+            >
+              Jul 28, 2017 4:38 pm
+            </div>
           </div>
-        </div>
-        <div
-          className="c12 c13"
-        >
           <div
-            className="c14 c11"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
+            className="c10 c11"
+          >
+            <div
+              className="c12 c9"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
               }
-            }
-            fontSize="14px"
-          >
-            Share
+              fontSize="14px"
+            >
+              Share
+            </div>
+            <a
+              className="c13"
+              href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 14 14"
+                width="14px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
+            <a
+              className="c13"
+              href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 16 14"
+                width="16px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
+            <a
+              className="c13"
+              href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 17 14"
+                width="17px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
           </div>
-          <a
-            className="c15"
-            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 14 14"
-              width="14px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
-          <a
-            className="c15"
-            href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 16 14"
-              width="16px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
-          <a
-            className="c15"
-            href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 17 14"
-              width="17px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="c16 c17"
+    className="c14"
+    width={
+      Array [
+        1,
+        1,
+        0.6666666666666666,
+        0.6666666666666666,
+      ]
+    }
   >
     <div
-      className="c4"
+      className="c3"
+      color="#000"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="28px"
     >
-      <div
-        className="c5"
-        color="black"
-      >
-        About the Film
-      </div>
-      <div
-        className="article__text-section c6"
-        color="black"
-      >
-        <div>
-          Child 
-          media.description
-        </div>
+      About the Film
+    </div>
+    <div
+      className="article__text-section c4 c15"
+      color="#000"
+    >
+      <div>
+        Child 
+        media.description
       </div>
     </div>
     <div
-      className="c18"
+      className="rrm-container rrm-lessThan-md"
     >
       <div
-        className="c8 c9"
+        className="c6"
       >
         <div
-          className="c10"
+          className="c7"
         >
           <div
-            className="c11"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
-              }
-            }
-            fontSize="14px"
+            className="c8"
           >
-            Jul 28, 2017 4:38 pm
+            <div
+              className="c9"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
+              }
+              fontSize="14px"
+            >
+              Jul 28, 2017 4:38 pm
+            </div>
           </div>
-        </div>
-        <div
-          className="c12 c13"
-        >
           <div
-            className="c14 c11"
-            fontFamily={
-              Object {
-                "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                "fontWeight": 500,
+            className="c10 c11"
+          >
+            <div
+              className="c12 c9"
+              fontFamily={
+                Object {
+                  "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                  "fontWeight": 500,
+                }
               }
-            }
-            fontSize="14px"
-          >
-            Share
+              fontSize="14px"
+            >
+              Share
+            </div>
+            <a
+              className="c13"
+              href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 14 14"
+                width="14px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
+            <a
+              className="c13"
+              href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 16 14"
+                width="16px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
+            <a
+              className="c13"
+              href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
+              onClick={[Function]}
+              target="_blank"
+            >
+              <svg
+                height="14px"
+                version="1.1"
+                viewBox="0 0 17 14"
+                width="17px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="none"
+                  strokeWidth="1"
+                >
+                  <path
+                    d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+                    fill="#000"
+                  />
+                </g>
+              </svg>
+            </a>
           </div>
-          <a
-            className="c15"
-            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 14 14"
-              width="14px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
-          <a
-            className="c15"
-            href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 16 14"
-              width="16px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
-          <a
-            className="c15"
-            href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
-            onClick={[Function]}
-            target="_blank"
-          >
-            <svg
-              height="14px"
-              version="1.1"
-              viewBox="0 0 17 14"
-              width="17px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="none"
-                strokeWidth="1"
-              >
-                <path
-                  d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
-                  fill="black"
-                />
-              </g>
-            </svg>
-          </a>
         </div>
       </div>
     </div>

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoCover.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoCover.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`Video Cover matches the snapshot 1`] = `
   line-height: 50px;
 }
 
-.c19 {
+.c18 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 18px;
   line-height: 26px;
@@ -117,10 +117,6 @@ exports[`Video Cover matches the snapshot 1`] = `
   height: 100%;
 }
 
-.c18 {
-  position: relative;
-}
-
 @media screen and (min-width:40em) {
   .c7 {
     padding-bottom: 60px;
@@ -128,37 +124,37 @@ exports[`Video Cover matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c19 {
+  .c18 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c19 {
+  .c18 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c19 {
+  .c18 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c19 {
+  .c18 {
     line-height: 32px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c19 {
+  .c18 {
     line-height: 32px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c19 {
+  .c18 {
     line-height: 32px;
   }
 }
@@ -250,7 +246,7 @@ exports[`Video Cover matches the snapshot 1`] = `
         className="c17"
       >
         <div
-          className="c18 c19"
+          className="c18"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize={
             Array [
@@ -310,7 +306,7 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
   line-height: 50px;
 }
 
-.c19 {
+.c18 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 18px;
   line-height: 26px;
@@ -386,10 +382,6 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
   height: 100%;
 }
 
-.c18 {
-  position: relative;
-}
-
 @media screen and (min-width:40em) {
   .c7 {
     padding-bottom: 60px;
@@ -397,37 +389,37 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c19 {
+  .c18 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c19 {
+  .c18 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c19 {
+  .c18 {
     font-size: 22px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c19 {
+  .c18 {
     line-height: 32px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c19 {
+  .c18 {
     line-height: 32px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c19 {
+  .c18 {
     line-height: 32px;
   }
 }
@@ -522,7 +514,7 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
         className="c17"
       >
         <div
-          className="c18 c19"
+          className="c18"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize={
             Array [

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoCover.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoCover.test.tsx.snap
@@ -1,70 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video Cover matches the snapshot 1`] = `
-.c8 {
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  padding-bottom: 40px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c16 {
+.c14 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 24px;
+  margin-right: 20px;
 }
 
-.c7 {
+.c15 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.c16 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 42px;
+  line-height: 50px;
+}
+
+.c19 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  padding-top: 30px;
+}
+
+.c8 {
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
   padding-bottom: 12px;
 }
 
-.c14 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
-}
-
 .c10 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+  padding-right: 20px;
+  width: 60px;
 }
 
-.c13 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c18 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c17 {
+  max-width: 100%;
 }
 
 .c12 {
@@ -72,22 +69,10 @@ exports[`Video Cover matches the snapshot 1`] = `
   height: 32px;
 }
 
-.c15 {
-  margin-right: 20px;
-}
-
-.c15 a {
+.c13 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c17 {
-  position: relative;
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
 }
 
 .c2 {
@@ -101,23 +86,13 @@ exports[`Video Cover matches the snapshot 1`] = `
 }
 
 .c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
   box-sizing: border-box;
-  padding-bottom: 60px;
   z-index: 1;
 }
 
 .c6 .c11 {
   height: 60px;
   width: 44px;
-  margin-right: 15px;
   cursor: pointer;
 }
 
@@ -142,94 +117,55 @@ exports[`Video Cover matches the snapshot 1`] = `
   height: 100%;
 }
 
-.c19 {
+.c18 {
   position: relative;
-  margin-top: 30px;
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
 }
 
-@media only screen and (min-width:0em) {
-  .c10 {
-    -webkit-flex-basis: 16.666666666666668%;
-    -ms-flex-preferred-size: 16.666666666666668%;
-    flex-basis: 16.666666666666668%;
-    max-width: 16.666666666666668%;
-    display: block;
+@media screen and (min-width:40em) {
+  .c7 {
+    padding-bottom: 60px;
   }
 }
 
-@media only screen and (min-width:48em) {
-  .c10 {
-    -webkit-flex-basis: 8.333333333333334%;
-    -ms-flex-preferred-size: 8.333333333333334%;
-    flex-basis: 8.333333333333334%;
-    max-width: 8.333333333333334%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c13 {
-    -webkit-flex-basis: 83.33333333333334%;
-    -ms-flex-preferred-size: 83.33333333333334%;
-    flex-basis: 83.33333333333334%;
-    max-width: 83.33333333333334%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c13 {
-    -webkit-flex-basis: 50%;
-    -ms-flex-preferred-size: 50%;
-    flex-basis: 50%;
-    max-width: 50%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c18 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c18 {
-    -webkit-flex-basis: 58.333333333333336%;
-    -ms-flex-preferred-size: 58.333333333333336%;
-    flex-basis: 58.333333333333336%;
-    max-width: 58.333333333333336%;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c9 {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-  }
-}
-
-@media (max-width:768px) {
-  .c6 {
-    padding-bottom: 40px;
-  }
-}
-
-@media (max-width:768px) {
+@media screen and (min-width:40em) {
   .c19 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c19 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c19 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c19 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c17 {
+    max-width: 60%;
   }
 }
 
@@ -244,17 +180,18 @@ exports[`Video Cover matches the snapshot 1`] = `
     className="c3 c4"
   />
   <div
-    className="c5 c6"
+    className="c5 c6 c7"
   >
     <div
-      className="c7"
+      className="c8"
     >
       <div
-        className="c8"
+        className="c9"
       >
         <div
-          className="c9 c10"
+          className="c10"
           onClick={[Function]}
+          width="60px"
         >
           <svg
             className="c11 c12"
@@ -278,21 +215,21 @@ exports[`Video Cover matches the snapshot 1`] = `
           </svg>
         </div>
         <div
-          className="c9 c13"
+          className=""
         >
           <div>
             <div
-              className="c14"
+              className="c9"
             >
               <div
-                className="c15 c16"
+                className="c13 c14"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize="14px"
               >
                 Future of Art
               </div>
               <div
-                className="c16"
+                className="c15"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize="14px"
               >
@@ -300,22 +237,29 @@ exports[`Video Cover matches the snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c14"
+              className="c16"
+              fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+              fontSize="42px"
             >
-              <span
-                className="c17"
-              >
-                Trevor Paglan
-              </span>
+              Trevor Paglan
             </div>
           </div>
         </div>
       </div>
       <div
-        className="c9 c18"
+        className="c17"
       >
         <div
-          className="c19"
+          className="c18 c19"
+          fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+          fontSize={
+            Array [
+              "18px",
+              "22px",
+              "22px",
+              "22px",
+            ]
+          }
         >
           The elegant spiral of the Nautilus shell, the sinuous pattern of the banks of a river, or the swirling vortex street of clouds - patterns exist.
         </div>
@@ -326,70 +270,67 @@ exports[`Video Cover matches the snapshot 1`] = `
 `;
 
 exports[`Video Cover matches the snapshot with edit props 1`] = `
-.c8 {
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  padding-bottom: 40px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c16 {
+.c14 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 24px;
+  margin-right: 20px;
 }
 
-.c7 {
+.c15 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.c16 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 42px;
+  line-height: 50px;
+}
+
+.c19 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+  padding-top: 30px;
+}
+
+.c8 {
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
   padding-bottom: 12px;
 }
 
-.c14 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
-}
-
 .c10 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+  padding-right: 20px;
+  width: 60px;
 }
 
-.c13 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
-}
-
-.c18 {
-  box-sizing: border-box;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+.c17 {
+  max-width: 100%;
 }
 
 .c12 {
@@ -397,22 +338,10 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
   height: 32px;
 }
 
-.c15 {
-  margin-right: 20px;
-}
-
-.c15 a {
+.c13 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c17 {
-  position: relative;
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
 }
 
 .c2 {
@@ -426,23 +355,13 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
 }
 
 .c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
   box-sizing: border-box;
-  padding-bottom: 60px;
   z-index: 1;
 }
 
 .c6 .c11 {
   height: 60px;
   width: 44px;
-  margin-right: 15px;
   cursor: pointer;
 }
 
@@ -467,94 +386,55 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
   height: 100%;
 }
 
-.c19 {
+.c18 {
   position: relative;
-  margin-top: 30px;
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 23px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
 }
 
-@media only screen and (min-width:0em) {
-  .c10 {
-    -webkit-flex-basis: 16.666666666666668%;
-    -ms-flex-preferred-size: 16.666666666666668%;
-    flex-basis: 16.666666666666668%;
-    max-width: 16.666666666666668%;
-    display: block;
+@media screen and (min-width:40em) {
+  .c7 {
+    padding-bottom: 60px;
   }
 }
 
-@media only screen and (min-width:48em) {
-  .c10 {
-    -webkit-flex-basis: 8.333333333333334%;
-    -ms-flex-preferred-size: 8.333333333333334%;
-    flex-basis: 8.333333333333334%;
-    max-width: 8.333333333333334%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c13 {
-    -webkit-flex-basis: 83.33333333333334%;
-    -ms-flex-preferred-size: 83.33333333333334%;
-    flex-basis: 83.33333333333334%;
-    max-width: 83.33333333333334%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c13 {
-    -webkit-flex-basis: 50%;
-    -ms-flex-preferred-size: 50%;
-    flex-basis: 50%;
-    max-width: 50%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:0em) {
-  .c18 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    max-width: 100%;
-    display: block;
-  }
-}
-
-@media only screen and (min-width:48em) {
-  .c18 {
-    -webkit-flex-basis: 58.333333333333336%;
-    -ms-flex-preferred-size: 58.333333333333336%;
-    flex-basis: 58.333333333333336%;
-    max-width: 58.333333333333336%;
-    display: block;
-  }
-}
-
-@media (max-width:768px) {
-  .c9 {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-  }
-}
-
-@media (max-width:768px) {
-  .c6 {
-    padding-bottom: 40px;
-  }
-}
-
-@media (max-width:768px) {
+@media screen and (min-width:40em) {
   .c19 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 19px;
-    line-height: 1.5em;
-    -webkit-font-smoothing: antialiased;
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c19 {
+    font-size: 22px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c19 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c19 {
+    line-height: 32px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c17 {
+    max-width: 60%;
   }
 }
 
@@ -569,17 +449,18 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
     className="c3 c4"
   />
   <div
-    className="c5 c6"
+    className="c5 c6 c7"
   >
     <div
-      className="c7"
+      className="c8"
     >
       <div
-        className="c8"
+        className="c9"
       >
         <div
-          className="c9 c10"
+          className="c10"
           onClick={[Function]}
+          width="60px"
         >
           <svg
             className="c11 c12"
@@ -603,21 +484,21 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
           </svg>
         </div>
         <div
-          className="c9 c13"
+          className=""
         >
           <div>
             <div
-              className="c14"
+              className="c9"
             >
               <div
-                className="c15 c16"
+                className="c13 c14"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize="14px"
               >
                 Future of Art
               </div>
               <div
-                className="c16"
+                className="c15"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize="14px"
               >
@@ -625,25 +506,32 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
               </div>
             </div>
             <div
-              className="c14"
+              className="c16"
+              fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+              fontSize="42px"
             >
-              <span
-                className="c17"
-              >
-                <div>
-                  Child 
-                  title
-                </div>
-              </span>
+              <div>
+                Child 
+                title
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
-        className="c9 c18"
+        className="c17"
       >
         <div
-          className="c19"
+          className="c18 c19"
+          fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+          fontSize={
+            Array [
+              "18px",
+              "22px",
+              "22px",
+              "22px",
+            ]
+          }
         >
           <div>
             Child 

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoInfoBlock.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoInfoBlock.test.tsx.snap
@@ -1,47 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video Info Block matches the snapshot 1`] = `
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 20px;
-}
-
 .c0 {
-  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
 }
 
-.c1 {
+.c2 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 24px;
   margin-right: 20px;
+}
+
+.c3 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 42px;
+  line-height: 50px;
 }
 
 .c1 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c3 {
-  position: relative;
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
 }
 
 <div>
@@ -56,7 +45,7 @@ exports[`Video Info Block matches the snapshot 1`] = `
       The Future of Art
     </div>
     <div
-      className="c2"
+      className="c3"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="14px"
     >
@@ -64,59 +53,46 @@ exports[`Video Info Block matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c0"
+    className="c4"
+    fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize="42px"
   >
-    <span
-      className="c3"
-    >
-      Trevor Paglan
-    </span>
+    Trevor Paglan
   </div>
 </div>
 `;
 
 exports[`Video Info Block matches the snapshot with edit props 1`] = `
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 20px;
-}
-
 .c0 {
-  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
 }
 
-.c1 {
+.c2 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 24px;
   margin-right: 20px;
+}
+
+.c3 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 42px;
+  line-height: 50px;
 }
 
 .c1 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c3 {
-  position: relative;
-  font-family: Unica77LLWebRegular,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 45px;
-  line-height: 1.2em;
 }
 
 <div>
@@ -131,7 +107,7 @@ exports[`Video Info Block matches the snapshot with edit props 1`] = `
       The Future of Art
     </div>
     <div
-      className="c2"
+      className="c3"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="14px"
     >
@@ -139,16 +115,14 @@ exports[`Video Info Block matches the snapshot with edit props 1`] = `
     </div>
   </div>
   <div
-    className="c0"
+    className="c4"
+    fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize="42px"
   >
-    <span
-      className="c3"
-    >
-      <div>
-        Child 
-        title
-      </div>
-    </span>
+    <div>
+      Child 
+      title
+    </div>
   </div>
 </div>
 `;

--- a/src/Components/Publishing/__stories__/RelatedArticleCards.story.tsx
+++ b/src/Components/Publishing/__stories__/RelatedArticleCards.story.tsx
@@ -42,6 +42,22 @@ storiesOf("Publishing/Related Articles/ArticleCards", module)
       </MaxWidthContainer>
     )
   })
+  .add("Block: Custom color", () => {
+    const article = clone({
+      ...StandardArticle,
+      seriesArticle: SeriesArticleSponsored,
+    } as ArticleData)
+
+    return (
+      <MaxWidthContainer>
+        <ArticleCardsBlock
+          color="coral"
+          article={article}
+          relatedArticles={[StandardArticle, VideoArticle]}
+        />
+      </MaxWidthContainer>
+    )
+  })
   .add("ArticleCards", () => {
     return (
       <MaxWidthContainer>


### PR DESCRIPTION
Quick refactor of components related to `series` and `video` article layouts
- Removes `styled-flexbox-grid`
- Use palette responsive components and fonts
- Removes restriction of feature layout `fullscreen` to show series data (is handled at top level)