### PR TITLE
Switch between Artist Insights variations based on A/B enrollment

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -12,6 +12,7 @@ import { Col, Row } from "Styleguide/Elements/Grid"
 import { Media } from "Utils/Responsive"
 import { CurrentEventFragmentContainer as CurrentEvent } from "./Components/CurrentEvent"
 
+import { withContext } from "Artsy/SystemContext"
 import {
   ArtistBioFragmentContainer as ArtistBio,
   MarketInsightsFragmentContainer as MarketInsights,
@@ -24,6 +25,7 @@ export interface OverviewRouteProps {
   artist: Overview_artist & {
     __fragments: object[]
   }
+  ARTIST_INSIGHTS?: string
 }
 
 interface State {
@@ -60,7 +62,8 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
 
   render() {
     const { artist } = this.props
-    const artistInsightsVariation = sd.ARTIST_INSIGHTS
+    const artistInsightsVariation =
+      this.props.ARTIST_INSIGHTS || sd.ARTIST_INSIGHTS
     const showArtistInsightsV1 =
       (artistInsightsVariation === undefined ||
         artistInsightsVariation === "v1") &&
@@ -201,7 +204,7 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
 }
 
 export const OverviewRouteFragmentContainer = createFragmentContainer(
-  OverviewRoute,
+  withContext(OverviewRoute),
   graphql`
     fragment Overview_artist on Artist
       @argumentDefinitions(

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -97,22 +97,13 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     const artistInsightsVariation =
       this.props.ARTIST_INSIGHTS || sd.ARTIST_INSIGHTS
     const showArtistInsightsV1 =
-      (artistInsightsVariation === undefined ||
-        artistInsightsVariation === "v1") &&
-      showMarketInsights(this.props.artist)
-    const showArtistInsightsV2BeforeBio =
-      artistInsightsVariation === "v2_before_bio" &&
+      artistInsightsVariation === "v1" && showMarketInsights(this.props.artist)
+    const showArtistInsightsV2 =
+      artistInsightsVariation === "v2" &&
       (showMarketInsights(this.props.artist) || artist.insights.length)
-    const showArtistInsightsV2AfterBio =
-      artistInsightsVariation === "v2_after_bio" &&
-      (showMarketInsights(this.props.artist) || artist.insights.length)
-    const showArtistInsights =
-      showArtistInsightsV1 ||
-      showArtistInsightsV2BeforeBio ||
-      showArtistInsightsV2AfterBio
+    const showArtistInsights = showArtistInsightsV1 || showArtistInsightsV2
     const showSelectedExhibitions =
-      Boolean(artist.exhibition_highlights.length) &&
-      !(showArtistInsightsV2BeforeBio || showArtistInsightsV2AfterBio)
+      Boolean(artist.exhibition_highlights.length) && !showArtistInsightsV2
     const showArtistBio = Boolean(artist.biography_blurb.text)
     const showCurrentEvent = Boolean(artist.currentEvent)
     const showConsignable = Boolean(artist.is_consignable)
@@ -133,7 +124,7 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
         <Row>
           <Col sm={colNum}>
             <>
-              {showArtistInsightsV2BeforeBio && (
+              {showArtistInsightsV2 && (
                 <>
                   {this.renderArtistInsightsV2()}
                   <Spacer mb={1} />
@@ -200,10 +191,8 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                       Learn more
                     </a>.
                   </Sans>
-                  {showArtistInsightsV2AfterBio && <Spacer mb={2} />}
                 </>
               )}
-              {showArtistInsightsV2AfterBio && this.renderArtistInsightsV2()}
             </>
           </Col>
 

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -55,6 +55,11 @@ export enum ActionType {
   ClickedReadMore = "Clicked read more",
 
   /**
+   * A/B Test Experiments
+   */
+  ExperimentViewed = "Experiment Viewed",
+
+  /**
    * Moving the mouse pointer over a UI element or, when browsing on a mobile
    * device, by first tapping the UI element once making it switch into
    * continuous hover mode.

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -16,6 +16,7 @@ declare module "sharify" {
      * These properties are set by Force and configured through environment variables.
      */
     export interface GlobalData {
+      readonly ARTIST_INSIGHTS: string
       readonly APP_URL: string
       readonly CMS_URL: string
       readonly ENABLE_MAKE_OFFER: string


### PR DESCRIPTION
`v1` -> Artist Insights v1
`v2_before_bio` -> Artist Insights v2 before bio
`v2_after_bio` -> Artist Insights v2 after bio