### PR TITLE
Refetch data after accepting/declining an offer to avoid redirect loop

### DIFF
--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -69,6 +69,9 @@ export class Accept extends Component<AcceptProps, AcceptState> {
                     __typename
                     order {
                       id
+                      ... on OfferOrder {
+                        awaitingResponseFrom
+                      }
                     }
                   }
                   ... on OrderWithMutationFailure {

--- a/src/Apps/Order/Routes/Reject/index.tsx
+++ b/src/Apps/Order/Routes/Reject/index.tsx
@@ -60,6 +60,9 @@ export class Reject extends Component<RejectProps, RejectState> {
                     __typename
                     order {
                       id
+                      ... on OfferOrder {
+                        awaitingResponseFrom
+                      }
                     }
                   }
                   ... on OrderWithMutationFailure {

--- a/src/__generated__/AcceptOfferMutation.graphql.ts
+++ b/src/__generated__/AcceptOfferMutation.graphql.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
+export type OrderParticipantEnum = "BUYER" | "SELLER" | "%future added value";
 export type buyerAcceptOfferInput = {
     readonly offerId: string;
     readonly clientMutationId?: string | null;
@@ -14,6 +15,7 @@ export type AcceptOfferMutationResponse = {
             readonly __typename: "OrderWithMutationSuccess";
             readonly order?: ({
                 readonly id: string | null;
+                readonly awaitingResponseFrom?: OrderParticipantEnum | null;
             }) | null;
             readonly error?: ({
                 readonly type: string;
@@ -42,6 +44,9 @@ mutation AcceptOfferMutation(
         order {
           __typename
           id
+          ... on OfferOrder {
+            awaitingResponseFrom
+          }
           __id: id
         }
       }
@@ -75,6 +80,40 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "InlineFragment",
+  "type": "OfferOrder",
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "awaitingResponseFrom",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v6 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -111,34 +150,13 @@ v2 = {
       ]
     }
   ]
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
 };
 return {
   "kind": "Request",
   "operationKind": "mutation",
   "name": "AcceptOfferMutation",
   "id": null,
-  "text": "mutation AcceptOfferMutation(\n  $input: buyerAcceptOfferInput!\n) {\n  ecommerceBuyerAcceptOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          id\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
+  "text": "mutation AcceptOfferMutation(\n  $input: buyerAcceptOfferInput!\n) {\n  ecommerceBuyerAcceptOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          id\n          ... on OfferOrder {\n            awaitingResponseFrom\n          }\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -165,12 +183,11 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -180,12 +197,14 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v3,
                       v4,
                       v5
                     ]
                   }
                 ]
-              }
+              },
+              v6
             ]
           }
         ]
@@ -215,13 +234,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -231,13 +249,15 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v2,
                       v3,
                       v4,
                       v5
                     ]
                   }
                 ]
-              }
+              },
+              v6
             ]
           }
         ]
@@ -246,5 +266,5 @@ return {
   }
 };
 })();
-(node as any).hash = '3c03e86ceed373404129410f6464b598';
+(node as any).hash = '73e3ed3a8fcf9d874db6ba8783be79bd';
 export default node;

--- a/src/__generated__/ArtistInfoQuery.graphql.ts
+++ b/src/__generated__/ArtistInfoQuery.graphql.ts
@@ -155,22 +155,18 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v4 = [
-  v3
-],
 v5 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "YYYY",
-    "type": "String"
-  }
-],
-v6 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -179,13 +175,17 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-};
+v6 = [
+  v4
+],
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "YYYY",
+    "type": "String"
+  }
+];
 return {
   "kind": "Request",
   "operationKind": "query",
@@ -234,103 +234,6 @@ return {
         "plural": false,
         "selections": [
           {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "exhibition_highlights",
-            "storageKey": "exhibition_highlights(size:3)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 3,
-                "type": "Int"
-              }
-            ],
-            "concreteType": "Show",
-            "plural": true,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "partner",
-                "storageKey": null,
-                "args": null,
-                "concreteType": null,
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "__typename",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  v2,
-                  {
-                    "kind": "InlineFragment",
-                    "type": "Partner",
-                    "selections": v4
-                  },
-                  {
-                    "kind": "InlineFragment",
-                    "type": "ExternalPartner",
-                    "selections": v4
-                  }
-                ]
-              },
-              v3,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "start_at",
-                "args": v5,
-                "storageKey": "start_at(format:\"YYYY\")"
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "cover_image",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Image",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "cropped",
-                    "storageKey": "cropped(height:600,width:800)",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 600,
-                        "type": "Int!"
-                      },
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 800,
-                        "type": "Int!"
-                      }
-                    ],
-                    "concreteType": "CroppedImageUrl",
-                    "plural": false,
-                    "selections": v6
-                  }
-                ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "city",
-                "args": null,
-                "storageKey": null
-              },
-              v2
-            ]
-          },
-          {
             "kind": "ScalarField",
             "alias": null,
             "name": "_id",
@@ -338,6 +241,7 @@ return {
             "storageKey": null
           },
           v3,
+          v4,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -375,7 +279,7 @@ return {
                 ],
                 "concreteType": "CroppedImageUrl",
                 "plural": false,
-                "selections": v6
+                "selections": v5
               }
             ]
           },
@@ -411,7 +315,103 @@ return {
               }
             ]
           },
-          v7,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "exhibition_highlights",
+            "storageKey": "exhibition_highlights(size:3)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 3,
+                "type": "Int"
+              }
+            ],
+            "concreteType": "Show",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "partner",
+                "storageKey": null,
+                "args": null,
+                "concreteType": null,
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "__typename",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v2,
+                  {
+                    "kind": "InlineFragment",
+                    "type": "ExternalPartner",
+                    "selections": v6
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "type": "Partner",
+                    "selections": v6
+                  }
+                ]
+              },
+              v4,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "start_at",
+                "args": v7,
+                "storageKey": "start_at(format:\"YYYY\")"
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "cover_image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "cropped",
+                    "storageKey": "cropped(height:600,width:800)",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 600,
+                        "type": "Int!"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 800,
+                        "type": "Int!"
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "plural": false,
+                    "selections": v5
+                  }
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "city",
+                "args": null,
+                "storageKey": null
+              },
+              v2
+            ]
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -532,7 +532,7 @@ return {
                             "concreteType": "Category",
                             "plural": true,
                             "selections": [
-                              v7
+                              v3
                             ]
                           },
                           v2
@@ -627,7 +627,7 @@ return {
                         "kind": "ScalarField",
                         "alias": null,
                         "name": "sale_date",
-                        "args": v5,
+                        "args": v7,
                         "storageKey": "sale_date(format:\"YYYY\")"
                       },
                       v2

--- a/src/__generated__/ArtistInfo_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistInfo_Test_Query.graphql.ts
@@ -143,22 +143,18 @@ v1 = {
 v2 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v3 = [
-  v2
-],
 v4 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "YYYY",
-    "type": "String"
-  }
-],
-v5 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -167,13 +163,17 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-};
+v5 = [
+  v3
+],
+v6 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "YYYY",
+    "type": "String"
+  }
+];
 return {
   "kind": "Request",
   "operationKind": "query",
@@ -222,103 +222,6 @@ return {
         "plural": false,
         "selections": [
           {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "exhibition_highlights",
-            "storageKey": "exhibition_highlights(size:3)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 3,
-                "type": "Int"
-              }
-            ],
-            "concreteType": "Show",
-            "plural": true,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "partner",
-                "storageKey": null,
-                "args": null,
-                "concreteType": null,
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "__typename",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  v1,
-                  {
-                    "kind": "InlineFragment",
-                    "type": "Partner",
-                    "selections": v3
-                  },
-                  {
-                    "kind": "InlineFragment",
-                    "type": "ExternalPartner",
-                    "selections": v3
-                  }
-                ]
-              },
-              v2,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "start_at",
-                "args": v4,
-                "storageKey": "start_at(format:\"YYYY\")"
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "cover_image",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Image",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "cropped",
-                    "storageKey": "cropped(height:600,width:800)",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 600,
-                        "type": "Int!"
-                      },
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 800,
-                        "type": "Int!"
-                      }
-                    ],
-                    "concreteType": "CroppedImageUrl",
-                    "plural": false,
-                    "selections": v5
-                  }
-                ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "city",
-                "args": null,
-                "storageKey": null
-              },
-              v1
-            ]
-          },
-          {
             "kind": "ScalarField",
             "alias": null,
             "name": "_id",
@@ -326,6 +229,7 @@ return {
             "storageKey": null
           },
           v2,
+          v3,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -363,7 +267,7 @@ return {
                 ],
                 "concreteType": "CroppedImageUrl",
                 "plural": false,
-                "selections": v5
+                "selections": v4
               }
             ]
           },
@@ -399,7 +303,103 @@ return {
               }
             ]
           },
-          v6,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "exhibition_highlights",
+            "storageKey": "exhibition_highlights(size:3)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 3,
+                "type": "Int"
+              }
+            ],
+            "concreteType": "Show",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "partner",
+                "storageKey": null,
+                "args": null,
+                "concreteType": null,
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "__typename",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v1,
+                  {
+                    "kind": "InlineFragment",
+                    "type": "ExternalPartner",
+                    "selections": v5
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "type": "Partner",
+                    "selections": v5
+                  }
+                ]
+              },
+              v3,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "start_at",
+                "args": v6,
+                "storageKey": "start_at(format:\"YYYY\")"
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "cover_image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "cropped",
+                    "storageKey": "cropped(height:600,width:800)",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 600,
+                        "type": "Int!"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 800,
+                        "type": "Int!"
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "plural": false,
+                    "selections": v4
+                  }
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "city",
+                "args": null,
+                "storageKey": null
+              },
+              v1
+            ]
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -520,7 +520,7 @@ return {
                             "concreteType": "Category",
                             "plural": true,
                             "selections": [
-                              v6
+                              v2
                             ]
                           },
                           v1
@@ -615,7 +615,7 @@ return {
                         "kind": "ScalarField",
                         "alias": null,
                         "name": "sale_date",
-                        "args": v4,
+                        "args": v6,
                         "storageKey": "sale_date(format:\"YYYY\")"
                       },
                       v1

--- a/src/__generated__/ArtistInfo_artist.graphql.ts
+++ b/src/__generated__/ArtistInfo_artist.graphql.ts
@@ -49,27 +49,16 @@ return {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "LinkedField",
+      "kind": "ScalarField",
       "alias": null,
-      "name": "counts",
-      "storageKey": null,
+      "name": "_id",
       "args": null,
-      "concreteType": "ArtistCounts",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "partner_shows",
-          "args": null,
-          "storageKey": null
-        }
-      ]
+      "storageKey": null
     },
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "_id",
+      "name": "id",
       "args": null,
       "storageKey": null
     },
@@ -137,11 +126,22 @@ return {
       "storageKey": null
     },
     {
-      "kind": "ScalarField",
+      "kind": "LinkedField",
       "alias": null,
-      "name": "id",
+      "name": "counts",
+      "storageKey": null,
       "args": null,
-      "storageKey": null
+      "concreteType": "ArtistCounts",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "partner_shows",
+          "args": null,
+          "storageKey": null
+        }
+      ]
     },
     {
       "kind": "LinkedField",

--- a/src/__generated__/ArtistShowsQuery.graphql.ts
+++ b/src/__generated__/ArtistShowsQuery.graphql.ts
@@ -452,12 +452,12 @@ return {
                           v2,
                           {
                             "kind": "InlineFragment",
-                            "type": "Partner",
+                            "type": "ExternalPartner",
                             "selections": v7
                           },
                           {
                             "kind": "InlineFragment",
-                            "type": "ExternalPartner",
+                            "type": "Partner",
                             "selections": v7
                           }
                         ]

--- a/src/__generated__/ArtistShows_artist.graphql.ts
+++ b/src/__generated__/ArtistShows_artist.graphql.ts
@@ -222,12 +222,12 @@ return {
                     v0,
                     {
                       "kind": "InlineFragment",
-                      "type": "Partner",
+                      "type": "ExternalPartner",
                       "selections": v2
                     },
                     {
                       "kind": "InlineFragment",
-                      "type": "ExternalPartner",
+                      "type": "Partner",
                       "selections": v2
                     }
                   ]

--- a/src/__generated__/ArtistsQuery.graphql.ts
+++ b/src/__generated__/ArtistsQuery.graphql.ts
@@ -468,14 +468,46 @@ return {
                                     "concreteType": "Artwork",
                                     "plural": false,
                                     "selections": [
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
-                                        "name": "collecting_institution",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
                                       v2,
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "image",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "Image",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "aspect_ratio",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "placeholder",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "url",
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "version",
+                                                "value": "large",
+                                                "type": "[String]"
+                                              }
+                                            ],
+                                            "storageKey": "url(version:\"large\")"
+                                          }
+                                        ]
+                                      },
                                       v5,
                                       {
                                         "kind": "ScalarField",
@@ -520,43 +552,11 @@ return {
                                         ]
                                       },
                                       {
-                                        "kind": "LinkedField",
+                                        "kind": "ScalarField",
                                         "alias": null,
-                                        "name": "image",
-                                        "storageKey": null,
+                                        "name": "collecting_institution",
                                         "args": null,
-                                        "concreteType": "Image",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "kind": "ScalarField",
-                                            "alias": null,
-                                            "name": "aspect_ratio",
-                                            "args": null,
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "kind": "ScalarField",
-                                            "alias": null,
-                                            "name": "placeholder",
-                                            "args": null,
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "kind": "ScalarField",
-                                            "alias": null,
-                                            "name": "url",
-                                            "args": [
-                                              {
-                                                "kind": "Literal",
-                                                "name": "version",
-                                                "value": "large",
-                                                "type": "[String]"
-                                              }
-                                            ],
-                                            "storageKey": "url(version:\"large\")"
-                                          }
-                                        ]
+                                        "storageKey": null
                                       },
                                       {
                                         "kind": "LinkedField",

--- a/src/__generated__/ArtworkContextArtistQuery.graphql.ts
+++ b/src/__generated__/ArtworkContextArtistQuery.graphql.ts
@@ -304,14 +304,46 @@ v11 = [
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
           v2,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "placeholder",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"large\")"
+              }
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -403,43 +435,11 @@ v11 = [
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "date",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "placeholder",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "large",
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:\"large\")"
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",

--- a/src/__generated__/ArtworkContextArtist_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkContextArtist_Test_Query.graphql.ts
@@ -278,14 +278,46 @@ v9 = [
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
           v1,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "placeholder",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"large\")"
+              }
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -377,43 +409,11 @@ v9 = [
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "date",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "placeholder",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "large",
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:\"large\")"
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",

--- a/src/__generated__/ArtworkContextAuctionQuery.graphql.ts
+++ b/src/__generated__/ArtworkContextAuctionQuery.graphql.ts
@@ -338,14 +338,46 @@ v11 = [
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
           v3,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "placeholder",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"large\")"
+              }
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -419,43 +451,11 @@ v11 = [
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "date",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "placeholder",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "large",
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:\"large\")"
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",
@@ -737,6 +737,37 @@ return {
               v3,
               {
                 "kind": "Condition",
+                "passingValue": false,
+                "condition": "isClosed",
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "sale",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artworksConnection",
+                        "storageKey": null,
+                        "args": [
+                          v12,
+                          v6
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": v11
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "Condition",
                 "passingValue": true,
                 "condition": "isClosed",
                 "selections": [
@@ -814,37 +845,6 @@ return {
                     ]
                   }
                 ]
-              },
-              {
-                "kind": "Condition",
-                "passingValue": false,
-                "condition": "isClosed",
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "sale",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "Sale",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "artworksConnection",
-                        "storageKey": null,
-                        "args": [
-                          v12,
-                          v6
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "plural": false,
-                        "selections": v11
-                      }
-                    ]
-                  }
-                ]
               }
             ]
           },
@@ -870,13 +870,6 @@ return {
             "concreteType": "Sale",
             "plural": true,
             "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "live_start_at",
-                "args": null,
-                "storageKey": null
-              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -919,6 +912,13 @@ return {
                   }
                 ]
               },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "end_at",
+                "args": null,
+                "storageKey": null
+              },
               v1,
               v5,
               v8,
