### PR TITLE
Manually update version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 11.1.0 (Thu Jan 17 2019)
+
+#### 🚀  Enhancement
+
+- Sort Collections alphabetically by title in Index page [#1848](https://github.com/artsy/reaction/pull/1848) ([@yuki24](https://github.com/yuki24))
+- User should see the mobile sign up modal in the artist page [#1861](https://github.com/artsy/reaction/pull/1861) ([@yuki24](https://github.com/yuki24))
+
+---
+
 # 11.0.3 (Wed Jan 16 2019)
 
 #### 🐛  Bug Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction",
-  "version": "11.0.3",
+  "version": "11.1.0",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",


### PR DESCRIPTION
For some reason the auto-release build failed to push a commit that updates the `package.json` but the tag/version `11.1.0` is actually on GitHub/npm. I'm sending this PR to fix the consistency.