### PR TITLE
Tidy up design implementation and component ordering for Artist Insights v2

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -77,86 +77,93 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     const colNum = 9 // artist.currentEvent ? 9 : 12
     const showGenes = this.maybeShowGenes()
 
-    let ArtistInsights
-    if (
+    const showArtistInsightsV2 =
       user &&
       user.type === "Admin" &&
       (showMarketInsights || artist.insights.length)
-    ) {
-      ArtistInsights = SelectedCareerAchievements
-    } else if (showMarketInsights) {
-      ArtistInsights = MarketInsights
-    }
+
+    const ArtistInsights = showArtistInsightsV2
+      ? SelectedCareerAchievements
+      : MarketInsights
+
+    const BioFragment = (
+      <>
+        <ArtistBio
+          onReadMoreClicked={() => {
+            this.setState({ isReadMoreExpanded: true })
+          }}
+          bio={artist}
+        />
+        <Spacer mb={1} />
+      </>
+    )
+
+    const GenesFragment = (
+      <>
+        <Media at="xs">
+          {bioLen < MAX_CHARS.xs ? (
+            <>
+              <Genes artist={artist} />
+              <Spacer mb={1} />
+            </>
+          ) : (
+            showGenes && <Genes artist={artist} />
+          )}
+        </Media>
+        <Media greaterThan="xs">
+          {bioLen < MAX_CHARS.default ? (
+            <>
+              <Genes artist={artist} />
+              <Spacer mb={1} />
+            </>
+          ) : (
+            showGenes && <Genes artist={artist} />
+          )}
+        </Media>
+        <Spacer mb={1} />
+      </>
+    )
+
+    const ConsignmentFragment = (
+      <>
+        <Spacer mb={2} />
+        <Sans size="2" color="black60">
+          Want to sell a work by this artist?{" "}
+          <a href="/consign" onClick={this.handleConsignClick.bind(this)}>
+            Learn more
+          </a>.
+        </Sans>
+      </>
+    )
 
     return (
       <>
         <Row>
           <Col sm={colNum}>
-            {ArtistInsights && (
-              <>
-                <ArtistInsights artist={artist} />
-                <Spacer mb={1} />
-              </>
-            )}
-            {showSelectedExhibitions && (
-              <>
-                <SelectedExhibitions
-                  artistID={artist.id}
-                  totalExhibitions={this.props.artist.counts.partner_shows}
-                  exhibitions={this.props.artist.exhibition_highlights}
-                />
-                <Spacer mb={1} />
-              </>
-            )}
-            {showArtistBio && (
-              <>
-                <ArtistBio
-                  onReadMoreClicked={() => {
-                    this.setState({ isReadMoreExpanded: true })
-                  }}
-                  bio={artist}
-                />
-                <Spacer mb={1} />
-              </>
-            )}
-            <>
-              <Media at="xs">
-                {bioLen < MAX_CHARS.xs ? (
-                  <>
-                    <Genes artist={artist} />
-                    <Spacer mb={1} />
-                  </>
-                ) : (
-                  showGenes && <Genes artist={artist} />
-                )}
-              </Media>
-              <Media greaterThan="xs">
-                {bioLen < MAX_CHARS.default ? (
-                  <>
-                    <Genes artist={artist} />
-                    <Spacer mb={1} />
-                  </>
-                ) : (
-                  showGenes && <Genes artist={artist} />
-                )}
-              </Media>
-
-              {showGenes && <Spacer mb={1} />}
-            </>
-            {showConsignable && (
-              <>
-                <Spacer mb={2} />
-                <Sans size="2" color="black60">
-                  Want to sell a work by this artist?{" "}
-                  <a
-                    href="/consign"
-                    onClick={this.handleConsignClick.bind(this)}
-                  >
-                    Learn more
-                  </a>.
-                </Sans>
-              </>
-            )}
+            {showArtistInsightsV2 && showArtistBio && BioFragment}
+            {showArtistInsightsV2 && showGenes && GenesFragment}
+            {showArtistInsightsV2 &&
+              showConsignable && (
+                <>
+                  {ConsignmentFragment}
+                  <Spacer mb={1} />
+                </>
+              )}
+            {ArtistInsights && <ArtistInsights artist={artist} />}
+            {!showArtistInsightsV2 &&
+              showSelectedExhibitions && (
+                <>
+                  <SelectedExhibitions
+                    artistID={artist.id}
+                    totalExhibitions={this.props.artist.counts.partner_shows}
+                    exhibitions={this.props.artist.exhibition_highlights}
+                  />
+                  <Spacer mb={1} />
+                </>
+              )}
+            {!showArtistInsightsV2 && showArtistBio && BioFragment}
+            {!showArtistInsightsV2 && showGenes && GenesFragment}
+            {!showArtistInsightsV2 && showConsignable && ConsignmentFragment}
           </Col>
 
           {showCurrentEvent && (

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -140,30 +140,42 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
       <>
         <Row>
           <Col sm={colNum}>
-            {showArtistInsightsV2 && showArtistBio && BioFragment}
-            {showArtistInsightsV2 && showGenes && GenesFragment}
-            {showArtistInsightsV2 &&
-              showConsignable && (
-                <>
-                  {ConsignmentFragment}
-                  <Spacer mb={1} />
-                </>
-              )}
-            {ArtistInsights && <ArtistInsights artist={artist} />}
-            {!showArtistInsightsV2 &&
-              showSelectedExhibitions && (
-                <>
-                  <SelectedExhibitions
-                    artistID={artist.id}
-                    totalExhibitions={this.props.artist.counts.partner_shows}
-                    exhibitions={this.props.artist.exhibition_highlights}
-                  />
-                  <Spacer mb={1} />
-                </>
-              )}
-            {!showArtistInsightsV2 && showArtistBio && BioFragment}
-            {!showArtistInsightsV2 && showGenes && GenesFragment}
-            {!showArtistInsightsV2 && showConsignable && ConsignmentFragment}
+            {showArtistInsightsV2 ? (
+              <>
+                {showArtistBio && BioFragment}
+                {showGenes && GenesFragment}
+                {showConsignable && (
+                  <>
+                    {ConsignmentFragment}
+                    <Spacer mb={1} />
+                  </>
+                )}
+                {ArtistInsights && <ArtistInsights artist={artist} />}
+              </>
+            ) : (
+              <>
+                {ArtistInsights && (
+                  <>
+                    <ArtistInsights artist={artist} />
+                    <Spacer mb={1} />
+                  </>
+                )}
+
+                {showSelectedExhibitions && (
+                  <>
+                    <SelectedExhibitions
+                      artistID={artist.id}
+                      totalExhibitions={this.props.artist.counts.partner_shows}
+                      exhibitions={this.props.artist.exhibition_highlights}
+                    />
+                    <Spacer mb={1} />
+                  </>
+                )}
+                {showArtistBio && BioFragment}
+                {showGenes && GenesFragment}
+                {showConsignable && ConsignmentFragment}
+              </>
+            )}
           </Col>
 
           {showCurrentEvent && (

--- a/src/Assets/Icons/Auction.tsx
+++ b/src/Assets/Icons/Auction.tsx
@@ -3,7 +3,7 @@ import React from "react"
 export const Auction: React.SFC = () => {
   return (
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
-      <g stroke="#333" fill="none" fillRule="evenodd">
+      <g stroke="#000" fill="none" fillRule="evenodd">
         <path d="M10.977 6.698l4.547 2.625-4.41 7.64-4.547-2.626zM13.385 13.243l4.546 2.625-.5.866-4.546-2.625z" />
       </g>
     </svg>

--- a/src/Assets/Icons/Group.tsx
+++ b/src/Assets/Icons/Group.tsx
@@ -5,7 +5,7 @@ export const Group: React.SFC = () => {
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
-        <g transform="translate(3.294 5.941)" stroke="#333">
+        <g transform="translate(3.294 5.941)" stroke="#000">
           <path d="M6.246 11.99V8.318a2 2 0 0 1 2-2h1.993a2 2 0 0 1 2 2v3.674M.246 11.99V8.318a2 2 0 0 1 2-2h1.993a2 2 0 0 1 2 2v3.674M12.246 11.99V8.318a2 2 0 0 1 2-2h1.993a2 2 0 0 1 2 2v3.674M3.461 4.14a1.633 1.633 0 1 0 0-3.265 1.633 1.633 0 0 0 0 3.265z" />
           <circle cx="9.104" cy="2.508" r="1.633" />
           <circle cx="14.747" cy="2.508" r="1.633" />

--- a/src/Assets/Icons/Solo.tsx
+++ b/src/Assets/Icons/Solo.tsx
@@ -5,7 +5,7 @@ export const Solo: React.SFC = () => {
     <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
-        <g transform="translate(7.294 4.941)" stroke="#333">
+        <g transform="translate(7.294 4.941)" stroke="#000">
           <path d="M0 13.717V10.86a3 3 0 0 1 3-3h4.195a3 3 0 0 1 3 3v2.856" />
           <circle cx="5.053" cy="2.807" r="2.807" />
         </g>

--- a/src/Styleguide/Components/ArtistInsight.tsx
+++ b/src/Styleguide/Components/ArtistInsight.tsx
@@ -51,10 +51,6 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
     this.setState({ expanded: true })
   }
 
-  handleCollapse() {
-    this.setState({ expanded: false })
-  }
-
   renderEntities() {
     const { entities } = this.props
 
@@ -63,8 +59,7 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
     } else if (this.state.expanded) {
       return (
         <Sans size="2" verticalAlign="top" color="black60">
-          {entities.join(", ")}.{" "}
-          <Link onClick={this.handleCollapse.bind(this)}>Show less</Link>
+          {entities.join(", ")}.
         </Sans>
       )
     } else {
@@ -76,7 +71,7 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
             <>
               , and{" "}
               <Link onClick={this.handleExpand.bind(this)}>
-                {entities.length - 1} more
+                {entities.length - 1}&nbsp;more
               </Link>
             </>
           )}

--- a/src/Styleguide/Components/ArtistInsightsModal.tsx
+++ b/src/Styleguide/Components/ArtistInsightsModal.tsx
@@ -82,7 +82,7 @@ export class ArtistInsightsModal extends React.Component {
         </Modal>
         <Sans mt={1} ml={1} size="2" color="black60">
           <Link onClick={this.handleOpen.bind(this)}>Learn more</Link> about
-          artist insights
+          artist insights.
         </Sans>
       </>
     )

--- a/src/Styleguide/Components/SelectedCareerAchievements.tsx
+++ b/src/Styleguide/Components/SelectedCareerAchievements.tsx
@@ -111,7 +111,7 @@ export class SelectedCareerAchievements extends React.Component<
         <Container>
           <Flex flexDirection="column" alignItems="left">
             <Sans size="2" weight="medium">
-              Selected Career Achievements
+              Selected career achievements
             </Sans>
             <Flex flexDirection="row" flexWrap="wrap">
               {this.renderGalleryRepresentation()}


### PR DESCRIPTION
- Tidy up design for new Artist Insights component
   - Sentence case "Selected career achievements"
   - Remove "show less" link
   - Add period at the end of "Learn more about artist insights"
   - Use non-breaking space within "[n] more" link
   - Ensure all icon colors are set to #000000

- Reorder artist overview components when displaying Artist Insights v2
  - Remove Selected exhibitions component
  - Display bio, genes, and consignment above Artist Insights v2

---

**Before**

![2019-01-09-143453_1283x1057_scrot](https://user-images.githubusercontent.com/123595/50923726-b1225300-141b-11e9-92ec-2f4d09fa70ff.png)


---

**After**

![2019-01-09-143348_1274x818_scrot](https://user-images.githubusercontent.com/123595/50923685-9b149280-141b-11e9-87cf-2a26b06b38fa.png)


ticket: https://artsyproduct.atlassian.net/browse/DISCO-662