@@ -926,7 +926,7 @@ return {
               {
                 "kind": "ScalarField",
                 "alias": null,
-                "name": "end_at",
+                "name": "live_start_at",
                 "args": null,
                 "storageKey": null
               },

--- a/src/__generated__/ArtworkContextAuction_viewer.graphql.ts
+++ b/src/__generated__/ArtworkContextAuction_viewer.graphql.ts
@@ -115,24 +115,24 @@ return {
         v0,
         {
           "kind": "Condition",
-          "passingValue": true,
-          "condition": "isClosed",
-          "selections": [
-            {
-              "kind": "FragmentSpread",
-              "name": "ArtistArtworkGrid_artwork",
-              "args": v1
-            }
-          ]
-        },
-        {
-          "kind": "Condition",
           "passingValue": false,
           "condition": "isClosed",
           "selections": [
             {
               "kind": "FragmentSpread",
               "name": "AuctionArtworkGrid_artwork",
+              "args": v1
+            }
+          ]
+        },
+        {
+          "kind": "Condition",
+          "passingValue": true,
+          "condition": "isClosed",
+          "selections": [
+            {
+              "kind": "FragmentSpread",
+              "name": "ArtistArtworkGrid_artwork",
               "args": v1
             }
           ]

--- a/src/__generated__/ArtworkContextFairQuery.graphql.ts
+++ b/src/__generated__/ArtworkContextFairQuery.graphql.ts
@@ -310,14 +310,46 @@ v10 = [
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
           v2,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "placeholder",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"large\")"
+              }
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -409,43 +441,11 @@ v10 = [
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "date",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "placeholder",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "large",
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:\"large\")"
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",

--- a/src/__generated__/ArtworkContextFair_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkContextFair_Test_Query.graphql.ts
@@ -284,14 +284,46 @@ v8 = [
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
           v1,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "placeholder",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"large\")"
+              }
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -383,43 +415,11 @@ v8 = [
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "date",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "placeholder",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "large",
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:\"large\")"
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",

--- a/src/__generated__/ArtworkContextPartnerShowQuery.graphql.ts
+++ b/src/__generated__/ArtworkContextPartnerShowQuery.graphql.ts
@@ -317,14 +317,46 @@ v11 = [
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
           v2,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "placeholder",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"large\")"
+              }
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -416,43 +448,11 @@ v11 = [
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "date",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "placeholder",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "large",
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:\"large\")"
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",

--- a/src/__generated__/ArtworkContextPartnerShow_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkContextPartnerShow_Test_Query.graphql.ts
@@ -291,14 +291,46 @@ v9 = [
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
           v1,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "placeholder",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"large\")"
+              }
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -390,43 +422,11 @@ v9 = [
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "date",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "placeholder",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "large",
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:\"large\")"
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",

--- a/src/__generated__/ArtworkDetailsQuery.graphql.ts
+++ b/src/__generated__/ArtworkDetailsQuery.graphql.ts
@@ -248,17 +248,11 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "series",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "description",
             "args": v3,
             "storageKey": "description(format:\"HTML\")"
           },
+          v2,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -413,7 +407,13 @@ return {
             "plural": false,
             "selections": v7
           },
-          v2,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "series",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "ScalarField",
             "alias": null,

--- a/src/__generated__/ArtworkDetails_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkDetails_Test_Query.graphql.ts
@@ -236,17 +236,11 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "series",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "description",
             "args": v2,
             "storageKey": "description(format:\"HTML\")"
           },
+          v1,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -401,7 +395,13 @@ return {
             "plural": false,
             "selections": v6
           },
-          v1,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "series",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "ScalarField",
             "alias": null,

--- a/src/__generated__/ArtworkFilterArtworkGridQuery.graphql.ts
+++ b/src/__generated__/ArtworkFilterArtworkGridQuery.graphql.ts
@@ -469,14 +469,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -568,43 +600,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/ArtworkFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkFilterRefetchQuery.graphql.ts
@@ -642,14 +642,46 @@ return {
                             "concreteType": "Artwork",
                             "plural": false,
                             "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "date",
-                                "args": null,
-                                "storageKey": null
-                              },
                               v2,
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "image",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "aspect_ratio",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "placeholder",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "url",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "large",
+                                        "type": "[String]"
+                                      }
+                                    ],
+                                    "storageKey": "url(version:\"large\")"
+                                  }
+                                ]
+                              },
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -741,43 +773,11 @@ return {
                                 "storageKey": null
                               },
                               {
-                                "kind": "LinkedField",
+                                "kind": "ScalarField",
                                 "alias": null,
-                                "name": "image",
-                                "storageKey": null,
+                                "name": "date",
                                 "args": null,
-                                "concreteType": "Image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "kind": "ScalarField",
-                                    "alias": null,
-                                    "name": "aspect_ratio",
-                                    "args": null,
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "kind": "ScalarField",
-                                    "alias": null,
-                                    "name": "placeholder",
-                                    "args": null,
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "kind": "ScalarField",
-                                    "alias": null,
-                                    "name": "url",
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "version",
-                                        "value": "large",
-                                        "type": "[String]"
-                                      }
-                                    ],
-                                    "storageKey": "url(version:\"large\")"
-                                  }
-                                ]
+                                "storageKey": null
                               },
                               {
                                 "kind": "ScalarField",

--- a/src/__generated__/ArtworkFilter_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkFilter_Test_Query.graphql.ts
@@ -617,14 +617,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v1,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -716,43 +748,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/ArtworkGridExampleQuery.graphql.ts
+++ b/src/__generated__/ArtworkGridExampleQuery.graphql.ts
@@ -292,14 +292,46 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "date",
-                        "args": null,
-                        "storageKey": null
-                      },
                       v3,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspect_ratio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "placeholder",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large",
+                                "type": "[String]"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -391,43 +423,11 @@ return {
                         "storageKey": null
                       },
                       {
-                        "kind": "LinkedField",
+                        "kind": "ScalarField",
                         "alias": null,
-                        "name": "image",
-                        "storageKey": null,
+                        "name": "date",
                         "args": null,
-                        "concreteType": "Image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "aspect_ratio",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "placeholder",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "large",
-                                "type": "[String]"
-                              }
-                            ],
-                            "storageKey": "url(version:\"large\")"
-                          }
-                        ]
+                        "storageKey": null
                       },
                       {
                         "kind": "ScalarField",

--- a/src/__generated__/ArtworkGridQuery.graphql.ts
+++ b/src/__generated__/ArtworkGridQuery.graphql.ts
@@ -292,14 +292,46 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "date",
-                        "args": null,
-                        "storageKey": null
-                      },
                       v3,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspect_ratio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "placeholder",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large",
+                                "type": "[String]"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -391,43 +423,11 @@ return {
                         "storageKey": null
                       },
                       {
-                        "kind": "LinkedField",
+                        "kind": "ScalarField",
                         "alias": null,
-                        "name": "image",
-                        "storageKey": null,
+                        "name": "date",
                         "args": null,
-                        "concreteType": "Image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "aspect_ratio",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "placeholder",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "large",
-                                "type": "[String]"
-                              }
-                            ],
-                            "storageKey": "url(version:\"large\")"
-                          }
-                        ]
+                        "storageKey": null
                       },
                       {
                         "kind": "ScalarField",

--- a/src/__generated__/ArtworkGrid_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkGrid_Test_Query.graphql.ts
@@ -271,14 +271,46 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "date",
-                        "args": null,
-                        "storageKey": null
-                      },
                       v1,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspect_ratio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "placeholder",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large",
+                                "type": "[String]"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -370,43 +402,11 @@ return {
                         "storageKey": null
                       },
                       {
-                        "kind": "LinkedField",
+                        "kind": "ScalarField",
                         "alias": null,
-                        "name": "image",
-                        "storageKey": null,
+                        "name": "date",
                         "args": null,
-                        "concreteType": "Image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "aspect_ratio",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "placeholder",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "large",
-                                "type": "[String]"
-                              }
-                            ],
-                            "storageKey": "url(version:\"large\")"
-                          }
-                        ]
+                        "storageKey": null
                       },
                       {
                         "kind": "ScalarField",

--- a/src/__generated__/ArtworkMeta_artwork.graphql.ts
+++ b/src/__generated__/ArtworkMeta_artwork.graphql.ts
@@ -64,14 +64,14 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "image_rights",
+      "name": "href",
       "args": null,
       "storageKey": null
     },
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "href",
+      "name": "date",
       "args": null,
       "storageKey": null
     },
@@ -105,7 +105,7 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "date",
+      "name": "image_rights",
       "args": null,
       "storageKey": null
     },

--- a/src/__generated__/ArtworkMetadataQuery.graphql.ts
+++ b/src/__generated__/ArtworkMetadataQuery.graphql.ts
@@ -204,14 +204,14 @@ return {
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
+          v3,
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "collecting_institution",
+            "name": "title",
             "args": null,
             "storageKey": null
           },
-          v3,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -250,7 +250,7 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "title",
+            "name": "collecting_institution",
             "args": null,
             "storageKey": null
           },

--- a/src/__generated__/ArtworkQuery.graphql.ts
+++ b/src/__generated__/ArtworkQuery.graphql.ts
@@ -138,7 +138,14 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = [
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -146,13 +153,6 @@ v3 = [
     "type": "Boolean"
   }
 ],
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "href",
-  "args": null,
-  "storageKey": null
-},
 v5 = {
   "kind": "ScalarField",
   "alias": null,
@@ -215,52 +215,9 @@ return {
         "plural": false,
         "selections": [
           {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "artists",
-            "storageKey": "artists(shallow:true)",
-            "args": v3,
-            "concreteType": "Artist",
-            "plural": true,
-            "selections": [
-              v2,
-              v4,
-              v5
-            ]
-          },
-          {
             "kind": "ScalarField",
             "alias": null,
             "name": "id",
-            "args": null,
-            "storageKey": null
-          },
-          v4,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "sale_message",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "cultural_maker",
             "args": null,
             "storageKey": null
           },
@@ -296,6 +253,49 @@ return {
               }
             ]
           },
+          v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "date",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "sale_message",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "cultural_maker",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artists",
+            "storageKey": "artists(shallow:true)",
+            "args": v4,
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              v2,
+              v3,
+              v5
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -308,12 +308,12 @@ return {
             "alias": null,
             "name": "partner",
             "storageKey": "partner(shallow:true)",
-            "args": v3,
+            "args": v4,
             "concreteType": "Partner",
             "plural": false,
             "selections": [
               v5,
-              v4,
+              v3,
               v2,
               {
                 "kind": "ScalarField",

--- a/src/__generated__/ArtworkSidebarCommercialOfferOrderMutation.graphql.ts
+++ b/src/__generated__/ArtworkSidebarCommercialOfferOrderMutation.graphql.ts
@@ -80,6 +80,34 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "mode",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -116,34 +144,6 @@ v2 = {
       ]
     }
   ]
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "mode",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
 };
 return {
   "kind": "Request",
@@ -177,12 +177,11 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -192,13 +191,14 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v3,
                       v4,
-                      v5,
-                      v6
+                      v5
                     ]
                   }
                 ]
-              }
+              },
+              v6
             ]
           }
         ]
@@ -228,13 +228,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -244,14 +243,15 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v2,
                       v3,
                       v4,
-                      v5,
-                      v6
+                      v5
                     ]
                   }
                 ]
-              }
+              },
+              v6
             ]
           }
         ]

--- a/src/__generated__/ArtworkSidebarCommercialOrderMutation.graphql.ts
+++ b/src/__generated__/ArtworkSidebarCommercialOrderMutation.graphql.ts
@@ -80,6 +80,34 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "mode",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -116,34 +144,6 @@ v2 = {
       ]
     }
   ]
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "mode",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
 };
 return {
   "kind": "Request",
@@ -177,12 +177,11 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -192,13 +191,14 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v3,
                       v4,
-                      v5,
-                      v6
+                      v5
                     ]
                   }
                 ]
-              }
+              },
+              v6
             ]
           }
         ]
@@ -228,13 +228,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -244,14 +243,15 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v2,
                       v3,
                       v4,
-                      v5,
-                      v6
+                      v5
                     ]
                   }
                 ]
-              }
+              },
+              v6
             ]
           }
         ]

--- a/src/__generated__/ArtworkSidebarMetadata_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebarMetadata_Test_Query.graphql.ts
@@ -133,16 +133,21 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "medium",
+            "name": "is_biddable",
             "args": null,
             "storageKey": null
           },
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "is_biddable",
+            "name": "edition_sets",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
+            "concreteType": "EditionSet",
+            "plural": true,
+            "selections": [
+              v1
+            ]
           },
           {
             "kind": "LinkedField",
@@ -178,16 +183,11 @@ return {
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "edition_sets",
-            "storageKey": null,
+            "name": "medium",
             "args": null,
-            "concreteType": "EditionSet",
-            "plural": true,
-            "selections": [
-              v1
-            ]
+            "storageKey": null
           },
           v1,
           {

--- a/src/__generated__/ArtworkSidebarQuery.graphql.ts
+++ b/src/__generated__/ArtworkSidebarQuery.graphql.ts
@@ -445,27 +445,16 @@ return {
         "plural": false,
         "selections": [
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "attribution_class",
-            "storageKey": null,
+            "name": "is_in_auction",
             "args": null,
-            "concreteType": "AttributionClass",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "short_description",
-                "args": null,
-                "storageKey": null
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "is_in_auction",
+            "name": "cultural_maker",
             "args": null,
             "storageKey": null
           },
@@ -760,18 +749,22 @@ return {
           v10,
           v11,
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "shippingOrigin",
+            "name": "attribution_class",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "cultural_maker",
-            "args": null,
-            "storageKey": null
+            "concreteType": "AttributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "short_description",
+                "args": null,
+                "storageKey": null
+              }
+            ]
           },
           v6,
           {
@@ -817,6 +810,30 @@ return {
             "concreteType": "Sale",
             "plural": false,
             "selections": [
+              v6,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_closed",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_with_buyers_premium",
+                "args": null,
+                "storageKey": null
+              },
+              v2,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_live_open",
+                "args": null,
+                "storageKey": null
+              },
+              v3,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -835,30 +852,6 @@ return {
                   },
                   v2
                 ]
-              },
-              v6,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_with_buyers_premium",
-                "args": null,
-                "storageKey": null
-              },
-              v2,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_live_open",
-                "args": null,
-                "storageKey": null
-              },
-              v3,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_closed",
-                "args": null,
-                "storageKey": null
               },
               {
                 "kind": "ScalarField",
@@ -962,6 +955,13 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "shippingInfo",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingOrigin",
             "args": null,
             "storageKey": null
           },

--- a/src/__generated__/ArtworkSidebar_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebar_Test_Query.graphql.ts
@@ -433,27 +433,16 @@ return {
         "plural": false,
         "selections": [
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "attribution_class",
-            "storageKey": null,
+            "name": "is_in_auction",
             "args": null,
-            "concreteType": "AttributionClass",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "short_description",
-                "args": null,
-                "storageKey": null
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "is_in_auction",
+            "name": "cultural_maker",
             "args": null,
             "storageKey": null
           },
@@ -748,18 +737,22 @@ return {
           v9,
           v10,
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "shippingOrigin",
+            "name": "attribution_class",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "cultural_maker",
-            "args": null,
-            "storageKey": null
+            "concreteType": "AttributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "short_description",
+                "args": null,
+                "storageKey": null
+              }
+            ]
           },
           v5,
           {
@@ -805,6 +798,30 @@ return {
             "concreteType": "Sale",
             "plural": false,
             "selections": [
+              v5,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_closed",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_with_buyers_premium",
+                "args": null,
+                "storageKey": null
+              },
+              v1,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_live_open",
+                "args": null,
+                "storageKey": null
+              },
+              v2,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -823,30 +840,6 @@ return {
                   },
                   v1
                 ]
-              },
-              v5,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_with_buyers_premium",
-                "args": null,
-                "storageKey": null
-              },
-              v1,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_live_open",
-                "args": null,
-                "storageKey": null
-              },
-              v2,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_closed",
-                "args": null,
-                "storageKey": null
               },
               {
                 "kind": "ScalarField",
@@ -950,6 +943,13 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "shippingInfo",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "shippingOrigin",
             "args": null,
             "storageKey": null
           },

--- a/src/__generated__/ArtworkSidebar_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebar_artwork.graphql.ts
@@ -40,16 +40,16 @@ return {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "FragmentSpread",
-      "name": "ArtworkSidebarBidAction_artwork",
-      "args": null
-    },
-    {
       "kind": "ScalarField",
       "alias": null,
       "name": "is_in_auction",
       "args": null,
       "storageKey": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ArtworkSidebarArtists_artwork",
+      "args": null
     },
     {
       "kind": "FragmentSpread",
@@ -68,7 +68,7 @@ return {
     },
     {
       "kind": "FragmentSpread",
-      "name": "ArtworkSidebarArtists_artwork",
+      "name": "ArtworkSidebarBidAction_artwork",
       "args": null
     },
     {

--- a/src/__generated__/AuctionCard_sale.graphql.ts
+++ b/src/__generated__/AuctionCard_sale.graphql.ts
@@ -49,13 +49,6 @@ return {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "live_start_at",
-      "args": null,
-      "storageKey": null
-    },
-    {
       "kind": "LinkedField",
       "alias": null,
       "name": "cover_image",
@@ -100,6 +93,13 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
+      "name": "end_at",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
       "name": "href",
       "args": null,
       "storageKey": null
@@ -128,7 +128,7 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "end_at",
+      "name": "live_start_at",
       "args": null,
       "storageKey": null
     },

--- a/src/__generated__/CVItemQuery.graphql.ts
+++ b/src/__generated__/CVItemQuery.graphql.ts
@@ -372,17 +372,17 @@ return {
                           v2,
                           {
                             "kind": "InlineFragment",
-                            "type": "Partner",
+                            "type": "ExternalPartner",
                             "selections": [
-                              v4,
-                              v5
+                              v4
                             ]
                           },
                           {
                             "kind": "InlineFragment",
-                            "type": "ExternalPartner",
+                            "type": "Partner",
                             "selections": [
-                              v4
+                              v4,
+                              v5
                             ]
                           }
                         ]

--- a/src/__generated__/CVItem_artist.graphql.ts
+++ b/src/__generated__/CVItem_artist.graphql.ts
@@ -214,17 +214,17 @@ return {
                     v0,
                     {
                       "kind": "InlineFragment",
-                      "type": "Partner",
+                      "type": "ExternalPartner",
                       "selections": [
-                        v1,
-                        v2
+                        v1
                       ]
                     },
                     {
                       "kind": "InlineFragment",
-                      "type": "ExternalPartner",
+                      "type": "Partner",
                       "selections": [
-                        v1
+                        v1,
+                        v2
                       ]
                     }
                   ]

--- a/src/__generated__/CV_Test_Query.graphql.ts
+++ b/src/__generated__/CV_Test_Query.graphql.ts
@@ -290,17 +290,17 @@ v12 = [
               v8,
               {
                 "kind": "InlineFragment",
-                "type": "Partner",
+                "type": "ExternalPartner",
                 "selections": [
-                  v10,
-                  v11
+                  v10
                 ]
               },
               {
                 "kind": "InlineFragment",
-                "type": "ExternalPartner",
+                "type": "Partner",
                 "selections": [
-                  v10
+                  v10,
+                  v11
                 ]
               }
             ]

--- a/src/__generated__/CollectAppTestQuery.graphql.ts
+++ b/src/__generated__/CollectAppTestQuery.graphql.ts
@@ -485,14 +485,14 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          v2,
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "price",
+                            "name": "availability",
                             "args": null,
                             "storageKey": null
                           },
-                          v2,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -513,7 +513,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "availability",
+                            "name": "price",
                             "args": null,
                             "storageKey": null
                           },
