### PR TITLE
Add separator to pagination component

### DIFF
--- a/src/Components/v2/Pagination.tsx
+++ b/src/Components/v2/Pagination.tsx
@@ -1,4 +1,4 @@
-import { LargePagination, SmallPagination } from "@artsy/palette"
+import { LargePagination, Separator, SmallPagination } from "@artsy/palette"
 import React from "react"
 import { Media } from "Utils/Responsive"
 import { ScrollIntoView } from "Utils/ScrollIntoView"
@@ -32,7 +32,10 @@ export class Pagination extends React.Component<Props> {
           <SmallPagination {...this.props} />
         </Media>
         <Media greaterThan="xs">
-          <LargePagination {...this.props} />
+          <div>
+            <Separator mb={3} pr={2} />
+            <LargePagination {...this.props} />
+          </div>
         </Media>
       </ScrollIntoView>
     )


### PR DESCRIPTION
When I migrated `LargePagination` from Reaction to Palette, I brought with it a separator component that is used in Force but not in Volt. I have put the separator component back in Reaction and [removed it from Palette](https://github.com/artsy/palette/pull/236) so that it doesn't become a part of the shared component library.