### PR TITLE
Pull `lastOffer` from `OrderOffer` instead of `Order`, due to deprecation

### DIFF
--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -245,10 +245,6 @@ export const AcceptFragmentContainer = createFragmentContainer(
     fragment Accept_order on Order {
       id
       stateExpiresAt
-      lastOffer {
-        id
-        createdAt
-      }
       lineItems {
         edges {
           node {
@@ -256,6 +252,12 @@ export const AcceptFragmentContainer = createFragmentContainer(
               id
             }
           }
+        }
+      }
+      ... on OfferOrder {
+        lastOffer {
+          id
+          createdAt
         }
       }
       ...TransactionDetailsSummaryItem_order

--- a/src/Apps/Order/Routes/Reject/index.tsx
+++ b/src/Apps/Order/Routes/Reject/index.tsx
@@ -222,10 +222,6 @@ export const RejectFragmentContainer = createFragmentContainer(
     fragment Reject_order on Order {
       id
       stateExpiresAt
-      lastOffer {
-        id
-        createdAt
-      }
       lineItems {
         edges {
           node {
@@ -233,6 +229,12 @@ export const RejectFragmentContainer = createFragmentContainer(
               id
             }
           }
+        }
+      }
+      ... on OfferOrder {
+        lastOffer {
+          id
+          createdAt
         }
       }
       ...ArtworkSummaryItem_order

--- a/src/__generated__/Accept_order.graphql.ts
+++ b/src/__generated__/Accept_order.graphql.ts
@@ -10,10 +10,6 @@ export type Accept_order$ref = typeof _Accept_order$ref;
 export type Accept_order = {
     readonly id: string | null;
     readonly stateExpiresAt: string | null;
-    readonly lastOffer: ({
-        readonly id: string | null;
-        readonly createdAt: string | null;
-    }) | null;
     readonly lineItems: ({
         readonly edges: ReadonlyArray<({
             readonly node: ({
@@ -22,6 +18,10 @@ export type Accept_order = {
                 }) | null;
             }) | null;
         }) | null> | null;
+    }) | null;
+    readonly lastOffer?: ({
+        readonly id: string | null;
+        readonly createdAt: string | null;
     }) | null;
     readonly " $fragmentRefs": TransactionDetailsSummaryItem_order$ref & ArtworkSummaryItem_order$ref & ShippingSummaryItem_order$ref & CreditCardSummaryItem_order$ref;
     readonly " $refType": Accept_order$ref;
@@ -58,26 +58,6 @@ return {
       "name": "stateExpiresAt",
       "args": null,
       "storageKey": null
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "lastOffer",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "Offer",
-      "plural": false,
-      "selections": [
-        v0,
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "createdAt",
-          "args": null,
-          "storageKey": null
-        },
-        v1
-      ]
     },
     {
       "kind": "LinkedField",
@@ -152,9 +132,35 @@ return {
       "name": "CreditCardSummaryItem_order",
       "args": null
     },
-    v1
+    v1,
+    {
+      "kind": "InlineFragment",
+      "type": "OfferOrder",
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "lastOffer",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Offer",
+          "plural": false,
+          "selections": [
+            v0,
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "createdAt",
+              "args": null,
+              "storageKey": null
+            },
+            v1
+          ]
+        }
+      ]
+    }
   ]
 };
 })();
-(node as any).hash = '4da70a63c78fb1819efe4c8ab0cc35e5';
+(node as any).hash = '1594b97f14c43f23bc0141ee9ce8bf2b';
 export default node;

--- a/src/__generated__/Reject_order.graphql.ts
+++ b/src/__generated__/Reject_order.graphql.ts
@@ -7,10 +7,6 @@ export type Reject_order$ref = typeof _Reject_order$ref;
 export type Reject_order = {
     readonly id: string | null;
     readonly stateExpiresAt: string | null;
-    readonly lastOffer: ({
-        readonly id: string | null;
-        readonly createdAt: string | null;
-    }) | null;
     readonly lineItems: ({
         readonly edges: ReadonlyArray<({
             readonly node: ({
@@ -19,6 +15,10 @@ export type Reject_order = {
                 }) | null;
             }) | null;
         }) | null> | null;
+    }) | null;
+    readonly lastOffer?: ({
+        readonly id: string | null;
+        readonly createdAt: string | null;
     }) | null;
     readonly " $fragmentRefs": ArtworkSummaryItem_order$ref;
     readonly " $refType": Reject_order$ref;