@@ -849,8 +849,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v3,
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -929,45 +967,7 @@ return {
                           },
                           v4,
                           v6,
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "image",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
-                          },
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/CollectAppTestWithMediumQuery.graphql.ts
+++ b/src/__generated__/CollectAppTestWithMediumQuery.graphql.ts
@@ -485,14 +485,14 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          v2,
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "price",
+                            "name": "availability",
                             "args": null,
                             "storageKey": null
                           },
-                          v2,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -513,7 +513,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "availability",
+                            "name": "price",
                             "args": null,
                             "storageKey": null
                           },
@@ -849,8 +849,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v3,
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -929,45 +967,7 @@ return {
                           },
                           v4,
                           v6,
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "image",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
-                          },
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/CollectArtworkGridQuery.graphql.ts
+++ b/src/__generated__/CollectArtworkGridQuery.graphql.ts
@@ -469,14 +469,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -568,43 +600,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/CollectArtworkGridTestQuery.graphql.ts
+++ b/src/__generated__/CollectArtworkGridTestQuery.graphql.ts
@@ -416,14 +416,46 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "date",
-                        "args": null,
-                        "storageKey": null
-                      },
                       v1,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspect_ratio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "placeholder",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large",
+                                "type": "[String]"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -515,43 +547,11 @@ return {
                         "storageKey": null
                       },
                       {
-                        "kind": "LinkedField",
+                        "kind": "ScalarField",
                         "alias": null,
-                        "name": "image",
-                        "storageKey": null,
+                        "name": "date",
                         "args": null,
-                        "concreteType": "Image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "aspect_ratio",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "placeholder",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "large",
-                                "type": "[String]"
-                              }
-                            ],
-                            "storageKey": "url(version:\"large\")"
-                          }
-                        ]
+                        "storageKey": null
                       },
                       {
                         "kind": "ScalarField",

--- a/src/__generated__/CollectRefetchQuery.graphql.ts
+++ b/src/__generated__/CollectRefetchQuery.graphql.ts
@@ -662,14 +662,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v1,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -761,43 +793,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/CollectionAppTestQuery.graphql.ts
+++ b/src/__generated__/CollectionAppTestQuery.graphql.ts
@@ -297,28 +297,28 @@ v1 = {
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "category",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "title",
+  "name": "description",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "description",
+  "name": "category",
   "args": null,
   "storageKey": null
 },
@@ -482,16 +482,6 @@ return {
         "plural": false,
         "selections": [
           v2,
-          v3,
-          v4,
-          v5,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "headerImage",
-            "args": null,
-            "storageKey": null
-          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -499,6 +489,16 @@ return {
             "args": null,
             "storageKey": null
           },
+          v3,
+          v4,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "headerImage",
+            "args": null,
+            "storageKey": null
+          },
+          v5,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -592,15 +592,15 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "price",
+                            "name": "availability",
                             "args": null,
                             "storageKey": null
                           },
-                          v7,
-                          v2,
+                          v5,
                           v8,
                           v9,
                           v10,
@@ -614,7 +614,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "availability",
+                            "name": "price",
                             "args": null,
                             "storageKey": null
                           },
@@ -625,7 +625,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v4,
+                          v3,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -658,7 +658,7 @@ return {
                             "concreteType": "ArtworkMeta",
                             "plural": false,
                             "selections": [
-                              v5
+                              v4
                             ]
                           },
                           {
@@ -797,7 +797,7 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      v3,
+                      v2,
                       v11,
                       {
                         "kind": "ScalarField",
@@ -956,8 +956,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v8,
                           v7,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1035,46 +1073,8 @@ return {
                             "storageKey": null
                           },
                           v9,
-                          v4,
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "image",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
-                          },
+                          v3,
+                          v8,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1187,7 +1187,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          v2,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/CollectionApp_collection.graphql.ts
+++ b/src/__generated__/CollectionApp_collection.graphql.ts
@@ -110,14 +110,14 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "category",
+      "name": "id",
       "args": null,
       "storageKey": null
     },
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "id",
+      "name": "slug",
       "args": null,
       "storageKey": null
     },
@@ -145,7 +145,7 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "slug",
+      "name": "category",
       "args": null,
       "storageKey": null
     },

--- a/src/__generated__/CollectionRefetchQuery.graphql.ts
+++ b/src/__generated__/CollectionRefetchQuery.graphql.ts
@@ -656,14 +656,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v3,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -755,43 +787,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/ComparablesQuery.graphql.ts
+++ b/src/__generated__/ComparablesQuery.graphql.ts
@@ -315,14 +315,8 @@ return {
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
           v4,
+          v5,
           v7,
           v8,
           {
@@ -447,7 +441,13 @@ return {
             "storageKey": null
           },
           v9,
-          v5,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "ScalarField",
             "alias": null,

--- a/src/__generated__/ComparablesViewQuery.graphql.ts
+++ b/src/__generated__/ComparablesViewQuery.graphql.ts
@@ -679,14 +679,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v1,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -778,43 +810,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/CounterSubmitMutation.graphql.ts
+++ b/src/__generated__/CounterSubmitMutation.graphql.ts
@@ -78,6 +78,33 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "state",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "InlineFragment",
+  "type": "OfferOrder",
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "awaitingResponseFrom",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v5 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -112,33 +139,6 @@ v2 = {
           "storageKey": null
         }
       ]
-    }
-  ]
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "state",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "InlineFragment",
-  "type": "OfferOrder",
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "awaitingResponseFrom",
-      "args": null,
-      "storageKey": null
     }
   ]
 },
@@ -181,7 +181,6 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -195,13 +194,14 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v2,
                       v3,
-                      v4,
-                      v5
+                      v4
                     ]
                   }
                 ]
-              }
+              },
+              v5
             ]
           }
         ]
@@ -232,7 +232,6 @@ return {
             "plural": false,
             "selections": [
               v6,
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -247,13 +246,14 @@ return {
                     "plural": false,
                     "selections": [
                       v6,
+                      v2,
                       v3,
-                      v4,
-                      v5
+                      v4
                     ]
                   }
                 ]
-              }
+              },
+              v5
             ]
           }
         ]

--- a/src/__generated__/Counter_order.graphql.ts
+++ b/src/__generated__/Counter_order.graphql.ts
@@ -36,21 +36,21 @@ var v0 = {
   "args": null,
   "storageKey": null
 },
-v1 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "precision",
     "value": 2,
     "type": "Int"
   }
-];
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Fragment",
   "name": "Counter_order",
@@ -59,7 +59,13 @@ return {
   "argumentDefinitions": [],
   "selections": [
     v0,
-    v1,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "mode",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "ScalarField",
       "alias": null,
@@ -71,27 +77,20 @@ return {
       "kind": "ScalarField",
       "alias": null,
       "name": "itemsTotal",
-      "args": v2,
+      "args": v1,
       "storageKey": "itemsTotal(precision:2)"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "totalListPrice",
-      "args": v2,
+      "args": v1,
       "storageKey": "totalListPrice(precision:2)"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "stateExpiresAt",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "mode",
       "args": null,
       "storageKey": null
     },
@@ -120,6 +119,7 @@ return {
       "name": "OfferHistoryItem_order",
       "args": null
     },
+    v2,
     {
       "kind": "InlineFragment",
       "type": "OfferOrder",
@@ -140,7 +140,7 @@ return {
               "args": null,
               "storageKey": null
             },
-            v1
+            v2
           ]
         },
         {
@@ -153,7 +153,7 @@ return {
           "plural": false,
           "selections": [
             v0,
-            v1
+            v2
           ]
         }
       ]

--- a/src/__generated__/Details_Test_Query.graphql.ts
+++ b/src/__generated__/Details_Test_Query.graphql.ts
@@ -78,7 +78,14 @@ v1 = {
   "args": null,
   "storageKey": null
 },
-v2 = [
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -86,13 +93,6 @@ v2 = [
     "type": "Boolean"
   }
 ],
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "href",
-  "args": null,
-  "storageKey": null
-},
 v4 = {
   "kind": "ScalarField",
   "alias": null,
@@ -154,21 +154,14 @@ return {
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
+          v2,
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "artists",
-            "storageKey": "artists(shallow:true)",
-            "args": v2,
-            "concreteType": "Artist",
-            "plural": true,
-            "selections": [
-              v1,
-              v3,
-              v4
-            ]
+            "name": "title",
+            "args": null,
+            "storageKey": null
           },
-          v3,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -191,11 +184,18 @@ return {
             "storageKey": null
           },
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
+            "name": "artists",
+            "storageKey": "artists(shallow:true)",
+            "args": v3,
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              v1,
+              v2,
+              v4
+            ]
           },
           {
             "kind": "ScalarField",
@@ -209,12 +209,12 @@ return {
             "alias": null,
             "name": "partner",
             "storageKey": "partner(shallow:true)",
-            "args": v2,
+            "args": v3,
             "concreteType": "Partner",
             "plural": false,
             "selections": [
               v4,
-              v3,
+              v2,
               v1
             ]
           },

--- a/src/__generated__/Details_artwork.graphql.ts
+++ b/src/__generated__/Details_artwork.graphql.ts
@@ -40,7 +40,14 @@ export type Details_artwork = {
 
 
 const node: ConcreteFragment = (function(){
-var v0 = [
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -48,17 +55,10 @@ var v0 = [
     "type": "Boolean"
   }
 ],
-v1 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "__id",
   "args": null,
   "storageKey": null
 },
@@ -83,21 +83,14 @@ return {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
+    v0,
     {
-      "kind": "LinkedField",
+      "kind": "ScalarField",
       "alias": null,
-      "name": "artists",
-      "storageKey": "artists(shallow:true)",
-      "args": v0,
-      "concreteType": "Artist",
-      "plural": true,
-      "selections": [
-        v1,
-        v2,
-        v3
-      ]
+      "name": "title",
+      "args": null,
+      "storageKey": null
     },
-    v2,
     {
       "kind": "ScalarField",
       "alias": null,
@@ -120,11 +113,18 @@ return {
       "storageKey": null
     },
     {
-      "kind": "ScalarField",
+      "kind": "LinkedField",
       "alias": null,
-      "name": "title",
-      "args": null,
-      "storageKey": null
+      "name": "artists",
+      "storageKey": "artists(shallow:true)",
+      "args": v1,
+      "concreteType": "Artist",
+      "plural": true,
+      "selections": [
+        v2,
+        v0,
+        v3
+      ]
     },
     {
       "kind": "ScalarField",
@@ -138,13 +138,13 @@ return {
       "alias": null,
       "name": "partner",
       "storageKey": "partner(shallow:true)",
-      "args": v0,
+      "args": v1,
       "concreteType": "Partner",
       "plural": false,
       "selections": [
         v3,
-        v2,
-        v1
+        v0,
+        v2
       ]
     },
     {
@@ -191,7 +191,7 @@ return {
           "args": null,
           "storageKey": null
         },
-        v1
+        v2
       ]
     },
     {
@@ -234,10 +234,10 @@ return {
             v4
           ]
         },
-        v1
+        v2
       ]
     },
-    v1
+    v2
   ]
 };
 })();

--- a/src/__generated__/FillwidthQuery.graphql.ts
+++ b/src/__generated__/FillwidthQuery.graphql.ts
@@ -284,14 +284,46 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "collecting_institution",
-                        "args": null,
-                        "storageKey": null
-                      },
                       v3,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspect_ratio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "placeholder",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large",
+                                "type": "[String]"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
                       v4,
                       {
                         "kind": "ScalarField",
@@ -336,43 +368,11 @@ return {
                         ]
                       },
                       {
-                        "kind": "LinkedField",
+                        "kind": "ScalarField",
                         "alias": null,
-                        "name": "image",
-                        "storageKey": null,
+                        "name": "collecting_institution",
                         "args": null,
-                        "concreteType": "Image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "aspect_ratio",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "placeholder",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "large",
-                                "type": "[String]"
-                              }
-                            ],
-                            "storageKey": "url(version:\"large\")"
-                          }
-                        ]
+                        "storageKey": null
                       },
                       {
                         "kind": "LinkedField",

--- a/src/__generated__/GeneArtworksContentQuery.graphql.ts
+++ b/src/__generated__/GeneArtworksContentQuery.graphql.ts
@@ -382,14 +382,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "sale_message",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -488,43 +520,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "sale_message",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/GeneContentsArtistsQuery.graphql.ts
+++ b/src/__generated__/GeneContentsArtistsQuery.graphql.ts
@@ -411,14 +411,46 @@ return {
                                 "concreteType": "Artwork",
                                 "plural": false,
                                 "selections": [
-                                  {
-                                    "kind": "ScalarField",
-                                    "alias": null,
-                                    "name": "collecting_institution",
-                                    "args": null,
-                                    "storageKey": null
-                                  },
                                   v2,
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "aspect_ratio",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "placeholder",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "url",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": "large",
+                                            "type": "[String]"
+                                          }
+                                        ],
+                                        "storageKey": "url(version:\"large\")"
+                                      }
+                                    ]
+                                  },
                                   v4,
                                   {
                                     "kind": "ScalarField",
@@ -463,43 +495,11 @@ return {
                                     ]
                                   },
                                   {
-                                    "kind": "LinkedField",
+                                    "kind": "ScalarField",
                                     "alias": null,
-                                    "name": "image",
-                                    "storageKey": null,
+                                    "name": "collecting_institution",
                                     "args": null,
-                                    "concreteType": "Image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
-                                        "name": "aspect_ratio",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
-                                        "name": "placeholder",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
-                                        "name": "url",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "large",
-                                            "type": "[String]"
-                                          }
-                                        ],
-                                        "storageKey": "url(version:\"large\")"
-                                      }
-                                    ]
+                                    "storageKey": null
                                   },
                                   {
                                     "kind": "LinkedField",

--- a/src/__generated__/GeneContentsArtworksQuery.graphql.ts
+++ b/src/__generated__/GeneContentsArtworksQuery.graphql.ts
@@ -545,14 +545,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "sale_message",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -651,43 +683,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "sale_message",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",
@@ -910,12 +910,12 @@ return {
                   v2,
                   {
                     "kind": "InlineFragment",
-                    "type": "ArtworkFilterGene",
+                    "type": "ArtworkFilterTag",
                     "selections": v9
                   },
                   {
                     "kind": "InlineFragment",
-                    "type": "ArtworkFilterTag",
+                    "type": "ArtworkFilterGene",
                     "selections": v9
                   }
                 ]

--- a/src/__generated__/Headline_facet.graphql.ts
+++ b/src/__generated__/Headline_facet.graphql.ts
@@ -36,12 +36,12 @@ return {
     },
     {
       "kind": "InlineFragment",
-      "type": "ArtworkFilterGene",
+      "type": "ArtworkFilterTag",
       "selections": v0
     },
     {
       "kind": "InlineFragment",
-      "type": "ArtworkFilterTag",
+      "type": "ArtworkFilterGene",
       "selections": v0
     }
   ]

--- a/src/__generated__/InquiryArtworkQuery.graphql.ts
+++ b/src/__generated__/InquiryArtworkQuery.graphql.ts
@@ -143,7 +143,14 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = [
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -151,13 +158,6 @@ v3 = [
     "type": "Boolean"
   }
 ],
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "href",
-  "args": null,
-  "storageKey": null
-},
 v5 = {
   "kind": "ScalarField",
   "alias": null,
@@ -220,52 +220,9 @@ return {
         "plural": false,
         "selections": [
           {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "artists",
-            "storageKey": "artists(shallow:true)",
-            "args": v3,
-            "concreteType": "Artist",
-            "plural": true,
-            "selections": [
-              v2,
-              v4,
-              v5
-            ]
-          },
-          {
             "kind": "ScalarField",
             "alias": null,
             "name": "id",
-            "args": null,
-            "storageKey": null
-          },
-          v4,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "sale_message",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "cultural_maker",
             "args": null,
             "storageKey": null
           },
@@ -301,6 +258,49 @@ return {
               }
             ]
           },
+          v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "date",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "sale_message",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "cultural_maker",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artists",
+            "storageKey": "artists(shallow:true)",
+            "args": v4,
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              v2,
+              v3,
+              v5
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -313,12 +313,12 @@ return {
             "alias": null,
             "name": "partner",
             "storageKey": "partner(shallow:true)",
-            "args": v3,
+            "args": v4,
             "concreteType": "Partner",
             "plural": false,
             "selections": [
               v5,
-              v4,
+              v3,
               v2,
               {
                 "kind": "ScalarField",

--- a/src/__generated__/OfferMutation.graphql.ts
+++ b/src/__generated__/OfferMutation.graphql.ts
@@ -96,6 +96,67 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "mode",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "totalListPrice",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "InlineFragment",
+  "type": "OfferOrder",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "myLastOffer",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Offer",
+      "plural": false,
+      "selections": [
+        v3,
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "amountCents",
+          "args": null,
+          "storageKey": null
+        },
+        v6
+      ]
+    }
+  ]
+},
+v8 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -132,67 +193,6 @@ v2 = {
       ]
     }
   ]
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "mode",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "totalListPrice",
-  "args": null,
-  "storageKey": null
-},
-v7 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v8 = {
-  "kind": "InlineFragment",
-  "type": "OfferOrder",
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "myLastOffer",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "Offer",
-      "plural": false,
-      "selections": [
-        v4,
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "amountCents",
-          "args": null,
-          "storageKey": null
-        },
-        v7
-      ]
-    }
-  ]
 };
 return {
   "kind": "Request",
@@ -226,12 +226,11 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -241,15 +240,16 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v3,
                       v4,
                       v5,
                       v6,
-                      v7,
-                      v8
+                      v7
                     ]
                   }
                 ]
-              }
+              },
+              v8
             ]
           }
         ]
