### PR TITLE
Remove obsolete offer fields from "schema.graphql"

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2377,26 +2377,6 @@ type BuyOrder implements Order {
 
   # Buyer phone number
   buyerPhoneNumber: String
-
-  # Latest offer
-  lastOffer: Offer
-
-  # List of submitted offers made on this order so far
-  offers: OfferConnection
-
-  # Total amount of latest offer
-  offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
-
-  # A formatted price with various currency formatting options.
-  offerTotal(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
 }
 
 enum CancelReasonType {
@@ -5836,31 +5816,17 @@ type OfferOrder implements Order {
   # Buyer phone number
   buyerPhoneNumber: String
 
-  # Latest offer
-  lastOffer: Offer
-
-  # List of submitted offers made on this order so far
-  offers: OfferConnection
-
-  # Total amount of latest offer
-  offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
-
-  # A formatted price with various currency formatting options.
-  offerTotal(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
-
   # Current User's latest offer
   myLastOffer: Offer
 
   # Waiting for one participants response
   awaitingResponseFrom: OrderParticipantEnum
+
+  # Latest offer
+  lastOffer: Offer
+
+  # List of submitted offers made on this order so far
+  offers: OfferConnection
 }
 
 interface Order {
@@ -6065,26 +6031,6 @@ interface Order {
 
   # Buyer phone number
   buyerPhoneNumber: String
-
-  # Latest offer
-  lastOffer: Offer
-
-  # List of submitted offers made on this order so far
-  offers: OfferConnection
-
-  # Total amount of latest offer
-  offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
-
-  # A formatted price with various currency formatting options.
-  offerTotal(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
 }
 
 # A connection to a list of items.
@@ -6398,6 +6344,9 @@ type Partner implements Node {
     status: EventStatus
   ): [PartnerShow]
   type: String
+
+  # The gallery partner's web address
+  website: String
 }
 
 type PartnerArtist {


### PR DESCRIPTION
Several fields were removed from offer types in metaphysics.

Not updating this promptly was causing the `validate_staging_schema` step to fail - https://circleci.com/gh/artsy/force/14477

