### PR TITLE
Fixes "related auction" image overlapping with text on RAP

### DIFF
--- a/src/Apps/__stories__/ArtworkApp.story.tsx
+++ b/src/Apps/__stories__/ArtworkApp.story.tsx
@@ -40,7 +40,7 @@ storiesOf("Apps/Artwork Page", module)
     return (
       <MockRouter
         routes={artworkRoutes}
-        initialRoute="/artwork/rembrandt-van-rijn-man-crying-out-bust-directed-three-quarter-to-the-left"
+        initialRoute="/artwork/charles-arnoldi-brig-1"
       />
     )
   })

--- a/src/Components/v2/AuctionCard.tsx
+++ b/src/Components/v2/AuctionCard.tsx
@@ -78,7 +78,7 @@ export const LargeAuctionCard = props => (
     </Serif>
     {props.src && (
       <Box height="200px">
-        <ResponsiveImage src={props.src} my={2} />
+        <ResponsiveImage src={props.src} my={2} pb="160px" />
       </Box>
     )}
     <Sans size="2" weight="medium">


### PR DESCRIPTION
Tiny PR to address [DISCO-678](https://artsyproduct.atlassian.net/browse/DISCO-678), thanks @damassi for helping me navigate Reaction!

Side note: there's some strange behavior with this component in the storybook (I think it's supposed to show up in the [OtherAuctions](https://artsy-reaction.netlify.com/?selectedKind=Apps%2FArtwork%20Page%2FComponents%2FOtherAuctions&selectedStory=Other%20Auctions&full=0&addons=0&stories=1&panelRight=0) section but doesn't, and it instead appears twice in the [OtherWorks](https://artsy-reaction.netlify.com/?selectedKind=Apps%2FArtwork%20Page%2FComponents%2FOtherWorks&selectedStory=Auctions&full=0&addons=0&stories=1&panelRight=0) section). Worth fixing, or is it a moot point since I believe this component is moving to Palette?