### PR TITLE
Fix 'Back to Artsy' link

### DIFF
--- a/src/Apps/Order/Routes/Status/index.tsx
+++ b/src/Apps/Order/Routes/Status/index.tsx
@@ -85,7 +85,7 @@ export class StatusRoute extends Component<StatusProps> {
                 {buyerRejectedOffer ? (
                   <Button
                     onClick={() => {
-                      this.props.router.push(`/`)
+                      window.location.href = "/"
                     }}
                     size="large"
                     width="100%"

--- a/src/Apps/Order/__tests__/getRedirect.test.ts
+++ b/src/Apps/Order/__tests__/getRedirect.test.ts
@@ -3,7 +3,7 @@ import { getRedirect, RedirectRecord } from "../getRedirect"
 describe("getRedirect", () => {
   const aNonMatchingPredicate = ({}) => null
   function aMatchingPredicateWithResult(matchedValue) {
-    return ({}) => matchedValue
+    return ({}) => ({ path: matchedValue, reason: "reason" })
   }
   function aRuleWithChildren(
     children: Array<RedirectRecord<{}>>
@@ -32,7 +32,7 @@ describe("getRedirect", () => {
     }
     const result = getRedirect(rule, "some-path", {})
 
-    expect(result).toEqual("the-root")
+    expect(result.path).toEqual("the-root")
   })
 
   it("passes the arguments through to the rules", () => {
@@ -61,15 +61,24 @@ describe("getRedirect", () => {
     const rule: RedirectRecord<number> = {
       path: "",
       rules: [
-        n => (n === 1 ? "/one" : null),
-        n => (n === 2 ? "/two" : null),
-        n => (n === 3 ? "/three" : null),
+        n => (n === 1 ? { path: "/one", reason: "first" } : null),
+        n => (n === 2 ? { path: "/two", reason: "second" } : null),
+        n => (n === 3 ? { path: "/three", reason: "third" } : null),
       ],
     }
 
-    expect(getRedirect(rule, "/hello", 1)).toBe("/one")
-    expect(getRedirect(rule, "/hello", 2)).toBe("/two")
-    expect(getRedirect(rule, "/hello", 3)).toBe("/three")
+    expect(getRedirect(rule, "/hello", 1)).toEqual({
+      path: "/one",
+      reason: "first",
+    })
+    expect(getRedirect(rule, "/hello", 2)).toEqual({
+      path: "/two",
+      reason: "second",
+    })
+    expect(getRedirect(rule, "/hello", 3)).toEqual({
+      path: "/three",
+      reason: "third",
+    })
     expect(getRedirect(rule, "/hello", 4)).toBe(null)
   })
 
@@ -97,7 +106,7 @@ describe("getRedirect", () => {
 
       const result = getRedirect(rule, "this-section", {})
 
-      expect(result).toEqual("this-section-route")
+      expect(result.path).toEqual("this-section-route")
     })
 
     it("matches child routes when the user is deep in this section", () => {
@@ -110,7 +119,7 @@ describe("getRedirect", () => {
 
       const result = getRedirect(rule, "this-section/and/this/page", {})
 
-      expect(result).toEqual("this-section-route")
+      expect(result.path).toEqual("this-section-route")
     })
 
     it("chooses the most specific matching child (i.e. longest path match", () => {
@@ -127,7 +136,7 @@ describe("getRedirect", () => {
 
       const result = getRedirect(rule, "this-section/and/this/page", {})
 
-      expect(result).toEqual("winning-route")
+      expect(result.path).toEqual("winning-route")
     })
 
     it("matches child routes despite slashes in current location", () => {
@@ -144,7 +153,7 @@ describe("getRedirect", () => {
         {}
       )
 
-      expect(result).toEqual("this-section-route")
+      expect(result.path).toEqual("this-section-route")
     })
   })
 })

--- a/src/Apps/Order/getRedirect.ts
+++ b/src/Apps/Order/getRedirect.ts
@@ -1,4 +1,9 @@
-export type RedirectPredicate<Arguments> = (args: Arguments) => string | void
+export interface Redirect {
+  path: string
+  reason: string
+}
+
+export type RedirectPredicate<Arguments> = (args: Arguments) => Redirect | void
 
 export interface RedirectRecord<Arguments> {
   path: string
@@ -12,13 +17,13 @@ export function getRedirect<Arguments>(
   redirects: RedirectRecord<Arguments>,
   location: string,
   args: Arguments
-): string | null {
+): Redirect | null {
   const trimmedLocation = trimLeadingSlashes(location)
 
   for (const rule of redirects.rules) {
-    const redirectPath = rule(args)
-    if (redirectPath) {
-      return redirectPath
+    const redirect = rule(args)
+    if (redirect) {
+      return redirect
     }
   }
 

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -41,10 +41,14 @@ export const confirmRouteExit = (
 }
 
 const goToStatusIf = (
-  pred: (order: routes_OrderQueryResponse["order"]) => boolean
+  pred: (order: routes_OrderQueryResponse["order"]) => boolean,
+  reason
 ): OrderPredicate => ({ order }) => {
   if (pred(order)) {
-    return `/orders/${order.id}/status`
+    return {
+      path: `/orders/${order.id}/status`,
+      reason,
+    }
   }
 }
 
@@ -52,51 +56,75 @@ const goToArtworkIfOrderWasAbandoned: OrderPredicate = ({ order }) => {
   if (order.state === "ABANDONED") {
     const artworkID = get(order, o => o.lineItems.edges[0].node.artwork.id)
     // If an artwork ID can't be found, redirect back to home page.
-    return artworkID ? `/artwork/${artworkID}` : "/"
+    return {
+      path: artworkID ? `/artwork/${artworkID}` : "/",
+      reason: "Order was abandoned",
+    }
   }
 }
 
 const goToStatusIfOrderIsNotPending = goToStatusIf(
-  order => order.state !== "PENDING"
+  order => order.state !== "PENDING",
+  "Order is no longer pending"
 )
 
 const goToShippingIfShippingIsNotCompleted: OrderPredicate = ({ order }) => {
   if (!order.requestedFulfillment) {
-    return `/orders/${order.id}/shipping`
+    return {
+      path: `/orders/${order.id}/shipping`,
+      reason: "Shipping was not yet completed",
+    }
   }
 }
 
 const goToPaymentIfPaymentIsNotCompleted: OrderPredicate = ({ order }) => {
   if (!order.creditCard) {
-    return `/orders/${order.id}/payment`
+    return {
+      path: `/orders/${order.id}/payment`,
+      reason: "Payment was not yet completed",
+    }
   }
 }
 
 const goToShippingIfOrderIsNotOfferOrder: OrderPredicate = ({ order }) => {
   if (order.mode !== "OFFER") {
-    return `/orders/${order.id}/shipping`
+    return {
+      path: `/orders/${order.id}/shipping`,
+      reason: "Order is not an offer order",
+    }
   }
 }
 
 const goToOfferIfNoOfferMade: OrderPredicate = ({ order }) => {
   if (order.mode === "OFFER" && !order.myLastOffer) {
-    return `/orders/${order.id}/offer`
+    return {
+      path: `/orders/${order.id}/offer`,
+      reason: "No offer has been made yet",
+    }
   }
 }
 
-const goToStatusIfNotOfferOrder = goToStatusIf(order => order.mode !== "OFFER")
+const goToStatusIfNotOfferOrder = goToStatusIf(
+  order => order.mode !== "OFFER",
+  "Not an offer order"
+)
 
 const goToStatusIfNotAwaitingBuyerResponse = goToStatusIf(
-  order => order.awaitingResponseFrom !== "BUYER"
+  order => order.awaitingResponseFrom !== "BUYER",
+  "Not currently awaiting buyer response"
 )
 
 const goToStatusIfOrderIsNotSubmitted = goToStatusIf(
-  order => order.state !== "SUBMITTED"
+  order => order.state !== "SUBMITTED",
+  "Order was not yet submitted"
 )
 
 const goToReviewIfOrderIsPending: OrderPredicate = ({ order }) => {
   if (order.state === "PENDING") {
-    return `/orders/${order.id}/review`
+    return {
+      path: `/orders/${order.id}/review`,
+      reason: "Order is still pending",
+    }
   }
 }
 
@@ -110,12 +138,18 @@ const goToRespondIfMyLastOfferIsNotMostRecentOffer: OrderPredicate = ({
   ) {
     return
   }
-  return `/orders/${order.id}/respond`
+  return {
+    path: `/orders/${order.id}/respond`,
+    reason: "myLastOffer is not most recent offer",
+  }
 }
 
 const goToRespondIfAwaitingBuyerResponse: OrderPredicate = ({ order }) => {
   if (order.awaitingResponseFrom === "BUYER") {
-    return `/orders/${order.id}/respond`
+    return {
+      path: `/orders/${order.id}/respond`,
+      reason: "Still awaiting buyer response",
+    }
   }
 }
 

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -57,7 +57,14 @@ export const routes: RouteConfig[] = [
             { order }
           )
           if (redirect !== null) {
-            throw new RedirectException(redirect)
+            if (process.env.NODE_ENV === "development") {
+              console.error(
+                `Redirecting from ${location.pathname} to ${
+                  redirect.path
+                } because '${redirect.reason}'`
+              )
+            }
+            throw new RedirectException(redirect.path)
           }
         }
 

--- a/src/Apps/__tests__/Fixtures/Order.ts
+++ b/src/Apps/__tests__/Fixtures/Order.ts
@@ -132,6 +132,7 @@ export const UntouchedOfferOrder = {
   mode: "OFFER",
   totalListPrice: "$16,000",
   lastOffer: OfferWithTotals,
+  awaitingResponseFrom: null,
   myLastOffer: {
     ...OfferWithTotals,
     id: "my-last-offer-id",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-765

Also observed some nondeterministic redirect behaviour in storybook, which turned out to be because the mock relay resolver was doing nondeterministic things because we hadn't specified a value for `awaitingResponseFrom`. In fixing that I decided to also add a 'reason' property to redirects so we can debug redirects a bit more easily.