### PR TITLE
Not show contact gallery for works enabled for BNMO

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -369,15 +369,6 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         ) : (
           <Separator mb={3} mt={3} />
         )}
-        {artwork.is_inquireable && (
-          <Button
-            width="100%"
-            size="large"
-            onClick={this.handleInquiry.bind(this)}
-          >
-            Contact gallery
-          </Button>
-        )}
         {artwork.is_acquireable && (
           <Button
             width="100%"
@@ -404,6 +395,17 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             </Button>
           </>
         )}
+        {artwork.is_inquireable &&
+          !artwork.is_acquireable &&
+          !artwork.is_offerable && (
+            <Button
+              width="100%"
+              size="large"
+              onClick={this.handleInquiry.bind(this)}
+            >
+              Contact gallery
+            </Button>
+          )}
 
         <ErrorModal
           onClose={this.onCloseModal}

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.test.tsx
@@ -2,6 +2,7 @@ import {
   ArtworkBuyNow,
   ArtworkBuyNowMakeOffer,
   ArtworkMakeOffer,
+  ArtworkOfferableAndInquireable,
   ArtworkSingleEditionHiddenAvailability,
   ArtworkSold,
 } from "Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarCommercial"
@@ -77,6 +78,15 @@ describe("ArtworkSidebarCommercial", () => {
     const wrapper = await getWrapper(artwork)
 
     expect(wrapper.text()).toContain("Make offer")
+  })
+
+  it("displays artwork enrolled in Make Offer when enbaled for both make offer and inquiry", async () => {
+    const artwork = Object.assign({}, ArtworkOfferableAndInquireable)
+
+    const wrapper = await getWrapper(artwork)
+
+    expect(wrapper.text()).toContain("Make offer")
+    expect(wrapper.text()).not.toContain("Contact gallery")
   })
 
   it("displays artwork enrolled in both Buy Now and Make Offer", async () => {

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.test.tsx
@@ -80,7 +80,7 @@ describe("ArtworkSidebarCommercial", () => {
     expect(wrapper.text()).toContain("Make offer")
   })
 
-  it("displays artwork enrolled in Make Offer when enbaled for both make offer and inquiry", async () => {
+  it("displays artwork enrolled in Make Offer when enabled for both make offer and inquiry", async () => {
     const artwork = Object.assign({}, ArtworkOfferableAndInquireable)
 
     const wrapper = await getWrapper(artwork)

--- a/src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarCommercial.ts
+++ b/src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarCommercial.ts
@@ -72,6 +72,18 @@ export const ContactForPriceWork = {
   ],
 }
 
+export const ArtworkOfferableAndInquireable = {
+  __id: "artwork_offer_inquireable",
+  sale_message: "$10,000",
+  is_acquireable: false,
+  is_inquireable: true,
+  is_offerable: true,
+  pickup_available: false,
+  edition_sets: [],
+  shippingInfo: "Shipping: Free shipping worldwide",
+  shippingOrigin: "New York, New York, US",
+}
+
 export const ArtworkBuyNow = {
   __id: "artwork_buy_now",
   sale_message: "$10,000",


### PR DESCRIPTION
# Problem
When works are enabled for offerable we should not show contact gallery.

![image](https://user-images.githubusercontent.com/1230819/50790815-fd3f8d00-128d-11e9-8075-c8d63d87edd8.png)

# Solution
Make sure we show contact gallery if work is not BN/MO enabled