### PR TITLE
Add spacing below buttons of some order/offer forms

### DIFF
--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -249,6 +249,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                     >
                       Continue
                     </Button>
+                    <Spacer mb={2} />
                   </>
                 </Media>
               </Flex>

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -277,6 +277,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
                       onClick={this.onContinue}
                       loading={isCommittingMutation}
                     />
+                    <Spacer mb={2} />
                   </>
                 </Media>
               </Flex>

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -412,6 +412,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                   >
                     Continue
                   </Button>
+                  <Spacer mb={2} />
                 </Media>
               </Flex>
             }


### PR DESCRIPTION
My previous PR (#1793) was a bit heavy-handed: while correcting spacing on some of the order/offer screens, others need spacing added back. They look like this:

![image](https://user-images.githubusercontent.com/1627089/50710752-827a3600-1031-11e9-9c98-8e67517615fc.png)

This PR adds a small spacer below some buttons on the order/offer screens. More specifically, pages where the button is the last element in the sidebar. So now they look like this:

![image](https://user-images.githubusercontent.com/1627089/50710731-71312980-1031-11e9-993d-78e57cafa4f4.png)
