### PR TITLE
[WIP] Start on adding view in room to artwork page v2

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -88,11 +88,6 @@ export class ArtworkActions extends React.Component<
         dimensions,
         image,
       })
-
-    // Still to do:
-    // - Use correct eye button (being updated in palette; we might not even have to change the code if we're lucky)
-    // - Define mediator behavior in Force
-    // - Fix unhappy onClick (line 121)
   }
 
   render() {
@@ -109,14 +104,13 @@ export class ArtworkActions extends React.Component<
               artwork={this.props.artwork}
               render={Save(this.props)}
             />
-            // Remove the admin flag for production
             {artwork.is_hangable &&
               this.isAdmin && (
                 <ContextConsumer>
                   {({ mediator }) => (
                     <UtilButton
                       name="viewInRoom"
-                      onClick={this.openViewInRoom(mediator)}
+                      onClick={() => this.openViewInRoom(mediator)}
                     />
                   )}
                 </ContextConsumer>

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -22,6 +22,7 @@ import {
   HeartIcon,
   Join,
   Link,
+  OpenEyeIcon,
   ShareIcon,
   Spacer,
 } from "@artsy/palette"
@@ -77,6 +78,23 @@ export class ArtworkActions extends React.Component<
     }
   }
 
+  openViewInRoom(mediator) {
+    const {
+      artwork: { dimensions, image },
+    } = this.props
+    mediator &&
+      mediator.trigger &&
+      mediator.trigger("openViewInRoom", {
+        dimensions,
+        image,
+      })
+
+    // Still to do:
+    // - Use correct eye button (being updated in palette; we might not even have to change the code if we're lucky)
+    // - Define mediator behavior in Force
+    // - Fix unhappy onClick (line 121)
+  }
+
   render() {
     const { artwork } = this.props
     const downloadableImageUrl = this.getDownloadableImageUrl()
@@ -91,11 +109,22 @@ export class ArtworkActions extends React.Component<
               artwork={this.props.artwork}
               render={Save(this.props)}
             />
+            // Remove the admin flag for production
+            {artwork.is_hangable &&
+              this.isAdmin && (
+                <ContextConsumer>
+                  {({ mediator }) => (
+                    <UtilButton
+                      name="viewInRoom"
+                      onClick={this.openViewInRoom(mediator)}
+                    />
+                  )}
+                </ContextConsumer>
+              )}
             <UtilButton
               name="share"
               onClick={this.toggleSharePanel.bind(this)}
             />
-
             {downloadableImageUrl && (
               <UtilButton name="download" href={downloadableImageUrl} />
             )}
@@ -132,12 +161,16 @@ export const ArtworkActionsFragmentContainer = createFragmentContainer(
         name
       }
       date
+      dimensions {
+        cm
+      }
       href
       id
       image {
         id
       }
       is_downloadable
+      is_hangable
       partner {
         id
       }
@@ -151,7 +184,14 @@ export const ArtworkActionsFragmentContainer = createFragmentContainer(
 )
 
 interface UtilButtonProps {
-  name: "bell" | "edit" | "download" | "genome" | "heart" | "share"
+  name:
+    | "bell"
+    | "edit"
+    | "download"
+    | "genome"
+    | "heart"
+    | "share"
+    | "viewInRoom"
   href?: string
   onClick?: () => void
   selected?: boolean
@@ -182,6 +222,8 @@ class UtilButton extends React.Component<
           return HeartIcon
         case "share":
           return ShareIcon
+        case "viewInRoom":
+          return OpenEyeIcon
       }
     }
 

--- a/src/__generated__/ArtworkActions_artwork.graphql.ts
+++ b/src/__generated__/ArtworkActions_artwork.graphql.ts
@@ -10,12 +10,16 @@ export type ArtworkActions_artwork = {
         readonly name: string | null;
     }) | null> | null;
     readonly date: string | null;
+    readonly dimensions: ({
+        readonly cm: string | null;
+    }) | null;
     readonly href: string | null;
     readonly id: string;
     readonly image: ({
         readonly id: string | null;
     }) | null;
     readonly is_downloadable: boolean | null;