@@ -279,13 +279,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -295,16 +294,17 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v2,
                       v3,
                       v4,
                       v5,
                       v6,
-                      v7,
-                      v8
+                      v7
                     ]
                   }
                 ]
-              }
+              },
+              v8
             ]
           }
         ]

--- a/src/__generated__/Overview_artist.graphql.ts
+++ b/src/__generated__/Overview_artist.graphql.ts
@@ -136,15 +136,13 @@ return {
   ],
   "selections": [
     {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "href",
-      "args": null,
-      "storageKey": null
+      "kind": "FragmentSpread",
+      "name": "ArtistBio_bio",
+      "args": null
     },
     {
       "kind": "FragmentSpread",
-      "name": "ArtistBio_bio",
+      "name": "CurrentEvent_artist",
       "args": null
     },
     {
@@ -255,9 +253,11 @@ return {
       ]
     },
     {
-      "kind": "FragmentSpread",
-      "name": "CurrentEvent_artist",
-      "args": null
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "href",
+      "args": null,
+      "storageKey": null
     },
     {
       "kind": "ScalarField",

--- a/src/__generated__/PaymentFormCreateCreditCardMutation.graphql.ts
+++ b/src/__generated__/PaymentFormCreateCreditCardMutation.graphql.ts
@@ -88,51 +88,13 @@ v1 = [
   }
 ],
 v2 = {
-  "kind": "InlineFragment",
-  "type": "CreditCardMutationFailure",
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "mutationError",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "GravityMutationError",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "type",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "message",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "detail",
-          "args": null,
-          "storageKey": null
-        }
-      ]
-    }
-  ]
-},
-v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v3 = {
   "kind": "InlineFragment",
   "type": "CreditCardMutationSuccess",
   "selections": [
@@ -196,8 +158,46 @@ v4 = {
               "args": null,
               "storageKey": null
             },
-            v3
+            v2
           ]
+        }
+      ]
+    }
+  ]
+},
+v4 = {
+  "kind": "InlineFragment",
+  "type": "CreditCardMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "mutationError",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "type",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "message",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "detail",
+          "args": null,
+          "storageKey": null
         }
       ]
     }
@@ -235,7 +235,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
+              v3,
               v4
             ]
           }
@@ -266,8 +266,8 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
               v2,
+              v3,
               v4
             ]
           }

--- a/src/__generated__/PaymentRouteCreateCreditCardMutation.graphql.ts
+++ b/src/__generated__/PaymentRouteCreateCreditCardMutation.graphql.ts
@@ -74,6 +74,37 @@ v1 = [
 ],
 v2 = {
   "kind": "InlineFragment",
+  "type": "CreditCardMutationSuccess",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "creditCard",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CreditCard",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "__id",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+},
+v3 = {
+  "kind": "InlineFragment",
   "type": "CreditCardMutationFailure",
   "selections": [
     {
@@ -103,37 +134,6 @@ v2 = {
           "kind": "ScalarField",
           "alias": null,
           "name": "detail",
-          "args": null,
-          "storageKey": null
-        }
-      ]
-    }
-  ]
-},
-v3 = {
-  "kind": "InlineFragment",
-  "type": "CreditCardMutationSuccess",
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "creditCard",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "CreditCard",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "id",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "__id",
           "args": null,
           "storageKey": null
         }

--- a/src/__generated__/PaymentRouteSetOrderPaymentMutation.graphql.ts
+++ b/src/__generated__/PaymentRouteSetOrderPaymentMutation.graphql.ts
@@ -93,44 +93,6 @@ v1 = [
   }
 ],
 v2 = {
-  "kind": "InlineFragment",
-  "type": "OrderWithMutationFailure",
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "error",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "EcommerceError",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "type",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "code",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "data",
-          "args": null,
-          "storageKey": null
-        }
-      ]
-    }
-  ]
-},
-v3 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "creditCard",
@@ -204,12 +166,50 @@ v3 = {
     }
   ]
 },
-v4 = {
+v3 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
+},
+v4 = {
+  "kind": "InlineFragment",
+  "type": "OrderWithMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "error",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "EcommerceError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "type",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "code",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "data",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
 },
 v5 = {
   "kind": "ScalarField",
@@ -250,7 +250,6 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -264,12 +263,13 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      v3,
-                      v4
+                      v2,
+                      v3
                     ]
                   }
                 ]
-              }
+              },
+              v4
             ]
           }
         ]
@@ -300,7 +300,6 @@ return {
             "plural": false,
             "selections": [
               v5,
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -315,12 +314,13 @@ return {
                     "plural": false,
                     "selections": [
                       v5,
-                      v3,
-                      v4
+                      v2,
+                      v3
                     ]
                   }
                 ]
-              }
+              },
+              v4
             ]
           }
         ]

--- a/src/__generated__/Payment_order.graphql.ts
+++ b/src/__generated__/Payment_order.graphql.ts
@@ -169,19 +169,6 @@ return {
         },
         {
           "kind": "InlineFragment",
-          "type": "Pickup",
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "fulfillmentType",
-              "args": null,
-              "storageKey": null
-            }
-          ]
-        },
-        {
-          "kind": "InlineFragment",
           "type": "Ship",
           "selections": [
             v1,
@@ -212,6 +199,19 @@ return {
               "kind": "ScalarField",
               "alias": null,
               "name": "postalCode",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "InlineFragment",
+          "type": "Pickup",
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "fulfillmentType",
               "args": null,
               "storageKey": null
             }

--- a/src/__generated__/RecentlyViewedQuery.graphql.ts
+++ b/src/__generated__/RecentlyViewedQuery.graphql.ts
@@ -243,14 +243,46 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "collecting_institution",
-                        "args": null,
-                        "storageKey": null
-                      },
                       v0,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspect_ratio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "placeholder",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large",
+                                "type": "[String]"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
                       v1,
                       {
                         "kind": "ScalarField",
@@ -295,43 +327,11 @@ return {
                         ]
                       },
                       {
-                        "kind": "LinkedField",
+                        "kind": "ScalarField",
                         "alias": null,
-                        "name": "image",
-                        "storageKey": null,
+                        "name": "collecting_institution",
                         "args": null,
-                        "concreteType": "Image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "aspect_ratio",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "placeholder",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "large",
-                                "type": "[String]"
-                              }
-                            ],
-                            "storageKey": "url(version:\"large\")"
-                          }
-                        ]
+                        "storageKey": null
                       },
                       {
                         "kind": "LinkedField",

--- a/src/__generated__/RejectOfferMutation.graphql.ts
+++ b/src/__generated__/RejectOfferMutation.graphql.ts
@@ -2,6 +2,7 @@
 
 import { ConcreteRequest } from "relay-runtime";
 export type CancelReasonType = "BUYER_REJECTED" | "SELLER_LAPSED" | "SELLER_REJECTED" | "SELLER_REJECTED_ARTWORK_UNAVAILABLE" | "SELLER_REJECTED_OFFER_TOO_LOW" | "SELLER_REJECTED_OTHER" | "SELLER_REJECTED_SHIPPING_UNAVAILABLE" | "%future added value";
+export type OrderParticipantEnum = "BUYER" | "SELLER" | "%future added value";
 export type buyerRejectOfferInput = {
     readonly offerId: string;
     readonly rejectReason?: CancelReasonType | null;
@@ -16,6 +17,7 @@ export type RejectOfferMutationResponse = {
             readonly __typename: "OrderWithMutationSuccess";
             readonly order?: ({
                 readonly id: string | null;
+                readonly awaitingResponseFrom?: OrderParticipantEnum | null;
             }) | null;
             readonly error?: ({
                 readonly type: string;
@@ -44,6 +46,9 @@ mutation RejectOfferMutation(
         order {
           __typename
           id
+          ... on OfferOrder {
+            awaitingResponseFrom
+          }
           __id: id
         }
       }
@@ -77,6 +82,40 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "InlineFragment",
+  "type": "OfferOrder",
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "awaitingResponseFrom",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v6 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -113,34 +152,13 @@ v2 = {
       ]
     }
   ]
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
 };
 return {
   "kind": "Request",
   "operationKind": "mutation",
   "name": "RejectOfferMutation",
   "id": null,
-  "text": "mutation RejectOfferMutation(\n  $input: buyerRejectOfferInput!\n) {\n  ecommerceBuyerRejectOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          id\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
+  "text": "mutation RejectOfferMutation(\n  $input: buyerRejectOfferInput!\n) {\n  ecommerceBuyerRejectOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          id\n          ... on OfferOrder {\n            awaitingResponseFrom\n          }\n          __id: id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -167,12 +185,11 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -182,12 +199,14 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v3,
                       v4,
                       v5
                     ]
                   }
                 ]
-              }
+              },
+              v6
             ]
           }
         ]
@@ -217,13 +236,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -233,13 +251,15 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v2,
                       v3,
                       v4,
                       v5
                     ]
                   }
                 ]
-              }
+              },
+              v6
             ]
           }
         ]
@@ -248,5 +268,5 @@ return {
   }
 };
 })();
-(node as any).hash = '6d2f6e5ccc97bac6502a0136c8085d41';
+(node as any).hash = '5e296dc504d7c9f69f520ab2058baa1f';
 export default node;

--- a/src/__generated__/RelatedWorksArtworkGridQuery.graphql.ts
+++ b/src/__generated__/RelatedWorksArtworkGridQuery.graphql.ts
@@ -323,14 +323,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -422,43 +454,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/RelatedWorksArtworkGridRefetchQuery.graphql.ts
+++ b/src/__generated__/RelatedWorksArtworkGridRefetchQuery.graphql.ts
@@ -345,14 +345,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -444,43 +476,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/RelatedWorksArtworkGrid_Test_Query.graphql.ts
+++ b/src/__generated__/RelatedWorksArtworkGrid_Test_Query.graphql.ts
@@ -311,14 +311,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v1,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -410,43 +442,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/RespondCounterOfferMutation.graphql.ts
+++ b/src/__generated__/RespondCounterOfferMutation.graphql.ts
@@ -256,6 +256,13 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -293,13 +300,6 @@ v2 = {
     }
   ]
 },
-v3 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
 v4 = {
   "kind": "ScalarField",
   "alias": null,
@@ -307,7 +307,14 @@ v4 = {
   "args": null,
   "storageKey": null
 },
-v5 = [
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v6 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -315,67 +322,60 @@ v5 = [
     "type": "Int"
   }
 ],
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "shippingTotal",
-  "args": v5,
-  "storageKey": "shippingTotal(precision:2)"
-},
 v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
+  "name": "shippingTotal",
+  "args": v6,
+  "storageKey": "shippingTotal(precision:2)"
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v5,
+  "args": v6,
   "storageKey": "taxTotal(precision:2)"
 },
-v12 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotalCents",
   "args": null,
   "storageKey": null
 },
-v13 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v5,
+  "args": v6,
   "storageKey": "buyerTotal(precision:2)"
+},
+v13 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
 },
 v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "amount",
-  "args": v5,
+  "args": v6,
   "storageKey": "amount(precision:2)"
 },
 v15 = {
@@ -431,7 +431,6 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -450,11 +449,12 @@ return {
                         "name": "Respond_order",
                         "args": null
                       },
-                      v3
+                      v2
                     ]
                   }
                 ]
-              }
+              },
+              v3
             ]
           }
         ]
@@ -485,7 +485,6 @@ return {
             "plural": false,
             "selections": [
               v4,
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -499,8 +498,14 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      v6,
-                      v7,
+                      v5,
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "mode",
+                        "args": null,
+                        "storageKey": null
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -512,14 +517,14 @@ return {
                         "kind": "ScalarField",
                         "alias": null,
                         "name": "itemsTotal",
-                        "args": v5,
+                        "args": v6,
                         "storageKey": "itemsTotal(precision:2)"
                       },
                       {
                         "kind": "ScalarField",
                         "alias": null,
                         "name": "totalListPrice",
-                        "args": v5,
+                        "args": v6,
                         "storageKey": "totalListPrice(precision:2)"
                       },
                       {
@@ -565,8 +570,8 @@ return {
                                     "concreteType": "Artwork",
                                     "plural": false,
                                     "selections": [
+                                      v5,
                                       v7,
-                                      v8,
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
@@ -633,9 +638,36 @@ return {
                                       }
                                     ]
                                   },
-                                  v3
+                                  v2
                                 ]
                               }
+                            ]
+                          }
+                        ]
+                      },
+                      v4,
+                      v8,
+                      v9,
+                      v10,
+                      v11,
+                      v12,
+                      v2,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "seller",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          v4,
+                          v7,
+                          {
+                            "kind": "InlineFragment",
+                            "type": "Partner",
+                            "selections": [
+                              v13
                             ]
                           }
                         ]
@@ -654,7 +686,7 @@ return {
                             "kind": "InlineFragment",
                             "type": "Ship",
                             "selections": [
-                              v9,
+                              v13,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -708,39 +740,6 @@ return {
                           }
                         ]
                       },
-                      v4,
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "mode",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      v10,
-                      v11,
-                      v12,
-                      v13,
-                      v3,
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "seller",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": null,
-                        "plural": false,
-                        "selections": [
-                          v4,
-                          v8,
-                          {
-                            "kind": "InlineFragment",
-                            "type": "Partner",
-                            "selections": [
-                              v9
-                            ]
-                          }
-                        ]
-                      },
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -778,7 +777,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v8
+                          v7
                         ]
                       },
                       {
@@ -794,7 +793,6 @@ return {
                             "concreteType": "Offer",
                             "plural": false,
                             "selections": [
-                              v10,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -802,14 +800,15 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v3,
+                              v5,
+                              v2,
                               v14,
                               v15,
-                              v6,
-                              v7,
+                              v8,
+                              v9,
+                              v10,
                               v11,
                               v12,
-                              v13,
                               v16,
                               v17
                             ]
@@ -823,17 +822,17 @@ return {
                             "concreteType": "Offer",
                             "plural": false,
                             "selections": [
-                              v11,
-                              v7,
-                              v15,
-                              v6,
-                              v10,
+                              v5,
                               v14,
+                              v15,
+                              v8,
+                              v9,
+                              v10,
+                              v11,
                               v12,
-                              v13,
                               v16,
                               v17,
-                              v3
+                              v2
                             ]
                           },
                           {
@@ -863,7 +862,7 @@ return {
                                     "concreteType": "Offer",
                                     "plural": false,
                                     "selections": [
-                                      v7,
+                                      v5,
                                       v14,
                                       {
                                         "kind": "ScalarField",
@@ -880,7 +879,7 @@ return {
                                         "storageKey": "createdAt(format:\"MMM D\")"
                                       },
                                       v17,
-                                      v3
+                                      v2
                                     ]
                                   }
                                 ]
@@ -892,7 +891,8 @@ return {
                     ]
                   }
                 ]
-              }
+              },
+              v3
             ]
           }
         ]

--- a/src/__generated__/Respond_order.graphql.ts
+++ b/src/__generated__/Respond_order.graphql.ts
@@ -43,21 +43,21 @@ var v0 = {
   "args": null,
   "storageKey": null
 },
-v1 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "precision",
     "value": 2,
     "type": "Int"
   }
-];
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Fragment",
   "name": "Respond_order",
@@ -66,7 +66,13 @@ return {
   "argumentDefinitions": [],
   "selections": [
     v0,
-    v1,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "mode",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "ScalarField",
       "alias": null,
@@ -78,14 +84,14 @@ return {
       "kind": "ScalarField",
       "alias": null,
       "name": "itemsTotal",
-      "args": v2,
+      "args": v1,
       "storageKey": "itemsTotal(precision:2)"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "totalListPrice",
-      "args": v2,
+      "args": v1,
       "storageKey": "totalListPrice(precision:2)"
     },
     {
@@ -141,19 +147,12 @@ return {
                     }
                   ]
                 },
-                v1
+                v2
               ]
             }
           ]
         }
       ]
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "mode",
-      "args": null,
-      "storageKey": null
     },
     {
       "kind": "FragmentSpread",
@@ -180,6 +179,7 @@ return {
       "name": "OfferHistoryItem_order",
       "args": null
     },
+    v2,
     {
       "kind": "InlineFragment",
       "type": "OfferOrder",
@@ -201,7 +201,7 @@ return {
               "storageKey": null
             },
             v0,
-            v1
+            v2
           ]
         }
       ]

--- a/src/__generated__/ReviewSubmitOfferOrderMutation.graphql.ts
+++ b/src/__generated__/ReviewSubmitOfferOrderMutation.graphql.ts
@@ -73,6 +73,20 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "state",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -109,20 +123,6 @@ v2 = {
       ]
     }
   ]
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "state",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
@@ -163,7 +163,6 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -177,12 +176,13 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      v3,
-                      v4
+                      v2,
+                      v3
                     ]
                   }
                 ]
-              }
+              },
+              v4
             ]
           }
         ]
@@ -213,7 +213,6 @@ return {
             "plural": false,
             "selections": [
               v5,
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -228,12 +227,13 @@ return {
                     "plural": false,
                     "selections": [
                       v5,
-                      v3,
-                      v4
+                      v2,
+                      v3
                     ]
                   }
                 ]
-              }
+              },
+              v4
             ]
           }
         ]

--- a/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
+++ b/src/__generated__/ReviewSubmitOrderMutation.graphql.ts
@@ -73,6 +73,20 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "state",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
   "kind": "InlineFragment",
   "type": "OrderWithMutationFailure",
   "selections": [
@@ -109,20 +123,6 @@ v2 = {
       ]
     }
   ]
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "state",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
@@ -163,7 +163,6 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -177,12 +176,13 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      v3,
-                      v4
+                      v2,
+                      v3
                     ]
                   }
                 ]
-              }
+              },
+              v4
             ]
           }
         ]
@@ -213,7 +213,6 @@ return {
             "plural": false,
             "selections": [
               v5,
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
@@ -228,12 +227,13 @@ return {
                     "plural": false,
                     "selections": [
                       v5,
-                      v3,
-                      v4
+                      v2,
+                      v3
                     ]
                   }
                 ]
-              }
+              },
+              v4
             ]
           }
         ]

