### PR TITLE
[Refactor] Remove useRelay fork code for ArtworkGrid

### DIFF
--- a/src/Components/Artwork/Fillwidth.tsx
+++ b/src/Components/Artwork/Fillwidth.tsx
@@ -5,35 +5,28 @@ import { createFragmentContainer, graphql } from "react-relay"
 import sizeMe from "react-sizeme"
 import styled from "styled-components"
 import fillwidthDimensions from "../../Utils/fillwidth"
-import RelayFillwidthItem, { FillwidthItem } from "./FillwidthItem"
+import FillwidthItem from "./FillwidthItem"
 
 interface Props extends React.HTMLAttributes<FillwidthContainer> {
   targetHeight?: number
   gutter?: number
   size?: any
-  useRelay?: boolean
   artworks: Fillwidth_artworks
 }
 
 class FillwidthContainer extends React.Component<Props, null> {
-  public static defaultProps: Partial<Props> = {
-    useRelay: true,
-  }
-
   renderArtwork(artwork, dimensions, i) {
-    const { gutter, useRelay } = this.props
+    const { gutter } = this.props
     const artworkSize = find(dimensions, ["__id", artwork.__id])
-    const FillWidthItemBlock = useRelay ? RelayFillwidthItem : FillwidthItem
 
     return (
-      <FillWidthItemBlock
+      <FillwidthItem
         artwork={artwork}
         key={"artwork--" + artwork.__id}
         targetHeight={artworkSize.height}
         imageHeight={artworkSize.height}
         width={artworkSize.width}
         margin={i === dimensions.length - 1 ? 0 : gutter}
-        useRelay={useRelay}
       />
     )
   }

--- a/src/Components/Artwork/FillwidthItem.tsx
+++ b/src/Components/Artwork/FillwidthItem.tsx
@@ -3,8 +3,8 @@ import { ContextProps } from "Artsy"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
-import RelayMetadata, { Metadata } from "./Metadata"
-import RelaySaveButton, { SaveButton } from "./Save"
+import Metadata from "./Metadata"
+import SaveButton from "./Save"
 
 // @ts-ignore
 import { Mediator } from "Artsy/SystemContext"
@@ -39,17 +39,12 @@ export interface FillwidthItemContainerProps
   mediator?: Mediator
   onClick?: () => void
   targetHeight?: number
-  useRelay?: boolean
   width?: number
 }
 
 export class FillwidthItemContainer extends React.Component<
   FillwidthItemContainerProps
 > {
-  static defaultProps = {
-    useRelay: true,
-  }
-
   getImageUrl() {
     const imageURL = this.props.artwork.image.url
 
@@ -82,7 +77,6 @@ export class FillwidthItemContainer extends React.Component<
       className,
       targetHeight,
       imageHeight,
-      useRelay,
       user,
       mediator,
     } = this.props
@@ -91,9 +85,6 @@ export class FillwidthItemContainer extends React.Component<
     if (user) {
       userSpread = { user }
     }
-    // FIXME: Remove useRelay code
-    const SaveButtonBlock: any = useRelay ? RelaySaveButton : SaveButton
-    const MetadataBlock: any = useRelay ? RelayMetadata : Metadata
 
     return (
       <div className={className}>
@@ -108,16 +99,15 @@ export class FillwidthItemContainer extends React.Component<
           >
             <Image src={this.getImageUrl()} height={imageHeight} />
           </ImageLink>
-          <SaveButtonBlock
+          <SaveButton
             {...userSpread}
             mediator={mediator}
             className="artwork-save"
             artwork={artwork}
             style={{ position: "absolute", right: "5px", bottom: "5px" }}
-            useRelay={useRelay}
           />
         </Placeholder>
-        <MetadataBlock artwork={artwork} useRelay={useRelay} extended />
+        <Metadata artwork={artwork} extended />
       </div>
     )
   }

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -8,8 +8,8 @@ import { data as sd } from "sharify"
 import styled from "styled-components"
 import { Responsive } from "Utils/Responsive"
 import colors from "../../Assets/Colors"
