### PR TITLE
[Release] Attempt 2 to send out major release

### DIFF
--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -5,3 +5,9 @@ export default {
   fillwidthDimensions,
   Events,
 }
+
+export * from "./BreakpointVisualizer"
+export * from "./ColorPreview"
+export * from "./Placeholder"
+export * from "./ScrollIntoView"
+export * from "./Section"

--- a/src/Utils/index.tsx
+++ b/src/Utils/index.tsx
@@ -1,5 +1,0 @@
-export * from "./BreakpointVisualizer"
-export * from "./ColorPreview"
-export * from "./Placeholder"
-export * from "./ScrollIntoView"
-export * from "./Section"


### PR DESCRIPTION
The release step failed here https://circleci.com/gh/artsy/reaction/23038.

I suspect it was because `yarn emit-types` failed yet the `auto-release` cli was consuming error. The error was a result of there being two index files in the `/Utils` folder (erroneously), which TypeScript was unable to merge. 