--- a/src/__generated__/SaveArtworkQuery.graphql.ts
+++ b/src/__generated__/SaveArtworkQuery.graphql.ts
@@ -233,16 +233,48 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "sale_message",
+            "name": "_id",
             "args": null,
             "storageKey": null
           },
           {
-            "kind": "ScalarField",
+            "kind": "LinkedField",
             "alias": null,
-            "name": "_id",
+            "name": "image",
+            "storageKey": null,
             "args": null,
-            "storageKey": null
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "placeholder",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"large\")"
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              }
+            ]
           },
           {
             "kind": "ScalarField",
@@ -335,43 +367,11 @@ return {
             "storageKey": null
           },
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "sale_message",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "placeholder",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "large",
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:\"large\")"
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              }
-            ]
+            "storageKey": null
           },
           {
             "kind": "ScalarField",

--- a/src/__generated__/SavedCreditCardsDeleteCreditCardMutation.graphql.ts
+++ b/src/__generated__/SavedCreditCardsDeleteCreditCardMutation.graphql.ts
@@ -74,6 +74,37 @@ v1 = [
 ],
 v2 = {
   "kind": "InlineFragment",
+  "type": "CreditCardMutationSuccess",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "creditCard",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CreditCard",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "__id",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+},
+v3 = {
+  "kind": "InlineFragment",
   "type": "CreditCardMutationFailure",
   "selections": [
     {
@@ -103,37 +134,6 @@ v2 = {
           "kind": "ScalarField",
           "alias": null,
           "name": "detail",
-          "args": null,
-          "storageKey": null
-        }
-      ]
-    }
-  ]
-},
-v3 = {
-  "kind": "InlineFragment",
-  "type": "CreditCardMutationSuccess",
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "creditCard",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "CreditCard",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "id",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "__id",
           "args": null,
           "storageKey": null
         }

--- a/src/__generated__/SelectedExhibitions_exhibitions.graphql.ts
+++ b/src/__generated__/SelectedExhibitions_exhibitions.graphql.ts
@@ -59,12 +59,12 @@ return {
         v0,
         {
           "kind": "InlineFragment",
-          "type": "Partner",
+          "type": "ExternalPartner",
           "selections": v2
         },
         {
           "kind": "InlineFragment",
-          "type": "ExternalPartner",
+          "type": "Partner",
           "selections": v2
         }
       ]

--- a/src/__generated__/SeoProductsForArtworks_artworks.graphql.ts
+++ b/src/__generated__/SeoProductsForArtworks_artworks.graphql.ts
@@ -143,14 +143,14 @@ return {
               "concreteType": "Artwork",
               "plural": false,
               "selections": [
+                v0,
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "price",
+                  "name": "availability",
                   "args": null,
                   "storageKey": null
                 },
-                v0,
                 {
                   "kind": "ScalarField",
                   "alias": null,
@@ -189,7 +189,7 @@ return {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "availability",
+                  "name": "price",
                   "args": null,
                   "storageKey": null
                 },

--- a/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
+++ b/src/__generated__/ShippingOrderAddressUpdateMutation.graphql.ts
@@ -118,65 +118,27 @@ v1 = [
   }
 ],
 v2 = {
-  "kind": "InlineFragment",
-  "type": "OrderWithMutationFailure",
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "error",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "EcommerceError",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "type",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "code",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "data",
-          "args": null,
-          "storageKey": null
-        }
-      ]
-    }
-  ]
-},
-v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "state",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v5 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "requestedFulfillment",
@@ -185,7 +147,7 @@ v6 = {
   "concreteType": null,
   "plural": false,
   "selections": [
-    v3,
+    v2,
     {
       "kind": "InlineFragment",
       "type": "Ship",
@@ -250,12 +212,50 @@ v6 = {
     }
   ]
 },
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
+},
+v7 = {
+  "kind": "InlineFragment",
+  "type": "OrderWithMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "error",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "EcommerceError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "type",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "code",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "data",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
 };
 return {
   "kind": "Request",
@@ -289,12 +289,11 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -304,14 +303,15 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v3,
                       v4,
                       v5,
-                      v6,
-                      v7
+                      v6
                     ]
                   }
                 ]
-              }
+              },
+              v7
             ]
           }
         ]
@@ -341,13 +341,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "OrderWithMutationSuccess",
                 "selections": [
-                  v3,
+                  v2,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -357,15 +356,16 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
+                      v2,
                       v3,
                       v4,
                       v5,
-                      v6,
-                      v7
+                      v6
                     ]
                   }
                 ]
-              }
+              },
+              v7
             ]
           }
         ]

--- a/src/__generated__/StatusQuery.graphql.ts
+++ b/src/__generated__/StatusQuery.graphql.ts
@@ -247,18 +247,25 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v6 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -267,13 +274,6 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
 v7 = [
   {
     "kind": "Literal",
@@ -318,8 +318,14 @@ v12 = {
   "storageKey": "buyerTotal(precision:2)"
 },
 v13 = [
-  v10,
-  v6,
+  v3,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "amount",
+    "args": v7,
+    "storageKey": "amount(precision:2)"
+  },
   {
     "kind": "ScalarField",
     "alias": null,
@@ -329,13 +335,7 @@ v13 = [
   },
   v8,
   v9,
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "amount",
-    "args": v7,
-    "storageKey": "amount(precision:2)"
-  },
+  v10,
   v11,
   v12,
   {
@@ -401,8 +401,8 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v1,
           v2,
+          v3,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -445,7 +445,7 @@ return {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v3,
+                  v4,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -509,12 +509,12 @@ return {
             "plural": false,
             "selections": [
               v2,
-              v4,
+              v5,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v3
+                  v4
                 ]
               }
             ]
@@ -555,11 +555,17 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "artist_names",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "title",
                             "args": null,
                             "storageKey": null
                           },
@@ -601,7 +607,7 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v5
+                                "selections": v6
                               },
                               {
                                 "kind": "LinkedField",
@@ -618,18 +624,12 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v5
+                                "selections": v6
                               }
                             ]
                           },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "title",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          v6,
+                          v5,
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -758,7 +758,7 @@ return {
               }
             ]
           },
-          v6,
+          v1,
           v8,
           v9,
           v10,
@@ -815,7 +815,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v4
+              v5
             ]
           },
           {

--- a/src/__generated__/Status_order.graphql.ts
+++ b/src/__generated__/Status_order.graphql.ts
@@ -66,16 +66,16 @@ var v0 = {
   "args": null,
   "storageKey": null
 },
-v1 = [
-  v0
-],
-v2 = {
+v1 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
+v2 = [
+  v0
+],
 v3 = {
   "kind": "ScalarField",
   "alias": "__id",
@@ -98,12 +98,8 @@ return {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
-    {
-      "kind": "FragmentSpread",
-      "name": "ArtworkSummaryItem_order",
-      "args": null
-    },
     v0,
+    v1,
     {
       "kind": "ScalarField",
       "alias": null,
@@ -143,17 +139,21 @@ return {
       "selections": [
         {
           "kind": "InlineFragment",
-          "type": "Pickup",
-          "selections": v1
+          "type": "Ship",
+          "selections": v2
         },
         {
           "kind": "InlineFragment",
-          "type": "Ship",
-          "selections": v1
+          "type": "Pickup",
+          "selections": v2
         }
       ]
     },
-    v2,
+    {
+      "kind": "FragmentSpread",
+      "name": "ArtworkSummaryItem_order",
+      "args": null
+    },
     {
       "kind": "FragmentSpread",
       "name": "TransactionDetailsSummaryItem_order",
@@ -267,7 +267,7 @@ return {
                   "concreteType": "Artwork",
                   "plural": false,
                   "selections": [
-                    v2,
+                    v1,
                     {
                       "kind": "ScalarField",
                       "alias": null,
@@ -310,7 +310,7 @@ return {
           "concreteType": "Offer",
           "plural": false,
           "selections": [
-            v2,
+            v1,
             {
               "kind": "ScalarField",
               "alias": null,

--- a/src/__generated__/TagArtworksContentQuery.graphql.ts
+++ b/src/__generated__/TagArtworksContentQuery.graphql.ts
@@ -382,14 +382,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "sale_message",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -488,43 +520,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "sale_message",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/TagContentsArtworksQuery.graphql.ts
+++ b/src/__generated__/TagContentsArtworksQuery.graphql.ts
@@ -539,14 +539,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "sale_message",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -645,43 +677,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "sale_message",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",
@@ -904,12 +904,12 @@ return {
                   v2,
                   {
                     "kind": "InlineFragment",
-                    "type": "ArtworkFilterGene",
+                    "type": "ArtworkFilterTag",
                     "selections": v9
                   },
                   {
                     "kind": "InlineFragment",
-                    "type": "ArtworkFilterTag",
+                    "type": "ArtworkFilterGene",
                     "selections": v9
                   }
                 ]

--- a/src/__generated__/TooltipsDataLoaderQuery.graphql.ts
+++ b/src/__generated__/TooltipsDataLoaderQuery.graphql.ts
@@ -287,20 +287,8 @@ return {
         "concreteType": "Artist",
         "plural": true,
         "selections": [
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "genes",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Gene",
-            "plural": true,
-            "selections": [
-              v6,
-              v4
-            ]
-          },
           v2,
+          v3,
           v6,
           {
             "kind": "ScalarField",
@@ -378,7 +366,19 @@ return {
               }
             ]
           },
-          v3,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "genes",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Gene",
+            "plural": true,
+            "selections": [
+              v6,
+              v4
+            ]
+          },
           v4,
           {
             "kind": "ScalarField",

--- a/src/__generated__/TransactionDetailsSummaryItemOfferProperties.graphql.ts
+++ b/src/__generated__/TransactionDetailsSummaryItemOfferProperties.graphql.ts
@@ -39,16 +39,16 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "taxTotal",
-      "args": v0,
-      "storageKey": "taxTotal(precision:2)"
+      "name": "id",
+      "args": null,
+      "storageKey": null
     },
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "id",
-      "args": null,
-      "storageKey": null
+      "name": "amount",
+      "args": v0,
+      "storageKey": "amount(precision:2)"
     },
     {
       "kind": "ScalarField",
@@ -74,9 +74,9 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "amount",
+      "name": "taxTotal",
       "args": v0,
-      "storageKey": "amount(precision:2)"
+      "storageKey": "taxTotal(precision:2)"
     },
     {
       "kind": "ScalarField",

--- a/src/__generated__/TransactionDetailsSummaryItemStoryQuery.graphql.ts
+++ b/src/__generated__/TransactionDetailsSummaryItemStoryQuery.graphql.ts
@@ -82,14 +82,7 @@ v1 = {
   "args": null,
   "storageKey": null
 },
-v2 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "taxTotalCents",
-  "args": null,
-  "storageKey": null
-},
-v3 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -97,36 +90,42 @@ v3 = [
     "type": "Int"
   }
 ],
-v4 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v3,
+  "args": v2,
   "storageKey": "shippingTotal(precision:2)"
 },
-v5 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v3,
+  "args": v2,
   "storageKey": "taxTotal(precision:2)"
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "taxTotalCents",
+  "args": null,
+  "storageKey": null
 },
 v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v3,
+  "args": v2,
   "storageKey": "buyerTotal(precision:2)"
 },
 v8 = [
-  v6,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -137,20 +136,21 @@ v8 = [
   {
     "kind": "ScalarField",
     "alias": null,
+    "name": "amount",
+    "args": v2,
+    "storageKey": "amount(precision:2)"
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
     "name": "amountCents",
     "args": null,
     "storageKey": null
   },
+  v3,
   v4,
   v5,
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "amount",
-    "args": v3,
-    "storageKey": "amount(precision:2)"
-  },
-  v2,
+  v6,
   v7,
   {
     "kind": "ScalarField",
@@ -215,7 +215,6 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v2,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -223,9 +222,6 @@ return {
             "args": null,
             "storageKey": null
           },
-          v4,
-          v5,
-          v6,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -233,18 +229,22 @@ return {
             "args": null,
             "storageKey": null
           },
+          v3,
+          v4,
+          v5,
+          v6,
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v3,
+            "args": v2,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v3,
+            "args": v2,
             "storageKey": "totalListPrice(precision:2)"
           },
           v7,

--- a/src/__generated__/TransactionDetailsSummaryItemTestQuery.graphql.ts
+++ b/src/__generated__/TransactionDetailsSummaryItemTestQuery.graphql.ts
@@ -82,14 +82,7 @@ v1 = {
   "args": null,
   "storageKey": null
 },
-v2 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "taxTotalCents",
-  "args": null,
-  "storageKey": null
-},
-v3 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -97,36 +90,42 @@ v3 = [
     "type": "Int"
   }
 ],
-v4 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v3,
+  "args": v2,
   "storageKey": "shippingTotal(precision:2)"
 },
-v5 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v3,
+  "args": v2,
   "storageKey": "taxTotal(precision:2)"
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "taxTotalCents",
+  "args": null,
+  "storageKey": null
 },
 v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v3,
+  "args": v2,
   "storageKey": "buyerTotal(precision:2)"
 },
 v8 = [
-  v6,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -137,20 +136,21 @@ v8 = [
   {
     "kind": "ScalarField",
     "alias": null,
+    "name": "amount",
+    "args": v2,
+    "storageKey": "amount(precision:2)"
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
     "name": "amountCents",
     "args": null,
     "storageKey": null
   },
+  v3,
   v4,
   v5,
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "amount",
-    "args": v3,
-    "storageKey": "amount(precision:2)"
-  },
-  v2,
+  v6,
   v7,
   {
     "kind": "ScalarField",
@@ -215,7 +215,6 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v2,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -223,9 +222,6 @@ return {
             "args": null,
             "storageKey": null
           },
-          v4,
-          v5,
-          v6,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -233,18 +229,22 @@ return {
             "args": null,
             "storageKey": null
           },
+          v3,
+          v4,
+          v5,
+          v6,
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v3,
+            "args": v2,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v3,
+            "args": v2,
             "storageKey": "totalListPrice(precision:2)"
           },
           v7,

--- a/src/__generated__/TransactionDetailsSummaryItem_order.graphql.ts
+++ b/src/__generated__/TransactionDetailsSummaryItem_order.graphql.ts
@@ -45,14 +45,7 @@ export type TransactionDetailsSummaryItem_order = {
 
 
 const node: ConcreteFragment = (function(){
-var v0 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "taxTotalCents",
-  "args": null,
-  "storageKey": null
-},
-v1 = [
+var v0 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -60,32 +53,39 @@ v1 = [
     "type": "Int"
   }
 ],
-v2 = {
+v1 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v1,
+  "args": v0,
   "storageKey": "shippingTotal(precision:2)"
 },
-v3 = {
+v2 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v1,
+  "args": v0,
   "storageKey": "taxTotal(precision:2)"
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "taxTotalCents",
+  "args": null,
+  "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v1,
+  "args": v0,
   "storageKey": "buyerTotal(precision:2)"
 },
 v6 = {
@@ -96,7 +96,6 @@ v6 = {
   "storageKey": null
 },
 v7 = [
-  v4,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -107,20 +106,21 @@ v7 = [
   {
     "kind": "ScalarField",
     "alias": null,
+    "name": "amount",
+    "args": v0,
+    "storageKey": "amount(precision:2)"
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
     "name": "amountCents",
     "args": null,
     "storageKey": null
   },
+  v1,
   v2,
   v3,
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "amount",
-    "args": v1,
-    "storageKey": "amount(precision:2)"
-  },
-  v0,
+  v4,
   v5,
   {
     "kind": "ScalarField",
@@ -145,7 +145,6 @@ return {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
-    v0,
     {
       "kind": "ScalarField",
       "alias": null,
@@ -153,9 +152,6 @@ return {
       "args": null,
       "storageKey": null
     },
-    v2,
-    v3,
-    v4,
     {
       "kind": "ScalarField",
       "alias": null,
@@ -163,18 +159,22 @@ return {
       "args": null,
       "storageKey": null
     },
+    v1,
+    v2,
+    v3,
+    v4,
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "itemsTotal",
-      "args": v1,
+      "args": v0,
       "storageKey": "itemsTotal(precision:2)"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "totalListPrice",
-      "args": v1,
+      "args": v0,
       "storageKey": "totalListPrice(precision:2)"
     },
     v5,

--- a/src/__generated__/WorksForYouArtistFeedPaginationQuery.graphql.ts
+++ b/src/__generated__/WorksForYouArtistFeedPaginationQuery.graphql.ts
@@ -475,14 +475,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "sale_message",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v3,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -581,43 +613,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "sale_message",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/WorksForYouFeedPaginationQuery.graphql.ts
+++ b/src/__generated__/WorksForYouFeedPaginationQuery.graphql.ts
@@ -438,14 +438,46 @@ return {
                                         "concreteType": "Artwork",
                                         "plural": false,
                                         "selections": [
-                                          {
-                                            "kind": "ScalarField",
-                                            "alias": null,
-                                            "name": "date",
-                                            "args": null,
-                                            "storageKey": null
-                                          },
                                           v1,
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "image",
+                                            "storageKey": null,
+                                            "args": null,
+                                            "concreteType": "Image",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "aspect_ratio",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "placeholder",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "url",
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": "large",
+                                                    "type": "[String]"
+                                                  }
+                                                ],
+                                                "storageKey": "url(version:\"large\")"
+                                              }
+                                            ]
+                                          },
                                           {
                                             "kind": "ScalarField",
                                             "alias": null,
@@ -537,43 +569,11 @@ return {
                                             "storageKey": null
                                           },
                                           {
-                                            "kind": "LinkedField",
+                                            "kind": "ScalarField",
                                             "alias": null,
-                                            "name": "image",
-                                            "storageKey": null,
+                                            "name": "date",
                                             "args": null,
-                                            "concreteType": "Image",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "kind": "ScalarField",
-                                                "alias": null,
-                                                "name": "aspect_ratio",
-                                                "args": null,
-                                                "storageKey": null
-                                              },
-                                              {
-                                                "kind": "ScalarField",
-                                                "alias": null,
-                                                "name": "placeholder",
-                                                "args": null,
-                                                "storageKey": null
-                                              },
-                                              {
-                                                "kind": "ScalarField",
-                                                "alias": null,
-                                                "name": "url",
-                                                "args": [
-                                                  {
-                                                    "kind": "Literal",
-                                                    "name": "version",
-                                                    "value": "large",
-                                                    "type": "[String]"
-                                                  }
-                                                ],
-                                                "storageKey": "url(version:\"large\")"
-                                              }
-                                            ]
+                                            "storageKey": null
                                           },
                                           {
                                             "kind": "ScalarField",

--- a/src/__generated__/WorksForYouQuery.graphql.ts
+++ b/src/__generated__/WorksForYouQuery.graphql.ts
@@ -242,20 +242,352 @@ var v0 = [
   }
 ],
 v1 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 10,
+  "type": "Int"
+},
+v2 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "PUBLISHED_AT_DESC",
+  "type": "ArtworkSorts"
+},
+v3 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "pageInfo",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "hasNextPage",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "endCursor",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "__id",
   "args": null,
   "storageKey": null
 },
-v2 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v3 = {
+v6 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "aspect_ratio",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "placeholder",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "url",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": "large",
+          "type": "[String]"
+        }
+      ],
+      "storageKey": "url(version:\"large\")"
+    }
+  ]
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "_id",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_biddable",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "sale",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Sale",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_preview",
+      "args": null,
+      "storageKey": null
+    },
+    v4,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_auction",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_live_open",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_open",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_closed",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "display_timely_at",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_acquireable",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_offerable",
+  "args": null,
+  "storageKey": null
+},
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "date",
+  "args": null,
+  "storageKey": null
+},
+v14 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "sale_message",
+  "args": null,
+  "storageKey": null
+},
+v15 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cultural_maker",
+  "args": null,
+  "storageKey": null
+},
+v16 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v17 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "artists",
+  "storageKey": "artists(shallow:true)",
+  "args": v16,
+  "concreteType": "Artist",
+  "plural": true,
+  "selections": [
+    v4,
+    v5,
+    v17
+  ]
+},
+v19 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "collecting_institution",
+  "args": null,
+  "storageKey": null
+},
+v20 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "partner",
+  "storageKey": "partner(shallow:true)",
+  "args": v16,
+  "concreteType": "Partner",
+  "plural": false,
+  "selections": [
+    v17,
+    v5,
+    v4,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "type",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v21 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "display",
+  "args": null,
+  "storageKey": null
+},
+v22 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "sale_artwork",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "SaleArtwork",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "highest_bid",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "SaleArtworkHighestBid",
+      "plural": false,
+      "selections": [
+        v21,
+        {
+          "kind": "ScalarField",
+          "alias": "__id",
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "opening_bid",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "SaleArtworkOpeningBid",
+      "plural": false,
+      "selections": [
+        v21
+      ]
+    },
+    v4,
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "counts",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "SaleArtworkCounts",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "bidder_positions",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+},
+v23 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_inquireable",
+  "args": null,
+  "storageKey": null
+},
+v24 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v25 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_saved",
+  "args": null,
+  "storageKey": null
+},
+v26 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -297,338 +629,6 @@ v3 = {
     }
   ]
 },