@@ -55,26 +55,6 @@ return {
       "name": "stateExpiresAt",
       "args": null,
       "storageKey": null
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "lastOffer",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "Offer",
-      "plural": false,
-      "selections": [
-        v0,
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "createdAt",
-          "args": null,
-          "storageKey": null
-        },
-        v1
-      ]
     },
     {
       "kind": "LinkedField",
@@ -134,9 +114,35 @@ return {
       "name": "ArtworkSummaryItem_order",
       "args": null
     },
-    v1
+    v1,
+    {
+      "kind": "InlineFragment",
+      "type": "OfferOrder",
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "lastOffer",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Offer",
+          "plural": false,
+          "selections": [
+            v0,
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "createdAt",
+              "args": null,
+              "storageKey": null
+            },
+            v1
+          ]
+        }
+      ]
+    }
   ]
 };
 })();
-(node as any).hash = 'fc041097094648b1b88b8990f06d9d1a';
+(node as any).hash = 'c81ec264932208f4ba9b2f58e6aa399f';
 export default node;

--- a/src/__generated__/routes_AcceptQuery.graphql.ts
+++ b/src/__generated__/routes_AcceptQuery.graphql.ts
@@ -31,11 +31,6 @@ query routes_AcceptQuery(
 fragment Accept_order on Order {
   id
   stateExpiresAt
-  lastOffer {
-    id
-    createdAt
-    __id: id
-  }
   lineItems {
     edges {
       node {
@@ -45,6 +40,13 @@ fragment Accept_order on Order {
         }
         __id: id
       }
+    }
+  }
+  ... on OfferOrder {
+    lastOffer {
+      id
+      createdAt
+      __id: id
     }
   }
   ...TransactionDetailsSummaryItem_order
@@ -225,7 +227,14 @@ v6 = {
   "args": null,
   "storageKey": null
 },
-v7 = [
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v8 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -233,54 +242,47 @@ v7 = [
     "type": "Int"
   }
 ],
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v7,
+  "args": v8,
   "storageKey": "shippingTotal(precision:2)"
 },
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v10 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "taxTotal",
-  "args": v7,
-  "storageKey": "taxTotal(precision:2)"
-},
 v11 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "buyerTotal",
-  "args": v7,
-  "storageKey": "buyerTotal(precision:2)"
+  "name": "taxTotal",
+  "args": v8,
+  "storageKey": "taxTotal(precision:2)"
 },
 v12 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
+  "name": "buyerTotal",
+  "args": v8,
+  "storageKey": "buyerTotal(precision:2)"
 },
 v13 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "amount",
+  "args": v8,
+  "storageKey": "amount(precision:2)"
+},
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "amountCents",
   "args": null,
   "storageKey": null
-},
-v14 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "amount",
-  "args": v7,
-  "storageKey": "amount(precision:2)"
 },
 v15 = {
   "kind": "ScalarField",
@@ -301,7 +303,7 @@ return {
   "operationKind": "query",
   "name": "routes_AcceptQuery",
   "id": null,
-  "text": "query routes_AcceptQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Accept_order\n    __id: id\n  }\n}\n\nfragment Accept_order on Order {\n  id\n  stateExpiresAt\n  lastOffer {\n    id\n    createdAt\n    __id: id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query routes_AcceptQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Accept_order\n    __id: id\n  }\n}\n\nfragment Accept_order on Order {\n  id\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      id\n      createdAt\n      __id: id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -345,26 +347,6 @@ return {
         "selections": [
           v3,
           v4,
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "lastOffer",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Offer",
-            "plural": false,
-            "selections": [
-              v4,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "createdAt",
-                "args": null,
-                "storageKey": null
-              },
-              v2
-            ]
-          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -476,39 +458,6 @@ return {
               }
             ]
           },
