### PR TITLE
Add specific error for insufficient inventory

### DIFF
--- a/src/Apps/Order/Routes/Counter/index.tsx
+++ b/src/Apps/Order/Routes/Counter/index.tsx
@@ -108,9 +108,18 @@ export class CounterRoute extends Component<CounterProps, CounterState> {
 
   onSubmitCompleted = orderOrError => {
     if (orderOrError.error) {
-      this.onMutationError(
-        new ErrorWithMetadata(orderOrError.error.code, orderOrError.error)
-      )
+      const errorCode = orderOrError.error.code
+      if (errorCode === "insufficient_inventory") {
+        this.onMutationError(
+          new ErrorWithMetadata(orderOrError.error.code, orderOrError.error),
+          "This work has already been sold.",
+          "Please contact orders@artsy.com with any questions."
+        )
+      } else {
+        this.onMutationError(
+          new ErrorWithMetadata(orderOrError.error.code, orderOrError.error)
+        )
+      }
     } else {
       this.setState({ isCommittingMutation: false })
       this.props.router.push(`/orders/${this.props.order.id}/status`)

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/submitPendingOffer.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/submitPendingOffer.ts
@@ -24,3 +24,15 @@ export const submitPendingOfferFailed = {
     },
   },
 }
+
+export const insufficientInventoryResponse = {
+  ecommerceSubmitPendingOffer: {
+    orderOrError: {
+      error: {
+        type: "validation",
+        code: "insufficient_inventory",
+        data: null,
+      },
+    },
+  },
+}

--- a/src/Apps/Order/Routes/__tests__/Counter.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.test.tsx
@@ -20,6 +20,7 @@ import { commitMutation as _commitMutation } from "react-relay"
 import { Stepper } from "Styleguide/Components"
 import { CountdownTimer } from "Styleguide/Components/CountdownTimer"
 import {
+  insufficientInventoryResponse,
   submitPendingOfferFailed,
   submitPendingOfferSuccess,
 } from "../__fixtures__/MutationResults/submitPendingOffer"
@@ -210,7 +211,27 @@ describe("Submit Pending Counter Offer", () => {
     })
   })
 
-  it("shows an error modal when there is an error from the server", () => {
+  it("shows an error modal with proper error when there is insufficient inventory", () => {
+    const component = getWrapper()
+    const mockCommitMutation = commitMutation as jest.Mock<any>
+    mockCommitMutation.mockImplementationOnce(
+      (_environment, { onCompleted }) => {
+        onCompleted(insufficientInventoryResponse)
+      }
+    )
+
+    const submitButton = component.find(Button).last()
+    submitButton.simulate("click")
+
+    const errorComponent = component.find(ErrorModal)
+    expect(errorComponent.props().show).toBe(true)
+    expect(errorComponent.text()).toContain("This work has already been sold.")
+    expect(errorComponent.text()).toContain(
+      "Please contact orders@artsy.com with any questions."
+    )
+  })
+
+  it("shows generic error modal when there is an error from the server", () => {
     const component = getWrapper()
     const mockCommitMutation = commitMutation as jest.Mock<any>
     mockCommitMutation.mockImplementationOnce(


### PR DESCRIPTION
# Problem
When submitting counter offer, if the artwork doesn't have enough inventory anymore, show proper error message.

# Solution
Added specific logic to check for `insufficient_inventory` error code coming back from Exchange.