### PR TITLE
Strongly type redirect predicates and create fragment for redirect logic

### DIFF
--- a/src/Apps/Order/getRedirect.ts
+++ b/src/Apps/Order/getRedirect.ts
@@ -1,6 +1,4 @@
-export type RedirectPredicate<Arguments = any> = (
-  args: Arguments
-) => string | void
+export type RedirectPredicate<Arguments> = (args: Arguments) => string | void
 
 export interface RedirectRecord<Arguments> {
   path: string

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -42,37 +42,7 @@ export const routes: RouteConfig[] = [
           name
         }
         order: ecommerceOrder(id: $orderID) {
-          id
-          mode
-          state
-          ... on OfferOrder {
-            myLastOffer {
-              id
-              createdAt
-            }
-            lastOffer {
-              id
-              createdAt
-            }
-          }
-          requestedFulfillment {
-            __typename
-          }
-          lineItems {
-            edges {
-              node {
-                artwork {
-                  id
-                }
-              }
-            }
-          }
-          creditCard {
-            id
-          }
-          ... on OfferOrder {
-            awaitingResponseFrom
-          }
+          ...redirects_order @relay(mask: false)
         }
       }
     `,

--- a/src/__generated__/redirects_order.graphql.ts
+++ b/src/__generated__/redirects_order.graphql.ts
@@ -1,0 +1,209 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type OrderModeEnum = "BUY" | "OFFER" | "%future added value";
+export type OrderParticipantEnum = "BUYER" | "SELLER" | "%future added value";
+declare const _redirects_order$ref: unique symbol;
+export type redirects_order$ref = typeof _redirects_order$ref;
+export type redirects_order = {
+    readonly id: string | null;
+    readonly mode: OrderModeEnum | null;
+    readonly state: string | null;
+    readonly requestedFulfillment: ({
+        readonly __typename: string;
+    }) | null;
+    readonly lineItems: ({
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly artwork: ({
+                    readonly id: string;
+                }) | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+    readonly creditCard: ({
+        readonly id: string;
+    }) | null;
+    readonly myLastOffer?: ({
+        readonly id: string | null;
+        readonly createdAt: string | null;
+    }) | null;
+    readonly lastOffer?: ({
+        readonly id: string | null;
+        readonly createdAt: string | null;
+    }) | null;
+    readonly awaitingResponseFrom?: OrderParticipantEnum | null;
+    readonly " $refType": redirects_order$ref;
+};
+
+
+
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v1 = [
+  v0,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "__id",
+    "args": null,
+    "storageKey": null
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  v0,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "createdAt",
+    "args": null,
+    "storageKey": null
+  },
+  v2
+];
+return {
+  "kind": "Fragment",
+  "name": "redirects_order",
+  "type": "Order",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    v0,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "mode",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "state",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "requestedFulfillment",
+      "storageKey": null,
+      "args": null,
+      "concreteType": null,
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "__typename",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "lineItems",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "OrderLineItemConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "OrderLineItemEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "OrderLineItem",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "artwork",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Artwork",
+                  "plural": false,
+                  "selections": v1
+                },
+                v2
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "creditCard",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CreditCard",
+      "plural": false,
+      "selections": v1
+    },
+    v2,
+    {
+      "kind": "InlineFragment",
+      "type": "OfferOrder",
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "myLastOffer",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Offer",
+          "plural": false,
+          "selections": v3
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "lastOffer",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Offer",
+          "plural": false,
+          "selections": v3
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "awaitingResponseFrom",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+};
+})();
+(node as any).hash = 'a3c8a9c08a025cc50e9126a7d8cb3b26';
+export default node;

--- a/src/__generated__/redirects_order.graphql.ts
+++ b/src/__generated__/redirects_order.graphql.ts
@@ -205,5 +205,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'a3c8a9c08a025cc50e9126a7d8cb3b26';
+(node as any).hash = '6ebbf99189725ca37c7015f849d436a4';
 export default node;

--- a/src/__generated__/routes_OrderQuery.graphql.ts
+++ b/src/__generated__/routes_OrderQuery.graphql.ts
@@ -354,5 +354,5 @@ return {
   }
 };
 })();
-(node as any).hash = '980157379498cf9019d77ed1e2e06bbf';
+(node as any).hash = '20d17f420895276adefe97677567a77d';
 export default node;


### PR DESCRIPTION
Done in collaboration with @ds300, and in response to feedback from @alloy [on a previously merged PR](https://github.com/artsy/reaction/pull/1711#issuecomment-449001723). 

1. We accidentally committed an "any" default to the `args` property of `RedirectPredicate`. That is removed, and actual types are specified by all implementing types.
2. A new fragment is added, to represent the `Order` that the `RedirectPredicate`s all need. 