### PR TITLE
DISCO-656: Add event tracking for Read more / Learn more artist insight actions

### DIFF
--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -207,6 +207,7 @@ export enum ContextModule {
   AboutTheWorkPartner = "About the Work (Partner)",
   ArtistOverview = "ArtistOverview",
   ArtistBio = "ArtistBio",
+  ArtistInsights = "ArtistInsights",
   Biography = "Biography",
   Sidebar = "Sidebar",
 

--- a/src/Styleguide/Components/ArtistInsight.tsx
+++ b/src/Styleguide/Components/ArtistInsight.tsx
@@ -1,4 +1,6 @@
 import { Box, Flex, Link, Sans } from "@artsy/palette"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import {
   Auction,
   BlueChip,
@@ -31,9 +33,26 @@ const ICON_MAPPING = {
   TOP_EMERGING: TopEmerging,
 }
 
+@track<ArtistInsightProps>(props => ({
+  context_module: Schema.ContextModule.ArtistInsights,
+  context_submodule: props.type,
+}))
 export class ArtistInsight extends React.Component<ArtistInsightProps> {
   state = {
     expanded: false,
+  }
+
+  @track<ArtistInsightProps>(() => ({
+    action_type: Schema.ActionType.Click,
+    subject: "Read more",
+    type: "Link",
+  }))
+  handleExpand() {
+    this.setState({ expanded: true })
+  }
+
+  handleCollapse() {
+    this.setState({ expanded: false })
   }
 
   renderEntities() {
@@ -45,9 +64,7 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
       return (
         <Sans size="2" verticalAlign="top" color="black60">
           {entities.join(", ")}.{" "}
-          <Link onClick={() => this.setState({ expanded: false })}>
-            Show less
-          </Link>
+          <Link onClick={this.handleCollapse.bind(this)}>Show less</Link>
         </Sans>
       )
     } else {
@@ -58,7 +75,7 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
           {entities.length > 1 && (
             <>
               , and{" "}
-              <Link onClick={() => this.setState({ expanded: true })}>
+              <Link onClick={this.handleExpand.bind(this)}>
                 {entities.length - 1} more
               </Link>
             </>

--- a/src/Styleguide/Components/ArtistInsightsModal.tsx
+++ b/src/Styleguide/Components/ArtistInsightsModal.tsx
@@ -1,18 +1,36 @@
 import { Link, Sans, Separator, Serif } from "@artsy/palette"
 
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { Modal } from "Components/Modal/Modal"
 import React from "react"
 
+@track(() => ({
+  context_module: Schema.ContextModule.ArtistInsights,
+}))
 export class ArtistInsightsModal extends React.Component {
   state = {
     showModal: false,
+  }
+
+  @track(() => ({
+    action_type: Schema.ActionType.Click,
+    subject: "Learn more",
+    type: "Link",
+  }))
+  handleOpen() {
+    this.setState({ showModal: true })
+  }
+
+  handleClose() {
+    this.setState({ showModal: false })
   }
 
   render() {
     return (
       <>
         <Modal
-          onClose={() => this.setState({ showModal: false })}
+          onClose={this.handleClose.bind(this)}
           show={this.state.showModal}
           style={{
             maxHeight: 540,
@@ -63,10 +81,8 @@ export class ArtistInsightsModal extends React.Component {
           </Serif>
         </Modal>
         <Sans mt={1} ml={1} size="2" color="black60">
-          <Link onClick={() => this.setState({ showModal: true })}>
-            Learn more
-          </Link>{" "}
-          about artist insights
+          <Link onClick={this.handleOpen.bind(this)}>Learn more</Link> about
+          artist insights
         </Sans>
       </>
     )

--- a/src/Styleguide/Components/SelectedCareerAchievements.tsx
+++ b/src/Styleguide/Components/SelectedCareerAchievements.tsx
@@ -52,6 +52,7 @@ export class SelectedCareerAchievements extends React.Component<
 
     return (
       <ArtistInsight
+        key="HIGH_AUCTION"
         type="HIGH_AUCTION"
         label="High auction record"
         value={display}
@@ -63,10 +64,12 @@ export class SelectedCareerAchievements extends React.Component<
     const { partners } = highlights
     if (partners && partners.edges && partners.edges.length > 0) {
       const highCategory = highestCategory(partners.edges)
+      const type = highCategory.toUpperCase().replace("-", "_")
 
       return (
         <ArtistInsight
-          type={highCategory.toUpperCase().replace("-", "_")}
+          key={type}
+          type={type}
           label={CATEGORIES[highCategory]}
           value={CATEGORY_LABEL_MAP[highCategory]}
         />
@@ -74,10 +77,10 @@ export class SelectedCareerAchievements extends React.Component<
     }
   }
 
-  renderInsight(insight, key) {
+  renderInsight(insight) {
     return (
       <ArtistInsight
-        key={key}
+        key={insight.type}
         type={insight.type}
         label={insight.label}
         entities={insight.entities}
@@ -114,8 +117,8 @@ export class SelectedCareerAchievements extends React.Component<
               {this.renderGalleryRepresentation()}
               {this.renderAuctionHighlight()}
 
-              {this.props.artist.insights.map((insight, index) => {
-                return this.renderInsight(insight, index)
+              {this.props.artist.insights.map(insight => {
+                return this.renderInsight(insight)
               })}
             </Flex>
           </Flex>


### PR DESCRIPTION
When users are interacting with the Artist Insights 2.0 data, we want to track user engagement (clicks) on the insights feature so that we can understand if this information impacts commercial activity on Artsy.net.

The context submodule name is derived from the Insight's type. A couple of these are created within the `SelectedCareerAchievements` component:

- `BLUE_CHIP`
- `HIGH_AUCTION`

The others are defined in Metaphysics:

- `SOLO_SHOW`
- `GROUP_SHOW`
- `REVIEWED`
- `COLLECTED`
- `BIENNIAL`

source: https://github.com/artsy/metaphysics/blob/master/src/schema/artist/insights.ts
ticket: https://artsyproduct.atlassian.net/browse/DISCO-656