### PR TITLE
[Artwork] Tighten up image size (more)

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -65,6 +65,7 @@ export class LargeArtworkImageBrowser extends React.Component<
                   <Flex
                     flexDirection="column"
                     justifyContent="center"
+                    px={hasMultipleImages ? [2, 2, 0] : 0}
                     key={image.id}
                   >
                     <Lightbox


### PR DESCRIPTION
Tiny follow up to https://github.com/artsy/reaction/pull/1799 that provides a little more padding for the arrows on smaller browsers.