+    readonly is_hangable: boolean | null;
     readonly partner: ({
         readonly id: string;
     }) | null;
@@ -96,6 +100,24 @@ return {
       "storageKey": null
     },
     {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "dimensions",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "dimensions",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "cm",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
       "kind": "ScalarField",
       "alias": null,
       "name": "href",
@@ -112,6 +134,13 @@ return {
       "kind": "ScalarField",
       "alias": null,
       "name": "is_downloadable",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_hangable",
       "args": null,
       "storageKey": null
     },
@@ -165,5 +194,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '5a7d8c9ed94943c1a06cc5bcaf5b21ed';
+(node as any).hash = '8a8f98f657f06798e16ed82a050c3ca0';
 export default node;

--- a/src/__generated__/ArtworkImageBrowserQuery.graphql.ts
+++ b/src/__generated__/ArtworkImageBrowserQuery.graphql.ts
@@ -66,12 +66,16 @@ fragment ArtworkActions_artwork on Artwork {
     __id
   }
   date
+  dimensions {
+    cm
+  }
   href
   id
   image {
     id
   }
   is_downloadable
+  is_hangable
   partner {
     id
     __id
@@ -131,14 +135,14 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "url",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "url",
   "args": null,
   "storageKey": null
 };
@@ -147,7 +151,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkImageBrowserQuery",
   "id": null,
-  "text": "query ArtworkImageBrowserQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkImageBrowser_artwork\n    __id\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  href\n  ...ArtworkActions_artwork\n  images {\n    id\n    uri: url(version: [\"larger\", \"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    __id\n  }\n  date\n  href\n  id\n  image {\n    id\n  }\n  is_downloadable\n  partner {\n    id\n    __id\n  }\n  title\n  sale {\n    is_closed\n    is_auction\n    __id\n  }\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n  __id\n}\n",
+  "text": "query ArtworkImageBrowserQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkImageBrowser_artwork\n    __id\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  href\n  ...ArtworkActions_artwork\n  images {\n    id\n    uri: url(version: [\"larger\", \"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    __id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  id\n  image {\n    id\n  }\n  is_downloadable\n  is_hangable\n  partner {\n    id\n    __id\n  }\n  title\n  sale {\n    is_closed\n    is_auction\n    __id\n  }\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -191,6 +195,61 @@ return {
         "selections": [
           {
             "kind": "LinkedField",
+            "alias": "artworkMeta",
+            "name": "meta",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ArtworkMeta",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "share",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "image_title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "href",
+            "args": null,
+            "storageKey": null
+          },
+          v2,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "_id",
+            "args": null,
+            "storageKey": null
+          },
+          v3,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "is_saved",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
             "alias": null,
             "name": "images",
             "storageKey": null,
@@ -198,8 +257,8 @@ return {
             "concreteType": "Image",
             "plural": true,
             "selections": [
-              v3,
               v4,
+              v3,
               {
                 "kind": "ScalarField",
                 "alias": "uri",
@@ -245,7 +304,7 @@ return {
                 "concreteType": "ResizedImageUrl",
                 "plural": false,
                 "selections": [
-                  v3
+                  v4
                 ]
               },
               {
@@ -348,65 +407,10 @@ return {
           },
           {
             "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "image_title",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "href",
-            "args": null,
-            "storageKey": null
-          },
-          v2,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "_id",
-            "args": null,
-            "storageKey": null
-          },
-          v4,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "is_saved",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
             "alias": "image_alt",
             "name": "to_s",
             "args": null,
             "storageKey": null
-          },
-          {
-            "kind": "LinkedField",
-            "alias": "artworkMeta",
-            "name": "meta",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "ArtworkMeta",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "share",
-                "args": null,
-                "storageKey": null
-              }
-            ]
           },
           {
             "kind": "LinkedField",
@@ -437,19 +441,44 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "dimensions",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "dimensions",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "cm",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "image",
             "storageKey": null,
             "args": null,
             "concreteType": "Image",
             "plural": false,
             "selections": [
-              v4
+              v3
             ]
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "is_downloadable",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "is_hangable",
             "args": null,
             "storageKey": null
           },
@@ -462,7 +491,7 @@ return {
             "concreteType": "Partner",
             "plural": false,
             "selections": [
-              v4,
+              v3,
               v2
             ]
           },

--- a/src/__generated__/routes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/routes_ArtworkQuery.graphql.ts
@@ -287,12 +287,16 @@ fragment ArtworkActions_artwork on Artwork {
     __id
   }
   date
+  dimensions {
+    cm
+  }
   href
   id
   image {
     id
   }
   is_downloadable
+  is_hangable
   partner {
     id
     __id
@@ -701,185 +705,6 @@ v2 = {
   "storageKey": null
 },
 v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_acquireable",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_offerable",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "_id",
-  "args": null,
-  "storageKey": null
-},
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v8 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "href",
-  "args": null,
-  "storageKey": null
-},
-v9 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_followed",
-  "args": null,
-  "storageKey": null
-},
-v10 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "counts",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "ArtistCounts",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "follows",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
-v11 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "url",
-  "args": null,
-  "storageKey": null
-},
-v12 = [
-  v11
-],
-v13 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "sale_message",
-  "args": null,
-  "storageKey": null
-},
-v14 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "type",
-  "args": null,
-  "storageKey": null
-},
-v15 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "initials",
-  "args": null,
-  "storageKey": null
-},
-v16 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "title",
-  "args": null,
-  "storageKey": null
-},
-v17 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v18 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_auction",
-  "args": null,
-  "storageKey": null
-},
-v19 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": "square",
-  "type": "[String]"
-},
-v20 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_closed",
-  "args": null,
-  "storageKey": null
-},
-v21 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_open",
-  "args": null,
-  "storageKey": null
-},
-v22 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "live_start_at",
-  "args": null,
-  "storageKey": null
-},
-v23 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "end_at",
-  "args": null,
-  "storageKey": null
-},
-v24 = [
-  {
-    "kind": "LinkedField",
-    "alias": "img",
-    "name": "resized",
-    "storageKey": "resized(height:70,version:\"square\",width:70)",
-    "args": [
-      {
-        "kind": "Literal",
-        "name": "height",
-        "value": 70,
-        "type": "Int"
-      },
-      v19,
-      {
-        "kind": "Literal",
-        "name": "width",
-        "value": 70,
-        "type": "Int"
-      }
-    ],
-    "concreteType": "ResizedImageUrl",
-    "plural": false,
-    "selections": v12
-  }
-],
-v25 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "dimensions",
@@ -904,6 +729,185 @@ v25 = {
     }
   ]
 },
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_acquireable",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_offerable",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "_id",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_followed",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "counts",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "ArtistCounts",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "follows",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "url",
+  "args": null,
+  "storageKey": null
+},
+v13 = [
+  v12
+],
+v14 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "sale_message",
+  "args": null,
+  "storageKey": null
+},
+v15 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "type",
+  "args": null,
+  "storageKey": null
+},
+v16 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "initials",
+  "args": null,
+  "storageKey": null
+},
+v17 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v19 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_auction",
+  "args": null,
+  "storageKey": null
+},
+v20 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square",
+  "type": "[String]"
+},
+v21 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_closed",
+  "args": null,
+  "storageKey": null
+},
+v22 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_open",
+  "args": null,
+  "storageKey": null
+},
+v23 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "live_start_at",
+  "args": null,
+  "storageKey": null
+},
+v24 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "end_at",
+  "args": null,
+  "storageKey": null
+},
+v25 = [
+  {
+    "kind": "LinkedField",
+    "alias": "img",
+    "name": "resized",
+    "storageKey": "resized(height:70,version:\"square\",width:70)",
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "height",
+        "value": 70,
+        "type": "Int"
+      },
+      v20,
+      {
+        "kind": "Literal",
+        "name": "width",
+        "value": 70,
+        "type": "Int"
+      }
+    ],
+    "concreteType": "ResizedImageUrl",
+    "plural": false,
+    "selections": v13
+  }
+],
 v26 = {
   "kind": "ScalarField",
   "alias": null,
@@ -961,7 +965,7 @@ return {
   "operationKind": "query",
   "name": "routes_ArtworkQuery",
   "id": null,
-  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_offerable\n  availability\n  price\n  is_in_auction\n  artists {\n    _id\n    id\n    __id\n  }\n  artist {\n    id\n    __id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  __id\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  artist {\n    href\n    related {\n      artists(kind: MAIN, first: 4) {\n        edges {\n          node {\n            ...ArtistCard_artist\n            __id\n          }\n        }\n      }\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  date\n  artist_names\n  sale_message\n  partner {\n    name\n    __id\n  }\n  image_rights\n  is_shareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on ArtworkContextFair {\n      id\n      name\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  sale {\n    is_auction\n    is_benefit\n    cover_image {\n      url(version: \"square\")\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  sale {\n    is_closed\n    ...AuctionTimer_sale\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsChecklist_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  href\n  ...ArtworkActions_artwork\n  images {\n    id\n    uri: url(version: [\"larger\", \"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment OtherWorks_artwork on Artwork {\n  id\n  _id\n  sale {\n    is_closed\n    __id\n  }\n  context {\n    __typename\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    __id\n  }\n  date\n  href\n  id\n  image {\n    id\n  }\n  is_downloadable\n  partner {\n    id\n    __id\n  }\n  title\n  sale {\n    is_closed\n    is_auction\n    __id\n  }\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information(format: HTML)\n  sale {\n    is_benefit\n    __id\n  }\n  partner {\n    _id\n    id\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    is_default_profile_public\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsChecklist_artwork on Artwork {\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker\n  artists {\n    __id\n    _id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  _id\n  sale {\n    is_closed\n    is_live_open\n    __id\n  }\n  sale_artwork {\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      __id\n    }\n    most_recent_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid {\n      max_bid {\n        cents\n      }\n      __id\n    }\n  }\n  id\n  sale {\n    id\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      cents\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_inquireable\n  is_offerable\n  sale_message\n  shippingInfo\n  shippingOrigin\n  edition_sets {\n    id\n    __id\n    is_acquireable\n    is_offerable\n    sale_message\n    ...ArtworkSidebarSizeInfo_piece\n  }\n  __id\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at\n  end_at\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          _id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  id\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_offerable\n  availability\n  price\n  is_in_auction\n  artists {\n    _id\n    id\n    __id\n  }\n  artist {\n    id\n    __id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  __id\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  artist {\n    href\n    related {\n      artists(kind: MAIN, first: 4) {\n        edges {\n          node {\n            ...ArtistCard_artist\n            __id\n          }\n        }\n      }\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  date\n  artist_names\n  sale_message\n  partner {\n    name\n    __id\n  }\n  image_rights\n  is_shareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on ArtworkContextFair {\n      id\n      name\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  sale {\n    is_auction\n    is_benefit\n    cover_image {\n      url(version: \"square\")\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  sale {\n    is_closed\n    ...AuctionTimer_sale\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsChecklist_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  href\n  ...ArtworkActions_artwork\n  images {\n    id\n    uri: url(version: [\"larger\", \"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment OtherWorks_artwork on Artwork {\n  id\n  _id\n  sale {\n    is_closed\n    __id\n  }\n  context {\n    __typename\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    __id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  id\n  image {\n    id\n  }\n  is_downloadable\n  is_hangable\n  partner {\n    id\n    __id\n  }\n  title\n  sale {\n    is_closed\n    is_auction\n    __id\n  }\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information(format: HTML)\n  sale {\n    is_benefit\n    __id\n  }\n  partner {\n    _id\n    id\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    is_default_profile_public\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsChecklist_artwork on Artwork {\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker\n  artists {\n    __id\n    _id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  _id\n  sale {\n    is_closed\n    is_live_open\n    __id\n  }\n  sale_artwork {\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      __id\n    }\n    most_recent_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid {\n      max_bid {\n        cents\n      }\n      __id\n    }\n  }\n  id\n  sale {\n    id\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      cents\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_inquireable\n  is_offerable\n  sale_message\n  shippingInfo\n  shippingOrigin\n  edition_sets {\n    id\n    __id\n    is_acquireable\n    is_offerable\n    sale_message\n    ...ArtworkSidebarSizeInfo_piece\n  }\n  __id\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at\n  end_at\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          _id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  id\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -1003,16 +1007,10 @@ return {
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "medium",
-            "args": null,
-            "storageKey": null
-          },
           v3,
           v4,
           v5,
+          v6,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -1043,13 +1041,13 @@ return {
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              v6,
-              v3,
-              v2,
               v7,
+              v4,
+              v2,
               v8,
               v9,
               v10,
+              v11,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1100,9 +1098,9 @@ return {
                             "plural": false,
                             "selections": [
                               v2,
-                              v6,
-                              v3,
                               v7,
+                              v4,
+                              v8,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -1133,7 +1131,7 @@ return {
                                     ],
                                     "concreteType": "CroppedImageUrl",
                                     "plural": false,
-                                    "selections": v12
+                                    "selections": v13
                                   }
                                 ]
                               }
@@ -1163,9 +1161,9 @@ return {
             "concreteType": "Artist",
             "plural": false,
             "selections": [
-              v3,
+              v4,
               v2,
-              v8,
+              v9,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1215,9 +1213,9 @@ return {
                             "concreteType": "Artist",
                             "plural": false,
                             "selections": [
-                              v7,
-                              v3,
                               v8,
+                              v4,
+                              v9,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -1248,7 +1246,7 @@ return {
                                     ],
                                     "concreteType": "CroppedImageUrl",
                                     "plural": false,
-                                    "selections": v12
+                                    "selections": v13
                                   }
                                 ]
                               },
@@ -1260,8 +1258,8 @@ return {
                                 "storageKey": null
                               },
                               v2,
-                              v9,
-                              v10
+                              v10,
+                              v11
                             ]
                           }
                         ]
@@ -1273,7 +1271,7 @@ return {
             ]
           },
           v2,
-          v8,
+          v9,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -1288,7 +1286,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          v13,
+          v14,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1298,10 +1296,10 @@ return {
             "concreteType": "Partner",
             "plural": false,
             "selections": [
-              v7,
+              v8,
               v2,
-              v14,
               v15,
+              v16,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1336,14 +1334,14 @@ return {
                       }
                     ]
                   },
-                  v8,
+                  v9,
                   v2,
-                  v3,
-                  v9
+                  v4,
+                  v10
                 ]
               },
-              v6,
-              v8,
+              v7,
+              v9,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1363,7 +1361,7 @@ return {
                   v2
                 ]
               },
-              v3,
+              v4,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1442,7 +1440,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v11
+                  v12
                 ]
               }
             ]
