### PR TITLE
Ensure artist insights flex container uses 100% of available space

### DIFF
--- a/src/Components/v2/SelectedCareerAchievements.tsx
+++ b/src/Components/v2/SelectedCareerAchievements.tsx
@@ -109,7 +109,7 @@ export class SelectedCareerAchievements extends React.Component<
     return (
       <>
         <Container>
-          <Flex flexDirection="column" alignItems="left">
+          <Flex flexDirection="column" alignItems="left" width="100%">
             <Sans size="2" weight="medium">
               Selected career achievements
             </Sans>


### PR DESCRIPTION
Fixes the following issue found during QA:

> Upon clicking "X more" link, the column seems to shift to the right
> slightly. See recording: https://cl.ly/4d787cb60e0d

ticket: https://artsyproduct.atlassian.net/browse/DISCO-676