### PR TITLE
[Artwork] Tighten up main Artwork image sizings 

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -65,7 +65,6 @@ export class LargeArtworkImageBrowser extends React.Component<
                   <Flex
                     flexDirection="column"
                     justifyContent="center"
-                    px={hasMultipleImages ? 3 : 0}
                     key={image.id}
                   >
                     <Lightbox
@@ -152,6 +151,7 @@ const ArrowButton = ({ direction, onClick }) => {
       flexDirection="column"
       justifyContent="center"
       height="100%"
+      alignItems={direction === "left" ? "flex-start" : "flex-end"}
       onClick={onClick}
     >
       <Arrow direction={direction} fontSize="24px" />

--- a/src/Apps/__stories__/ArtworkApp.story.tsx
+++ b/src/Apps/__stories__/ArtworkApp.story.tsx
@@ -100,3 +100,11 @@ storiesOf("Apps/Artwork Page", module)
       />
     )
   })
+  .add("Artwork with multiple images", () => {
+    return (
+      <MockRouter
+        routes={artworkRoutes}
+        initialRoute="/artwork/pablo-picasso-jamie-sebartes-a-los-toros-mit-picasso-bloch-1014-47-cramer-113-4"
+      />
+    )
+  })


### PR DESCRIPTION
Decreases padding here and there and fixes some alignment in order to increase the size: 

<img width="969" alt="screen shot 2019-01-04 at 3 45 08 pm" src="https://user-images.githubusercontent.com/236943/50716730-cf610b00-1037-11e9-9135-39b79d76cad1.png">
