### PR TITLE
Remove extra space at bottom of order/offer pages

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -1,4 +1,3 @@
-import { Spacer } from "@artsy/palette"
 import { routes_OrderQueryResponse } from "__generated__/routes_OrderQuery.graphql"
 import { ContextConsumer } from "Artsy/SystemContext"
 import { ErrorPage } from "Components/ErrorPage"
@@ -101,10 +100,7 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
             ) : null}
             <StripeProvider stripe={this.state.stripe}>
               <Elements>
-                <>
-                  {children}
-                  <Spacer mb={6} />
-                </>
+                <>{children}</>
               </Elements>
             </StripeProvider>
             <ConnectedModalDialog />


### PR DESCRIPTION
Resolves [PURCHASE-779](https://artsyproduct.atlassian.net/browse/PURCHASE-779).

Currently, there is a bit of extra space at the bottom of all the order/offer pages, at xs resolutions. It shows itself especially well on mobile, where it looks like this: 

![image](https://user-images.githubusercontent.com/1627089/50708058-979e9700-1028-11e9-9217-39a93f4d3226.png)

This PR removes that extra space, like this: 

![image](https://user-images.githubusercontent.com/1627089/50708062-9ec5a500-1028-11e9-85bc-d7b691e1def4.png)
