### PR TITLE
Modal: Support background scroll locking and close via escape key

### DIFF
--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -33,6 +33,8 @@ injectGlobal`
   }
 `
 
+const KEYBOARD_EVENT = "keyup"
+
 export class ModalWrapper extends React.Component<
   ModalWrapperProps,
   ModalWrapperState
@@ -59,6 +61,14 @@ export class ModalWrapper extends React.Component<
     }
   }
 
+  componentDidMount() {
+    this.updateBodyScrollBlock()
+  }
+
+  componentDidUpdate() {
+    this.updateBodyScrollBlock()
+  }
+
   componentWillUnmount() {
     this.removeBlurToContainers()
   }
@@ -77,6 +87,14 @@ export class ModalWrapper extends React.Component<
   removeBlurToContainers = () => {
     for (const container of this.state.blurContainers) {
       container.classList.remove("blurred")
+    }
+  }
+
+  updateBodyScrollBlock() {
+    if (this.props.show) {
+      document.body.style.overflowY = "hidden"
+    } else {
+      document.body.style.overflowY = "auto"
     }
   }
 

--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -63,10 +63,12 @@ export class ModalWrapper extends React.Component<
 
   componentDidMount() {
     this.updateBodyScrollBlock()
+    this.updateEscapeKeyListener()
   }
 
   componentDidUpdate() {
     this.updateBodyScrollBlock()
+    this.updateEscapeKeyListener()
   }
 
   componentWillUnmount() {
@@ -95,6 +97,20 @@ export class ModalWrapper extends React.Component<
       document.body.style.overflowY = "hidden"
     } else {
       document.body.style.overflowY = "auto"
+    }
+  }
+
+  handleEscapeKey = event => {
+    if (event && event.key === "Escape") {
+      this.close()
+    }
+  }
+
+  updateEscapeKeyListener() {
+    if (this.props.show) {
+      document.addEventListener(KEYBOARD_EVENT, this.handleEscapeKey, true)
+    } else {
+      document.removeEventListener(KEYBOARD_EVENT, this.handleEscapeKey, true)
     }
   }
 


### PR DESCRIPTION
- Disable scrolling of background content while modal is open 

    This commit disables vertical scrolling of the background content while the modal is open. This covers scrolling while the cursor is positioned off of the modal window and for smaller viewports, scrolling beyond the modal content, which would also cause the background content to scroll.

- Close open modal via escape key

    This commit sets up an event listener while the modal is open to close
the modal if the escape key is pressed.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-674