### PR TITLE
Add ability to customize sign up form title

### DIFF
--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -26,6 +26,7 @@ export interface FormSwitcherProps {
   onFacebookLogin?: (e: Event) => void
   onTwitterLogin?: (e: Event) => void
   options: ModalOptions
+  title?: string
   tracking?: TrackingProp
   type: ModalType
   submitUrls?: { [P in ModalType]: string } & {
@@ -116,7 +117,7 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
   }
 
   render() {
-    const { error, isMobile, options } = this.props
+    const { error, isMobile, title, options } = this.props
 
     const queryData = Object.assign(
       {},
@@ -165,6 +166,7 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
 
     return (
       <Form
+        title={title}
         contextModule={options.contextModule}
         error={error}
         values={defaultValues}

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -174,7 +174,9 @@ export class MobileSignUpForm extends Component<
                     fontSize="16px"
                   />
                 </BackButton>
-                <MobileHeader>Sign up for Artsy</MobileHeader>
+                <MobileHeader>
+                  {this.props.title || "Sign up for Artsy"}
+                </MobileHeader>
                 {currentStep}
                 {this.showError(status)}
                 <SubmitButton

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -32,6 +32,7 @@ export interface FormProps {
   onFacebookLogin?: (e: Event) => void
   onTwitterLogin?: (e: Event) => void
   onBackButtonClicked?: (e: Event) => void
+  title?: string
 }
 
 interface AfterSignUpAction {
@@ -89,6 +90,10 @@ export interface ModalOptions {
    * the number of seconds before a modal was triggered
    */
   triggerSeconds?: number
+  /**
+   * The form or modal title in case it needs to be customized
+   */
+  title?: string
 }
 
 export type FormComponentType =

--- a/src/Components/Authentication/__tests__/Mobile/SignUpForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Mobile/SignUpForm.test.tsx
@@ -8,6 +8,7 @@ describe("MobileSignUpForm", () => {
   const getWrapper = props =>
     mount(
       <MobileSignUpForm
+        {...props}
         values={props.values || {}}
         handleSubmit={handleSubmit}
         handleTypeChange={jest.fn()}
@@ -19,6 +20,7 @@ describe("MobileSignUpForm", () => {
     const input = wrapper.find(Input)
     expect(input.length).toBe(1)
     expect(input.props().type).toEqual("email")
+    expect(wrapper.text()).toContain("Sign up for Artsy")
   })
 
   it("renders errors", done => {
@@ -38,6 +40,12 @@ describe("MobileSignUpForm", () => {
     formik.setStatus({ error: "some password error" })
     wrapper.update()
     expect(wrapper.html()).toMatch("some password error")
+  })
+
+  it("renders the specified title", () => {
+    const wrapper = getWrapper({ title: "Sign up to follow Andy Warhol" })
+
+    expect(wrapper.text()).toContain("Sign up to follow Andy Warhol")
   })
 
   it("renders global errors", () => {


### PR DESCRIPTION
partially addresses https://artsyproduct.atlassian.net/browse/GROW-1080

This PR adds the ability to override the title in the sign up form. I wonder if we should do the same to the log in form. Let me know if that is the case.