### PR TITLE
Add MO speedbump analytics

### DIFF
--- a/src/Apps/Order/Components/OfferInput.tsx
+++ b/src/Apps/Order/Components/OfferInput.tsx
@@ -5,13 +5,14 @@ export interface OfferInputProps {
   id: string
   showError?: boolean
   onChange: (value: number) => void
+  onFocus?: () => void
 }
 
 export class OfferInput extends React.Component<OfferInputProps> {
   inputRef = React.createRef<HTMLInputElement>()
 
   render() {
-    const { id, showError } = this.props
+    const { id, showError, onFocus } = this.props
 
     return (
       <Input
@@ -22,6 +23,7 @@ export class OfferInput extends React.Component<OfferInputProps> {
         innerRef={this.inputRef}
         defaultValue={null}
         error={showError ? "Offer amount missing or invalid." : null}
+        onFocus={onFocus}
         onChange={ev => {
           const currentValue = ev.currentTarget.value
           const nonDigitMatch = currentValue.match(/\D/)

--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -8,7 +8,8 @@ import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSum
 import { TwoColumnLayout } from "Apps/Order/Components/TwoColumnLayout"
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
-import { ActionType, Flow, track } from "Artsy/Analytics"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics"
 import { Router } from "found"
 import React, { Component } from "react"
 import {
@@ -54,8 +55,8 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
 
   @track<OfferProps>(props => ({
     order_id: props.order.id,
-    action_type: ActionType.FocusedOnOfferInput,
-    flow: Flow.MakeOffer,
+    action_type: Schema.ActionType.FocusedOnOfferInput,
+    flow: Schema.Flow.MakeOffer,
   }))
   onOfferInputFocus() {
     // noop
@@ -63,8 +64,8 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
 
   @track<OfferProps>(props => ({
     order_id: props.order.id,
-    action_type: ActionType.ViewedOfferTooLow,
-    flow: Flow.MakeOffer,
+    action_type: Schema.ActionType.ViewedOfferTooLow,
+    flow: Schema.Flow.MakeOffer,
   }))
   showLowSpeedbump() {
     this.setState({ lowSpeedBumpEncountered: true })
@@ -78,8 +79,8 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
 
   @track<OfferProps>(props => ({
     order_id: props.order.id,
-    action_type: ActionType.ViewedOfferHigherThanListPrice,
-    flow: Flow.MakeOffer,
+    action_type: Schema.ActionType.ViewedOfferHigherThanListPrice,
+    flow: Schema.Flow.MakeOffer,
   }))
   showHighSpeedbump() {
     this.setState({ highSpeedBumpEncountered: true })

--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -52,18 +52,20 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     highSpeedBumpEncountered: false,
   }
 
-  @track({
+  @track<OfferProps>(props => ({
+    order_id: props.order.id,
     action_type: ActionType.FocusedOnOfferInput,
     flow: Flow.MakeOffer,
-  })
+  }))
   onOfferInputFocus() {
     // noop
   }
 
-  @track({
+  @track<OfferProps>(props => ({
+    order_id: props.order.id,
     action_type: ActionType.ViewedOfferTooLow,
     flow: Flow.MakeOffer,
-  })
+  }))
   showLowSpeedbump() {
     this.setState({ lowSpeedBumpEncountered: true })
     this.props.dialog.showErrorDialog({
@@ -74,10 +76,11 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     })
   }
 
-  @track({
+  @track<OfferProps>(props => ({
+    order_id: props.order.id,
     action_type: ActionType.ViewedOfferHigherThanListPrice,
     flow: Flow.MakeOffer,
-  })
+  }))
   showHighSpeedbump() {
     this.setState({ highSpeedBumpEncountered: true })
     this.props.dialog.showErrorDialog({

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -69,18 +69,20 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
     highSpeedBumpEncountered: false,
   }
 
-  @track({
+  @track<RespondProps>(props => ({
+    order_id: props.order.id,
     action_type: ActionType.FocusedOnOfferInput,
     flow: Flow.MakeOffer,
-  })
+  }))
   onOfferInputFocus() {
     // noop
   }
 
-  @track({
+  @track<RespondProps>(props => ({
+    order_id: props.order.id,
     action_type: ActionType.ViewedOfferTooLow,
     flow: Flow.MakeOffer,
-  })
+  }))
   showLowSpeedbump() {
     this.setState({ lowSpeedBumpEncountered: true })
     this.props.dialog.showErrorDialog({
@@ -91,10 +93,11 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
     })
   }
 
-  @track({
+  @track<RespondProps>(props => ({
+    order_id: props.order.id,
     action_type: ActionType.ViewedOfferHigherThanListPrice,
     flow: Flow.MakeOffer,
-  })
+  }))
   showHighSpeedbump() {
     this.setState({ highSpeedBumpEncountered: true })
     this.props.dialog.showErrorDialog({

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -14,7 +14,8 @@ import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSum
 import { TwoColumnLayout } from "Apps/Order/Components/TwoColumnLayout"
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
-import { ActionType, Flow, track } from "Artsy"
+import { track } from "Artsy"
+import * as Schema from "Artsy/Analytics/Schema"
 import { StaticCollapse } from "Components/StaticCollapse"
 import { Router } from "found"
 import React, { Component } from "react"
@@ -71,8 +72,8 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
 
   @track<RespondProps>(props => ({
     order_id: props.order.id,
-    action_type: ActionType.FocusedOnOfferInput,
-    flow: Flow.MakeOffer,
+    action_type: Schema.ActionType.FocusedOnOfferInput,
+    flow: Schema.Flow.MakeOffer,
   }))
   onOfferInputFocus() {
     // noop
@@ -80,8 +81,8 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
 
   @track<RespondProps>(props => ({
     order_id: props.order.id,
-    action_type: ActionType.ViewedOfferTooLow,
-    flow: Flow.MakeOffer,
+    action_type: Schema.ActionType.ViewedOfferTooLow,
+    flow: Schema.Flow.MakeOffer,
   }))
   showLowSpeedbump() {
     this.setState({ lowSpeedBumpEncountered: true })
@@ -95,8 +96,8 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
 
   @track<RespondProps>(props => ({
     order_id: props.order.id,
-    action_type: ActionType.ViewedOfferHigherThanListPrice,
-    flow: Flow.MakeOffer,
+    action_type: Schema.ActionType.ViewedOfferHigherThanListPrice,
+    flow: Schema.Flow.MakeOffer,
   }))
   showHighSpeedbump() {
     this.setState({ highSpeedBumpEncountered: true })

--- a/src/Apps/Order/Routes/__tests__/Offer.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Offer.test.tsx
@@ -318,6 +318,7 @@ describe("Offer InitialMutation", () => {
 
       expect(mockPostEvent).toHaveBeenCalledTimes(1)
       expect(mockPostEvent).toHaveBeenLastCalledWith({
+        order_id: "1234",
         action_type: "Focused on offer input",
         flow: "Make offer",
       })
@@ -336,6 +337,7 @@ describe("Offer InitialMutation", () => {
       component.find(Button).simulate("click")
 
       expect(mockPostEvent).toHaveBeenLastCalledWith({
+        order_id: "1234",
         action_type: "Viewed offer too low",
         flow: "Make offer",
       })
@@ -354,6 +356,7 @@ describe("Offer InitialMutation", () => {
       component.find(Button).simulate("click")
 
       expect(mockPostEvent).toHaveBeenLastCalledWith({
+        order_id: "1234",
         action_type: "Viewed offer higher than listed price",
         flow: "Make offer",
       })

--- a/src/Apps/Order/Routes/__tests__/Respond.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Respond.test.tsx
@@ -525,6 +525,7 @@ Object {
 
       expect(mockPostEvent).toHaveBeenCalledTimes(1)
       expect(mockPostEvent).toHaveBeenLastCalledWith({
+        order_id: "2939023",
         action_type: "Focused on offer input",
         flow: "Make offer",
       })
@@ -549,6 +550,7 @@ Object {
         .onClick({})
 
       expect(mockPostEvent).toHaveBeenLastCalledWith({
+        order_id: "2939023",
         action_type: "Viewed offer too low",
         flow: "Make offer",
       })
@@ -573,6 +575,7 @@ Object {
         .onClick({})
 
       expect(mockPostEvent).toHaveBeenLastCalledWith({
+        order_id: "2939023",
         action_type: "Viewed offer higher than listed price",
         flow: "Make offer",
       })

--- a/src/Apps/Order/Routes/__tests__/Respond.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Respond.test.tsx
@@ -20,6 +20,15 @@ import { Stepper } from "Styleguide/Components"
 import { CountdownTimer } from "Styleguide/Components/CountdownTimer"
 import { RespondFragmentContainer as RespondRoute } from "../Respond"
 
+// Need to mock Utils/Events instead of using mockTracking because
+// Boot's `dispatch` tracking prop overrides the one injected by
+// mockTracking
+jest.unmock("react-tracking")
+jest.mock("Utils/Events", () => ({
+  postEvent: jest.fn(),
+}))
+const mockPostEvent = require("Utils/Events").postEvent as jest.Mock
+
 jest.mock("Apps/Order/Utils/trackPageView")
 
 jest.mock("Utils/getCurrentTimeAsIsoString")
@@ -80,6 +89,7 @@ describe("Offer InitialMutation", () => {
   }
 
   beforeEach(() => {
+    mockPostEvent.mockReset()
     mockPushRoute = jest.fn()
     commitMutationMock.mockReset()
   })
@@ -493,9 +503,79 @@ Object {
     })
   })
 
-  it("tracks a pageview", () => {
-    getWrapper()
+  describe("Analaytics", () => {
+    it("tracks a pageview", () => {
+      getWrapper()
 
-    expect(trackPageView).toHaveBeenCalledTimes(1)
+      expect(trackPageView).toHaveBeenCalledTimes(1)
+    })
+
+    it("tracks the offer input focus", () => {
+      const counter = getWrapper()
+
+      const counterRadio = counter.find(BorderedRadio).at(1)
+      counterRadio.props().onSelect({ selected: true, value: "COUNTER" })
+
+      expect(mockPostEvent).not.toHaveBeenCalled()
+
+      counter
+        .find(OfferInput)
+        .find("input")
+        .simulate("focus")
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toHaveBeenLastCalledWith({
+        action_type: "Focused on offer input",
+        flow: "Make offer",
+      })
+    })
+
+    it("tracks viwing the low offer speedbump", async () => {
+      const component = getWrapper()
+      const counterRadio = component.find(BorderedRadio).at(1)
+      counterRadio.props().onSelect({ selected: true, value: "COUNTER" })
+
+      component
+        .find(OfferInput)
+        .props()
+        .onChange(1000)
+
+      expect(mockPostEvent).not.toHaveBeenCalled()
+
+      component
+        .find(Button)
+        .last()
+        .props()
+        .onClick({})
+
+      expect(mockPostEvent).toHaveBeenLastCalledWith({
+        action_type: "Viewed offer too low",
+        flow: "Make offer",
+      })
+    })
+
+    it("tracks viwing the high offer speedbump", async () => {
+      const component = getWrapper()
+      const counterRadio = component.find(BorderedRadio).at(1)
+      counterRadio.props().onSelect({ selected: true, value: "COUNTER" })
+
+      component
+        .find(OfferInput)
+        .props()
+        .onChange(20000)
+
+      expect(mockPostEvent).not.toHaveBeenCalled()
+
+      component
+        .find(Button)
+        .last()
+        .props()
+        .onClick({})
+
+      expect(mockPostEvent).toHaveBeenLastCalledWith({
+        action_type: "Viewed offer higher than listed price",
+        flow: "Make offer",
+      })
+    })
   })
 })

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -86,6 +86,11 @@ export enum ActionType {
   SubmittedOffer = "submitted_offer",
   SubmittedCounterOffer = "submitted_counter_offer",
   ViewedProduct = "Viewed Product",
+  FocusedOnOfferInput = "Focused on offer input",
+
+  // MO speedbumps
+  ViewedOfferTooLow = "Viewed offer too low",
+  ViewedOfferHigherThanListPrice = "Viewed offer higher than listed price",
 }
 
 /**


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-791

Only issue is that I couldn't figure out how to use `mockTracking` and `MockBoot` together so had to figure out a new way of mocking the event tracker.