-v4 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 10,
-  "type": "Int"
-},
-v5 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "PUBLISHED_AT_DESC",
-  "type": "ArtworkSorts"
-},
-v6 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "pageInfo",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "PageInfo",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "hasNextPage",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "endCursor",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "sale_message",
-  "args": null,
-  "storageKey": null
-},
-v8 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
-v9 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "_id",
-  "args": null,
-  "storageKey": null
-},
-v10 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_biddable",
-  "args": null,
-  "storageKey": null
-},
-v11 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "sale",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "Sale",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_preview",
-      "args": null,
-      "storageKey": null
-    },
-    v8,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_auction",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_live_open",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_open",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_closed",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "display_timely_at",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
-v12 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_acquireable",
-  "args": null,
-  "storageKey": null
-},
-v13 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_offerable",
-  "args": null,
-  "storageKey": null
-},
-v14 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "title",
-  "args": null,
-  "storageKey": null
-},
-v15 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "date",
-  "args": null,
-  "storageKey": null
-},
-v16 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "image",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "Image",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "aspect_ratio",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "placeholder",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "url",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "version",
-          "value": "large",
-          "type": "[String]"
-        }
-      ],
-      "storageKey": "url(version:\"large\")"
-    }
-  ]
-},
-v17 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "cultural_maker",
-  "args": null,
-  "storageKey": null
-},
-v18 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true,
-    "type": "Boolean"
-  }
-],
-v19 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "artists",
-  "storageKey": "artists(shallow:true)",
-  "args": v18,
-  "concreteType": "Artist",
-  "plural": true,
-  "selections": [
-    v8,
-    v2,
-    v1
-  ]
-},
-v20 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "collecting_institution",
-  "args": null,
-  "storageKey": null
-},
-v21 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "partner",
-  "storageKey": "partner(shallow:true)",
-  "args": v18,
-  "concreteType": "Partner",
-  "plural": false,
-  "selections": [
-    v1,
-    v2,
-    v8,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "type",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
-v22 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "display",
-  "args": null,
-  "storageKey": null
-},
-v23 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "sale_artwork",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "SaleArtwork",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "highest_bid",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "SaleArtworkHighestBid",
-      "plural": false,
-      "selections": [
-        v22,
-        {
-          "kind": "ScalarField",
-          "alias": "__id",
-          "name": "id",
-          "args": null,
-          "storageKey": null
-        }
-      ]
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "opening_bid",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "SaleArtworkOpeningBid",
-      "plural": false,
-      "selections": [
-        v22
-      ]
-    },
-    v8,
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "counts",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "SaleArtworkCounts",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "bidder_positions",
-          "args": null,
-          "storageKey": null
-        }
-      ]
-    }
-  ]
-},
-v24 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_inquireable",
-  "args": null,
-  "storageKey": null
-},
-v25 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v26 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_saved",
-  "args": null,
-  "storageKey": null
-},
 v27 = {
   "kind": "ScalarField",
   "alias": null,
@@ -668,6 +668,25 @@ return {
         "selections": [
           {
             "kind": "Condition",
+            "passingValue": false,
+            "condition": "includeSelectedArtist",
+            "selections": [
+              {
+                "kind": "FragmentSpread",
+                "name": "WorksForYouFeed_viewer",
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "for_sale",
+                    "variableName": "forSale",
+                    "type": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "Condition",
             "passingValue": true,
             "condition": "includeSelectedArtist",
             "selections": [
@@ -685,25 +704,6 @@ return {
                     "kind": "Variable",
                     "name": "filter",
                     "variableName": "filter",
-                    "type": null
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "kind": "Condition",
-            "passingValue": false,
-            "condition": "includeSelectedArtist",
-            "selections": [
-              {
-                "kind": "FragmentSpread",
-                "name": "WorksForYouFeed_viewer",
-                "args": [
-                  {
-                    "kind": "Variable",
-                    "name": "for_sale",
-                    "variableName": "forSale",
                     "type": null
                   }
                 ]
@@ -728,145 +728,6 @@ return {
         "concreteType": "Viewer",
         "plural": false,
         "selections": [
-          {
-            "kind": "Condition",
-            "passingValue": true,
-            "condition": "includeSelectedArtist",
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "artist",
-                "storageKey": null,
-                "args": [
-                  {
-                    "kind": "Variable",
-                    "name": "id",
-                    "variableName": "artistID",
-                    "type": "String!"
-                  }
-                ],
-                "concreteType": "Artist",
-                "plural": false,
-                "selections": [
-                  v1,
-                  v2,
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "counts",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "ArtistCounts",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "artworks",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "for_sale_artworks",
-                        "args": null,
-                        "storageKey": null
-                      }
-                    ]
-                  },
-                  v3,
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "artworks_connection",
-                    "storageKey": null,
-                    "args": [
-                      {
-                        "kind": "Variable",
-                        "name": "filter",
-                        "variableName": "filter",
-                        "type": "[ArtistArtworksFilters]"
-                      },
-                      v4,
-                      v5
-                    ],
-                    "concreteType": "ArtworkConnection",
-                    "plural": false,
-                    "selections": [
-                      v6,
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "edges",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": "ArtworkEdge",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "node",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Artwork",
-                            "plural": false,
-                            "selections": [
-                              v7,
-                              v8,
-                              v9,
-                              v10,
-                              v11,
-                              v12,
-                              v13,
-                              v2,
-                              v14,
-                              v15,
-                              v16,
-                              v17,
-                              v19,
-                              v20,
-                              v21,
-                              v23,
-                              v24,
-                              v25,
-                              v26,
-                              v27
-                            ]
-                          },
-                          v28
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "LinkedHandle",
-                    "alias": null,
-                    "name": "artworks_connection",
-                    "args": [
-                      {
-                        "kind": "Variable",
-                        "name": "filter",
-                        "variableName": "filter",
-                        "type": "[ArtistArtworksFilters]"
-                      },
-                      v4,
-                      v5
-                    ],
-                    "handle": "connection",
-                    "key": "WorksForYouArtistFeed_artworks_connection",
-                    "filters": [
-                      "sort",
-                      "filter"
-                    ]
-                  },
-                  v8
-                ]
-              }
-            ]
-          },
           {
             "kind": "Condition",
             "passingValue": false,
@@ -896,19 +757,19 @@ return {
                         "name": "bundledArtworksByArtist",
                         "storageKey": null,
                         "args": [
-                          v4,
+                          v1,
                           {
                             "kind": "Variable",
                             "name": "for_sale",
                             "variableName": "forSale",
                             "type": "Boolean"
                           },
-                          v5
+                          v2
                         ],
                         "concreteType": "FollowedArtistsArtworksGroupConnection",
                         "plural": false,
                         "selections": [
-                          v6,
+                          v3,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -927,8 +788,8 @@ return {
                                 "concreteType": "FollowedArtistsArtworksGroup",
                                 "plural": false,
                                 "selections": [
-                                  v8,
-                                  v2,
+                                  v4,
+                                  v5,
                                   {
                                     "kind": "ScalarField",
                                     "alias": null,
@@ -984,32 +845,32 @@ return {
                                             "concreteType": "Artwork",
                                             "plural": false,
                                             "selections": [
-                                              v15,
+                                              v4,
+                                              v6,
+                                              v7,
                                               v8,
                                               v9,
                                               v10,
                                               v11,
+                                              v5,
                                               v12,
                                               v13,
-                                              v2,
                                               v14,
-                                              v16,
-                                              v7,
-                                              v17,
+                                              v15,
+                                              v18,
                                               v19,
                                               v20,
-                                              v21,
+                                              v22,
                                               v23,
                                               v24,
-                                              v25,
-                                              v26
+                                              v25
                                             ]
                                           }
                                         ]
                                       }
                                     ]
                                   },
-                                  v3,
+                                  v26,
                                   v27
                                 ]
                               },
@@ -1023,14 +884,14 @@ return {
                         "alias": "notifications",
                         "name": "bundledArtworksByArtist",
                         "args": [
-                          v4,
+                          v1,
                           {
                             "kind": "Variable",
                             "name": "for_sale",
                             "variableName": "forSale",
                             "type": "Boolean"
                           },
-                          v5
+                          v2
                         ],
                         "handle": "connection",
                         "key": "WorksForYou_notifications",
@@ -1041,7 +902,146 @@ return {
                       }
                     ]
                   },
-                  v8
+                  v4
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "Condition",
+            "passingValue": true,
+            "condition": "includeSelectedArtist",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artist",
+                "storageKey": null,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "id",
+                    "variableName": "artistID",
+                    "type": "String!"
+                  }
+                ],
+                "concreteType": "Artist",
+                "plural": false,
+                "selections": [
+                  v17,
+                  v5,
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistCounts",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artworks",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "for_sale_artworks",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  },
+                  v26,
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artworks_connection",
+                    "storageKey": null,
+                    "args": [
+                      {
+                        "kind": "Variable",
+                        "name": "filter",
+                        "variableName": "filter",
+                        "type": "[ArtistArtworksFilters]"
+                      },
+                      v1,
+                      v2
+                    ],
+                    "concreteType": "ArtworkConnection",
+                    "plural": false,
+                    "selections": [
+                      v3,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "edges",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtworkEdge",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "node",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "plural": false,
+                            "selections": [
+                              v4,
+                              v6,
+                              v7,
+                              v8,
+                              v9,
+                              v10,
+                              v11,
+                              v5,
+                              v12,
+                              v13,
+                              v14,
+                              v15,
+                              v18,
+                              v19,
+                              v20,
+                              v22,
+                              v23,
+                              v24,
+                              v25,
+                              v27
+                            ]
+                          },
+                          v28
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "LinkedHandle",
+                    "alias": null,
+                    "name": "artworks_connection",
+                    "args": [
+                      {
+                        "kind": "Variable",
+                        "name": "filter",
+                        "variableName": "filter",
+                        "type": "[ArtistArtworksFilters]"
+                      },
+                      v1,
+                      v2
+                    ],
+                    "handle": "connection",
+                    "key": "WorksForYouArtistFeed_artworks_connection",
+                    "filters": [
+                      "sort",
+                      "filter"
+                    ]
+                  },
+                  v4
                 ]
               }
             ]

--- a/src/__generated__/routes_AcceptQuery.graphql.ts
+++ b/src/__generated__/routes_AcceptQuery.graphql.ts
@@ -200,32 +200,25 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "taxTotalCents",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "__id",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v7 = [
+v6 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -233,32 +226,39 @@ v7 = [
     "type": "Int"
   }
 ],
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v7,
+  "args": v6,
   "storageKey": "shippingTotal(precision:2)"
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v7,
+  "args": v6,
   "storageKey": "taxTotal(precision:2)"
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "taxTotalCents",
+  "args": null,
+  "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v7,
+  "args": v6,
   "storageKey": "buyerTotal(precision:2)"
 },
 v12 = {
@@ -271,16 +271,16 @@ v12 = {
 v13 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "amountCents",
-  "args": null,
-  "storageKey": null
+  "name": "amount",
+  "args": v6,
+  "storageKey": "amount(precision:2)"
 },
 v14 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "amount",
-  "args": v7,
-  "storageKey": "amount(precision:2)"
+  "name": "amountCents",
+  "args": null,
+  "storageKey": null
 },
 v15 = {
   "kind": "ScalarField",
@@ -344,7 +344,13 @@ return {
         "plural": false,
         "selections": [
           v3,
-          v4,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "stateExpiresAt",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -354,7 +360,7 @@ return {
             "concreteType": "Offer",
             "plural": false,
             "selections": [
-              v4,
+              v3,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -401,8 +407,8 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          v3,
                           v4,
-                          v5,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -476,7 +482,7 @@ return {
               }
             ]
           },
-          v6,
+          v5,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -484,31 +490,53 @@ return {
             "args": null,
             "storageKey": null
           },
+          v7,
           v8,
           v9,
           v10,
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "stateExpiresAt",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "itemsTotal",
-            "args": v7,
+            "args": v6,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v7,
+            "args": v6,
             "storageKey": "totalListPrice(precision:2)"
           },
           v11,
+          v2,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "seller",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v5,
+              v4,
+              {
+                "kind": "InlineFragment",
+                "type": "Partner",
+                "selections": [
+                  v12
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "state",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -518,7 +546,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v6,
+              v5,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
@@ -577,34 +605,6 @@ return {
               }
             ]
           },
-          v2,
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "seller",
-            "storageKey": null,
-            "args": null,
-            "concreteType": null,
-            "plural": false,
-            "selections": [
-              v6,
-              v5,
-              {
-                "kind": "InlineFragment",
-                "type": "Partner",
-                "selections": [
-                  v12
-                ]
-              }
-            ]
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "state",
-            "args": null,
-            "storageKey": null
-          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -642,7 +642,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v5
+              v4
             ]
           },
           {
@@ -658,12 +658,12 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v10,
                   v13,
+                  v14,
+                  v7,
                   v8,
                   v9,
-                  v14,
-                  v3,
+                  v10,
                   v11,
                   v15,
                   v16
@@ -678,13 +678,13 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v10,
-                  v4,
+                  v3,
                   v13,
+                  v14,
+                  v7,
                   v8,
                   v9,
-                  v14,
-                  v3,
+                  v10,
                   v11,
                   v15,
                   v16,

--- a/src/__generated__/routes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/routes_ArtworkQuery.graphql.ts
@@ -665,98 +665,116 @@ v4 = {
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "sale_message",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "url",
   "args": null,
   "storageKey": null
 },
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "type",
-  "args": null,
-  "storageKey": null
-},
+v7 = [
+  v6
+],
 v8 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "initials",
-  "args": null,
-  "storageKey": null
-},
-v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_followed",
   "args": null,
   "storageKey": null
 },
+v9 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "counts",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "ArtistCounts",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "follows",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "_id",
+  "name": "sale_message",
   "args": null,
   "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "url",
+  "name": "type",
   "args": null,
   "storageKey": null
 },
 v12 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "title",
+  "name": "initials",
   "args": null,
   "storageKey": null
 },
 v13 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "_id",
   "args": null,
   "storageKey": null
 },
 v14 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "is_closed",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v15 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "is_open",
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
 v16 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "live_start_at",
+  "name": "is_closed",
   "args": null,
   "storageKey": null
 },
 v17 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "is_open",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "live_start_at",
+  "args": null,
+  "storageKey": null
+},
+v19 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "end_at",
   "args": null,
   "storageKey": null
 },
