### PR TITLE
User should see the mobile sign up modal in the artist page

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -5,6 +5,7 @@ import * as Schema from "Artsy/Analytics/Schema"
 import { ContextConsumer, Mediator } from "Artsy/SystemContext"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import { Carousel } from "Components/v2"
+import { stringify } from "qs"
 import React, { Component, Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
@@ -246,16 +247,18 @@ export class SmallArtistHeader extends Component<Props> {
             buttonProps={{ width: "100%" }}
             user={user}
             onOpenAuthModal={() => {
-              props.mediator.trigger("open:auth", {
-                mode: "signup",
-                copy: `Sign up to follow ${props.artist.name}`,
-                signupIntent: "follow artist",
-                afterSignUpAction: {
-                  kind: "artist",
-                  action: "follow",
-                  objectId: props.artist.id,
-                },
+              const params = stringify({
+                action: "follow",
+                contextModule: "Artist page",
+                intent: "follow artist",
+                kind: "artist",
+                objectId: props.artist.id,
+                signUpIntent: "follow artist",
+                trigger: "click",
               })
+              const href = `/sign_up?redirect-to=${window.location}&${params}`
+
+              location.href = href
             }}
           >
             Follow


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-1032

This PR replaces the responsive sign up modal with the mobile sign up modal in e.g http://staging.artsy.net/artist/charles-arnoldi-1. Our hypothesis is that the mobile sign up modal converts more - I don't have specific numbers right now but is definitely something we want to compare.

## Screenshot

<img width="800" alt="mobile-sign-up" src="https://user-images.githubusercontent.com/386234/51065768-96470e80-15d4-11e9-8cd0-c17f290783f5.png">
