### PR TITLE
Fix offer cancelled messages

### DIFF
--- a/src/Apps/Order/Routes/Status/index.tsx
+++ b/src/Apps/Order/Routes/Status/index.tsx
@@ -99,7 +99,7 @@ export class StatusRoute extends Component<StatusProps> {
       }
       case "CANCELED":
       case "REFUNDED":
-        return isOfferFlow
+        return isOfferFlow && state === "CANCELED"
           ? this.getCanceledOfferOrderCopy()
           : {
               title: "Your order was canceled and refunded",

--- a/src/Apps/Order/Routes/Status/index.tsx
+++ b/src/Apps/Order/Routes/Status/index.tsx
@@ -38,6 +38,7 @@ export interface StatusProps {
 
 const Paragraph = styled.p`
   margin-top: 0;
+
   :last-child {
     margin-bottom: 0;
   }

--- a/src/Apps/Order/Routes/Status/index.tsx
+++ b/src/Apps/Order/Routes/Status/index.tsx
@@ -17,10 +17,19 @@ import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { HorizontalPadding } from "Styleguide/Utils/HorizontalPadding"
 import { get } from "Utils/get"
+import createLogger from "Utils/logger"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "../../Components/ArtworkSummaryItem"
 import { CreditCardSummaryItemFragmentContainer as CreditCardSummaryItem } from "../../Components/CreditCardSummaryItem"
 import { Helper } from "../../Components/Helper"
 import { ShippingSummaryItemFragmentContainer as ShippingSummaryItem } from "../../Components/ShippingSummaryItem"
+
+const logger = createLogger("Order/Routes/Status/index.tsx")
+
+interface StatusData {
+  title: React.ReactNode
+  description: React.ReactNode
+  backToArtsyHref?: string
+}
 
 export interface StatusProps {
   order: Status_order
@@ -28,161 +37,145 @@ export interface StatusProps {
 }
 
 export class StatusRoute extends Component<StatusProps> {
-  stateCopy = () => {
+  getStatusCopy(): StatusData {
     const { state, requestedFulfillment, mode, stateReason } = this.props.order
     const isOfferFlow = mode === "OFFER"
-    const buyerRejectedOffer = stateReason === "buyer_rejected"
+    const isShip = requestedFulfillment.__typename === "Ship"
+
     switch (state) {
       case "SUBMITTED":
         return isOfferFlow
-          ? "Your offer has been submitted"
-          : "Your order has been submitted"
+          ? {
+              title: "Your offer has been submitted",
+              description: (
+                <>
+                  The seller has 48 hours to respond to your offer. Keep in mind
+                  making an offer doesn’t guarantee you the work.
+                </>
+              ),
+            }
+          : {
+              title: "Your order has been submitted",
+              description: (
+                <>
+                  Thank you for your purchase. You will receive a confirmation
+                  email within 2 days.
+                </>
+              ),
+            }
       case "APPROVED":
-        return isOfferFlow ? "Offer accepted" : "Your order is confirmed"
-      case "FULFILLED":
-        return requestedFulfillment.__typename === "Ship"
-          ? "Your order has shipped"
-          : "Your order has been picked up"
-      case "CANCELED":
-        if (buyerRejectedOffer) {
-          return "Offer declined"
-        } else {
-          return "Your order was canceled and refunded"
-        }
-    }
-  }
-
-  render() {
-    const { order } = this.props
-
-    const isOfferFlow = order.mode === "OFFER"
-    const buyerRejectedOffer = order.stateReason === "buyer_rejected"
-    const message = isOfferFlow
-      ? offerMessages[order.state] || orderMessages[order.state]
-      : orderMessages[order.state]
-    const flowName = isOfferFlow ? "Offer" : "Order"
-    const userMessage = message && message(this.props)
-
-    return (
-      <HorizontalPadding>
-        <Serif size="6" weight="regular" color="black100">
-          {this.stateCopy()}
-        </Serif>
-        <Sans size="2" weight="regular" color="black60" mb={[2, 3]}>
-          {flowName} #{order.code}
-        </Sans>
-        <TwoColumnLayout
-          Content={
+        return {
+          title: isOfferFlow ? "Offer accepted" : "Your order is confirmed",
+          description: isShip ? (
             <>
-              <Title>{flowName} status | Artsy</Title>
-              <Join separator={<Spacer mb={[2, 3]} />}>
-                {userMessage && <Message p={[2, 3]}>{userMessage}</Message>}
-                {buyerRejectedOffer ? (
-                  <Button
-                    onClick={() => {
-                      window.location.href = "/"
-                    }}
-                    size="large"
-                    width="100%"
-                  >
-                    Back to Artsy
-                  </Button>
-                ) : (
-                  <Flex flexDirection="column">
-                    <ArtworkSummaryItem order={order} />
-                    <TransactionDetailsSummaryItem
-                      order={order}
-                      useLastSubmittedOffer
-                    />
-                  </Flex>
-                )}
-              </Join>
-              <Spacer mb={[2, 3]} />
+              Thank you for your purchase. You will be notified when the work
+              has shipped, typically within 5–7 business days.
             </>
+          ) : (
+            <>
+              Thank you for your purchase. A specialist will contact you within
+              2 business days to coordinate pickup.
+            </>
+          ),
+        }
+      case "FULFILLED": {
+        return isShip
+          ? {
+              title: "Your order has shipped",
+              description: this.getFulfilmentDescription(),
+            }
+          : {
+              title: "Your order has been picked up",
+              description: null,
+            }
+      }
+      case "CANCELED": {
+        if (!isOfferFlow) {
+          return {
+            title: "Your order was canceled and refunded",
+            description: (
+              <>
+                Please allow 5–7 business days for the refund to appear on your
+                bank statement. Contact{" "}
+                <a href="mailto:orders@artsy.net">orders@artsy.net</a> with any
+                questions.
+              </>
+            ),
           }
-          Sidebar={
-            !buyerRejectedOffer && (
-              <Flex flexDirection="column">
-                <Flex flexDirection="column">
-                  <ShippingSummaryItem order={order} />
-                  <CreditCardSummaryItem order={order} />
-                </Flex>
-                <Spacer mb={[2, 3]} />
-                <Helper
-                  artworkId={get(
-                    order,
-                    o => o.lineItems.edges[0].node.artwork.id
-                  )}
-                />
-              </Flex>
-            )
-          }
-        />
-      </HorizontalPadding>
-    )
-  }
-}
+        }
 
-const offerMessages = {
-  SUBMITTED: () => {
-    return (
-      <>
-        The seller has 48 hours to respond to your offer. Keep in mind making an
-        offer doesn’t guarantee you the work.
-      </>
-    )
-  },
-  CANCELED: (props: StatusProps) => {
-    if (props.order.stateReason === "buyer_rejected") {
-      return orderMessages.CANCELED()
+        switch (stateReason) {
+          case "buyer_rejected":
+            return {
+              title: "Offer declined",
+              description: (
+                <>
+                  <p>
+                    Thank you for your response. The seller will be informed of
+                    your decision to end the negotiation process.
+                  </p>
+                  <p>
+                    We’d love to get your feedback. Contact{" "}
+                    <a href="mailto:orders@artsy.net">orders@artsy.net</a> with
+                    any comments you have.
+                  </p>
+                </>
+              ),
+            }
+          case "seller_rejected_offer_too_low":
+          case "seller_rejected_shipping_unavailable":
+          case "seller_rejected":
+          case "seller_rejected_artwork_unavailable":
+          case "seller_rejected_other":
+            return {
+              title: "Offer declined",
+              description: (
+                <p>
+                  Sorry, the seller declined your offer and has ended the
+                  negotiation process.
+                </p>
+              ),
+            }
+          case "buyer_lapsed":
+            return {
+              title: "Offer expired",
+              description: (
+                <p>
+                  The seller’s offer expired because you didn’t respond in time.
+                </p>
+              ),
+            }
+          case "seller_lapsed":
+            return {
+              title: "Offer expired",
+              description: (
+                <p>
+                  Your offer expired because the seller didn’t respond to your
+                  offer in time.
+                </p>
+              ),
+            }
+          default:
+            // This should not happen. Check the cancel reasons are all accounted for:
+            // https://github.com/artsy/exchange/blob/master/app/models/order.rb
+            logger.error(`Unhandled cancellation reason: ${stateReason}`)
+            return {
+              title: "Offer declined",
+              description: null,
+            }
+        }
+      }
     }
-    return (
-      <>
-        <p>
-          Thank you for your response. The seller will be informed of your
-          decision to end the negotiation process.
-        </p>
-        <p>
-          We’d love to get your feedback. Contact{" "}
-          <a href="mailto:orders@artsy.net">orders@artsy.net</a> with any
-          comments you have.
-        </p>
-      </>
-    )
-  },
-}
+  }
 
-const orderMessages = {
-  SUBMITTED: () => (
-    <>
-      Thank you for your purchase. You will receive a confirmation email within
-      2 days.
-    </>
-  ),
-  APPROVED: ({ order: { requestedFulfillment } }) => {
-    return requestedFulfillment.__typename === "Ship" ? (
-      <>
-        Thank you for your purchase. You will be notified when the work has
-        shipped, typically within 5–7 business days.
-      </>
-    ) : (
-      <>
-        Thank you for your purchase. A specialist will contact you within 2
-        business days to coordinate pickup.
-      </>
-    )
-  },
-  FULFILLED: ({ order }) => {
+  getFulfilmentDescription(): React.ReactNode {
     const fulfillment = get(
-      order,
+      this.props.order,
       o => o.lineItems.edges[0].node.fulfillments.edges[0].node
     )
+
     if (!fulfillment) {
-      return false
-    }
-    const { requestedFulfillment } = order
-    if (requestedFulfillment.__typename !== "Ship") {
-      return false
+      return null
     }
 
     return (
@@ -207,14 +200,74 @@ const orderMessages = {
         )}
       </>
     )
-  },
-  CANCELED: () => (
-    <>
-      Please allow 5–7 business days for the refund to appear on your bank
-      statement. Contact <a href="mailto:orders@artsy.net">orders@artsy.net</a>{" "}
-      with any questions.
-    </>
-  ),
+  }
+
+  render() {
+    const { order } = this.props
+
+    const isOfferFlow = order.mode === "OFFER"
+    const offerOrderCanceled = isOfferFlow && order.state === "CANCELED"
+    const flowName = isOfferFlow ? "Offer" : "Order"
+    const { title, description } = this.getStatusCopy()
+
+    return (
+      <HorizontalPadding>
+        <Serif size="6" weight="regular" color="black100">
+          {title}
+        </Serif>
+        <Sans size="2" weight="regular" color="black60" mb={[2, 3]}>
+          {flowName} #{order.code}
+        </Sans>
+        <TwoColumnLayout
+          Content={
+            <>
+              <Title>{flowName} status | Artsy</Title>
+              <Join separator={<Spacer mb={[2, 3]} />}>
+                {description && <Message p={[2, 3]}>{description}</Message>}
+                {offerOrderCanceled ? (
+                  <Button
+                    onClick={() => {
+                      window.location.href = "/"
+                    }}
+                    size="large"
+                    width="100%"
+                  >
+                    Back to Artsy
+                  </Button>
+                ) : (
+                  <Flex flexDirection="column">
+                    <ArtworkSummaryItem order={order} />
+                    <TransactionDetailsSummaryItem
+                      order={order}
+                      useLastSubmittedOffer
+                    />
+                  </Flex>
+                )}
+              </Join>
+              <Spacer mb={[2, 3]} />
+            </>
+          }
+          Sidebar={
+            !offerOrderCanceled && (
+              <Flex flexDirection="column">
+                <Flex flexDirection="column">
+                  <ShippingSummaryItem order={order} />
+                  <CreditCardSummaryItem order={order} />
+                </Flex>
+                <Spacer mb={[2, 3]} />
+                <Helper
+                  artworkId={get(
+                    order,
+                    o => o.lineItems.edges[0].node.artwork.id
+                  )}
+                />
+              </Flex>
+            )
+          }
+        />
+      </HorizontalPadding>
+    )
+  }
 }
 
 export const StatusFragmentContainer = createFragmentContainer(

--- a/src/Apps/Order/Routes/__tests__/Status.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.test.tsx
@@ -6,6 +6,7 @@ import {
   OfferOrderPickup,
   OfferOrderWithShippingDetails,
 } from "Apps/__tests__/Fixtures/Order"
+import { TransactionDetailsSummaryItem } from "Apps/Order/Components/TransactionDetailsSummaryItem"
 import { trackPageView } from "Apps/Order/Utils/trackPageView"
 import { MockBoot, renderRelayTree } from "DevTools"
 import { render } from "enzyme"
@@ -161,6 +162,19 @@ describe("Status", () => {
         })
         expect(wrapper.text()).toContain("Your order was canceled and refunded")
         expect(wrapper.find(Message).length).toBe(1)
+      })
+    })
+
+    describe("canceled after accpet", () => {
+      it("should say that order was canceled", async () => {
+        const wrapper = await getWrapper({
+          ...OfferOrderPickup,
+          state: "CANCELED",
+          stateReason: null,
+        })
+        expect(wrapper.text()).toContain("Your order was canceled and refunded")
+        expect(wrapper.find(Message).length).toBe(1)
+        expect(wrapper.find(TransactionDetailsSummaryItem).length).toBe(1)
       })
     })
   })

--- a/src/Apps/Order/Routes/__tests__/Status.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.test.tsx
@@ -152,6 +152,17 @@ describe("Status", () => {
         expect(wrapper.find(Message).length).toBe(1)
       })
     })
+
+    describe("refunded", () => {
+      it("should say that order was canceled", async () => {
+        const wrapper = await getWrapper({
+          ...OfferOrderPickup,
+          state: "REFUNDED",
+        })
+        expect(wrapper.text()).toContain("Your order was canceled and refunded")
+        expect(wrapper.find(Message).length).toBe(1)
+      })
+    })
   })
 
   describe("orders", () => {
@@ -221,6 +232,17 @@ describe("Status", () => {
         const wrapper = await getWrapper({
           ...BuyOrderPickup,
           state: "CANCELED",
+        })
+        expect(wrapper.text()).toContain("Your order was canceled and refunded")
+        expect(wrapper.find(Message).length).toBe(1)
+      })
+    })
+
+    describe("refunded", () => {
+      it("should say that order was canceled", async () => {
+        const wrapper = await getWrapper({
+          ...BuyOrderPickup,
+          state: "REFUNDED",
         })
         expect(wrapper.text()).toContain("Your order was canceled and refunded")
         expect(wrapper.find(Message).length).toBe(1)

--- a/src/Apps/Order/Routes/__tests__/Status.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.test.tsx
@@ -39,7 +39,13 @@ describe("Status", () => {
   describe("offers", () => {
     it("should should have a title containing status", async () => {
       const headTags: JSX.Element[] = []
-      await getWrapper(OfferOrderWithShippingDetails, headTags)
+      await getWrapper(
+        {
+          ...OfferOrderWithShippingDetails,
+          state: "SUBMITTED",
+        },
+        headTags
+      )
       expect(headTags.length).toEqual(1)
       expect(render(headTags[0]).text()).toBe("Offer status | Artsy")
     })
@@ -99,28 +105,6 @@ describe("Status", () => {
       })
     })
 
-    describe("canceled (ship)", () => {
-      it("should say that order was canceled", async () => {
-        const wrapper = await getWrapper({
-          ...OfferOrderWithShippingDetails,
-          state: "CANCELED",
-        })
-        expect(wrapper.text()).toContain("Your order was canceled and refunded")
-        expect(wrapper.find(Message).length).toBe(1)
-      })
-    })
-
-    describe("canceled (pickup)", () => {
-      it("should say that order was canceled", async () => {
-        const wrapper = await getWrapper({
-          ...OfferOrderPickup,
-          state: "CANCELED",
-        })
-        expect(wrapper.text()).toContain("Your order was canceled and refunded")
-        expect(wrapper.find(Message).length).toBe(1)
-      })
-    })
-
     describe("buyer rejected", () => {
       it("should say that offer was declined", async () => {
         const wrapper = await getWrapper({
@@ -129,6 +113,42 @@ describe("Status", () => {
           stateReason: "buyer_rejected",
         })
         expect(wrapper.text()).toContain("Offer declined")
+        expect(wrapper.find(Message).length).toBe(1)
+      })
+    })
+
+    describe("seller rejected", () => {
+      it("should say that offer was declined", async () => {
+        const wrapper = await getWrapper({
+          ...OfferOrderPickup,
+          state: "CANCELED",
+          stateReason: "seller_rejected",
+        })
+        expect(wrapper.text()).toContain("Offer declined")
+        expect(wrapper.find(Message).length).toBe(1)
+      })
+    })
+
+    describe("seller lapsed", () => {
+      it("should say that offer expired", async () => {
+        const wrapper = await getWrapper({
+          ...OfferOrderPickup,
+          state: "CANCELED",
+          stateReason: "seller_lapsed",
+        })
+        expect(wrapper.text()).toContain("offer expired")
+        expect(wrapper.find(Message).length).toBe(1)
+      })
+    })
+
+    describe("buyer lapsed", () => {
+      it("should say that offer expired", async () => {
+        const wrapper = await getWrapper({
+          ...OfferOrderPickup,
+          state: "CANCELED",
+          stateReason: "buyer_lapsed",
+        })
+        expect(wrapper.text()).toContain("offer expired")
         expect(wrapper.find(Message).length).toBe(1)
       })
     })

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -327,30 +327,42 @@ storiesOf("Apps/Order Page/Make Offer/Status", module)
       })}
     />
   ))
-  .add("canceled (ship)", () => (
-    <Router
-      initialRoute="/orders/123/status"
-      mockResolvers={mockResolver({
-        ...OfferOrderWithShippingDetails,
-        state: "CANCELED",
-      })}
-    />
-  ))
-  .add("canceled (pickup)", () => (
-    <Router
-      initialRoute="/orders/123/status"
-      mockResolvers={mockResolver({
-        ...OfferOrderPickup,
-        state: "CANCELED",
-      })}
-    />
-  ))
   .add("buyer rejected", () => (
     <Router
       initialRoute="/orders/123/status"
       mockResolvers={mockResolver({
         ...OfferOrderWithShippingDetails,
         stateReason: "buyer_rejected",
+        state: "CANCELED",
+      })}
+    />
+  ))
+  .add("seller rejected", () => (
+    <Router
+      initialRoute="/orders/123/status"
+      mockResolvers={mockResolver({
+        ...OfferOrderWithShippingDetails,
+        stateReason: "seller_rejected",
+        state: "CANCELED",
+      })}
+    />
+  ))
+  .add("buyer lapsed", () => (
+    <Router
+      initialRoute="/orders/123/status"
+      mockResolvers={mockResolver({
+        ...OfferOrderWithShippingDetails,
+        stateReason: "buyer_lapsed",
+        state: "CANCELED",
+      })}
+    />
+  ))
+  .add("seller lapsed", () => (
+    <Router
+      initialRoute="/orders/123/status"
+      mockResolvers={mockResolver({
+        ...OfferOrderWithShippingDetails,
+        stateReason: "seller_lapsed",
         state: "CANCELED",
       })}
     />

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -123,6 +123,12 @@ storiesOf("Apps/Order Page/Buy Now/Status", module)
       mockResolvers={mockResolver({ ...BuyOrderPickup, state: "CANCELED" })}
     />
   ))
+  .add("refunded", () => (
+    <Router
+      initialRoute="/orders/123/status"
+      mockResolvers={mockResolver({ ...BuyOrderPickup, state: "REFUNDED" })}
+    />
+  ))
 
 storiesOf("Apps/Order Page/Make Offer/Offer", module).add("Empty", () => (
   <Router
@@ -364,6 +370,15 @@ storiesOf("Apps/Order Page/Make Offer/Status", module)
         ...OfferOrderWithShippingDetails,
         stateReason: "seller_lapsed",
         state: "CANCELED",
+      })}
+    />
+  ))
+  .add("refunded", () => (
+    <Router
+      initialRoute="/orders/123/status"
+      mockResolvers={mockResolver({
+        ...OfferOrderWithShippingDetails,
+        state: "REFUNDED",
       })}
     />
   ))

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -382,3 +382,13 @@ storiesOf("Apps/Order Page/Make Offer/Status", module)
       })}
     />
   ))
+  .add("cancelled after accept", () => (
+    <Router
+      initialRoute="/orders/123/status"
+      mockResolvers={mockResolver({
+        ...OfferOrderWithShippingDetails,
+        state: "CANCELED",
+        stateReason: null,
+      })}
+    />
+  ))


### PR DESCRIPTION
Hi! :wave:

https://artsyproduct.atlassian.net/browse/PURCHASE-784

This ticket was filed because the copy on the status page was wrong for cancelled offer orders. We were incorrectly handing the 'buyer_rejected' cancellation reason and not even handling any of the others. (see here for the full list https://github.com/artsy/exchange/blob/6fb90698b1c0c33c3a50341f460e6a90647f48d4/app/models/order.rb#L39)

Brian and Joanna had a sync and we decided to handle the following four reasons with specific copy: `buyer_rejected`, `seller_rejected`, `seller_lapsed`, and `buyer_lapsed`. The remaining reasons fall under `seller_rejected` for now.

So that's what I've added here.

In addition I decided to refactor the logic for deciding which copy to show on the status page. It was getting messy (which I believe was the reason we ended up handling `buyer_rejected` incorrectly in the first place) and these new requirements would have made it even messier. So apologies for the big diff. Hopefully it will be a little easier to see what's going on now.

Finally I noticed that we weren't handling the `REFUNDED` state 🙈 so I did that too (it's the same as the BN `CANCELED` status page).