@@ -1456,7 +1454,7 @@ return {
             "concreteType": "ArtworkMeta",
             "plural": false,
             "selections": [
-              v16,
+              v17,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1496,14 +1494,14 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v17,
+              v18,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextFair",
                 "selections": [
-                  v3,
-                  v7
+                  v4,
+                  v8
                 ]
               }
             ]
@@ -1524,7 +1522,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v18,
+              v19,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1539,15 +1537,15 @@ return {
                     "alias": null,
                     "name": "url",
                     "args": [
-                      v19
+                      v20
                     ],
                     "storageKey": "url(version:\"square\")"
                   }
                 ]
               },
               v2,
-              v6,
-              v20,
+              v7,
+              v21,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1562,7 +1560,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v3,
+              v4,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1589,7 +1587,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v21,
+              v22,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1597,8 +1595,8 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v22,
-              v23
+              v23,
+              v24
             ]
           },
           {
@@ -1610,18 +1608,18 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v17,
+              v18,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextAuction",
                 "selections": [
-                  v7,
                   v8,
-                  v18,
-                  v20,
+                  v9,
+                  v19,
                   v21,
                   v22,
+                  v23,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1642,14 +1640,14 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v17,
+              v18,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextFair",
                 "selections": [
-                  v7,
                   v8,
+                  v9,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1664,7 +1662,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v23,
+                  v24,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -1674,7 +1672,7 @@ return {
                     "concreteType": "Profile",
                     "plural": false,
                     "selections": [
-                      v15,
+                      v16,
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1683,7 +1681,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": false,
-                        "selections": v24
+                        "selections": v25
                       },
                       v2
                     ]
@@ -1701,15 +1699,15 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v17,
+              v18,
               v2,
               {
                 "kind": "InlineFragment",
                 "type": "ArtworkContextPartnerShow",
                 "selections": [
-                  v7,
                   v8,
-                  v14,
+                  v9,
+                  v15,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1725,7 +1723,7 @@ return {
                     "args": null,
                     "concreteType": "Image",
                     "plural": false,
-                    "selections": v24
+                    "selections": v25
                   }
                 ]
               }
@@ -1755,11 +1753,11 @@ return {
             "plural": true,
             "selections": [
               v2,
-              v3,
               v4,
               v5,
-              v13,
-              v25,
+              v6,
+              v14,
+              v3,
               v26
             ]
           },
@@ -1853,21 +1851,22 @@ return {
               }
             ]
           },
-          v16,
-          v6,
-          v25,
+          v17,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "medium",
+            "args": null,
+            "storageKey": null
+          },
+          v7,
           v26,
           {
-            "kind": "LinkedField",
+            "kind": "ScalarField",
             "alias": null,
-            "name": "image",
-            "storageKey": null,
+            "name": "is_downloadable",
             "args": null,
-            "concreteType": "Image",
-            "plural": false,
-            "selections": [
-              v3
-            ]
+            "storageKey": null
           },
           {
             "kind": "LinkedField",
@@ -2072,11 +2071,11 @@ return {
                 "concreteType": "Author",
                 "plural": false,
                 "selections": [
-                  v7,
+                  v8,
                   v2
                 ]
               },
-              v8,
+              v9,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -2115,7 +2114,7 @@ return {
                     ],
                     "concreteType": "ResizedImageUrl",
                     "plural": false,
-                    "selections": v12
+                    "selections": v13
                   }
                 ]
               },
