### PR TITLE
[Bugfix] Guard against missing images on /artwork/id

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -295,3 +295,5 @@ const Save = (actionProps: ArtworkActionsProps) => (
     return <UtilButton name="heart" selected={isSaved} />
   }
 }
+
+ArtworkActionsFragmentContainer.displayName = "ArtworkActions"

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.test.tsx
@@ -2,18 +2,20 @@ import { ArtworkImageBrowserFixture } from "Apps/__tests__/Fixtures/Artwork/Artw
 import { MockBoot } from "DevTools"
 import { RelayStubProvider } from "DevTools/RelayStubProvider"
 import { mount, ReactWrapper } from "enzyme"
+import { cloneDeep } from "lodash"
 import React from "react"
 import { Breakpoint } from "Utils/Responsive"
 import { ArtworkImageBrowserFragmentContainer } from "../"
 
 describe("ArtworkImageBrowser", () => {
-  const getWrapper = (breakpoint: Breakpoint = "lg") => {
+  const getWrapper = (
+    breakpoint: Breakpoint = "lg",
+    data = ArtworkImageBrowserFixture
+  ) => {
     return mount(
       <RelayStubProvider>
         <MockBoot breakpoint={breakpoint}>
-          <ArtworkImageBrowserFragmentContainer
-            artwork={ArtworkImageBrowserFixture.artwork as any}
-          />
+          <ArtworkImageBrowserFragmentContainer artwork={data.artwork as any} />
         </MockBoot>
       </RelayStubProvider>
     )
@@ -40,6 +42,14 @@ describe("ArtworkImageBrowser", () => {
 
     it("renders directional arrows", () => {
       expect(wrapper.find("ArrowButton").length).toBe(2)
+    })
+
+    it("returns null if missing images", () => {
+      const data = cloneDeep(ArtworkImageBrowserFixture) as any
+      data.artwork.images = []
+      wrapper = getWrapper("lg", data)
+      expect(wrapper.find("ArtworkImageBrowser").length).toBe(0)
+      expect(wrapper.find("ArtworkActions").length).toBe(0)
     })
   })
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
@@ -16,9 +16,13 @@ export const ArtworkImageBrowserFragmentContainer = createFragmentContainer<
   ImageBrowserProps
 >(
   props => {
+    const { images } = props.artwork
+    if (!images.length) {
+      return null
+    }
     return (
       <>
-        <ArtworkImageBrowser images={props.artwork.images} />
+        <ArtworkImageBrowser images={images} />
         <ArtworkActions artwork={props.artwork} />
       </>
     )


### PR DESCRIPTION
Fixes https://sentry.io/artsynet/force-production/issues/858572548/?referrer=alert_email
Fixes https://artsyproduct.atlassian.net/browse/BUGS-746

This guards against an artist not having images. Tracked it down to the slider throwing perhaps due to a data issue. 