### PR TITLE
[Artwork] Add action_types to click

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
@@ -22,6 +22,7 @@ export class ArtworkRelatedArtists extends React.Component<
 > {
   @track({
     type: Schema.Type.ArtistCard,
+    action_type: Schema.ActionType.Click,
   })
   trackArtistCardClick() {
     // noop

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/ArtistArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/ArtistArtworkGrid.tsx
@@ -20,6 +20,7 @@ interface ArtistArtworkGridProps {
 export class ArtistArtworkGrid extends React.Component<ArtistArtworkGridProps> {
   @track({
     type: Schema.Type.ArtworkBrick,
+    action_type: Schema.ActionType.Click,
   })
   trackBrickClick() {
     // noop

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/AuctionArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/AuctionArtworkGrid.tsx
@@ -20,6 +20,7 @@ interface AuctionArtworkGridProps {
 class AuctionArtworkGrid extends React.Component<AuctionArtworkGridProps> {
   @track({
     type: Schema.Type.ArtworkBrick,
+    action_type: Schema.ActionType.Click,
   })
   trackBrickClick() {
     // noop

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/FairArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/FairArtworkGrid.tsx
@@ -20,6 +20,7 @@ interface FairArtworkGridProps {
 class FairArtworkGrid extends React.Component<FairArtworkGridProps> {
   @track({
     type: Schema.Type.ArtworkBrick,
+    action_type: Schema.ActionType.Click,
   })
   trackBrickClick() {
     // noop

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerArtworkGrid.tsx
@@ -20,6 +20,7 @@ interface PartnerArtworkGridProps {
 class PartnerArtworkGrid extends React.Component<PartnerArtworkGridProps> {
   @track({
     type: Schema.Type.ArtworkBrick,
+    action_type: Schema.ActionType.Click,
   })
   trackBrickClick() {
     // noop

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerShowArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/PartnerShowArtworkGrid.tsx
@@ -22,6 +22,7 @@ class PartnerShowArtworkGrid extends React.Component<
 > {
   @track({
     type: Schema.Type.ArtworkBrick,
+    action_type: Schema.ActionType.Click,
   })
   trackBrickClick() {
     // noop

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
@@ -68,6 +68,7 @@ class RelatedWorksArtworkGrid extends React.Component<
 
   @track({
     type: Schema.Type.ArtworkBrick,
+    action_type: Schema.ActionType.Click,
   })
   trackBrickClick() {
     // noop

--- a/src/Styleguide/Components/RecentlyViewed.tsx
+++ b/src/Styleguide/Components/RecentlyViewed.tsx
@@ -28,6 +28,7 @@ export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
 
   @track({
     type: Schema.Type.Thumbnail,
+    action_type: Schema.ActionType.Click,
   })
   trackClick() {
     //


### PR DESCRIPTION
Follow up to https://github.com/artsy/reaction/pull/1816. Each click was missing an `action_type`. 