-v18 = [
-  v11
-],
-v19 = [
+v20 = [
   {
     "kind": "LinkedField",
     "alias": "img",
@@ -784,27 +802,9 @@ v19 = [
     ],
     "concreteType": "ResizedImageUrl",
     "plural": false,
-    "selections": v18
+    "selections": v7
   }
 ],
-v20 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "counts",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "ArtistCounts",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "follows",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
 v21 = {
   "kind": "ScalarField",
   "alias": null,
@@ -936,25 +936,125 @@ return {
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
+          v3,
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "attribution_class",
+            "name": "artist",
             "storageKey": null,
             "args": null,
-            "concreteType": "AttributionClass",
+            "concreteType": "Artist",
             "plural": false,
             "selections": [
+              v3,
+              v2,
+              v4,
               {
-                "kind": "ScalarField",
+                "kind": "LinkedField",
                 "alias": null,
-                "name": "short_description",
+                "name": "related",
+                "storageKey": null,
                 "args": null,
-                "storageKey": null
+                "concreteType": "ArtistRelatedData",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artists",
+                    "storageKey": "artists(first:4,kind:\"MAIN\")",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 4,
+                        "type": "Int"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "kind",
+                        "value": "MAIN",
+                        "type": "RelatedArtistsKind"
+                      }
+                    ],
+                    "concreteType": "ArtistConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "edges",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistEdge",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "node",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "plural": false,
+                            "selections": [
+                              v5,
+                              v3,
+                              v4,
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "image",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "cropped",
+                                    "storageKey": "cropped(height:300,width:400)",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "height",
+                                        "value": 300,
+                                        "type": "Int!"
+                                      },
+                                      {
+                                        "kind": "Literal",
+                                        "name": "width",
+                                        "value": 400,
+                                        "type": "Int!"
+                                      }
+                                    ],
+                                    "concreteType": "CroppedImageUrl",
+                                    "plural": false,
+                                    "selections": v7
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "formatted_nationality_and_birthday",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              v2,
+                              v8,
+                              v9
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
-          v3,
           v2,
           v4,
           {
@@ -971,7 +1071,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          v5,
+          v10,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -981,10 +1081,10 @@ return {
             "concreteType": "Partner",
             "plural": false,
             "selections": [
-              v6,
+              v5,
               v2,
-              v7,
-              v8,
+              v11,
+              v12,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1022,10 +1122,10 @@ return {
                   v4,
                   v2,
                   v3,
-                  v9
+                  v8
                 ]
               },
-              v10,
+              v13,
               v4,
               {
                 "kind": "LinkedField",
@@ -1125,7 +1225,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v11
+                  v6
                 ]
               }
             ]
@@ -1139,7 +1239,7 @@ return {
             "concreteType": "ArtworkMeta",
             "plural": false,
             "selections": [
-              v12,
+              v14,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1179,14 +1279,14 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v13,
+              v15,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextFair",
                 "selections": [
                   v3,
-                  v6
+                  v5
                 ]
               }
             ]
@@ -1200,13 +1300,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v13,
+              v15,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextAuction",
                 "selections": [
-                  v6,
+                  v5,
                   v4,
                   {
                     "kind": "ScalarField",
@@ -1215,9 +1315,9 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v14,
-                  v15,
                   v16,
+                  v17,
+                  v18,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1238,13 +1338,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v13,
+              v15,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextFair",
                 "selections": [
-                  v6,
+                  v5,
                   v4,
                   {
                     "kind": "ScalarField",
@@ -1260,7 +1360,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v17,
+                  v19,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -1270,7 +1370,7 @@ return {
                     "concreteType": "Profile",
                     "plural": false,
                     "selections": [
-                      v8,
+                      v12,
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1279,7 +1379,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": false,
-                        "selections": v19
+                        "selections": v20
                       },
                       v2
                     ]
@@ -1297,15 +1397,15 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v13,
+              v15,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextPartnerShow",
                 "selections": [
-                  v6,
+                  v5,
                   v4,
-                  v7,
+                  v11,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1321,7 +1421,7 @@ return {
                     "args": null,
                     "concreteType": "Image",
                     "plural": false,
-                    "selections": v19
+                    "selections": v20
                   }
                 ]
               }
@@ -1352,10 +1452,10 @@ return {
             "selections": [
               v2,
               v3,
-              v6,
+              v5,
               v4,
+              v8,
               v9,
-              v20,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1407,8 +1507,8 @@ return {
                             "selections": [
                               v2,
                               v3,
-                              v10,
-                              v6,
+                              v13,
+                              v5,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -1439,7 +1539,7 @@ return {
                                     ],
                                     "concreteType": "CroppedImageUrl",
                                     "plural": false,
-                                    "selections": v18
+                                    "selections": v7
                                   }
                                 ]
                               }
@@ -1451,7 +1551,7 @@ return {
                   }
                 ]
               },
-              v10,
+              v13,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1481,7 +1581,7 @@ return {
               v3,
               v21,
               v22,
-              v5,
+              v10,
               v23,
               v24
             ]
@@ -1576,7 +1676,7 @@ return {
               }
             ]
           },
-          v12,
+          v14,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -1589,277 +1689,22 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "images",
+            "name": "attribution_class",
             "storageKey": null,
             "args": null,
-            "concreteType": "Image",
-            "plural": true,
-            "selections": [
-              v11,
-              v3,
-              {
-                "kind": "ScalarField",
-                "alias": "uri",
-                "name": "url",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": [
-                      "larger",
-                      "large"
-                    ],
-                    "type": "[String]"
-                  }
-                ],
-                "storageKey": "url(version:[\"larger\",\"large\"])"
-              },
-              {
-                "kind": "LinkedField",
-                "alias": "placeholder",
-                "name": "resized",
-                "storageKey": "resized(height:30,version:\"small\",width:30)",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "height",
-                    "value": 30,
-                    "type": "Int"
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "small",
-                    "type": "[String]"
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 30,
-                    "type": "Int"
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "plural": false,
-                "selections": v18
-              },
-              {
-                "kind": "ScalarField",
-                "alias": "aspectRatio",
-                "name": "aspect_ratio",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_zoomable",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "LinkedField",
-                "alias": "deepZoom",
-                "name": "deep_zoom",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "DeepZoom",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "Image",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "DeepZoomImage",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "xmlns",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "Url",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "Format",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "TileSize",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "Overlap",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "Size",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": "DeepZoomImageSize",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "Width",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "Height",
-                            "args": null,
-                            "storageKey": null
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "artist",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Artist",
+            "concreteType": "AttributionClass",
             "plural": false,
             "selections": [
-              v3,
-              v2,
-              v4,
               {
-                "kind": "LinkedField",
+                "kind": "ScalarField",
                 "alias": null,
-                "name": "related",
-                "storageKey": null,
+                "name": "short_description",
                 "args": null,
-                "concreteType": "ArtistRelatedData",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "artists",
-                    "storageKey": "artists(first:4,kind:\"MAIN\")",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "first",
-                        "value": 4,
-                        "type": "Int"
-                      },
-                      {
-                        "kind": "Literal",
-                        "name": "kind",
-                        "value": "MAIN",
-                        "type": "RelatedArtistsKind"
-                      }
-                    ],
-                    "concreteType": "ArtistConnection",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "edges",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": "ArtistEdge",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "node",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Artist",
-                            "plural": false,
-                            "selections": [
-                              v6,
-                              v3,
-                              v4,
-                              {
-                                "kind": "LinkedField",
-                                "alias": null,
-                                "name": "image",
-                                "storageKey": null,
-                                "args": null,
-                                "concreteType": "Image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "kind": "LinkedField",
-                                    "alias": null,
-                                    "name": "cropped",
-                                    "storageKey": "cropped(height:300,width:400)",
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "height",
-                                        "value": 300,
-                                        "type": "Int!"
-                                      },
-                                      {
-                                        "kind": "Literal",
-                                        "name": "width",
-                                        "value": 400,
-                                        "type": "Int!"
-                                      }
-                                    ],
-                                    "concreteType": "CroppedImageUrl",
-                                    "plural": false,
-                                    "selections": v18
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "formatted_nationality_and_birthday",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              v2,
-                              v9,
-                              v20
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
+                "storageKey": null
               }
             ]
           },
-          v10,
+          v13,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1869,6 +1714,24 @@ return {
             "concreteType": "Sale",
             "plural": false,
             "selections": [
+              v13,
+              v16,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_with_buyers_premium",
+                "args": null,
+                "storageKey": null
+              },
+              v2,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_live_open",
+                "args": null,
+                "storageKey": null
+              },
+              v3,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1888,24 +1751,6 @@ return {
                   v2
                 ]
               },
-              v10,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_with_buyers_premium",
-                "args": null,
-                "storageKey": null
-              },
-              v2,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_live_open",
-                "args": null,
-                "storageKey": null
-              },
-              v3,
-              v14,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1913,7 +1758,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v15,
+              v17,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1921,8 +1766,8 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v16,
-              v17
+              v18,
+              v19
             ]
           },
           {
@@ -2105,7 +1950,7 @@ return {
                 "concreteType": "Author",
                 "plural": false,
                 "selections": [
-                  v6,
+                  v5,
                   v2
                 ]
               },
@@ -2148,7 +1993,7 @@ return {
                     ],
                     "concreteType": "ResizedImageUrl",
                     "plural": false,
-                    "selections": v18
+                    "selections": v7
                   }
                 ]
               },
@@ -2204,6 +2049,161 @@ return {
             "name": "is_saved",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "images",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": true,
+            "selections": [
+              v6,
+              v3,
+              {
+                "kind": "ScalarField",
+                "alias": "uri",
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": [
+                      "larger",
+                      "large"
+                    ],
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:[\"larger\",\"large\"])"
+              },
+              {
+                "kind": "LinkedField",
+                "alias": "placeholder",
+                "name": "resized",
+                "storageKey": "resized(height:30,version:\"small\",width:30)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 30,
+                    "type": "Int"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "small",
+                    "type": "[String]"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 30,
+                    "type": "Int"
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "plural": false,
+                "selections": v7
+              },
+              {
+                "kind": "ScalarField",
+                "alias": "aspectRatio",
+                "name": "aspect_ratio",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_zoomable",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": "deepZoom",
+                "name": "deep_zoom",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "DeepZoom",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "Image",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "DeepZoomImage",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "xmlns",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "Url",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "Format",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "TileSize",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "Overlap",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "Size",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "DeepZoomImageSize",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "Width",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "Height",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           {
             "kind": "LinkedField",

--- a/src/__generated__/routes_CVQuery.graphql.ts
+++ b/src/__generated__/routes_CVQuery.graphql.ts
@@ -290,17 +290,17 @@ v12 = [
               v8,
               {
                 "kind": "InlineFragment",
-                "type": "Partner",
+                "type": "ExternalPartner",
                 "selections": [
-                  v10,
-                  v11
+                  v10
                 ]
               },
               {
                 "kind": "InlineFragment",
-                "type": "ExternalPartner",
+                "type": "Partner",
                 "selections": [
-                  v10
+                  v10,
+                  v11
                 ]
               }
             ]

--- a/src/__generated__/routes_CollectAppQuery.graphql.ts
+++ b/src/__generated__/routes_CollectAppQuery.graphql.ts
@@ -644,14 +644,14 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "price",
+                            "name": "availability",
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -672,7 +672,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "availability",
+                            "name": "price",
                             "args": null,
                             "storageKey": null
                           },
@@ -1062,8 +1062,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v4,
                           v3,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1142,45 +1180,7 @@ return {
                           },
                           v5,
                           v7,
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "image",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
-                          },
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/routes_CounterQuery.graphql.ts
+++ b/src/__generated__/routes_CounterQuery.graphql.ts
@@ -225,18 +225,11 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "shippingTotalCents",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -244,52 +237,59 @@ v5 = [
     "type": "Int"
   }
 ],
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "shippingTotal",
+  "args": v4,
+  "storageKey": "shippingTotal(precision:2)"
+},
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "shippingTotal",
-  "args": v5,
-  "storageKey": "shippingTotal(precision:2)"
-},
-v9 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "taxTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "taxTotal(precision:2)"
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotalCents",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "buyerTotal(precision:2)"
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
 },
 v12 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__id",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
@@ -297,7 +297,7 @@ v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "amount",
-  "args": v5,
+  "args": v4,
   "storageKey": "amount(precision:2)"
 },
 v14 = {
@@ -369,7 +369,13 @@ return {
         "plural": false,
         "selections": [
           v3,
-          v4,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -381,14 +387,14 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v5,
+            "args": v4,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v5,
+            "args": v4,
             "storageKey": "totalListPrice(precision:2)"
           },
           {
@@ -398,86 +404,12 @@ return {
             "args": null,
             "storageKey": null
           },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "requestedFulfillment",
-            "storageKey": null,
-            "args": null,
-            "concreteType": null,
-            "plural": false,
-            "selections": [
-              v6,
-              {
-                "kind": "InlineFragment",
-                "type": "Ship",
-                "selections": [
-                  v7,
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "addressLine1",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "addressLine2",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "city",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "postalCode",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "region",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "country",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "phoneNumber",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              }
-            ]
-          },
+          v5,
           v6,
+          v7,
           v8,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
           v9,
           v10,
-          v11,
           v2,
           {
             "kind": "LinkedField",
@@ -488,13 +420,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v6,
-              v12,
+              v5,
+              v11,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v7
+                  v12
                 ]
               }
             ]
@@ -599,11 +531,79 @@ return {
                               }
                             ]
                           },
-                          v12
+                          v11
                         ]
                       },
                       v2
                     ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "requestedFulfillment",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v5,
+              {
+                "kind": "InlineFragment",
+                "type": "Ship",
+                "selections": [
+                  v12,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "addressLine1",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "addressLine2",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "city",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "postalCode",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "region",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "country",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "phoneNumber",
+                    "args": null,
+                    "storageKey": null
                   }
                 ]
               }
@@ -646,7 +646,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v12
+              v11
             ]
           },
           {
@@ -662,7 +662,6 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v3,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -670,14 +669,15 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v4,
+                  v2,
+                  v3,
                   v13,
                   v14,
+                  v6,
+                  v7,
                   v8,
-                  v2,
                   v9,
                   v10,
-                  v11,
                   v15,
                   v16
                 ]
@@ -692,14 +692,14 @@ return {
                 "plural": false,
                 "selections": [
                   v3,
-                  v4,
+                  v2,
                   v13,
                   v14,
+                  v6,
+                  v7,
                   v8,
-                  v2,
                   v9,
                   v10,
-                  v11,
                   v15,
                   v16
                 ]
@@ -731,7 +731,7 @@ return {
                         "concreteType": "Offer",
                         "plural": false,
                         "selections": [
-                          v4,
+                          v3,
                           v13,
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/routes_MarketingCollectionAppQuery.graphql.ts
+++ b/src/__generated__/routes_MarketingCollectionAppQuery.graphql.ts
@@ -373,28 +373,28 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "category",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "title",
+  "name": "description",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "description",
+  "name": "category",
   "args": null,
   "storageKey": null
 },
@@ -607,16 +607,6 @@ return {
         "plural": false,
         "selections": [
           v3,
-          v4,
-          v5,
-          v6,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "headerImage",
-            "args": null,
-            "storageKey": null
-          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -624,6 +614,16 @@ return {
             "args": null,
             "storageKey": null
           },
+          v4,
+          v5,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "headerImage",
+            "args": null,
+            "storageKey": null
+          },
+          v6,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -717,15 +717,15 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          v8,
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "price",
+                            "name": "availability",
                             "args": null,
                             "storageKey": null
                           },
-                          v8,
-                          v3,
+                          v6,
                           v9,
                           v10,
                           v11,
@@ -739,7 +739,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "availability",
+                            "name": "price",
                             "args": null,
                             "storageKey": null
                           },
@@ -750,7 +750,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v5,
+                          v4,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -783,7 +783,7 @@ return {
                             "concreteType": "ArtworkMeta",
                             "plural": false,
                             "selections": [
-                              v6
+                              v5
                             ]
                           },
                           {
@@ -922,7 +922,7 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      v4,
+                      v3,
                       v12,
                       {
                         "kind": "ScalarField",
@@ -1117,8 +1117,46 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v9,
                           v8,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1196,46 +1234,8 @@ return {
                             "storageKey": null
                           },
                           v10,
-                          v5,
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "image",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
-                          },
+                          v4,
+                          v9,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1348,7 +1348,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v4,
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/routes_OfferQuery.graphql.ts
+++ b/src/__generated__/routes_OfferQuery.graphql.ts
@@ -153,18 +153,11 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -172,10 +165,17 @@ v5 = [
     "type": "Int"
   }
 ],
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
@@ -183,7 +183,7 @@ v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "shippingTotal(precision:2)"
 },
 v8 = {
@@ -197,7 +197,7 @@ v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "taxTotal(precision:2)"
 },
 v10 = {
@@ -211,12 +211,18 @@ v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "buyerTotal(precision:2)"
 },
 v12 = [
-  v9,
-  v4,
+  v3,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "amount",
+    "args": v4,
+    "storageKey": "amount(precision:2)"
+  },
   {
     "kind": "ScalarField",
     "alias": null,
@@ -226,13 +232,7 @@ v12 = [
   },
   v7,
   v8,
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "amount",
-    "args": v5,
-    "storageKey": "amount(precision:2)"
-  },
+  v9,
   v10,
   v11,
   {
@@ -299,7 +299,13 @@ return {
         "plural": false,
         "selections": [
           v3,
-          v4,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -311,7 +317,7 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v5,
+            "args": v4,
             "storageKey": "totalListPrice(precision:2)"
           },
           {
@@ -350,8 +356,8 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v4,
-                          v6,
+                          v3,
+                          v5,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -434,8 +440,8 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
               v6,
+              v5,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
@@ -452,13 +458,7 @@ return {
             ]
           },
           v2,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
+          v6,
           v7,
           v8,
           v9,
@@ -467,7 +467,7 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v5,
+            "args": v4,
             "storageKey": "itemsTotal(precision:2)"
           },
           v11,

--- a/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
@@ -469,18 +469,11 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -489,24 +482,31 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "_id",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
   "args": null,
   "storageKey": null
 },
