### PR TITLE
Surface only time periods that match a defined list in filters

### DIFF
--- a/src/Apps/Collect/Components/Filters/TimePeriodFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/TimePeriodFilter.tsx
@@ -10,27 +10,33 @@ export const TimePeriodFilter: React.SFC<{
 }> = ({ filters, timePeriods }) => (
   <ContextConsumer>
     {({ mediator }) =>
-      (timePeriods || allowedPeriods).map((timePeriod, index) => {
-        const isSelected = filters.state.major_periods[0] === timePeriod
+      (timePeriods || allowedPeriods)
+        .filter(timePeriod => allowedPeriods.includes(timePeriod))
+        .map((timePeriod, index) => {
+          const isSelected = filters.state.major_periods[0] === timePeriod
 
-        return (
-          <Radio
-            my={0.3}
-            selected={isSelected}
-            value={timePeriod}
-            onSelect={({ selected }) => {
-              if (selected) {
-                return filters.setFilter("major_periods", timePeriod, mediator)
-              } else {
-                return filters.unsetFilter("major_periods", mediator)
-              }
-            }}
-            key={index}
-          >
-            {timePeriod}
-          </Radio>
-        )
-      })
+          return (
+            <Radio
+              my={0.3}
+              selected={isSelected}
+              value={timePeriod}
+              onSelect={({ selected }) => {
+                if (selected) {
+                  return filters.setFilter(
+                    "major_periods",
+                    timePeriod,
+                    mediator
+                  )
+                } else {
+                  return filters.unsetFilter("major_periods", mediator)
+                }
+              }}
+              key={index}
+            >
+              {timePeriod}
+            </Radio>
+          )
+        })
     }
   </ContextConsumer>
 )

--- a/src/Apps/Collect/Components/Filters/__tests__/TimePeriodFilter.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/TimePeriodFilter.test.tsx
@@ -19,6 +19,19 @@ describe("TimePeriodFilter", () => {
     expect(timePeriodFilter.find(Radio).length).toBe(15)
   })
 
+  it("filters out incorrect years", () => {
+    timePeriodFilter = mount(
+      <ContextProvider mediator={mediator}>
+        <TimePeriodFilter
+          filters={filterState}
+          timePeriods={["2910", "2010", "2000"]}
+        />
+      </ContextProvider>
+    )
+
+    expect(timePeriodFilter.find(Radio).length).toBe(2)
+  })
+
   it("updates the state with the correct time period", done => {
     timePeriodFilter
       .find(Radio)


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-1057

## Before

<img width="593" alt="time-period-before" src="https://user-images.githubusercontent.com/386234/50649337-82b4fb80-0f75-11e9-8b98-4d7acf85c2ac.png">

## After

<img width="625" alt="time-period-after" src="https://user-images.githubusercontent.com/386234/50649343-85175580-0f75-11e9-9630-c68a233306ae.png">
