### PR TITLE
Add gutter space between artist insight components

### DIFF
--- a/src/Components/v2/ArtistInsight.tsx
+++ b/src/Components/v2/ArtistInsight.tsx
@@ -92,7 +92,7 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
 
     if (value || (entities && entities.length > 0)) {
       return (
-        <Flex mt={1} width={["100%", "50%"]}>
+        <Flex mt={1} width={["100%", "48%"]}>
           <Flex pr={1}>{this.renderIcon(type)}</Flex>
           <Flex flexDirection="column">
             <Box>

--- a/src/Components/v2/SelectedCareerAchievements.tsx
+++ b/src/Components/v2/SelectedCareerAchievements.tsx
@@ -113,7 +113,11 @@ export class SelectedCareerAchievements extends React.Component<
             <Sans size="2" weight="medium">
               Selected career achievements
             </Sans>
-            <Flex flexDirection="row" flexWrap="wrap">
+            <Flex
+              flexDirection="row"
+              flexWrap="wrap"
+              justifyContent="space-between"
+            >
               {this.renderGalleryRepresentation()}
               {this.renderAuctionHighlight()}
 


### PR DESCRIPTION
By setting the width of individual artist insight components set to 50%, the text can occasionally brush up to the icons in the next columns.

Instead of adding padding, considering we don't know whether a particiular insight will show up on the left or right side, limit the Artist Insight component to 48% width and use `justify-content: space-between`.

**Before**

<img width="870" alt="0b4c4363004bc3a4120ce00336f6887b _screen shot 2019-01-14 at 3 40 52 pm" src="https://user-images.githubusercontent.com/123595/51143436-8ae62400-181c-11e9-9220-d20bbc7c3462.png">


**After**

![2019-01-14-165136_1279x569_scrot](https://user-images.githubusercontent.com/123595/51143463-9afe0380-181c-11e9-9cae-8741f453ce7d.png)