-import RelayMetadata, { Metadata } from "./Metadata"
-import RelaySaveButton, { SaveButton } from "./Save"
+import Metadata from "./Metadata"
+import SaveButton from "./Save"
 
 const Image = styled.img`
   width: 100%;
@@ -31,8 +31,6 @@ interface Props extends React.HTMLProps<ArtworkGridItemContainer> {
   onClick?: () => void
   style?: any
   user?: User
-  // FIXME: Remove
-  useRelay?: boolean
 }
 
 interface State {
@@ -59,10 +57,6 @@ const Badges = styled(Flex)`
 `
 
 class ArtworkGridItemContainer extends React.Component<Props, State> {
-  static defaultProps = {
-    useRelay: true,
-  }
-
   state = {
     isMounted: false,
   }
@@ -151,10 +145,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
   }
 
   render() {
-    const { style, className, artwork, useRelay, user } = this.props
-    // FIXME: Remove `useRelay` branch + any
-    const SaveButtonBlock: any = useRelay ? RelaySaveButton : SaveButton
-    const MetadataBlock: any = useRelay ? RelayMetadata : Metadata
+    const { style, className, artwork, user } = this.props
 
     let userSpread = {}
     if (user) {
@@ -187,7 +178,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
                     Reaction code without wrapping the tree in a Responsive
                     provider component. */}
                 {(hover === undefined || hover) && (
-                  <SaveButtonBlock
+                  <SaveButton
                     className="artwork-save"
                     artwork={artwork}
                     style={{
@@ -195,13 +186,12 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
                       right: "10px",
                       bottom: "10px",
                     }}
-                    useRelay={useRelay}
                     {...userSpread}
                     mediator={this.props.mediator}
                   />
                 )}
               </Placeholder>
-              <MetadataBlock artwork={artwork} useRelay={useRelay} />
+              <Metadata artwork={artwork} />
             </div>
           )
         }}

--- a/src/Components/Artwork/Metadata.tsx
+++ b/src/Components/Artwork/Metadata.tsx
@@ -6,30 +6,27 @@ import StyledTextLink from "Components/TextLink"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import { Details, DetailsFragmentContainer } from "./Details"
+import { DetailsFragmentContainer as Details } from "./Details"
 
 export interface MetadataProps extends React.HTMLProps<MetadataContainer> {
   artwork: Metadata_artwork
   extended?: boolean
-  useRelay?: boolean
 }
 
 export class MetadataContainer extends React.Component<MetadataProps> {
   static defaultProps = {
     extended: true,
-    useRelay: true,
   }
 
   render() {
-    const { artwork, className, extended, useRelay } = this.props
-    const DetailsBlock = useRelay ? DetailsFragmentContainer : Details
+    const { artwork, className, extended } = this.props
 
     return (
       <ContextConsumer>
         {({ user }) => {
           const detailsContent = (
             <div className={className}>
-              <DetailsBlock
+              <Details
                 includeLinks={false}
                 showSaleLine={extended}
                 artwork={artwork}

--- a/src/Components/Artwork/index.tsx
+++ b/src/Components/Artwork/index.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { ComponentRef, createFragmentContainer, graphql } from "react-relay"
 import styled, { css } from "styled-components"
 import theme from "../../Assets/Theme"
-import RelayMetadata, { Metadata } from "./Metadata"
+import Metadata from "./Metadata"
 
 const Container = styled.div`
   width: 100%;