-          v6,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
-          v8,
-          v9,
-          v10,
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "stateExpiresAt",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "itemsTotal",
-            "args": v7,
-            "storageKey": "itemsTotal(precision:2)"
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "totalListPrice",
-            "args": v7,
-            "storageKey": "totalListPrice(precision:2)"
-          },
-          v11,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -523,7 +472,7 @@ return {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v12,
+                  v7,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -577,6 +526,39 @@ return {
               }
             ]
           },
+          v6,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
+          v9,
+          v10,
+          v11,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "stateExpiresAt",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "itemsTotal",
+            "args": v8,
+            "storageKey": "itemsTotal(precision:2)"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "totalListPrice",
+            "args": v8,
+            "storageKey": "totalListPrice(precision:2)"
+          },
+          v12,
           v2,
           {
             "kind": "LinkedField",
@@ -593,7 +575,7 @@ return {
                 "kind": "InlineFragment",
                 "type": "Partner",
                 "selections": [
-                  v12
+                  v7
                 ]
               }
             ]
@@ -659,12 +641,21 @@ return {
                 "plural": false,
                 "selections": [
                   v10,
+                  v4,
+                  v2,
                   v13,
-                  v8,
-                  v9,
                   v14,
-                  v3,
+                  v9,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "createdAt",
+                    "args": null,
+                    "storageKey": null
+                  },
                   v11,
+                  v3,
+                  v12,
                   v15,
                   v16
                 ]
@@ -678,14 +669,14 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v10,
-                  v4,
-                  v13,
-                  v8,
-                  v9,
-                  v14,
-                  v3,
                   v11,
+                  v4,
+                  v14,
+                  v9,
+                  v10,
+                  v13,
+                  v3,
+                  v12,
                   v15,
                   v16,
                   v2

--- a/src/__generated__/routes_RejectQuery.graphql.ts
+++ b/src/__generated__/routes_RejectQuery.graphql.ts
@@ -31,11 +31,6 @@ query routes_RejectQuery(
 fragment Reject_order on Order {
   id
   stateExpiresAt
-  lastOffer {
-    id
-    createdAt
-    __id: id
-  }
   lineItems {
     edges {
       node {
@@ -45,6 +40,13 @@ fragment Reject_order on Order {
         }
         __id: id
       }
+    }
+  }
+  ... on OfferOrder {
+    lastOffer {
+      id
+      createdAt
+      __id: id
     }
   }
   ...ArtworkSummaryItem_order
@@ -137,7 +139,7 @@ return {
   "operationKind": "query",
   "name": "routes_RejectQuery",
   "id": null,
-  "text": "query routes_RejectQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Reject_order\n    __id: id\n  }\n}\n\nfragment Reject_order on Order {\n  id\n  stateExpiresAt\n  lastOffer {\n    id\n    createdAt\n    __id: id\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_RejectQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Reject_order\n    __id: id\n  }\n}\n\nfragment Reject_order on Order {\n  id\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      id\n      createdAt\n      __id: id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -187,26 +189,6 @@ return {
             "name": "stateExpiresAt",
             "args": null,
             "storageKey": null
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "lastOffer",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "Offer",
-            "plural": false,
-            "selections": [
-              v4,
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "createdAt",
-                "args": null,
-                "storageKey": null
-              },
-              v2
-            ]
           },
           {
             "kind": "LinkedField",
@@ -345,7 +327,33 @@ return {
               }
             ]
           },
-          v2
+          v2,
+          {
+            "kind": "InlineFragment",
+            "type": "OfferOrder",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "lastOffer",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Offer",
+                "plural": false,
+                "selections": [
+                  v4,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "createdAt",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v2
+                ]
+              }
+            ]
+          }
         ]
       }
     ]


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PURCHASE-810.

We want to remove the `lastOffer` and `offers` fields from the `Order` type in exchange/metaphysics, as they have been moved to the `OrderOffer` type instead. In order to do this, we need to remove any last references to these fields on the `Order` type. This PR accomplishes that in reaction.