@@ -565,7 +565,7 @@ v15 = {
   "storageKey": null
 },
 v16 = [
-  v6
+  v5
 ];
 return {
   "kind": "Request",
@@ -663,7 +663,6 @@ return {
         "concreteType": "Artist",
         "plural": false,
         "selections": [
-          v3,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -702,6 +701,7 @@ return {
               }
             ]
           },
+          v2,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -720,7 +720,7 @@ return {
                 "concreteType": null,
                 "plural": false,
                 "selections": [
-                  v4,
+                  v3,
                   v2
                 ]
               },
@@ -748,11 +748,11 @@ return {
                     ],
                     "concreteType": "ResizedImageUrl",
                     "plural": false,
-                    "selections": v5
+                    "selections": v4
                   }
                 ]
               },
-              v6,
+              v5,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -774,10 +774,10 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v7
+              v6
             ]
           },
-          v8,
+          v7,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -859,7 +859,7 @@ return {
                             "concreteType": "Category",
                             "plural": true,
                             "selections": [
-                              v3
+                              v8
                             ]
                           },
                           v2
@@ -1000,10 +1000,10 @@ return {
                         "concreteType": "Gene",
                         "plural": false,
                         "selections": [
-                          v7,
                           v6,
+                          v5,
                           v2,
-                          v3
+                          v8
                         ]
                       }
                     ]
@@ -1012,8 +1012,8 @@ return {
               }
             ]
           },
-          v2,
-          v6,
+          v8,
+          v5,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -1122,8 +1122,8 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      v6,
-                      v3,
+                      v5,
+                      v8,
                       v2
                     ]
                   }
@@ -1319,15 +1319,47 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
                           v2,
-                          v8,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "aspect_ratio",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "placeholder",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"large\")"
+                              }
+                            ]
+                          },
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1403,7 +1435,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v7,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1412,43 +1444,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "image",
-                            "storageKey": null,
+                            "name": "date",
                             "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspect_ratio",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "placeholder",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "url",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"large\")"
-                              }
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "ScalarField",
@@ -1474,8 +1474,8 @@ return {
                             "plural": true,
                             "selections": [
                               v2,
-                              v7,
-                              v6
+                              v6,
+                              v5
                             ]
                           },
                           {
@@ -1494,8 +1494,8 @@ return {
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
+                              v5,
                               v6,
-                              v7,
                               v2,
                               {
                                 "kind": "ScalarField",
@@ -1574,7 +1574,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          v8,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1615,21 +1615,21 @@ return {
                 "concreteType": null,
                 "plural": false,
                 "selections": [
-                  v4,
+                  v3,
                   v2,
-                  {
-                    "kind": "InlineFragment",
-                    "type": "Partner",
-                    "selections": v16
-                  },
                   {
                     "kind": "InlineFragment",
                     "type": "ExternalPartner",
                     "selections": v16
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "type": "Partner",
+                    "selections": v16
                   }
                 ]
               },
-              v6,
+              v5,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1667,7 +1667,7 @@ return {
                     ],
                     "concreteType": "CroppedImageUrl",
                     "plural": false,
-                    "selections": v5
+                    "selections": v4
                   }
                 ]
               },
@@ -1681,7 +1681,7 @@ return {
               v2
             ]
           },
-          v7,
+          v6,
           {
             "kind": "ScalarField",
             "alias": null,

--- a/src/__generated__/routes_PaymentQuery.graphql.ts
+++ b/src/__generated__/routes_PaymentQuery.graphql.ts
@@ -173,7 +173,49 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = [
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "city",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "country",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v9 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -181,54 +223,12 @@ v3 = [
     "type": "Int"
   }
 ],
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "shippingTotal",
-  "args": v3,
-  "storageKey": "shippingTotal(precision:2)"
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "city",
-  "args": null,
-  "storageKey": null
-},
-v8 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "country",
-  "args": null,
-  "storageKey": null
-},
-v9 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
+  "name": "shippingTotal",
+  "args": v9,
+  "storageKey": "shippingTotal(precision:2)"
 },
 v11 = {
   "kind": "ScalarField",
@@ -241,7 +241,7 @@ v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v3,
+  "args": v9,
   "storageKey": "taxTotal(precision:2)"
 },
 v13 = {
@@ -255,12 +255,18 @@ v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v3,
+  "args": v9,
   "storageKey": "buyerTotal(precision:2)"
 },
 v15 = [
-  v12,
-  v5,
+  v3,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "amount",
+    "args": v9,
+    "storageKey": "amount(precision:2)"
+  },
   {
     "kind": "ScalarField",
     "alias": null,
@@ -268,15 +274,9 @@ v15 = [
     "args": null,
     "storageKey": null
   },
-  v4,
+  v10,
   v11,
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "amount",
-    "args": v3,
-    "storageKey": "amount(precision:2)"
-  },
+  v12,
   v13,
   v14,
   {
@@ -342,8 +342,14 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v4,
-          v5,
+          v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -353,7 +359,7 @@ return {
             "concreteType": "CreditCard",
             "plural": false,
             "selections": [
-              v6,
+              v4,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -368,7 +374,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v7,
+              v5,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -376,7 +382,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v8,
+              v6,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -384,7 +390,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v9
+              v7
             ]
           },
           {
@@ -396,25 +402,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v10,
-              {
-                "kind": "InlineFragment",
-                "type": "Pickup",
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "fulfillmentType",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
+              v8,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v6,
+                  v4,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -429,7 +422,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v7,
+                  v5,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -437,11 +430,24 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v8,
+                  v6,
                   {
                     "kind": "ScalarField",
                     "alias": null,
                     "name": "postalCode",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "InlineFragment",
+                "type": "Pickup",
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "fulfillmentType",
                     "args": null,
                     "storageKey": null
                   }
@@ -485,8 +491,8 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v5,
-                          v9,
+                          v3,
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -569,26 +575,20 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v10,
-              v9,
+              v8,
+              v7,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v6
+                  v4
                 ]
               }
             ]
           },
           v2,
+          v8,
           v10,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
           v11,
           v12,
           v13,
@@ -596,14 +596,14 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v3,
+            "args": v9,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v3,
+            "args": v9,
             "storageKey": "totalListPrice(precision:2)"
           },
           v14,

--- a/src/__generated__/routes_RespondQuery.graphql.ts
+++ b/src/__generated__/routes_RespondQuery.graphql.ts
@@ -230,7 +230,14 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = [
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -238,74 +245,67 @@ v3 = [
     "type": "Int"
   }
 ],
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "shippingTotal",
-  "args": v3,
-  "storageKey": "shippingTotal(precision:2)"
-},
 v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
+  "name": "shippingTotal",
+  "args": v4,
+  "storageKey": "shippingTotal(precision:2)"
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v3,
+  "args": v4,
   "storageKey": "taxTotal(precision:2)"
 },
-v11 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotalCents",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v3,
+  "args": v4,
   "storageKey": "buyerTotal(precision:2)"
+},
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
 },
 v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "amount",
-  "args": v3,
+  "args": v4,
   "storageKey": "amount(precision:2)"
 },
 v14 = {
@@ -376,8 +376,14 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v4,
-          v5,
+          v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -389,14 +395,14 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v3,
+            "args": v4,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v3,
+            "args": v4,
             "storageKey": "totalListPrice(precision:2)"
           },
           {
@@ -442,8 +448,8 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          v3,
                           v5,
-                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -517,6 +523,33 @@ return {
               }
             ]
           },
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v2,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "seller",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v6,
+              v5,
+              {
+                "kind": "InlineFragment",
+                "type": "Partner",
+                "selections": [
+                  v12
+                ]
+              }
+            ]
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -526,12 +559,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v7,
+              v6,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v8,
+                  v12,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -585,39 +618,6 @@ return {
               }
             ]
           },
-          v7,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
-          v9,
-          v10,
-          v11,
-          v12,
-          v2,
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "seller",
-            "storageKey": null,
-            "args": null,
-            "concreteType": null,
-            "plural": false,
-            "selections": [
-              v7,
-              v6,
-              {
-                "kind": "InlineFragment",
-                "type": "Partner",
-                "selections": [
-                  v8
-                ]
-              }
-            ]
-          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -655,7 +655,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v6
+              v5
             ]
           },
           {
@@ -671,7 +671,6 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v9,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -679,14 +678,15 @@ return {
                     "args": null,
                     "storageKey": null
                   },
+                  v3,
                   v2,
                   v13,
                   v14,
-                  v4,
-                  v5,
+                  v7,
+                  v8,
+                  v9,
                   v10,
                   v11,
-                  v12,
                   v15,
                   v16
                 ]
@@ -700,14 +700,14 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v10,
-                  v5,
-                  v14,
-                  v4,
-                  v9,
+                  v3,
                   v13,
+                  v14,
+                  v7,
+                  v8,
+                  v9,
+                  v10,
                   v11,
-                  v12,
                   v15,
                   v16,
                   v2
@@ -740,7 +740,7 @@ return {
                         "concreteType": "Offer",
                         "plural": false,
                         "selections": [
-                          v5,
+                          v3,
                           v13,
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -238,25 +238,18 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "shippingTotalCents",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -265,21 +258,21 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v9 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -287,18 +280,25 @@ v9 = [
     "type": "Int"
   }
 ],
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v9,
+  "args": v8,
   "storageKey": "shippingTotal(precision:2)"
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "shippingTotalCents",
+  "args": null,
+  "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v9,
+  "args": v8,
   "storageKey": "taxTotal(precision:2)"
 },
 v12 = {
@@ -312,14 +312,14 @@ v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v9,
+  "args": v8,
   "storageKey": "buyerTotal(precision:2)"
 },
 v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "amount",
-  "args": v9,
+  "args": v8,
   "storageKey": "amount(precision:2)"
 },
 v15 = {
@@ -391,7 +391,13 @@ return {
         "plural": false,
         "selections": [
           v3,
-          v4,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -428,14 +434,20 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
+                          v3,
                           {
-                            "kind": "ScalarField",
+                            "kind": "LinkedField",
                             "alias": null,
-                            "name": "medium",
+                            "name": "artists",
+                            "storageKey": null,
                             "args": null,
-                            "storageKey": null
+                            "concreteType": "Artist",
+                            "plural": true,
+                            "selections": [
+                              v3,
+                              v4
+                            ]
                           },
-                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -458,17 +470,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "kind": "LinkedField",
+                            "kind": "ScalarField",
                             "alias": null,
-                            "name": "artists",
-                            "storageKey": null,
+                            "name": "medium",
                             "args": null,
-                            "concreteType": "Artist",
-                            "plural": true,
-                            "selections": [
-                              v4,
-                              v5
-                            ]
+                            "storageKey": null
                           },
                           {
                             "kind": "LinkedField",
@@ -537,7 +543,7 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v6
+                                "selections": v5
                               },
                               {
                                 "kind": "LinkedField",
@@ -554,11 +560,11 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v6
+                                "selections": v5
                               }
                             ]
                           },
-                          v5,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -578,18 +584,66 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "seller",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v6,
+              v4,
+              {
+                "kind": "InlineFragment",
+                "type": "Partner",
+                "selections": [
+                  v7
+                ]
+              }
+            ]
+          },
+          v2,
+          v6,
+          v9,
+          v10,
+          v11,
+          v12,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "itemsTotal",
+            "args": v8,
+            "storageKey": "itemsTotal(precision:2)"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "totalListPrice",
+            "args": v8,
+            "storageKey": "totalListPrice(precision:2)"
+          },
+          v13,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "state",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "requestedFulfillment",
             "storageKey": null,
             "args": null,
             "concreteType": null,
             "plural": false,
             "selections": [
-              v7,
+              v6,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v8,
+                  v7,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -646,60 +700,6 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
-            "name": "seller",
-            "storageKey": null,
-            "args": null,
-            "concreteType": null,
-            "plural": false,
-            "selections": [
-              v7,
-              v5,
-              {
-                "kind": "InlineFragment",
-                "type": "Partner",
-                "selections": [
-                  v8
-                ]
-              }
-            ]
-          },
-          v2,
-          v7,
-          v10,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
-          v11,
-          v12,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "itemsTotal",
-            "args": v9,
-            "storageKey": "itemsTotal(precision:2)"
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "totalListPrice",
-            "args": v9,
-            "storageKey": "totalListPrice(precision:2)"
-          },
-          v13,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "state",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
             "name": "creditCard",
             "storageKey": null,
             "args": null,
@@ -734,7 +734,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v5
+              v4
             ]
           },
           {
@@ -751,11 +751,11 @@ return {
                 "plural": false,
                 "selections": [
                   v3,
-                  v4,
+                  v2,
                   v14,
                   v15,
+                  v9,
                   v10,
-                  v2,
                   v11,
                   v12,
                   v13,
@@ -772,12 +772,12 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v11,
-                  v4,
-                  v15,
-                  v10,
                   v3,
                   v14,
+                  v15,
+                  v9,
+                  v10,
+                  v11,
                   v12,
                   v13,
                   v16,

--- a/src/__generated__/routes_ShippingQuery.graphql.ts
+++ b/src/__generated__/routes_ShippingQuery.graphql.ts
@@ -164,7 +164,35 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = [
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v7 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -172,40 +200,12 @@ v3 = [
     "type": "Int"
   }
 ],
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "shippingTotal",
-  "args": v3,
-  "storageKey": "shippingTotal(precision:2)"
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
+  "name": "shippingTotal",
+  "args": v7,
+  "storageKey": "shippingTotal(precision:2)"
 },
 v9 = {
   "kind": "ScalarField",
@@ -218,7 +218,7 @@ v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v3,
+  "args": v7,
   "storageKey": "taxTotal(precision:2)"
 },
 v11 = {
@@ -232,12 +232,18 @@ v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v3,
+  "args": v7,
   "storageKey": "buyerTotal(precision:2)"
 },
 v13 = [
-  v10,
-  v5,
+  v3,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "amount",
+    "args": v7,
+    "storageKey": "amount(precision:2)"
+  },
   {
     "kind": "ScalarField",
     "alias": null,
@@ -245,15 +251,9 @@ v13 = [
     "args": null,
     "storageKey": null
   },
-  v4,
+  v8,
   v9,
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "amount",
-    "args": v3,
-    "storageKey": "amount(precision:2)"
-  },
+  v10,
   v11,
   v12,
   {
@@ -319,8 +319,14 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v4,
-          v5,
+          v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -337,12 +343,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v6,
+              v4,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v7,
+                  v5,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -432,7 +438,7 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v5,
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -447,7 +453,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v8,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -530,26 +536,20 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
+              v4,
               v6,
-              v8,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v7
+                  v5
                 ]
               }
             ]
           },
           v2,
-          v6,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
+          v4,
+          v8,
           v9,
           v10,
           v11,
@@ -557,14 +557,14 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v3,
+            "args": v7,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v3,
+            "args": v7,
             "storageKey": "totalListPrice(precision:2)"
           },
           v12,

--- a/src/__generated__/routes_ShowsQuery.graphql.ts
+++ b/src/__generated__/routes_ShowsQuery.graphql.ts
@@ -376,12 +376,12 @@ v10 = [
               v7,
               {
                 "kind": "InlineFragment",
-                "type": "Partner",
+                "type": "ExternalPartner",
                 "selections": v9
               },
               {
                 "kind": "InlineFragment",
-                "type": "ExternalPartner",
+                "type": "Partner",
                 "selections": v9
               }
             ]

--- a/src/__generated__/routes_StatusQuery.graphql.ts
+++ b/src/__generated__/routes_StatusQuery.graphql.ts
@@ -259,18 +259,25 @@ v3 = {
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v6 = [
+v7 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -279,13 +286,6 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
 v8 = [
   {
     "kind": "Literal",
@@ -330,8 +330,14 @@ v13 = {
   "storageKey": "buyerTotal(precision:2)"
 },
 v14 = [
-  v11,
-  v7,
+  v4,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "amount",
+    "args": v8,
+    "storageKey": "amount(precision:2)"
+  },
   {
     "kind": "ScalarField",
     "alias": null,
@@ -341,13 +347,7 @@ v14 = [
   },
   v9,
   v10,
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "amount",
-    "args": v8,
-    "storageKey": "amount(precision:2)"
-  },
+  v11,
   v12,
   v13,
   {
@@ -413,8 +413,8 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v2,
           v3,
+          v4,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -457,7 +457,7 @@ return {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v4,
+                  v5,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -521,12 +521,12 @@ return {
             "plural": false,
             "selections": [
               v3,
-              v5,
+              v6,
               {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v4
+                  v5
                 ]
               }
             ]
@@ -567,11 +567,17 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v5,
                           {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "artist_names",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "title",
                             "args": null,
                             "storageKey": null
                           },
@@ -613,7 +619,7 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v6
+                                "selections": v7
                               },
                               {
                                 "kind": "LinkedField",
@@ -630,18 +636,12 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v6
+                                "selections": v7
                               }
                             ]
                           },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "title",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          v7,
+                          v6,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -770,7 +770,7 @@ return {
               }
             ]
           },
-          v7,
+          v2,
           v9,
           v10,
           v11,
@@ -827,7 +827,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v5
+              v6
             ]
           },
           {


### PR DESCRIPTION
Follow up from: https://github.com/artsy/reaction/pull/1736 

We need to fetch this data here so when we advance to the next page it can correctly _not_ redirect back to the `/respond` page.

Addresses https://artsyproduct.atlassian.net/browse/PURCHASE-769

cc @alloy @mzikherman or others... I don't believe I should have so many changes to the `__generated__` files. I re-installed my node modules, but doesn't appear to have helped. Any ideas? I'm guessing I have an outdated version of... _something_ but I can't find the slack convo where we discussed this before 😞.