@@ -60,13 +60,11 @@ const Image = styled.img`
 
 export interface OverlayProps {
   selected: boolean
-  useRelay?: boolean
 }
 
 export interface ArtworkProps {
   extended?: boolean
   Overlay?: React.SFC<OverlayProps>
-  useRelay?: boolean
   artwork: Artwork_artwork
   onSelect?: (selected: boolean) => void
   showOverlayOnHover?: boolean
@@ -80,7 +78,6 @@ export class Artwork extends React.Component<ArtworkProps, ArtworkState> {
   static defaultProps = {
     extended: true,
     overlay: null,
-    useRelay: true,
     showOverlayOnHover: false,
   }
 
@@ -103,29 +100,21 @@ export class Artwork extends React.Component<ArtworkProps, ArtworkState> {
   }
 
   render() {
-    const { artwork, Overlay, useRelay, showOverlayOnHover } = this.props
+    const { artwork, Overlay, showOverlayOnHover } = this.props
     let overlayClasses = "overlay-container"
 
     overlayClasses += showOverlayOnHover ? " hovered" : ""
     overlayClasses += this.state.isSelected ? " selected" : ""
-
-    const MetadataBlock = useRelay ? RelayMetadata : Metadata
 
     return (
       <Container onClick={this.onSelected}>
         <ImageContainer>
           <Image src={artwork.image.url} />
           <div className={overlayClasses}>
-            {Overlay && (
-              <Overlay selected={this.state.isSelected} useRelay={useRelay} />
-            )}
+            {Overlay && <Overlay selected={this.state.isSelected} />}
           </div>
         </ImageContainer>
-        <MetadataBlock
-          extended={this.props.extended}
-          artwork={artwork}
-          useRelay={useRelay}
-        />
+        <Metadata extended={this.props.extended} artwork={artwork} />
       </Container>
     )
   }

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -11,7 +11,7 @@ import { ComponentRef, createFragmentContainer, graphql } from "react-relay"
 // @ts-ignore
 import styled, { StyledComponentClass } from "styled-components"
 import { Media, valuesWithBreakpointProps } from "Utils/Responsive"
-import RelayGridItem, { ArtworkGridItem } from "../Artwork/GridItem"
+import GridItem from "../Artwork/GridItem"
 
 type SectionedArtworks = Array<Array<ArtworkGrid_artworks["edges"][0]["node"]>>
 
@@ -26,7 +26,6 @@ export interface ArtworkGridProps
   onLoadMore?: () => any
   sectionMargin?: number
   user?: User
-  useRelay?: boolean
 }
 
 export interface ArtworkGridContainerState {
@@ -42,7 +41,6 @@ export class ArtworkGridContainer extends React.Component<
     columnCount: [3],
     sectionMargin: 20,
     itemMargin: 20,
-    useRelay: true,
   }
 
   state = {
@@ -108,14 +106,10 @@ export class ArtworkGridContainer extends React.Component<
       const artworkComponents = []
       for (let j = 0; j < sectionedArtworks[i].length; j++) {
         const artwork = sectionedArtworks[i][j]
-        const GridItem: typeof RelayGridItem = (this.props.useRelay
-          ? RelayGridItem
-          : ArtworkGridItem) as any
         artworkComponents.push(
           <GridItem
             artwork={artwork}
             key={"artwork-" + j + "-" + artwork.__id}
-            useRelay={this.props.useRelay}
             user={this.props.user}
             mediator={this.props.mediator}
             onClick={() => {

--- a/src/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
@@ -31,3 +31,5 @@ const EmptyMessage = styled(Message)`
     cursor: pointer;
   }
 `
+
+EmptyMessage.displayName = "EmptyMessage"

--- a/src/Components/ArtworkGrid/__stories__/ArtworkGrid.story.tsx
+++ b/src/Components/ArtworkGrid/__stories__/ArtworkGrid.story.tsx
@@ -3,8 +3,7 @@ import React from "react"
 import { graphql } from "react-relay"
 
 import { RootQueryRenderer } from "Artsy/Relay/RootQueryRenderer"
-import RelayArtworkGrid, { ArtworkGrid } from "../ArtworkGrid"
-import { ArtworkGridFixture } from "./ArtworkGridFixture"
+import ArtworkGrid from "../ArtworkGrid"
 
 export function ArtworkGridExample(props: {
   artistID: string
@@ -25,7 +24,7 @@ export function ArtworkGridExample(props: {
       render={readyState => {
         return (
           readyState.props && (
-            <RelayArtworkGrid {...readyState.props.artist as any} {...props} />
+            <ArtworkGrid {...readyState.props.artist as any} {...props} />
           )
         )
       }}
@@ -39,7 +38,4 @@ storiesOf("Components/Artworks/ArtworkGrid", module)
   })
   .add("An empty grid", () => {
     return <ArtworkGridExample artistID="sydney-shen" />
-  })
-  .add("Without Relay", () => {
-    return <ArtworkGrid artworks={ArtworkGridFixture as any} useRelay={false} />
   })

--- a/src/Components/ArtworkGrid/__tests__/ArtworkGrid.test.tsx
+++ b/src/Components/ArtworkGrid/__tests__/ArtworkGrid.test.tsx
@@ -1,5 +1,6 @@
 import { ArtworkGrid_artworks } from "__generated__/ArtworkGrid_artworks.graphql"
 import { renderRelayTree } from "DevTools"
+import { RelayStubProvider } from "DevTools/RelayStubProvider"
 import { mount } from "enzyme"
 import { cloneDeep } from "lodash"
 import React from "react"
@@ -116,7 +117,11 @@ describe("ArtworkGrid", () => {
 
     let props
     const getWrapper = passedProps => {
-      return mount(<ArtworkGridContainer {...passedProps} useRelay={false} />)
+      return mount(
+        <RelayStubProvider>
+          <ArtworkGridContainer {...passedProps} />
+        </RelayStubProvider>
+      )
     }
 
     beforeEach(() => {
@@ -150,27 +155,31 @@ describe("ArtworkGrid", () => {
 
     it("#componentDidMount sets state.interval if props.onLoadMore", () => {
       props.onLoadMore = jest.fn()
-      const wrapper = getWrapper(props)
+      const wrapper = getWrapper(props).find(ArtworkGridContainer)
       const { interval } = wrapper.state() as ArtworkGridContainerState
       expect(interval).toBeGreaterThan(0)
     })
 
     it("#componentWillUnmount calls #clearInterval if state.interval exists", () => {
       props.onLoadMore = jest.fn()
-      const wrapper = getWrapper(props)
+      const wrapper = getWrapper(props).find(ArtworkGridContainer)
       wrapper.instance().componentWillUnmount()
       expect(global.clearInterval).toBeCalled()
     })
 
     it("#maybeLoadMore calls props.onLoadMore if scroll position is at end", () => {
       props.onLoadMore = jest.fn()
-      const wrapper = getWrapper(props).instance() as ArtworkGridContainer
+      const wrapper = getWrapper(props)
+        .find(ArtworkGridContainer)
+        .instance() as ArtworkGridContainer
       wrapper.maybeLoadMore()
       expect(props.onLoadMore).toBeCalled()
     })
 
     it("#sectionedArtworks divides artworks into columns", () => {
-      const wrapper = getWrapper(props).instance() as ArtworkGridContainer
+      const wrapper = getWrapper(props)
+        .find(ArtworkGridContainer)
+        .instance() as ArtworkGridContainer
       const artworks = wrapper.sectionedArtworksForAllBreakpoints(
         props.artworks,
         [2, 2, 2, 3]
@@ -179,7 +188,7 @@ describe("ArtworkGrid", () => {
     })
 
     it("Renders artworks if present", () => {
-      const wrapper = getWrapper(props)
+      const wrapper = getWrapper(props).find(ArtworkGridContainer)
       expect(wrapper.text()).toMatch(ArtworkGridFixture.edges[0].node.title)
       expect(wrapper.find(ArtworkGridItem).length).toBe(4)
     })

--- a/src/Components/__stories__/Artwork.story.tsx
+++ b/src/Components/__stories__/Artwork.story.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { graphql } from "react-relay"
 
 import { RootQueryRenderer } from "Artsy/Relay/RootQueryRenderer"
-import RelayArtwork, { Artwork } from "../Artwork"
+import Artwork from "../Artwork"
 
 function ArtworkExample(props: { artworkID: string }) {
   return (
@@ -17,7 +17,7 @@ function ArtworkExample(props: { artworkID: string }) {
       `}
       variables={{ artworkID: props.artworkID }}
       render={readyState =>
-        readyState.props && <RelayArtwork {...readyState.props as any} />
+        readyState.props && <Artwork {...readyState.props as any} />
       }
     />
   )
