### PR TITLE
Remove release label requirement

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,6 +1,5 @@
 {
   "no-version-prefix": true,
-  "onlyPublishWithReleaseLabel": true,
   "name": "Artsy",
   "email": "it@artsymail.com",
   "labels": {


### PR DESCRIPTION
We interpreted the _onlyPublishWithReleaseLabel_ wrong. With this option set you have to include the actual release label for a release to happen. Not just the major, minor, patch label. 

Every since auto-release was updated in #1787 our deployments have stopped. Before that the patch versions were being released because the config wasn't reading properly and it was falling back to the default behavior of releasing everything as a patch. 

This should fix the releases not happening. 