@@ -2127,7 +2126,7 @@ return {
                 "storageKey": null
               },
               v2,
-              v3
+              v4
             ]
           },
           {
@@ -2181,8 +2180,8 @@ return {
             "concreteType": "Image",
             "plural": true,
             "selections": [
-              v11,
-              v3,
+              v12,
+              v4,
               {
                 "kind": "ScalarField",
                 "alias": "uri",
@@ -2227,7 +2226,7 @@ return {
                 ],
                 "concreteType": "ResizedImageUrl",
                 "plural": false,
-                "selections": v12
+                "selections": v13
               },
               {
                 "kind": "ScalarField",
@@ -2346,9 +2345,21 @@ return {
             ]
           },
           {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              v4
+            ]
+          },
+          {
             "kind": "ScalarField",
             "alias": null,
-            "name": "is_downloadable",
+            "name": "is_hangable",
             "args": null,
             "storageKey": null
           }


### PR DESCRIPTION
@oxaudo, @zephraph, and myself are working on porting the old View in Room function to the new artwork page. This is a start on the Reaction side of things—there's a sister [WIP Force PR](https://github.com/artsy/force/pull/3388) as well.

There are a few TODOs left here, the biggest of which is figuring out how to actually pass the image to Force since the old View in Room functionality actually expects the full image tag and not just a src url. Justin suggested passing it using the component that wraps ArtworkActions as a prop; I think that's ArtworkActionsFragmentContainer.

One possible hiccup here: the artwork page v2 doesn't actually use an `<img>` tag for the image; it's a `<div>`. Not sure if that means we need to rethink the strategy a bit.

Tracked: [DISCO-465](https://artsyproduct.atlassian.net/browse/DISCO-465)