@@ -39,30 +39,3 @@ storiesOf("Components/Artwork/Singular", module)
   .add("A portrait artwork (extra tall)", () => (
     <ArtworkExample artworkID="snik-untitled-vertical" />
   ))
-  .add("Without Relay", () => {
-    const artwork = {
-      id: "mikael-olson-some-kind-of-dinosaur",
-      title: "Some Kind of Dinosaur",
-      date: "2015",
-      sale_message: "$875",
-      is_in_auction: false,
-      image: {
-        url:
-          "https://d32dm0rphc51dk.cloudfront.net/WhROiQBIHoXNIBr2zW3RUw/larger.jpg",
-        aspect_ratio: 0.74,
-        placeholder: "134.6445824706694%",
-      },
-      artists: [
-        {
-          __id: "mikael-olson",
-          name: "Mikael Olson",
-        },
-      ],
-      partner: {
-        name: "Gallery 1261",
-      },
-      href: "/artwork/mikael-olson-some-kind-of-dinosaur",
-    }
-
-    return <Artwork artwork={artwork as any} useRelay={false} />
-  })

--- a/src/Components/__stories__/ArtworkMetadata.story.tsx
+++ b/src/Components/__stories__/ArtworkMetadata.story.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { graphql } from "react-relay"
 
 import { RootQueryRenderer } from "Artsy/Relay/RootQueryRenderer"
