### PR TITLE
Styling changes to Collections blurb font sizes

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -50,11 +50,11 @@ const getReadMoreContent = (description, credit) => {
 }
 
 const maxChars = {
-  xs: 200,
-  sm: 430,
-  md: 450,
-  lg: 460,
-  xl: 510,
+  xs: 350,
+  sm: 730,
+  md: 670,
+  lg: 660,
+  xl: 820,
 }
 
 const imageWidthSizes = {
@@ -124,7 +124,7 @@ export class CollectionHeader extends Component<Props> {
                     <Grid>
                       <Row>
                         <Col xl="8" lg="8" md="10" sm="12" xs="12">
-                          <ExtendedSerif size="5" px={[0, 1]}>
+                          <ExtendedSerif size="3" px={[0, 1]}>
                             <ReadMore
                               onReadMoreClicked={this.trackReadMoreClick.bind(
                                 this


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-1053

- Changes font size to body-2 serif
- Truncate to 7 lines

**XL**
<img width="1203" alt="screen shot 2019-01-17 at 11 31 32 am" src="https://user-images.githubusercontent.com/5201004/51333416-a2572400-1a4b-11e9-9b2e-a20e46478ff0.png">

**Large**
<img width="915" alt="screen shot 2019-01-17 at 11 38 55 am" src="https://user-images.githubusercontent.com/5201004/51333889-ad5e8400-1a4c-11e9-991d-69bfb3a81eec.png">

**Medium**
<img width="805" alt="screen shot 2019-01-17 at 11 39 06 am" src="https://user-images.githubusercontent.com/5201004/51333912-b8191900-1a4c-11e9-89bd-8c62968b6997.png">

**Small**
<img width="745" alt="screen shot 2019-01-17 at 11 43 56 am" src="https://user-images.githubusercontent.com/5201004/51334164-42fa1380-1a4d-11e9-84c0-3a4d7ebc21ed.png">

**XS**
<img width="291" alt="screen shot 2019-01-17 at 11 45 54 am" src="https://user-images.githubusercontent.com/5201004/51334274-7dfc4700-1a4d-11e9-933c-203253ec3a77.png">

