### PR TITLE
ArtworkBanner for auctions should show sale cover image instead of partner profile image

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkBanner/__tests__/ArtworkBanner.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkBanner/__tests__/ArtworkBanner.test.tsx
@@ -6,7 +6,6 @@ import {
 } from "Apps/__tests__/Fixtures/Artwork/ArtworkBanner"
 import { ArtworkBannerFragmentContainer } from "Apps/Artwork/Components/ArtworkBanner"
 import { renderRelayTree } from "DevTools"
-import { GraphQLResolveInfo } from "graphql"
 import { graphql } from "react-relay"
 
 jest.unmock("react-relay")
@@ -22,17 +21,7 @@ describe("ArtworkBanner", () => {
           }
         }
       `,
-      mockResolvers: {
-        Artwork: () => ({
-          ...response,
-          // FIXME: Need to figure out how to return proper values for aliesed objects
-          context: (_source, _args, _context, info: GraphQLResolveInfo) => {
-            const alias = info.fieldNodes[0].alias!.value
-            const x = response[alias]
-            return x
-          },
-        }),
-      },
+      mockData: { artwork: response },
     })
   }
 
@@ -54,8 +43,12 @@ describe("ArtworkBanner", () => {
     })
     it("renders a correct data for the auction", () => {
       const html = wrapper.html()
+
       expect(html).toContain("In auction")
       // expect(html).toContain("Doyle: Post-War & Contemporary Art")
+      expect(html).toContain(
+        "https://d32dm0rphc51dk.cloudfront.net/teoB9Znrq-78iSh6_Vh6Og/square.jpg"
+      )
       expect(html).toContain("Doyle")
     })
   })

--- a/src/Apps/Artwork/Components/ArtworkBanner/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkBanner/index.tsx
@@ -17,6 +17,7 @@ export const ArtworkBanner: React.SFC<ArtworkBannerProps> = props => {
     artworkContextFair,
     artworkContextPartnerShow,
     partner,
+    sale,
   } = props.artwork
 
   // Auction
@@ -24,7 +25,7 @@ export const ArtworkBanner: React.SFC<ArtworkBannerProps> = props => {
     artworkContextAuction &&
     artworkContextAuction.__typename === "ArtworkContextAuction"
   ) {
-    const auctionImage = get(partner, p => p.profile.icon.url)
+    const auctionImage = get(sale, s => s.is_auction && s.cover_image.url)
     return (
       <Banner
         imageUrl={auctionImage}
@@ -94,6 +95,12 @@ export const ArtworkBannerFragmentContainer = createFragmentContainer(
             url(version: "square140")
           }
           href
+        }
+      }
+      sale {
+        is_auction
+        cover_image {
+          url(version: "square")
         }
       }
       # This aliasing selection of the context is done to work around a type generator bug, see below.

--- a/src/Apps/__tests__/Fixtures/Artwork/ArtworkBanner.ts
+++ b/src/Apps/__tests__/Fixtures/Artwork/ArtworkBanner.ts
@@ -9,6 +9,7 @@ export const ArtwrorkNoBannerFixture = {
     initials: "D",
     profile: null,
   },
+  sale: null,
 }
 export const ArtworkAuctionBannerFixture = {
   id: "richard-anuszkiewicz-lino-yellow-318",
@@ -29,6 +30,14 @@ export const ArtworkAuctionBannerFixture = {
     name: "Doyle",
     initials: "D",
     profile: null,
+  },
+  sale: {
+    name: "Doyle: Post-War & Contemporary Art",
+    is_auction: true,
+    cover_image: {
+      url:
+        "https://d32dm0rphc51dk.cloudfront.net/teoB9Znrq-78iSh6_Vh6Og/square.jpg",
+    },
   },
 }
 export const ArtworkFairBannerFixture = {
@@ -61,8 +70,10 @@ export const ArtworkFairBannerFixture = {
         url:
           "https://d32dm0rphc51dk.cloudfront.net/wayPSO-tWo5yvs0Lu864GA/square140.png",
       },
+      href: "/white-cube",
     },
   },
+  sale: null,
 }
 export const ArtworkUpcomingShowBannerFixture = {
   id: "claudia-giraudo-affinita-verde-amarillo",
@@ -90,8 +101,10 @@ export const ArtworkUpcomingShowBannerFixture = {
         url:
           "https://d32dm0rphc51dk.cloudfront.net/5M6lXKjC3NIG5KM-x1SplA/square140.png",
       },
+      href: "/galleria-punto-sullarte",
     },
   },
+  sale: null,
 }
 export const ArtworkCurrentShowBannerFixture = {
   id: "marcel-barbeau-diamants-larmes",
@@ -119,8 +132,10 @@ export const ArtworkCurrentShowBannerFixture = {
         url:
           "https://d32dm0rphc51dk.cloudfront.net/9KdRZamUZCROfC6j_xpk_A/square140.png",
       },
+      href: "/galerie-deste",
     },
   },
+  sale: null,
 }
 export const ArtworkPastShowBannerFixture = {
   id:
@@ -149,6 +164,8 @@ export const ArtworkPastShowBannerFixture = {
         url:
           "https://d32dm0rphc51dk.cloudfront.net/h4j--cdqWuEdmbJ96B0lPw/square140.png",
       },
+      href: "/pamm",
     },
   },
+  sale: null,
 }

--- a/src/__generated__/ArtworkBannerQuery.graphql.ts
+++ b/src/__generated__/ArtworkBannerQuery.graphql.ts
@@ -41,6 +41,13 @@ fragment ArtworkBanner_artwork on Artwork {
     }
     __id
   }
+  sale {
+    is_auction
+    cover_image {
+      url(version: "square")
+    }
+    __id
+  }
   artworkContextAuction: context {
     __typename
     ... on ArtworkContextAuction {
@@ -161,11 +168,24 @@ v6 = {
 v7 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "is_auction",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square",
+  "type": "[String]"
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v8 = [
+v10 = [
   {
     "kind": "LinkedField",
     "alias": "img",
@@ -178,12 +198,7 @@ v8 = [
         "value": 70,
         "type": "Int"
       },
-      {
-        "kind": "Literal",
-        "name": "version",
-        "value": "square",
-        "type": "[String]"
-      },
+      v8,
       {
         "kind": "Literal",
         "name": "width",
@@ -209,7 +224,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkBannerQuery",
   "id": null,
-  "text": "query ArtworkBannerQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkBanner_artwork\n    __id\n  }\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n",
+  "text": "query ArtworkBannerQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkBanner_artwork\n    __id\n  }\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  sale {\n    is_auction\n    cover_image {\n      url(version: \"square\")\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -306,6 +321,39 @@ return {
           },
           {
             "kind": "LinkedField",
+            "alias": null,
+            "name": "sale",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Sale",
+            "plural": false,
+            "selections": [
+              v7,
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "cover_image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "url",
+                    "args": [
+                      v8
+                    ],
+                    "storageKey": "url(version:\"square\")"
+                  }
+                ]
+              },
+              v2
+            ]
+          },
+          {
+            "kind": "LinkedField",
             "alias": "artworkContextAuction",
             "name": "context",
             "storageKey": null,
@@ -313,7 +361,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v7,
+              v9,
               v2,
               {
                 "kind": "InlineFragment",
@@ -321,13 +369,7 @@ return {
                 "selections": [
                   v4,
                   v6,
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "is_auction",
-                    "args": null,
-                    "storageKey": null
-                  },
+                  v7,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -369,7 +411,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v7,
+              v9,
               v2,
               {
                 "kind": "InlineFragment",
@@ -416,7 +458,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": false,
-                        "selections": v8
+                        "selections": v10
                       },
                       v2
                     ]
@@ -434,7 +476,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v7,
+              v9,
               v2,
               {
                 "kind": "InlineFragment",
@@ -458,7 +500,7 @@ return {
                     "args": null,
                     "concreteType": "Image",
                     "plural": false,
-                    "selections": v8
+                    "selections": v10
                   }
                 ]
               }

--- a/src/__generated__/ArtworkBanner_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkBanner_Test_Query.graphql.ts
@@ -37,6 +37,13 @@ fragment ArtworkBanner_artwork on Artwork {
     }
     __id
   }
+  sale {
+    is_auction
+    cover_image {
+      url(version: "square")
+    }
+    __id
+  }
   artworkContextAuction: context {
     __typename
     ... on ArtworkContextAuction {
@@ -149,11 +156,24 @@ v5 = {
 v6 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "is_auction",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square",
+  "type": "[String]"
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v7 = [
+v9 = [
   {
     "kind": "LinkedField",
     "alias": "img",
@@ -166,12 +186,7 @@ v7 = [
         "value": 70,
         "type": "Int"
       },
-      {
-        "kind": "Literal",
-        "name": "version",
-        "value": "square",
-        "type": "[String]"
-      },
+      v7,
       {
         "kind": "Literal",
         "name": "width",
@@ -197,7 +212,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkBanner_Test_Query",
   "id": null,
-  "text": "query ArtworkBanner_Test_Query {\n  artwork(id: \"richard-anuszkiewicz-lino-yellow-318\") {\n    ...ArtworkBanner_artwork\n    __id\n  }\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n",
+  "text": "query ArtworkBanner_Test_Query {\n  artwork(id: \"richard-anuszkiewicz-lino-yellow-318\") {\n    ...ArtworkBanner_artwork\n    __id\n  }\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  sale {\n    is_auction\n    cover_image {\n      url(version: \"square\")\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -294,6 +309,39 @@ return {
           },
           {
             "kind": "LinkedField",
+            "alias": null,
+            "name": "sale",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Sale",
+            "plural": false,
+            "selections": [
+              v6,
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "cover_image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "url",
+                    "args": [
+                      v7
+                    ],
+                    "storageKey": "url(version:\"square\")"
+                  }
+                ]
+              },
+              v1
+            ]
+          },
+          {
+            "kind": "LinkedField",
             "alias": "artworkContextAuction",
             "name": "context",
             "storageKey": null,
@@ -301,7 +349,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v6,
+              v8,
               v1,
               {
                 "kind": "InlineFragment",
@@ -309,13 +357,7 @@ return {
                 "selections": [
                   v3,
                   v5,
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "is_auction",
-                    "args": null,
-                    "storageKey": null
-                  },
+                  v6,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -357,7 +399,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v6,
+              v8,
               v1,
               {
                 "kind": "InlineFragment",
@@ -404,7 +446,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": false,
-                        "selections": v7
+                        "selections": v9
                       },
                       v1
                     ]
@@ -422,7 +464,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v6,
+              v8,
               v1,
               {
                 "kind": "InlineFragment",
@@ -446,7 +488,7 @@ return {
                     "args": null,
                     "concreteType": "Image",
                     "plural": false,
-                    "selections": v7
+                    "selections": v9
                   }
                 ]
               }

--- a/src/__generated__/ArtworkBanner_artwork.graphql.ts
+++ b/src/__generated__/ArtworkBanner_artwork.graphql.ts
@@ -15,6 +15,12 @@ export type ArtworkBanner_artwork = {
             readonly href: string | null;
         }) | null;
     }) | null;
+    readonly sale: ({
+        readonly is_auction: boolean | null;
+        readonly cover_image: ({
+            readonly url: string | null;
+        }) | null;
+    }) | null;
     readonly artworkContextAuction: ({
         readonly __typename: "ArtworkContextAuction";
         readonly name: string | null;
@@ -109,11 +115,24 @@ v4 = {
 v5 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "is_auction",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square",
+  "type": "[String]"
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v6 = [
+v8 = [
   {
     "kind": "LinkedField",
     "alias": "img",
@@ -126,12 +145,7 @@ v6 = [
         "value": 70,
         "type": "Int"
       },
-      {
-        "kind": "Literal",
-        "name": "version",
-        "value": "square",
-        "type": "[String]"
-      },
+      v6,
       {
         "kind": "Literal",
         "name": "width",
@@ -214,6 +228,39 @@ return {
     },
     {
       "kind": "LinkedField",
+      "alias": null,
+      "name": "sale",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Sale",
+      "plural": false,
+      "selections": [
+        v5,
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "cover_image",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Image",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "url",
+              "args": [
+                v6
+              ],
+              "storageKey": "url(version:\"square\")"
+            }
+          ]
+        },
+        v4
+      ]
+    },
+    {
+      "kind": "LinkedField",
       "alias": "artworkContextAuction",
       "name": "context",
       "storageKey": null,
@@ -221,7 +268,7 @@ return {
       "concreteType": null,
       "plural": false,
       "selections": [
-        v5,
+        v7,
         v4,
         {
           "kind": "InlineFragment",
@@ -229,13 +276,7 @@ return {
           "selections": [
             v1,
             v3,
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "is_auction",
-              "args": null,
-              "storageKey": null
-            },
+            v5,
             {
               "kind": "ScalarField",
               "alias": null,
@@ -277,7 +318,7 @@ return {
       "concreteType": null,
       "plural": false,
       "selections": [
-        v5,
+        v7,
         v4,
         {
           "kind": "InlineFragment",
@@ -324,7 +365,7 @@ return {
                   "args": null,
                   "concreteType": "Image",
                   "plural": false,
-                  "selections": v6
+                  "selections": v8
                 },
                 v4
               ]
@@ -342,7 +383,7 @@ return {
       "concreteType": null,
       "plural": false,
       "selections": [
-        v5,
+        v7,
         v4,
         {
           "kind": "InlineFragment",
@@ -366,7 +407,7 @@ return {
               "args": null,
               "concreteType": "Image",
               "plural": false,
-              "selections": v6
+              "selections": v8
             }
           ]
         }
@@ -376,5 +417,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'b531b77ce0ce6685452abe05f1e40192';
+(node as any).hash = '342fe946015d9601deab03cd20f4a95a';
 export default node;

--- a/src/__generated__/routes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/routes_ArtworkQuery.graphql.ts
@@ -123,6 +123,13 @@ fragment ArtworkBanner_artwork on Artwork {
     }
     __id
   }
+  sale {
+    is_auction
+    cover_image {
+      url(version: "square")
+    }
+    __id
+  }
   artworkContextAuction: context {
     __typename
     ... on ArtworkContextAuction {
@@ -689,80 +696,55 @@ v2 = {
   "storageKey": null
 },
 v3 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "dimensions",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "dimensions",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "in",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "cm",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
-v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_offerable",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "_id",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_followed",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v10 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "counts",
@@ -780,64 +762,70 @@ v11 = {
     }
   ]
 },
-v12 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "url",
   "args": null,
   "storageKey": null
 },
-v13 = [
-  v12
+v12 = [
+  v11
 ],
-v14 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "sale_message",
   "args": null,
   "storageKey": null
 },
-v15 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v16 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "initials",
   "args": null,
   "storageKey": null
 },
-v17 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v18 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v19 = {
+v18 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_auction",
   "args": null,
   "storageKey": null
 },
-v20 = {
+v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_closed",
   "args": null,
   "storageKey": null
+},
+v20 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square",
+  "type": "[String]"
 },
 v21 = {
   "kind": "ScalarField",
@@ -873,12 +861,7 @@ v24 = [
         "value": 70,
         "type": "Int"
       },
-      {
-        "kind": "Literal",
-        "name": "version",
-        "value": "square",
-        "type": "[String]"
-      },
+      v20,
       {
         "kind": "Literal",
         "name": "width",
@@ -888,38 +871,63 @@ v24 = [
     ],
     "concreteType": "ResizedImageUrl",
     "plural": false,
-    "selections": v13
+    "selections": v12
   }
 ],
 v25 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "dimensions",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "dimensions",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "in",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "cm",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v26 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "edition_of",
   "args": null,
   "storageKey": null
 },
-v26 = {
+v27 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
   "args": null,
   "storageKey": null
 },
-v27 = {
+v28 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cents",
   "args": null,
   "storageKey": null
 },
-v28 = {
+v29 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_winning",
   "args": null,
   "storageKey": null
 },
-v29 = [
+v30 = [
   {
     "kind": "Literal",
     "name": "format",
@@ -927,7 +935,7 @@ v29 = [
     "type": "Format"
   }
 ],
-v30 = [
+v31 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -948,7 +956,7 @@ return {
   "operationKind": "query",
   "name": "routes_ArtworkQuery",
   "id": null,
-  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_offerable\n  availability\n  price\n  is_in_auction\n  artists {\n    _id\n    id\n    __id\n  }\n  artist {\n    id\n    __id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  __id\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  artist {\n    href\n    related {\n      artists(kind: MAIN, first: 4) {\n        edges {\n          node {\n            ...ArtistCard_artist\n            __id\n          }\n        }\n      }\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  date\n  artist_names\n  sale_message\n  partner {\n    name\n    __id\n  }\n  image_rights\n  is_shareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on ArtworkContextFair {\n      id\n      name\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  sale {\n    is_closed\n    ...AuctionTimer_sale\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsChecklist_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  href\n  ...ArtworkActions_artwork\n  images {\n    id\n    uri: url(version: [\"larger\", \"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment OtherWorks_artwork on Artwork {\n  id\n  _id\n  sale {\n    is_closed\n    __id\n  }\n  context {\n    __typename\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    __id\n  }\n  date\n  href\n  id\n  image {\n    id\n  }\n  is_downloadable\n  partner {\n    id\n    __id\n  }\n  title\n  sale {\n    is_closed\n    is_auction\n    __id\n  }\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information(format: HTML)\n  partner {\n    _id\n    id\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    is_default_profile_public\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsChecklist_artwork on Artwork {\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker\n  artists {\n    __id\n    _id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  _id\n  sale {\n    is_closed\n    is_live_open\n    __id\n  }\n  sale_artwork {\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      __id\n    }\n    most_recent_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid {\n      max_bid {\n        cents\n      }\n      __id\n    }\n  }\n  id\n  sale {\n    id\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      cents\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_inquireable\n  is_offerable\n  sale_message\n  shippingInfo\n  shippingOrigin\n  edition_sets {\n    id\n    __id\n    is_acquireable\n    is_offerable\n    sale_message\n    ...ArtworkSidebarSizeInfo_piece\n  }\n  __id\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at\n  end_at\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          _id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  id\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_offerable\n  availability\n  price\n  is_in_auction\n  artists {\n    _id\n    id\n    __id\n  }\n  artist {\n    id\n    __id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  __id\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  artist {\n    href\n    related {\n      artists(kind: MAIN, first: 4) {\n        edges {\n          node {\n            ...ArtistCard_artist\n            __id\n          }\n        }\n      }\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  date\n  artist_names\n  sale_message\n  partner {\n    name\n    __id\n  }\n  image_rights\n  is_shareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on ArtworkContextFair {\n      id\n      name\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  sale {\n    is_auction\n    cover_image {\n      url(version: \"square\")\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  sale {\n    is_closed\n    ...AuctionTimer_sale\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsChecklist_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  href\n  ...ArtworkActions_artwork\n  images {\n    id\n    uri: url(version: [\"larger\", \"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment OtherWorks_artwork on Artwork {\n  id\n  _id\n  sale {\n    is_closed\n    __id\n  }\n  context {\n    __typename\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    __id\n  }\n  date\n  href\n  id\n  image {\n    id\n  }\n  is_downloadable\n  partner {\n    id\n    __id\n  }\n  title\n  sale {\n    is_closed\n    is_auction\n    __id\n  }\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information(format: HTML)\n  partner {\n    _id\n    id\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    is_default_profile_public\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsChecklist_artwork on Artwork {\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker\n  artists {\n    __id\n    _id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  _id\n  sale {\n    is_closed\n    is_live_open\n    __id\n  }\n  sale_artwork {\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      __id\n    }\n    most_recent_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid {\n      max_bid {\n        cents\n      }\n      __id\n    }\n  }\n  id\n  sale {\n    id\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      cents\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_inquireable\n  is_offerable\n  sale_message\n  shippingInfo\n  shippingOrigin\n  edition_sets {\n    id\n    __id\n    is_acquireable\n    is_offerable\n    sale_message\n    ...ArtworkSidebarSizeInfo_piece\n  }\n  __id\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at\n  end_at\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          _id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  id\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -990,10 +998,16 @@ return {
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "medium",
+            "args": null,
+            "storageKey": null
+          },
           v3,
           v4,
           v5,
-          v6,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -1024,13 +1038,13 @@ return {
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              v7,
-              v4,
+              v6,
+              v3,
               v2,
+              v7,
               v8,
               v9,
               v10,
-              v11,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1081,9 +1095,9 @@ return {
                             "plural": false,
                             "selections": [
                               v2,
+                              v6,
+                              v3,
                               v7,
-                              v4,
-                              v8,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -1114,7 +1128,7 @@ return {
                                     ],
                                     "concreteType": "CroppedImageUrl",
                                     "plural": false,
-                                    "selections": v13
+                                    "selections": v12
                                   }
                                 ]
                               }
@@ -1144,9 +1158,9 @@ return {
             "concreteType": "Artist",
             "plural": false,
             "selections": [
-              v4,
+              v3,
               v2,
-              v9,
+              v8,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1196,9 +1210,9 @@ return {
                             "concreteType": "Artist",
                             "plural": false,
                             "selections": [
+                              v7,
+                              v3,
                               v8,
-                              v4,
-                              v9,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -1229,7 +1243,7 @@ return {
                                     ],
                                     "concreteType": "CroppedImageUrl",
                                     "plural": false,
-                                    "selections": v13
+                                    "selections": v12
                                   }
                                 ]
                               },
@@ -1241,8 +1255,8 @@ return {
                                 "storageKey": null
                               },
                               v2,
-                              v10,
-                              v11
+                              v9,
+                              v10
                             ]
                           }
                         ]
@@ -1254,7 +1268,7 @@ return {
             ]
           },
           v2,
-          v9,
+          v8,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -1269,7 +1283,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          v14,
+          v13,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1279,10 +1293,10 @@ return {
             "concreteType": "Partner",
             "plural": false,
             "selections": [
-              v8,
+              v7,
               v2,
+              v14,
               v15,
-              v16,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1317,14 +1331,14 @@ return {
                       }
                     ]
                   },
-                  v9,
+                  v8,
                   v2,
-                  v4,
-                  v10
+                  v3,
+                  v9
                 ]
               },
-              v7,
-              v9,
+              v6,
+              v8,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1344,7 +1358,7 @@ return {
                   v2
                 ]
               },
-              v4,
+              v3,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1423,7 +1437,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v12
+                  v11
                 ]
               }
             ]
@@ -1437,7 +1451,7 @@ return {
             "concreteType": "ArtworkMeta",
             "plural": false,
             "selections": [
-              v17,
+              v16,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1477,16 +1491,102 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v18,
+              v17,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextFair",
                 "selections": [
-                  v4,
-                  v8
+                  v3,
+                  v7
                 ]
               }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "sale",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Sale",
+            "plural": false,
+            "selections": [
+              v3,
+              v18,
+              v2,
+              v6,
+              v19,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_with_buyers_premium",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_live_open",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "cover_image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "url",
+                    "args": [
+                      v20
+                    ],
+                    "storageKey": "url(version:\"square\")"
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "registrationStatus",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Bidder",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "qualified_for_bidding",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v2
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_preview",
+                "args": null,
+                "storageKey": null
+              },
+              v21,
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "is_registration_closed",
+                "args": null,
+                "storageKey": null
+              },
+              v22,
+              v23
             ]
           },
           {
@@ -1498,16 +1598,16 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v18,
+              v17,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextAuction",
                 "selections": [
+                  v7,
                   v8,
-                  v9,
+                  v18,
                   v19,
-                  v20,
                   v21,
                   v22,
                   {
@@ -1530,14 +1630,14 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v18,
+              v17,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextFair",
                 "selections": [
+                  v7,
                   v8,
-                  v9,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1562,7 +1662,7 @@ return {
                     "concreteType": "Profile",
                     "plural": false,
                     "selections": [
-                      v16,
+                      v15,
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1589,15 +1689,15 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v18,
+              v17,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextPartnerShow",
                 "selections": [
+                  v7,
                   v8,
-                  v9,
-                  v15,
+                  v14,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1643,12 +1743,12 @@ return {
             "plural": true,
             "selections": [
               v2,
+              v3,
               v4,
               v5,
-              v6,
-              v14,
-              v3,
-              v25
+              v13,
+              v25,
+              v26
             ]
           },
           {
@@ -1705,7 +1805,7 @@ return {
                 "concreteType": "SaleArtworkCurrentBid",
                 "plural": false,
                 "selections": [
-                  v26
+                  v27
                 ]
               },
               {
@@ -1735,22 +1835,16 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
-                  v27,
-                  v26
+                  v28,
+                  v27
                 ]
               }
             ]
           },
-          v17,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "medium",
-            "args": null,
-            "storageKey": null
-          },
-          v7,
+          v16,
+          v6,
           v25,
+          v26,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1760,7 +1854,7 @@ return {
             "concreteType": "Image",
             "plural": false,
             "selections": [
-              v4
+              v3
             ]
           },
           {
@@ -1779,72 +1873,6 @@ return {
                 "args": null,
                 "storageKey": null
               }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "sale",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Sale",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "registrationStatus",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Bidder",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "qualified_for_bidding",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  v2
-                ]
-              },
-              v7,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_with_buyers_premium",
-                "args": null,
-                "storageKey": null
-              },
-              v2,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_live_open",
-                "args": null,
-                "storageKey": null
-              },
-              v4,
-              v20,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_preview",
-                "args": null,
-                "storageKey": null
-              },
-              v21,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "is_registration_closed",
-                "args": null,
-                "storageKey": null
-              },
-              v22,
-              v23,
-              v19
             ]
           },
           {
@@ -1872,7 +1900,7 @@ return {
                 "concreteType": "BidderPosition",
                 "plural": false,
                 "selections": [
-                  v28,
+                  v29,
                   v2
                 ]
               },
@@ -1885,7 +1913,7 @@ return {
                 "concreteType": "BidderPosition",
                 "plural": false,
                 "selections": [
-                  v28,
+                  v29,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -1895,8 +1923,8 @@ return {
                     "concreteType": "BidderPositionMaxBid",
                     "plural": false,
                     "selections": [
-                      v26,
-                      v27
+                      v27,
+                      v28
                     ]
                   },
                   v2
@@ -1936,14 +1964,14 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "description",
-            "args": v29,
+            "args": v30,
             "storageKey": "description(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "additional_information",
-            "args": v29,
+            "args": v30,
             "storageKey": "additional_information(format:\"HTML\")"
           },
           {
@@ -1954,7 +1982,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": v30
+            "selections": v31
           },
           {
             "kind": "LinkedField",
@@ -1964,7 +1992,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": v30
+            "selections": v31
           },
           {
             "kind": "LinkedField",
@@ -1974,7 +2002,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": v30
+            "selections": v31
           },
           {
             "kind": "LinkedField",
@@ -1984,7 +2012,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": v30
+            "selections": v31
           },
           {
             "kind": "ScalarField",
@@ -2032,11 +2060,11 @@ return {
                 "concreteType": "Author",
                 "plural": false,
                 "selections": [
-                  v8,
+                  v7,
                   v2
                 ]
               },
-              v9,
+              v8,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -2075,7 +2103,7 @@ return {
                     ],
                     "concreteType": "ResizedImageUrl",
                     "plural": false,
-                    "selections": v13
+                    "selections": v12
                   }
                 ]
               },
@@ -2087,28 +2115,28 @@ return {
                 "storageKey": null
               },
               v2,
-              v4
+              v3
             ]
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "literature",
-            "args": v29,
+            "args": v30,
             "storageKey": "literature(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "exhibition_history",
-            "args": v29,
+            "args": v30,
             "storageKey": "exhibition_history(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "provenance",
-            "args": v29,
+            "args": v30,
             "storageKey": "provenance(format:\"HTML\")"
           },
           {
@@ -2141,8 +2169,8 @@ return {
             "concreteType": "Image",
             "plural": true,
             "selections": [
-              v12,
-              v4,
+              v11,
+              v3,
               {
                 "kind": "ScalarField",
                 "alias": "uri",
@@ -2187,7 +2215,7 @@ return {
                 ],
                 "concreteType": "ResizedImageUrl",
                 "plural": false,
-                "selections": v13
+                "selections": v12
               },
               {
                 "kind": "ScalarField",


### PR DESCRIPTION
Address https://artsyproduct.atlassian.net/browse/DISCO-530

Huge props to @ds300 for simplifying relay mocking here. Unfortunately this still has our original issue here that fields that are redefined for different Contexts come out undefined, but at least the set up here is much simpler. cc @alloy - who originally helped me to figure out this mockResolver.

![screen shot 2019-01-16 at 4 57 52 pm](https://user-images.githubusercontent.com/437156/51281270-e694e680-19af-11e9-8701-d0e442f75155.png)