-import RelayMetadata, { Metadata } from "../Artwork/Metadata"
+import Metadata from "../Artwork/Metadata"
 
 function ArtworkExample(props: { artworkID: string }) {
   return (
@@ -17,7 +17,7 @@ function ArtworkExample(props: { artworkID: string }) {
       `}
       variables={{ artworkID: props.artworkID }}
       render={readyState =>
-        readyState.props && <RelayMetadata {...readyState.props as any} />
+        readyState.props && <Metadata {...readyState.props as any} />
       }
     />
   )
@@ -30,30 +30,3 @@ storiesOf("Components/Artwork/Metadata", module)
   .add("A for-sale artwork with exact price", () => (
     <ArtworkExample artworkID="stephen-berkman-a-history-of-dread" />
   ))
-  .add("Without Relay", () => (
-    <Metadata artwork={artwork as any} useRelay={false} />
-  ))
-
-const artwork = {
-  id: "mikael-olson-some-kind-of-dinosaur",
-  title: "Some Kind of Dinosaur",
-  date: "2015",
-  sale_message: "$875",
-  is_in_auction: false,
-  image: {
-    url:
-      "https://d32dm0rphc51dk.cloudfront.net/WhROiQBIHoXNIBr2zW3RUw/larger.jpg",
-    aspect_ratio: 0.74,
-    placeholder: "134.6445824706694%",
-  },
-  artists: [
-    {
-      __id: "mikael-olson",
-      name: "Mikael Olson",
-    },
-  ],
-  partner: {
-    name: "Gallery 1261",
-  },
-  href: "/artwork/mikael-olson-some-kind-of-dinosaur",
-}

--- a/src/Components/__stories__/Fillwidth.story.tsx
+++ b/src/Components/__stories__/Fillwidth.story.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { graphql } from "react-relay"
 
 import { RootQueryRenderer } from "Artsy/Relay/RootQueryRenderer"
-import RelayFillwidth, { Fillwidth } from "../Artwork/Fillwidth"
+import Fillwidth from "../Artwork/Fillwidth"
 
 function FillwidthExample(props: { artistID: string }) {
   return (
@@ -20,168 +20,16 @@ function FillwidthExample(props: { artistID: string }) {
       variables={{ artistID: props.artistID }}
       render={readyState => {
         return (
-          readyState.props && (
-            <RelayFillwidth {...readyState.props.artist as any} />
-          )
+          readyState.props && <Fillwidth {...readyState.props.artist as any} />
         )
       }}
     />
   )
 }
 
-storiesOf("Components/Artworks/Fillwidth", module)
-  .add("A typical fillwidth", () => {
+storiesOf("Components/Artworks/Fillwidth", module).add(
+  "A typical fillwidth",
+  () => {
     return <FillwidthExample artistID="stephen-willats" />
-  })
-  .add("Without Relay", () => {
-    return <Fillwidth artworks={artworks as any} useRelay={false} />
-  })
-
-const artworks = {
-  edges: [
-    {
-      node: {
-        __id: "QXJ0d29yazpiYW5rc3ktd2UtbG92ZS15b3Utc28tbG92ZS11cw==",
-        image: {
-          aspect_ratio: 1,
-          placeholder: "100%",
-          url:
-            "https://d32dm0rphc51dk.cloudfront.net/hoFocUdpgF4mazPIgekpZA/large.jpg",
-        },
-        href: "/artwork/banksy-we-love-you-so-love-us",
-        title: "We Love You So Love Us",
-        date: "2000",
-        sale_message: "Contact For Price",
-        cultural_maker: null,
-        artists: [
-          {
-            __id: "QXJ0aXN0OmJhbmtzeQ==",
-            href: "/artist/banksy",
-            name: "Banksy",
-          },
-        ],
-        collecting_institution: null,
-        partner: {
-          name: "EHC Fine Art",
-          href: "/ehc-fine-art",
-          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
-          type: "Gallery",
-        },
-        sale: null,
-        _id: "58e1a19d275b247d353ff0d9",
-        is_inquireable: true,
-        sale_artwork: null,
-        id: "banksy-we-love-you-so-love-us",
-        is_saved: null,
-      },
-    },
-    {
-      node: {
-        __id: "QXJ0d29yazpiYW5rc3ktcmFkYXItcmF0LWRpcnR5LWZ1bmtlci1scA==",
-        image: {
-          aspect_ratio: 1,
-          placeholder: "100%",
-          url:
-            "https://d32dm0rphc51dk.cloudfront.net/NQvnb87U8oGDm6kpdJ9jLA/large.jpg",
-        },
-        href: "/artwork/banksy-radar-rat-dirty-funker-lp",
-        title: "Radar Rat (Dirty Funker LP)",
-        date: "2008",
-        sale_message: "$950",
-        cultural_maker: null,
-        artists: [
-          {
-            __id: "QXJ0aXN0OmJhbmtzeQ==",
-            href: "/artist/banksy",
-            name: "Banksy",
-          },
-        ],
-        collecting_institution: null,
-        partner: {
-          name: "EHC Fine Art",
-          href: "/ehc-fine-art",
-          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
-          type: "Gallery",
-        },
-        sale: null,
-        _id: "58e1a19ecd530e4d612cb07f",
-        is_inquireable: true,
-        sale_artwork: null,
-        id: "banksy-radar-rat-dirty-funker-lp",
-        is_saved: null,
-      },
-    },
-    {
-      node: {
-        __id: "QXJ0d29yazpiYW5rc3ktZmxvd2VyLWJvbWJlci1ieS1icmFuZGFsaXNt",
-        image: {
-          aspect_ratio: 1.5,
-          placeholder: "66.66666666666666%",
-          url:
-            "https://d32dm0rphc51dk.cloudfront.net/88LaQZxzQdksn76f0LGFoQ/large.jpg",
-        },
-        href: "/artwork/banksy-flower-bomber-by-brandalism",
-        title: "Flower Bomber (by Brandalism)",
-        date: "ca. 2017",
-        sale_message: "Contact For Price",
-        cultural_maker: null,
-        artists: [
-          {
-            __id: "QXJ0aXN0OmJhbmtzeQ==",
-            href: "/artist/banksy",
-            name: "Banksy",
-          },
-        ],
-        collecting_institution: null,
-        partner: {
-          name: "EHC Fine Art",
-          href: "/ehc-fine-art",
-          __id: "UGFydG5lcjplaGMtZmluZS1hcnQ=",
-          type: "Gallery",
-        },
-        sale: null,
-        _id: "58e1a19f275b247d353ff0e2",
-        is_inquireable: true,
-        sale_artwork: null,
-        id: "banksy-flower-bomber-by-brandalism",
-        is_saved: null,
-      },
-    },
-    {
-      node: {
-        __id: "QXJ0d29yazpiYW5rc3ktZ2lybC13aXRoLWJhbGxvb24tMTQ=",
-        image: {
-          aspect_ratio: 0.75,
-          placeholder: "132.9%",
-          url:
-            "https://d32dm0rphc51dk.cloudfront.net/RRGE9Ild18_IPghZXT6wuQ/large.jpg",
-        },
-        href: "/artwork/banksy-girl-with-balloon-14",
-        title: "Girl With Balloon",
-        date: "2004",
-        sale_message: "Contact For Price",
-        cultural_maker: null,
-        artists: [
-          {
-            __id: "QXJ0aXN0OmJhbmtzeQ==",
-            href: "/artist/banksy",
-            name: "Banksy",
-          },
-        ],
-        collecting_institution: null,
-        partner: {
-          name: "Graffik Gallery / Banksy Editions",
-          href: "/graffik-gallery-slash-banksy-editions",
-          __id: "UGFydG5lcjpncmFmZmlrLWdhbGxlcnktc2xhc2gtYmFua3N5LWVkaXRpb25z",
-          type: "Gallery",
-        },
-        sale: null,
-        _id: "58e370659c18db774f25ed5b",
-        is_inquireable: true,
-        sale_artwork: null,
-        id: "banksy-girl-with-balloon-14",
-        is_saved: null,
-      },
-    },
-  ],
-}
+  }
+)

--- a/src/Styleguide/Components/RecentlyViewed.tsx
+++ b/src/Styleguide/Components/RecentlyViewed.tsx
@@ -13,7 +13,6 @@ import { Carousel } from "Styleguide/Components/Carousel"
 
 export interface RecentlyViewedProps {
   me: RecentlyViewed_me
-  useRelay?: boolean
 }
 
 const HEIGHT = 180
@@ -22,10 +21,6 @@ const HEIGHT = 180
   context_module: Schema.ContextModule.RecentlyViewedArtworks,
 })
 export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
-  static defaultProps = {
-    useRelay: true,
-  }
-
   @track({
     type: Schema.Type.Thumbnail,
     action_type: Schema.ActionType.Click,
@@ -35,7 +30,7 @@ export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
   }
 
   render() {
-    const { me, useRelay } = this.props
+    const { me } = this.props
 
     return (
       <ContextConsumer>
@@ -65,7 +60,6 @@ export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
                         imageHeight={HEIGHT}
                         width={HEIGHT * aspect_ratio}
                         margin={10}
-                        useRelay={useRelay}
                         user={user}
                         mediator={mediator}
                         onClick={this.trackClick.bind(this)}

--- a/src/Styleguide/Components/__stories__/Carousel.story.tsx
+++ b/src/Styleguide/Components/__stories__/Carousel.story.tsx
@@ -83,7 +83,6 @@ storiesOf("Styleguide/Components", module).add("Carousel", () => {
                   imageHeight={200}
                   width={200 * aspect_ratio}
                   margin={20}
-                  useRelay={false}
                 />
               )
             }}

--- a/src/Styleguide/Components/__stories__/RecentlyViewed.story.tsx
+++ b/src/Styleguide/Components/__stories__/RecentlyViewed.story.tsx
@@ -18,7 +18,6 @@ storiesOf("Styleguide/Components", module).add("Recently Viewed", () => {
                 },
               } as any
             }
-            useRelay={false}
           />
         </Box>
       </Section>


### PR DESCRIPTION
About a year ago there was an aborted effort to find a way to migrate all of the artwork bricks across force to a standardized format (Reaction). This required a fork in all Relay brick code, since the data coming through force made direct requests to MP or Gravity. This was before we had upgraded our systems with the latest architectural updates and started rebuilding pages completely in Relay. (As soon as that effort began this one was abandoned.) This removes that code. 