### PR TITLE
[Artwork] Add tracking to OtherWorks ArtworkGrid bricks

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
@@ -1,21 +1,32 @@
 import { Box, Flex } from "@artsy/palette"
+import { ArtworkRelatedArtists_artwork } from "__generated__/ArtworkRelatedArtists_artwork.graphql"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { ContextConsumer } from "Artsy/Router"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { ArtistCardFragmentContainer as ArtistCard } from "Styleguide/Components"
-import { Header } from "./OtherWorks/Header"
-
-import { ArtworkRelatedArtists_artwork } from "__generated__/ArtworkRelatedArtists_artwork.graphql"
 import { hideGrid } from "./OtherWorks/ArtworkContexts/ArtworkGrids"
+import { Header } from "./OtherWorks/Header"
 
 export interface ArtworkRelatedArtistsProps {
   artwork: ArtworkRelatedArtists_artwork
 }
 
+@track({
+  context_module: Schema.ContextModule.RelatedArtists,
+})
 export class ArtworkRelatedArtists extends React.Component<
   ArtworkRelatedArtistsProps
 > {
+  @track({
+    type: Schema.Type.ArtistCard,
+  })
+  trackArtistCardClick() {
+    // noop
+  }
+
   render() {
     const {
       artwork: { artist },
@@ -40,6 +51,7 @@ export class ArtworkRelatedArtists extends React.Component<
                         artist={node}
                         mediator={mediator}
                         user={user}
+                        onClick={this.trackArtistCardClick.bind(this)}
                       />
                     </Box>
                   )

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/ArtistArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/ArtistArtworkGrid.tsx
@@ -1,19 +1,28 @@
 import { ArtistArtworkGrid_artwork } from "__generated__/ArtistArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
-import { withContext } from "Artsy/SystemContext"
+import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { Header } from "../../Header"
 
-export const ArtistArtworkGridFragmentContainer = createFragmentContainer<{
+interface ArtistArtworkGridProps {
   artwork: ArtistArtworkGrid_artwork
-}>(
-  withContext(({ artwork: { artist }, mediator }) => {
+  mediator?: Mediator
+}
+
+export class ArtistArtworkGrid extends React.Component<ArtistArtworkGridProps> {
+  render() {
+    const {
+      artwork: { artist },
+      mediator,
+    } = this.props
+
     if (!artist || hideGrid(artist.artworks_connection)) {
       return null
     }
+
     return (
       <>
         <Header
@@ -24,10 +33,17 @@ export const ArtistArtworkGridFragmentContainer = createFragmentContainer<{
           artworks={artist.artworks_connection}
           columnCount={[2, 3, 4]}
           mediator={mediator}
+          onBrickClick={() => {
+            console.log("clicking artist artwork grid")
+          }}
         />
       </>
     )
-  }),
+  }
+}
+
+export const ArtistArtworkGridFragmentContainer = createFragmentContainer(
+  withContext(ArtistArtworkGrid),
   graphql`
     fragment ArtistArtworkGrid_artwork on Artwork
       @argumentDefinitions(excludeArtworkIDs: { type: "[String!]" }) {
@@ -57,5 +73,3 @@ export const ArtistArtworkGridFragmentContainer = createFragmentContainer<{
     }
   `
 )
-
-ArtistArtworkGridFragmentContainer.displayName = "ArtistArtworkGrid"

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/ArtistArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/ArtistArtworkGrid.tsx
@@ -1,5 +1,7 @@
 import { ArtistArtworkGrid_artwork } from "__generated__/ArtistArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
@@ -12,7 +14,17 @@ interface ArtistArtworkGridProps {
   mediator?: Mediator
 }
 
+@track({
+  context_module: Schema.ContextModule.OtherWorksByArtist,
+})
 export class ArtistArtworkGrid extends React.Component<ArtistArtworkGridProps> {
+  @track({
+    type: Schema.Type.ArtworkBrick,
+  })
+  trackBrickClick() {
+    // noop
+  }
+
   render() {
     const {
       artwork: { artist },
@@ -33,9 +45,7 @@ export class ArtistArtworkGrid extends React.Component<ArtistArtworkGridProps> {
           artworks={artist.artworks_connection}
           columnCount={[2, 3, 4]}
           mediator={mediator}
-          onBrickClick={() => {
-            console.log("clicking artist artwork grid")
-          }}
+          onBrickClick={this.trackBrickClick.bind(this)}
         />
       </>
     )

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/AuctionArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/AuctionArtworkGrid.tsx
@@ -1,41 +1,52 @@
 import { AuctionArtworkGrid_artwork } from "__generated__/AuctionArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
-import { withContext } from "Artsy/SystemContext"
+import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { Header } from "../../Header"
 
-export const AuctionArtworkGridFragmentContainer = createFragmentContainer<{
+interface AuctionArtworkGridProps {
   artwork: AuctionArtworkGrid_artwork
-}>(
-  withContext(
-    ({
+  mediator?: Mediator
+}
+
+class AuctionArtworkGrid extends React.Component<AuctionArtworkGridProps> {
+  render() {
+    const {
       artwork: {
         sale: { artworksConnection, href },
       },
       mediator,
-    }) => {
-      if (hideGrid(artworksConnection)) {
-        return null
-      }
-      return (
-        <>
-          <Header
-            title="Other works from the auction"
-            buttonHref={sd.APP_URL + href}
-          />
+    } = this.props
 
-          <ArtworkGrid
-            artworks={artworksConnection}
-            columnCount={[2, 3, 4]}
-            mediator={mediator}
-          />
-        </>
-      )
+    if (hideGrid(artworksConnection)) {
+      return null
     }
-  ),
+
+    return (
+      <>
+        <Header
+          title="Other works from the auction"
+          buttonHref={sd.APP_URL + href}
+        />
+
+        <ArtworkGrid
+          artworks={artworksConnection}
+          columnCount={[2, 3, 4]}
+          mediator={mediator}
+          onBrickClick={() => {
+            console.log("clicking auction artwork grid")
+          }}
+        />
+      </>
+    )
+  }
+}
+
+export const AuctionArtworkGridFragmentContainer = createFragmentContainer(
+  withContext(AuctionArtworkGrid),
   graphql`
     fragment AuctionArtworkGrid_artwork on Artwork
       @argumentDefinitions(excludeArtworkIDs: { type: "[String!]" }) {
@@ -55,5 +66,3 @@ export const AuctionArtworkGridFragmentContainer = createFragmentContainer<{
     }
   `
 )
-
-AuctionArtworkGridFragmentContainer.displayName = "AuctionArtworkGrid"

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/AuctionArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/AuctionArtworkGrid.tsx
@@ -1,5 +1,7 @@
 import { AuctionArtworkGrid_artwork } from "__generated__/AuctionArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
@@ -12,7 +14,17 @@ interface AuctionArtworkGridProps {
   mediator?: Mediator
 }
 
+@track({
+  context_module: Schema.ContextModule.OtherWorksInAuction,
+})
 class AuctionArtworkGrid extends React.Component<AuctionArtworkGridProps> {
+  @track({
+    type: Schema.Type.ArtworkBrick,
+  })
+  trackBrickClick() {
+    // noop
+  }
+
   render() {
     const {
       artwork: {
@@ -36,9 +48,7 @@ class AuctionArtworkGrid extends React.Component<AuctionArtworkGridProps> {
           artworks={artworksConnection}
           columnCount={[2, 3, 4]}
           mediator={mediator}
-          onBrickClick={() => {
-            console.log("clicking auction artwork grid")
-          }}
+          onBrickClick={this.trackBrickClick.bind(this)}
         />
       </>
     )

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/FairArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/FairArtworkGrid.tsx
@@ -1,5 +1,7 @@
 import { FairArtworkGrid_artwork } from "__generated__/FairArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
@@ -12,7 +14,17 @@ interface FairArtworkGridProps {
   mediator?: Mediator
 }
 
+@track({
+  context_module: Schema.ContextModule.OtherWorksInFair,
+})
 class FairArtworkGrid extends React.Component<FairArtworkGridProps> {
+  @track({
+    type: Schema.Type.ArtworkBrick,
+  })
+  trackBrickClick() {
+    // noop
+  }
+
   render() {
     const {
       artwork: {
@@ -35,9 +47,7 @@ class FairArtworkGrid extends React.Component<FairArtworkGridProps> {
           artworks={artworksConnection}
           columnCount={[2, 3, 4]}
           mediator={mediator}
-          onBrickClick={() => {
-            console.log("clicking fair artwork grid")
-          }}
+          onBrickClick={this.trackBrickClick.bind(this)}
         />
       </>
     )

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/FairArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/FairArtworkGrid.tsx
@@ -1,40 +1,51 @@
 import { FairArtworkGrid_artwork } from "__generated__/FairArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
-import { withContext } from "Artsy/SystemContext"
+import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { Header } from "../../Header"
 
-export const FairArtworkGridFragmentContainer = createFragmentContainer<{
+interface FairArtworkGridProps {
   artwork: FairArtworkGrid_artwork
-}>(
-  withContext(
-    ({
+  mediator?: Mediator
+}
+
+class FairArtworkGrid extends React.Component<FairArtworkGridProps> {
+  render() {
+    const {
       artwork: {
         fair: { href, artworksConnection },
       },
       mediator,
-    }) => {
-      if (hideGrid(artworksConnection)) {
-        return null
-      }
-      return (
-        <>
-          <Header
-            title={"Other works from the booth"}
-            buttonHref={sd.APP_URL + href}
-          />
-          <ArtworkGrid
-            artworks={artworksConnection}
-            columnCount={[2, 3, 4]}
-            mediator={mediator}
-          />
-        </>
-      )
+    } = this.props
+
+    if (hideGrid(artworksConnection)) {
+      return null
     }
-  ),
+
+    return (
+      <>
+        <Header
+          title={"Other works from the booth"}
+          buttonHref={sd.APP_URL + href}
+        />
+        <ArtworkGrid
+          artworks={artworksConnection}
+          columnCount={[2, 3, 4]}
+          mediator={mediator}
+          onBrickClick={() => {
+            console.log("clicking fair artwork grid")
+          }}
+        />
+      </>
+    )
+  }
+}
+
+export const FairArtworkGridFragmentContainer = createFragmentContainer(
+  withContext(FairArtworkGrid),
   graphql`
     fragment FairArtworkGrid_artwork on Artwork
       @argumentDefinitions(excludeArtworkIDs: { type: "[String!]" }) {
@@ -55,5 +66,3 @@ export const FairArtworkGridFragmentContainer = createFragmentContainer<{
     }
   `
 )
-
-FairArtworkGridFragmentContainer.displayName = "FairArtworkGrid"

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerArtworkGrid.tsx
@@ -1,40 +1,51 @@
 import { PartnerArtworkGrid_artwork } from "__generated__/PartnerArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
-import { withContext } from "Artsy/SystemContext"
+import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { Header } from "../../Header"
 
-export const PartnerArtworkGridFragmentContainer = createFragmentContainer<{
+interface PartnerArtworkGridProps {
   artwork: PartnerArtworkGrid_artwork
-}>(
-  withContext(
-    ({
+  mediator?: Mediator
+}
+
+class PartnerArtworkGrid extends React.Component<PartnerArtworkGridProps> {
+  render() {
+    const {
       artwork: {
         partner: { artworksConnection, href, name },
       },
       mediator,
-    }) => {
-      if (hideGrid(artworksConnection)) {
-        return null
-      }
-      return (
-        <>
-          <Header
-            title={`Other works from ${name}`}
-            buttonHref={sd.APP_URL + href}
-          />
-          <ArtworkGrid
-            artworks={artworksConnection}
-            columnCount={[2, 3, 4]}
-            mediator={mediator}
-          />
-        </>
-      )
+    } = this.props
+
+    if (hideGrid(artworksConnection)) {
+      return null
     }
-  ),
+
+    return (
+      <>
+        <Header
+          title={`Other works from ${name}`}
+          buttonHref={sd.APP_URL + href}
+        />
+        <ArtworkGrid
+          artworks={artworksConnection}
+          columnCount={[2, 3, 4]}
+          mediator={mediator}
+          onBrickClick={() => {
+            console.log("clicking partner artwork grid")
+          }}
+        />
+      </>
+    )
+  }
+}
+
+export const PartnerArtworkGridFragmentContainer = createFragmentContainer(
+  withContext(PartnerArtworkGrid),
   graphql`
     fragment PartnerArtworkGrid_artwork on Artwork
       @argumentDefinitions(excludeArtworkIDs: { type: "[String!]" }) {
@@ -60,5 +71,3 @@ export const PartnerArtworkGridFragmentContainer = createFragmentContainer<{
     }
   `
 )
-
-PartnerArtworkGridFragmentContainer.displayName = "PartnerArtworkGrid"

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerArtworkGrid.tsx
@@ -1,5 +1,7 @@
 import { PartnerArtworkGrid_artwork } from "__generated__/PartnerArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
@@ -12,7 +14,17 @@ interface PartnerArtworkGridProps {
   mediator?: Mediator
 }
 
+@track({
+  context_module: Schema.ContextModule.OtherWorksFromGallery,
+})
 class PartnerArtworkGrid extends React.Component<PartnerArtworkGridProps> {
+  @track({
+    type: Schema.Type.ArtworkBrick,
+  })
+  trackBrickClick() {
+    // noop
+  }
+
   render() {
     const {
       artwork: {
@@ -35,9 +47,7 @@ class PartnerArtworkGrid extends React.Component<PartnerArtworkGridProps> {
           artworks={artworksConnection}
           columnCount={[2, 3, 4]}
           mediator={mediator}
-          onBrickClick={() => {
-            console.log("clicking partner artwork grid")
-          }}
+          onBrickClick={this.trackBrickClick.bind(this)}
         />
       </>
     )

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerShowArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerShowArtworkGrid.tsx
@@ -1,5 +1,7 @@
 import { PartnerShowArtworkGrid_artwork } from "__generated__/PartnerShowArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
@@ -12,9 +14,19 @@ interface PartnerShowArtworkGridProps {
   mediator?: Mediator
 }
 
+@track({
+  context_module: Schema.ContextModule.OtherWorksFromShow,
+})
 class PartnerShowArtworkGrid extends React.Component<
   PartnerShowArtworkGridProps
 > {
+  @track({
+    type: Schema.Type.ArtworkBrick,
+  })
+  trackBrickClick() {
+    // noop
+  }
+
   render() {
     const {
       artwork: {
@@ -37,9 +49,7 @@ class PartnerShowArtworkGrid extends React.Component<
           artworks={artworksConnection}
           columnCount={[2, 3, 4]}
           mediator={mediator}
-          onBrickClick={() => {
-            console.log("clicking partner show artwork grid")
-          }}
+          onBrickClick={this.trackBrickClick.bind(this)}
         />
       </>
     )

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerShowArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerShowArtworkGrid.tsx
@@ -1,40 +1,53 @@
 import { PartnerShowArtworkGrid_artwork } from "__generated__/PartnerShowArtworkGrid_artwork.graphql"
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
-import { withContext } from "Artsy/SystemContext"
+import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { Header } from "../../Header"
 
-export const PartnerShowArtworkGridFragmentContainer = createFragmentContainer<{
+interface PartnerShowArtworkGridProps {
   artwork: PartnerShowArtworkGrid_artwork
-}>(
-  withContext(
-    ({
+  mediator?: Mediator
+}
+
+class PartnerShowArtworkGrid extends React.Component<
+  PartnerShowArtworkGridProps
+> {
+  render() {
+    const {
       artwork: {
         show: { artworksConnection, href, name },
       },
       mediator,
-    }) => {
-      if (hideGrid(artworksConnection)) {
-        return null
-      }
-      return (
-        <>
-          <Header
-            title={`Other works from ${name}`}
-            buttonHref={sd.APP_URL + href}
-          />
-          <ArtworkGrid
-            artworks={artworksConnection}
-            columnCount={[2, 3, 4]}
-            mediator={mediator}
-          />
-        </>
-      )
+    } = this.props
+
+    if (hideGrid(artworksConnection)) {
+      return null
     }
-  ),
+
+    return (
+      <>
+        <Header
+          title={`Other works from ${name}`}
+          buttonHref={sd.APP_URL + href}
+        />
+        <ArtworkGrid
+          artworks={artworksConnection}
+          columnCount={[2, 3, 4]}
+          mediator={mediator}
+          onBrickClick={() => {
+            console.log("clicking partner show artwork grid")
+          }}
+        />
+      </>
+    )
+  }
+}
+
+export const PartnerShowArtworkGridFragmentContainer = createFragmentContainer(
+  withContext(PartnerShowArtworkGrid),
   graphql`
     fragment PartnerShowArtworkGrid_artwork on Artwork
       @argumentDefinitions(excludeArtworkIDs: { type: "[String!]" }) {
@@ -56,5 +69,3 @@ export const PartnerShowArtworkGridFragmentContainer = createFragmentContainer<{
     }
   `
 )
-
-PartnerShowArtworkGridFragmentContainer.displayName = "PartnerShowArtworkGrid"

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
@@ -4,6 +4,8 @@ import { RelatedWorksArtworkGridQuery } from "__generated__/RelatedWorksArtworkG
 import { hideGrid } from "Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids"
 import { Header } from "Apps/Artwork/Components/OtherWorks/Header"
 import { ContextConsumer } from "Artsy"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { Mediator, withContext } from "Artsy/SystemContext"
 import ArtworkGrid from "Components/ArtworkGrid"
@@ -34,6 +36,9 @@ interface RelatedWorksArtworkGridState {
   isLoading: boolean
 }
 
+@track({
+  context_module: Schema.ContextModule.RelatedWorks,
+})
 class RelatedWorksArtworkGrid extends React.Component<
   RelatedWorksArtworkGridProps,
   RelatedWorksArtworkGridState
@@ -59,6 +64,13 @@ class RelatedWorksArtworkGrid extends React.Component<
         }
       }
     )
+  }
+
+  @track({
+    type: Schema.Type.ArtworkBrick,
+  })
+  trackBrickClick() {
+    // noop
   }
 
   render() {
@@ -94,9 +106,7 @@ class RelatedWorksArtworkGrid extends React.Component<
                       artworks={artworksConnection}
                       columnCount={[2, 3, 4]}
                       mediator={mediator}
-                      onBrickClick={() => {
-                        console.log("clicking related works artwork grid")
-                      }}
+                      onBrickClick={this.trackBrickClick.bind(this)}
                     />
                   )}
                 </ArtworksContainer>

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
@@ -94,6 +94,9 @@ class RelatedWorksArtworkGrid extends React.Component<
                       artworks={artworksConnection}
                       columnCount={[2, 3, 4]}
                       mediator={mediator}
+                      onBrickClick={() => {
+                        console.log("clicking related works artwork grid")
+                      }}
                     />
                   )}
                 </ArtworksContainer>

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -188,6 +188,7 @@ export enum Subject {
 export enum ContextModule {
   Header = "Header",
   NavigationTabs = "NavigationTabs",
+  RecentlyViewedArtworks = "recently_viewed_artworks",
 
   /**
    * Artist page
@@ -203,6 +204,13 @@ export enum ContextModule {
    * Artwork page
    */
   ArtworkTabs = "Artwork tabs",
+  OtherWorksByArtist = "Other works by artist",
+  OtherWorksInAuction = "Other works in auction",
+  OtherWorksInFair = "Other works in fair",
+  OtherWorksFromGallery = "Other works from gallery",
+  OtherWorksFromShow = "Other works from show",
+  RelatedArtists = "RelatedArtists",
+  RelatedWorks = "RelatedWorks",
   ShareButton = "Share button",
   Zoom = "Zoom",
 
@@ -249,7 +257,10 @@ export enum Label {
 }
 
 export enum Type {
+  ArtistCard = "Artist card",
+  ArtworkBrick = "Artwork brick",
   Button = "Button",
-  Tab = "Tab",
   Link = "Link",
+  Tab = "Tab",
+  Thumbnail = "thumbnail",
 }

--- a/src/Components/Artwork/FillwidthItem.tsx
+++ b/src/Components/Artwork/FillwidthItem.tsx
@@ -33,13 +33,14 @@ const Placeholder = styled.div`
 export interface FillwidthItemContainerProps
   extends ContextProps,
     React.HTMLProps<FillwidthItemContainer> {
-  targetHeight?: number
-  imageHeight?: number
-  width?: number
-  margin?: number
-  useRelay?: boolean
   artwork: FillwidthItem_artwork
+  imageHeight?: number
+  margin?: number
   mediator?: Mediator
+  onClick?: () => void
+  targetHeight?: number
+  useRelay?: boolean
+  width?: number
 }
 
 export class FillwidthItemContainer extends React.Component<
@@ -90,13 +91,21 @@ export class FillwidthItemContainer extends React.Component<
     if (user) {
       userSpread = { user }
     }
-    const SaveButtonBlock = useRelay ? RelaySaveButton : SaveButton
-    const MetadataBlock = useRelay ? RelayMetadata : Metadata
+    // FIXME: Remove useRelay code
+    const SaveButtonBlock: any = useRelay ? RelaySaveButton : SaveButton
+    const MetadataBlock: any = useRelay ? RelayMetadata : Metadata
 
     return (
       <div className={className}>
         <Placeholder style={{ height: targetHeight }}>
-          <ImageLink href={artwork.href}>
+          <ImageLink
+            href={artwork.href}
+            onClick={() => {
+              if (this.props.onClick) {
+                this.props.onClick()
+              }
+            }}
+          >
             <Image src={this.getImageUrl()} height={imageHeight} />
           </ImageLink>
           <SaveButtonBlock

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -26,11 +26,13 @@ const Placeholder = styled.div`
 `
 
 interface Props extends React.HTMLProps<ArtworkGridItemContainer> {
-  useRelay?: boolean
   artwork: GridItem_artwork
+  mediator?: Mediator
+  onClick?: () => void
   style?: any
   user?: User
-  mediator?: Mediator
+  // FIXME: Remove
+  useRelay?: boolean
 }
 
 interface State {
@@ -150,8 +152,9 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
 
   render() {
     const { style, className, artwork, useRelay, user } = this.props
-    const SaveButtonBlock = useRelay ? RelaySaveButton : SaveButton
-    const MetadataBlock = useRelay ? RelayMetadata : Metadata
+    // FIXME: Remove `useRelay` branch + any
+    const SaveButtonBlock: any = useRelay ? RelaySaveButton : SaveButton
+    const MetadataBlock: any = useRelay ? RelayMetadata : Metadata
 
     let userSpread = {}
     if (user) {
@@ -169,7 +172,15 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
               data-id={artwork._id}
             >
               <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
-                <a href={artwork.href}>
+                <a
+                  href={artwork.href}
+                  onClick={event => {
+                    event.preventDefault()
+                    if (this.props.onClick) {
+                      this.props.onClick()
+                    }
+                  }}
+                >
                   <Image src={this.getImageUrl(breakpoints)} />
                 </a>
                 {this.renderArtworkBadge(artwork)}

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -174,8 +174,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
               <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
                 <a
                   href={artwork.href}
-                  onClick={event => {
-                    event.preventDefault()
+                  onClick={() => {
                     if (this.props.onClick) {
                       this.props.onClick()
                     }

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -19,13 +19,14 @@ export interface ArtworkGridProps
   extends React.HTMLProps<ArtworkGridContainer> {
   artworks: ArtworkGrid_artworks
   columnCount?: number | number[]
-  sectionMargin?: number
   itemMargin?: number
+  mediator?: Mediator
+  onBrickClick?: () => void
   onClearFilters?: () => any
   onLoadMore?: () => any
-  useRelay?: boolean
+  sectionMargin?: number
   user?: User
-  mediator?: Mediator
+  useRelay?: boolean
 }
 
 export interface ArtworkGridContainerState {
@@ -117,6 +118,11 @@ export class ArtworkGridContainer extends React.Component<
             useRelay={this.props.useRelay}
             user={this.props.user}
             mediator={this.props.mediator}
+            onClick={() => {
+              if (this.props.onBrickClick) {
+                this.props.onBrickClick()
+              }
+            }}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -54,6 +54,7 @@ const SuggestionsPopoverContainer = styled(Box)`
   z-index: 1;
 `
 
+@track()
 export class FollowArtistButton extends React.Component<Props, State> {
   static defaultProps = {
     useDeprecatedButtonStyle: true,
@@ -187,22 +188,20 @@ export class FollowArtistButton extends React.Component<Props, State> {
   }
 }
 
-export const FollowArtistButtonFragmentContainer = track({})(
-  createFragmentContainer(
-    Artsy.withContext(FollowArtistButton),
-    graphql`
-      fragment FollowArtistButton_artist on Artist
-        @argumentDefinitions(
-          showFollowSuggestions: { type: "Boolean", defaultValue: false }
-        ) {
-        __id
-        id
-        is_followed
-        counts {
-          follows
-        }
-        ...FollowArtistPopover_suggested @include(if: $showFollowSuggestions)
+export const FollowArtistButtonFragmentContainer = createFragmentContainer(
+  Artsy.withContext(FollowArtistButton),
+  graphql`
+    fragment FollowArtistButton_artist on Artist
+      @argumentDefinitions(
+        showFollowSuggestions: { type: "Boolean", defaultValue: false }
+      ) {
+      __id
+      id
+      is_followed
+      counts {
+        follows
       }
-    `
-  )
+      ...FollowArtistPopover_suggested @include(if: $showFollowSuggestions)
+    }
+  `
 )

--- a/src/Styleguide/Components/ArtistCard.tsx
+++ b/src/Styleguide/Components/ArtistCard.tsx
@@ -24,6 +24,7 @@ interface Props {
   artist: ArtistCard_artist
   user: User
   mediator?: Mediator
+  onClick?: () => void
 }
 
 export class ArtistCard extends React.Component<Props> {

--- a/src/Styleguide/Components/RecentlyViewed.tsx
+++ b/src/Styleguide/Components/RecentlyViewed.tsx
@@ -1,6 +1,8 @@
 import { Separator, Serif, Spacer } from "@artsy/palette"
 import { RecentlyViewed_me } from "__generated__/RecentlyViewed_me.graphql"
 import { RecentlyViewedQuery } from "__generated__/RecentlyViewedQuery.graphql"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { ContextConsumer } from "Artsy/Router"
 import { FillwidthItem } from "Components/Artwork/FillwidthItem"
@@ -16,54 +18,67 @@ export interface RecentlyViewedProps {
 
 const HEIGHT = 180
 
-export const RecentlyViewed: React.SFC<RecentlyViewedProps> = props => {
-  const { me } = props
+@track({
+  context_module: Schema.ContextModule.RecentlyViewedArtworks,
+})
+export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
+  static defaultProps = {
+    useRelay: true,
+  }
 
-  return (
-    <ContextConsumer>
-      {({ user, mediator }) => {
-        return (
-          me && (
-            <React.Fragment>
-              <Separator my={6} />
+  @track({
+    type: Schema.Type.Thumbnail,
+  })
+  trackClick() {
+    //
+  }
 
-              <Serif size="6">Recently viewed</Serif>
+  render() {
+    const { me, useRelay } = this.props
 
-              <Spacer mb={3} />
+    return (
+      <ContextConsumer>
+        {({ user, mediator }) => {
+          return (
+            me && (
+              <React.Fragment>
+                <Separator my={6} />
 
-              <Carousel
-                data={me.recentlyViewedArtworks.edges as object[]}
-                render={artwork => {
-                  const {
-                    node: {
-                      image: { aspect_ratio },
-                    },
-                  } = artwork
+                <Serif size="6">Recently viewed</Serif>
 
-                  return (
-                    <FillwidthItem
-                      artwork={artwork.node}
-                      targetHeight={HEIGHT}
-                      imageHeight={HEIGHT}
-                      width={HEIGHT * aspect_ratio}
-                      margin={10}
-                      useRelay={props.useRelay}
-                      user={user}
-                      mediator={mediator}
-                    />
-                  )
-                }}
-              />
-            </React.Fragment>
+                <Spacer mb={3} />
+
+                <Carousel
+                  data={me.recentlyViewedArtworks.edges as object[]}
+                  render={artwork => {
+                    const {
+                      node: {
+                        image: { aspect_ratio },
+                      },
+                    } = artwork
+
+                    return (
+                      <FillwidthItem
+                        artwork={artwork.node}
+                        targetHeight={HEIGHT}
+                        imageHeight={HEIGHT}
+                        width={HEIGHT * aspect_ratio}
+                        margin={10}
+                        useRelay={useRelay}
+                        user={user}
+                        mediator={mediator}
+                        onClick={this.trackClick.bind(this)}
+                      />
+                    )
+                  }}
+                />
+              </React.Fragment>
+            )
           )
-        )
-      }}
-    </ContextConsumer>
-  )
-}
-
-RecentlyViewed.defaultProps = {
-  useRelay: true,
+        }}
+      </ContextConsumer>
+    )
+  }
 }
 
 export const RecentlyViewedFragmentContainer = createFragmentContainer(


### PR DESCRIPTION
This updates the OtherWorks grids with new tracking functionality, but two key parts had to be extended:
- `ArtworkGrid` now accepts an optional `onBrickClick` callback prop
- `GridItem` now accepts an optional `onClick` callback prop

