### PR TITLE
Add hook to artwork image for view in room

### DIFF
--- a/src/Components/v2/Lightbox/Lightbox.tsx
+++ b/src/Components/v2/Lightbox/Lightbox.tsx
@@ -281,6 +281,7 @@ export class Lightbox extends React.Component<LightboxProps, LightboxState> {
           ...(enabled && {
             style: { cursor: "zoom-in" },
             onClick: this.show.bind(this),
+            "data-type": "artwork-image",
           }),
         })
       }

--- a/src/Components/v2/Lightbox/Lightbox.tsx
+++ b/src/Components/v2/Lightbox/Lightbox.tsx
@@ -281,6 +281,7 @@ export class Lightbox extends React.Component<LightboxProps, LightboxState> {
           ...(enabled && {
             style: { cursor: "zoom-in" },
             onClick: this.show.bind(this),
+            // Used by view-in-room
             "data-type": "artwork-image",
           }),
         })


### PR DESCRIPTION
Adds a hook for legacy view-in-room to hook into the artwork image for dimension info. 