### PR TITLE
Article titles have h1 headers

### DIFF
--- a/src/Components/Publishing/Header/Layouts/ClassicHeader.tsx
+++ b/src/Components/Publishing/Header/Layouts/ClassicHeader.tsx
@@ -17,7 +17,7 @@ export const ClassicHeader: React.SFC<ClassicHeaderProps> = props => {
   const { article, date, editTitle, editLeadParagraph } = props
   return (
     <ClassicHeaderContainer>
-      <Title>{editTitle || article.title}</Title>
+      <Title>{editTitle || <h1>{article.title}</h1>}</Title>
 
       {editLeadParagraph ? (
         <LeadParagraph>{editLeadParagraph}</LeadParagraph>
@@ -50,6 +50,14 @@ const ClassicHeaderContainer = styled.div`
 export const Title = styled.div`
   padding-bottom: ${space(3)}px;
   ${garamond("s37")};
+
+  h1 {
+    font-style: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    margin: 0;
+  }
 
   ${pMedia.xs`
     ${garamond("s34")}

--- a/src/Components/Publishing/Header/Layouts/Components/FeatureInnerContent.tsx
+++ b/src/Components/Publishing/Header/Layouts/Components/FeatureInnerContent.tsx
@@ -26,7 +26,9 @@ export const FeatureInnerContent: React.SFC<FeatureHeaderProps> = props => {
           color={verticalColor}
           vertical={vertical || editVertical}
         />
-        <Title color={TextColor || undefined}>{editTitle || title}</Title>
+        <Title color={TextColor || undefined}>
+          {editTitle || <h1>{title}</h1>}
+        </Title>
       </div>
       <FeatureInnerSubContent {...props} />
     </TextContainer>
@@ -49,6 +51,15 @@ export const Title = styled.div.attrs<{ color?: string }>({})`
   ${unica("s100")};
   margin-bottom: 75px;
   letter-spacing: -0.035em;
+
+  h1 {
+    font-style: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    margin: 0;
+  }
+
   ${pMedia.xl`
     ${unica("s80")}
   `};

--- a/src/Components/Publishing/Header/Layouts/Components/FeatureInnerContent.tsx
+++ b/src/Components/Publishing/Header/Layouts/Components/FeatureInnerContent.tsx
@@ -26,7 +26,9 @@ export const FeatureInnerContent: React.SFC<FeatureHeaderProps> = props => {
           color={verticalColor}
           vertical={vertical || editVertical}
         />
-        <Title color={TextColor}>{editTitle || <h1>{title}</h1>}</Title>
+        <Title color={TextColor || undefined}>
+          {editTitle || <h1>{title}</h1>}
+        </Title>
       </div>
       <FeatureInnerSubContent {...props} />
     </TextContainer>

--- a/src/Components/Publishing/Header/Layouts/Components/FeatureInnerContent.tsx
+++ b/src/Components/Publishing/Header/Layouts/Components/FeatureInnerContent.tsx
@@ -26,9 +26,7 @@ export const FeatureInnerContent: React.SFC<FeatureHeaderProps> = props => {
           color={verticalColor}
           vertical={vertical || editVertical}
         />
-        <Title color={TextColor || undefined}>
-          {editTitle || <h1>{title}</h1>}
-        </Title>
+        <Title color={TextColor}>{editTitle || <h1>{title}</h1>}</Title>
       </div>
       <FeatureInnerSubContent {...props} />
     </TextContainer>

--- a/src/Components/Publishing/Header/Layouts/StandardHeader.tsx
+++ b/src/Components/Publishing/Header/Layouts/StandardHeader.tsx
@@ -30,7 +30,7 @@ export const StandardHeader: React.SFC<StandardHeaderProps> = props => {
             />
           </Vertical>
         )}
-        <Title>{editTitle || article.title}</Title>
+        <Title>{editTitle || <h1>{article.title}</h1>}</Title>
         <Byline article={article} date={date && date} />
       </StandardHeaderContainer>
     </StandardHeaderParent>
@@ -61,6 +61,14 @@ const StandardHeaderContainer = styled.div`
 const Title = styled.div`
   ${garamond("s50")};
   padding-bottom: 50px;
+
+  h1 {
+    font-style: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    margin: 0;
+  }
 
   ${pMedia.sm`
     ${garamond("s34")}

--- a/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/ClassicHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/ClassicHeader.test.tsx.snap
@@ -50,6 +50,14 @@ exports[`Classic Header Snapshots renders editable props properly 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c1 h1 {
+  font-style: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: inherit;
+  margin: 0;
+}
+
 .c2 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 19px;
@@ -181,6 +189,14 @@ exports[`Classic Header Snapshots renders properly 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c1 h1 {
+  font-style: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: inherit;
+  margin: 0;
+}
+
 .c2 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 19px;
@@ -235,7 +251,9 @@ exports[`Classic Header Snapshots renders properly 1`] = `
   <div
     className="c1"
   >
-    New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple
+    <h1>
+      New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple
+    </h1>
   </div>
   <div
     className="c2"

--- a/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/StandardHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/StandardHeader.test.tsx.snap
@@ -111,6 +111,14 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
   padding-bottom: 50px;
 }
 
+.c5 h1 {
+  font-style: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: inherit;
+  margin: 0;
+}
+
 .c2 {
   padding-bottom: 10px;
 }
@@ -407,6 +415,14 @@ exports[`Standard Header Snapshots renders properly 1`] = `
   padding-bottom: 50px;
 }
 
+.c5 h1 {
+  font-style: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: inherit;
+  margin: 0;
+}
+
 .c2 {
   padding-bottom: 10px;
 }
@@ -460,7 +476,9 @@ exports[`Standard Header Snapshots renders properly 1`] = `
     <div
       className="c5"
     >
-      New York's Next Art District
+      <h1>
+        New York's Next Art District
+      </h1>
     </div>
     <div
       className="Byline c6"


### PR DESCRIPTION
For SEO, adds `<h1>` wrappers for article titles.

This brings up a q for text blocks in articles generally -- we are using `h1` in article body text, but it would probably be better for SEO structure if we bumped the body text to use `h2` rather than `h1`, etc. so that inner text of the article indicates a hierarchy below the title.