### PR TITLE
Add a skip release label

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -7,6 +7,6 @@
     "major": "Version: Major",
     "minor": "Version: Minor",
     "patch": "Version: Patch",
-    "no-release": "Version: Trivial"
-  }
+  },
+  "noReleaseLabels": ["Version: Trivial", "Skip Release"]
 }


### PR DESCRIPTION
Enables `Skip Release` as a label to skip the release without specifying a version. 