### PR TITLE
Address React warnings found via React Dev Tools

### DIFF
--- a/src/Assets/Icons/Auction.tsx
+++ b/src/Assets/Icons/Auction.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export const Auction: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g stroke="#333" fill="none" fill-rule="evenodd">
+      <g stroke="#333" fill="none" fillRule="evenodd">
         <path d="M10.977 6.698l4.547 2.625-4.41 7.64-4.547-2.626zM13.385 13.243l4.546 2.625-.5.866-4.546-2.625z" />
       </g>
     </svg>

--- a/src/Assets/Icons/BlueChip.tsx
+++ b/src/Assets/Icons/BlueChip.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export const BlueChip: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <g transform="translate(6.25 6.25)" stroke="#000">
           <circle cx="6.25" cy="6.25" r="6.25" />

--- a/src/Assets/Icons/Book.tsx
+++ b/src/Assets/Icons/Book.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export const Book: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <g stroke="#000">
           <path d="M17.5 8.616v7.73L12.808 17.5H12.5V9.667l5-1.05zM7.5 8.616v7.73l4.692 1.154h.308V9.667l-5-1.05z" />

--- a/src/Assets/Icons/Fair.tsx
+++ b/src/Assets/Icons/Fair.tsx
@@ -3,9 +3,9 @@ import React from "react"
 export const Fair: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
-        <path d="M5.526 17.5h14.04" stroke="#000" stroke-linecap="square" />
+        <path d="M5.526 17.5h14.04" stroke="#000" strokeLinecap="square" />
         <path stroke="#000" d="M7.5 9.5h10v8h-10z" />
         <path fill="#000" d="M11 13h3v5h-3z" />
         <path stroke="#000" d="M12.5 4.5h1v4h-1z" />

--- a/src/Assets/Icons/Group.tsx
+++ b/src/Assets/Icons/Group.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export const Group: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <g transform="translate(3.294 5.941)" stroke="#333">
           <path d="M6.246 11.99V8.318a2 2 0 0 1 2-2h1.993a2 2 0 0 1 2 2v3.674M.246 11.99V8.318a2 2 0 0 1 2-2h1.993a2 2 0 0 1 2 2v3.674M12.246 11.99V8.318a2 2 0 0 1 2-2h1.993a2 2 0 0 1 2 2v3.674M3.461 4.14a1.633 1.633 0 1 0 0-3.265 1.633 1.633 0 0 0 0 3.265z" />

--- a/src/Assets/Icons/Museum.tsx
+++ b/src/Assets/Icons/Museum.tsx
@@ -3,9 +3,9 @@ import React from "react"
 export const Museum: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
-        <path d="M6.526 17.5h11.94" stroke="#000" stroke-linecap="square" />
+        <path d="M6.526 17.5h11.94" stroke="#000" strokeLinecap="square" />
         <path
           fill="#000"
           d="M8 10h1v6H8zM10 10h1v6h-1zM12 10h1v6h-1zM14 10h1v6h-1zM16 10h1v6h-1z"

--- a/src/Assets/Icons/Solo.tsx
+++ b/src/Assets/Icons/Solo.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export const Solo: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <g transform="translate(7.294 4.941)" stroke="#333">
           <path d="M0 13.717V10.86a3 3 0 0 1 3-3h4.195a3 3 0 0 1 3 3v2.856" />

--- a/src/Assets/Icons/TopEmerging.tsx
+++ b/src/Assets/Icons/TopEmerging.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export const TopEmerging: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <circle
           cx="6.25"

--- a/src/Assets/Icons/TopEstablished.tsx
+++ b/src/Assets/Icons/TopEstablished.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export const TopEstablished: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <circle stroke="#000" cx="12.5" cy="12.5" r="6.25" />
         <path
           d="M10.3 10h4.399a.3.3 0 0 1 .3.3v4.846a.3.3 0 0 1-.451.259L12.65 14.3a.3.3 0 0 0-.302 0l-1.897 1.104a.3.3 0 0 1-.451-.26V10.3a.3.3 0 0 1 .3-.3zm.7 1v3.036l1.5-.941 1.499.94V11H11z"

--- a/src/Styleguide/Components/SelectedCareerAchievements.tsx
+++ b/src/Styleguide/Components/SelectedCareerAchievements.tsx
@@ -74,9 +74,10 @@ export class SelectedCareerAchievements extends React.Component<
     }
   }
 
-  renderInsight(insight) {
+  renderInsight(insight, key) {
     return (
       <ArtistInsight
+        key={key}
         type={insight.type}
         label={insight.label}
         entities={insight.entities}
@@ -113,8 +114,8 @@ export class SelectedCareerAchievements extends React.Component<
               {this.renderGalleryRepresentation()}
               {this.renderAuctionHighlight()}
 
-              {this.props.artist.insights.map(insight => {
-                return this.renderInsight(insight)
+              {this.props.artist.insights.map((insight, index) => {
+                return this.renderInsight(insight, index)
               })}
             </Flex>
           </Flex>


### PR DESCRIPTION
- Update svg element attribute names for JSX

    JSX expectes camelCased attribute names so these should be translated
from their non-JSX hypen-separated formats.

- Add key prop to ArtistInsight components rendered via insights array  …

    Addresses the following React dev-tools warning:

      Warning: Each child in an array or iterator should have a unique "key" prop.

      Check the render method of `SelectedCareerAchievements`. See
      https://fb.me/react-warning-keys for more information.

      in ArtistInsight (created by SelectedCareerAchievements)