### PR TITLE
Adds text labels to ArtworkActions and conditionally renders them for mobile web

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -10,6 +10,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
 import { slugify } from "underscore.string"
+import { Media } from "Utils/Responsive"
 import { ArtworkSharePanelFragmentContainer as ArtworkSharePanel } from "./ArtworkSharePanel"
 
 import {
@@ -23,9 +24,11 @@ import {
   Join,
   Link,
   OpenEyeIcon,
+  Sans,
   ShareIcon,
   Spacer,
 } from "@artsy/palette"
+import { ArtworkMorePanel } from "./ArtworkMorePanel"
 
 interface ArtworkActionsProps {
   artwork: ArtworkActions_artwork
@@ -34,6 +37,7 @@ interface ArtworkActionsProps {
 
 interface ArtworkActionsState {
   showSharePanel: boolean
+  showMorePanel: boolean
 }
 
 @track()
@@ -43,6 +47,7 @@ export class ArtworkActions extends React.Component<
 > {
   state = {
     showSharePanel: false,
+    showMorePanel: false,
   }
 
   @track({
@@ -56,6 +61,11 @@ export class ArtworkActions extends React.Component<
     this.setState({
       showSharePanel,
     })
+  }
+
+  toggleMorePanel() {
+    const showMorePanel = !this.state.showMorePanel
+    this.setState({ showMorePanel })
   }
 
   get isAdmin() {
@@ -117,6 +127,7 @@ export class ArtworkActions extends React.Component<
                     <UtilButton
                       name="viewInRoom"
                       onClick={() => this.openViewInRoom(mediator)}
+                      label="View in room"
                     />
                   )}
                 </ContextConsumer>
@@ -124,12 +135,30 @@ export class ArtworkActions extends React.Component<
             <UtilButton
               name="share"
               onClick={this.toggleSharePanel.bind(this)}
+              label="Share"
             />
-            {downloadableImageUrl && (
-              <UtilButton name="download" href={downloadableImageUrl} />
-            )}
-            {this.isAdmin && <UtilButton name="edit" href={editUrl} />}
-            {this.isAdmin && <UtilButton name="genome" href={genomeUrl} />}
+
+            <Media greaterThan="xs">
+              <Flex>
+                <Join separator={<Spacer mx={0} />}>
+                  {downloadableImageUrl && (
+                    <UtilButton
+                      name="download"
+                      href={downloadableImageUrl}
+                      label="Download"
+                    />
+                  )}
+                  {this.isAdmin && (
+                    <UtilButton name="edit" href={editUrl} label="Edit" />
+                  )}
+                  {this.isAdmin && (
+                    <UtilButton name="genome" href={genomeUrl} label="Genome" />
+                  )}
+                </Join>
+              </Flex>
+            </Media>
+
+            <Media at="xs">hi</Media>
           </Join>
 
           {this.state.showSharePanel && (
@@ -137,6 +166,10 @@ export class ArtworkActions extends React.Component<
               artwork={this.props.artwork}
               onClose={this.toggleSharePanel.bind(this)}
             />
+          )}
+
+          {this.state.showMorePanel && (
+            <ArtworkMorePanel onClose={this.toggleMorePanel.bind(this)} />
           )}
         </Container>
       </>
@@ -198,9 +231,10 @@ interface UtilButtonProps {
   href?: string
   onClick?: () => void
   selected?: boolean
+  label: string
 }
 
-class UtilButton extends React.Component<
+export class UtilButton extends React.Component<
   UtilButtonProps,
   { hovered: boolean }
 > {
@@ -209,7 +243,7 @@ class UtilButton extends React.Component<
   }
 
   render() {
-    const { href, name, onClick, ...props } = this.props
+    const { href, label, name, onClick, ...props } = this.props
 
     const getIcon = () => {
       switch (name) {
@@ -238,7 +272,11 @@ class UtilButton extends React.Component<
         p={1}
         pt={0}
         onMouseOver={() => this.setState({ hovered: true })}
-        onMouseOut={() => this.setState({ hovered: false })}
+        onMouseOut={() =>
+          this.setState({
+            hovered: false,
+          })
+        }
         onClick={onClick}
       >
         {href ? (
@@ -248,6 +286,10 @@ class UtilButton extends React.Component<
         ) : (
           <Icon {...props} fill={fill} />
         )}
+
+        <Sans size="2" pl={0.5} pt={0.2}>
+          {label}
+        </Sans>
       </UtilButtonContainer>
     )
   }
@@ -290,9 +332,9 @@ const Save = (actionProps: ArtworkActionsProps) => (
 
   // If an Auction, use Bell (for notifications); if a standard artwork use Heart
   if (isOpenSale) {
-    return <UtilButton name="bell" selected={isSaved} />
+    return <UtilButton name="bell" selected={isSaved} label="Watch lot" />
   } else {
-    return <UtilButton name="heart" selected={isSaved} />
+    return <UtilButton name="heart" selected={isSaved} label="Save" />
   }
 }
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -23,12 +23,13 @@ import {
   HeartIcon,
   Join,
   Link,
+  MoreIcon,
   OpenEyeIcon,
   Sans,
   ShareIcon,
   Spacer,
 } from "@artsy/palette"
-import { ArtworkMorePanel } from "./ArtworkMorePanel"
+import { ArtworkPopoutPanel } from "./ArtworkPopoutPanel"
 
 interface ArtworkActionsProps {
   artwork: ArtworkActions_artwork
@@ -60,12 +61,13 @@ export class ArtworkActions extends React.Component<
     const showSharePanel = !this.state.showSharePanel
     this.setState({
       showSharePanel,
+      showMorePanel: false,
     })
   }
 
   toggleMorePanel() {
     const showMorePanel = !this.state.showMorePanel
-    this.setState({ showMorePanel })
+    this.setState({ showMorePanel, showSharePanel: false })
   }
 
   get isAdmin() {
@@ -158,7 +160,12 @@ export class ArtworkActions extends React.Component<
               </Flex>
             </Media>
 
-            <Media at="xs">hi</Media>
+            <Media at="xs">
+              <UtilButton
+                name="more"
+                onClick={this.toggleMorePanel.bind(this)}
+              />
+            </Media>
           </Join>
 
           {this.state.showSharePanel && (
@@ -169,7 +176,32 @@ export class ArtworkActions extends React.Component<
           )}
 
           {this.state.showMorePanel && (
-            <ArtworkMorePanel onClose={this.toggleMorePanel.bind(this)} />
+            <ArtworkPopoutPanel
+              title="More actions"
+              onClose={this.toggleMorePanel.bind(this)}
+            >
+              <Flex flexDirection="row" flexWrap="wrap">
+                {downloadableImageUrl && (
+                  <Flex flexDirection="row" flexBasis="50%">
+                    <UtilButton
+                      name="download"
+                      href={downloadableImageUrl}
+                      label="Download"
+                    />
+                  </Flex>
+                )}
+                {this.isAdmin && (
+                  <Flex flexDirection="row" flexBasis="50%">
+                    <UtilButton name="edit" href={editUrl} label="Edit" />
+                  </Flex>
+                )}
+                {this.isAdmin && (
+                  <Flex flexDirection="row" flexBasis="50%">
+                    <UtilButton name="genome" href={genomeUrl} label="Genome" />
+                  </Flex>
+                )}
+              </Flex>
+            </ArtworkPopoutPanel>
           )}
         </Container>
       </>
@@ -226,12 +258,13 @@ interface UtilButtonProps {
     | "download"
     | "genome"
     | "heart"
+    | "more"
     | "share"
     | "viewInRoom"
   href?: string
   onClick?: () => void
   selected?: boolean
-  label: string
+  label?: string
 }
 
 export class UtilButton extends React.Component<
@@ -257,6 +290,8 @@ export class UtilButton extends React.Component<
           return GenomeIcon
         case "heart":
           return HeartIcon
+        case "more":
+          return MoreIcon
         case "share":
           return ShareIcon
         case "viewInRoom":
@@ -265,7 +300,8 @@ export class UtilButton extends React.Component<
     }
 
     const Icon = getIcon()
-    const fill = this.state.hovered ? color("purple100") : color("black100")
+    const defaultFill = name === "more" ? null : color("black100")
+    const fill = this.state.hovered ? color("purple100") : defaultFill
 
     return (
       <UtilButtonContainer
@@ -287,9 +323,11 @@ export class UtilButton extends React.Component<
           <Icon {...props} fill={fill} />
         )}
 
-        <Sans size="2" pl={0.5} pt={0.2}>
-          {label}
-        </Sans>
+        {label && (
+          <Sans size="2" pl={0.5} pt={0.2}>
+            {label}
+          </Sans>
+        )}
       </UtilButtonContainer>
     )
   }

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -371,7 +371,7 @@ export class UtilButton extends React.Component<
         )}
 
         {label && (
-          <Sans size="2" pl={0.5} pt={0.2}>
+          <Sans size="2" pl={0.5} pt="1px">
             {label}
           </Sans>
         )}

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -163,18 +163,28 @@ export class ArtworkActions extends React.Component<
     const downloadableImageUrl = this.getDownloadableImageUrl()
 
     const actionsToShow = [
-      { condition: true, renderer: this.renderSaveButton },
+      { name: "save", condition: true, renderer: this.renderSaveButton },
       {
+        name: "viewInRoom",
         condition: artwork.is_hangable && this.isAdmin,
         renderer: this.renderViewInRoomButton,
       },
-      { condition: true, renderer: this.renderShareButton },
+      { name: "share", condition: true, renderer: this.renderShareButton },
       {
+        name: "download",
         condition: !!downloadableImageUrl,
         renderer: this.renderDownloadButton,
       },
-      { condition: this.isAdmin, renderer: this.renderEditButton },
-      { condition: this.isAdmin, renderer: this.renderGenomeButton },
+      {
+        name: "edit",
+        condition: this.isAdmin,
+        renderer: this.renderEditButton,
+      },
+      {
+        name: "genome",
+        condition: this.isAdmin,
+        renderer: this.renderGenomeButton,
+      },
     ]
 
     const showableActions = actionsToShow.filter(action => {
@@ -191,7 +201,9 @@ export class ArtworkActions extends React.Component<
             <Media greaterThan="xs">
               <Flex>
                 {showableActions.map(action => {
-                  return action.renderer.bind(this)()
+                  return (
+                    <div key={action.name}>{action.renderer.bind(this)()}</div>
+                  )
                 })}
               </Flex>
             </Media>
@@ -199,7 +211,9 @@ export class ArtworkActions extends React.Component<
             <Media at="xs">
               <Flex>
                 {initialActions.map(action => {
-                  return action.renderer.bind(this)()
+                  return (
+                    <div key={action.name}>{action.renderer.bind(this)()}</div>
+                  )
                 })}
 
                 {moreActions &&
@@ -228,7 +242,7 @@ export class ArtworkActions extends React.Component<
               <Flex flexDirection="row" flexWrap="wrap">
                 {moreActions.map(action => {
                   return (
-                    <Flex flexDirection="row" flexBasis="50%">
+                    <Flex flexDirection="row" flexBasis="50%" key={action.name}>
                       {action.renderer.bind(this)()}
                     </Flex>
                   )

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkMorePanel.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkMorePanel.tsx
@@ -1,0 +1,45 @@
+import { Box, color, Flex, Sans, Separator, space } from "@artsy/palette"
+import Icon from "Components/Icon"
+import React from "react"
+import styled from "styled-components"
+
+interface ArtworkMorePanelProps {
+  onClose: () => void
+}
+
+export class ArtworkMorePanel extends React.Component<ArtworkMorePanelProps> {
+  render() {
+    return (
+      <Container>
+        <Box position="absolute" top={space(1)} right={space(1)}>
+          <CloseIcon name="close" onClick={this.props.onClose} />
+        </Box>
+        <Flex flexDirection="column" p={2}>
+          <Flex flexDirection="row" mb={2}>
+            <Sans size="3" weight="medium" color="black100">
+              More actions
+            </Sans>
+          </Flex>
+          <Separator />
+        </Flex>
+      </Container>
+    )
+  }
+}
+
+// TODO: We need to figure out if this is going to be a new re-usable panel type
+//       in which I wouldn’t want to add this into Share
+const Container = styled.div`
+  position: absolute;
+  width: 300px;
+  top: -230px;
+  border-radius: 2px;
+  background-color: #ffffff;
+  box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.2);
+`
+
+const CloseIcon = styled(Icon)`
+  color: ${color("black30")};
+  cursor: pointer;
+  font-size: 12px;
+`

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkPopoutPanel.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkPopoutPanel.tsx
@@ -33,7 +33,7 @@ export class ArtworkPopoutPanel extends React.Component<
 const Container = styled.div`
   position: absolute;
   width: 300px;
-  bottom: 30px;
+  bottom: 40px;
   border-radius: 2px;
   background-color: #ffffff;
   box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.2);

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkPopoutPanel.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkPopoutPanel.tsx
@@ -1,13 +1,16 @@
-import { Box, color, Flex, Sans, Separator, space } from "@artsy/palette"
+import { Box, color, Flex, Sans, space } from "@artsy/palette"
 import Icon from "Components/Icon"
 import React from "react"
 import styled from "styled-components"
 
-interface ArtworkMorePanelProps {
+interface ArtworkPopoutPanelProps {
   onClose: () => void
+  title: string
 }
 
-export class ArtworkMorePanel extends React.Component<ArtworkMorePanelProps> {
+export class ArtworkPopoutPanel extends React.Component<
+  ArtworkPopoutPanelProps
+> {
   render() {
     return (
       <Container>
@@ -17,22 +20,20 @@ export class ArtworkMorePanel extends React.Component<ArtworkMorePanelProps> {
         <Flex flexDirection="column" p={2}>
           <Flex flexDirection="row" mb={2}>
             <Sans size="3" weight="medium" color="black100">
-              More actions
+              {this.props.title}
             </Sans>
           </Flex>
-          <Separator />
+          {this.props.children}
         </Flex>
       </Container>
     )
   }
 }
 
-// TODO: We need to figure out if this is going to be a new re-usable panel type
-//       in which I wouldn’t want to add this into Share
 const Container = styled.div`
   position: absolute;
   width: 300px;
-  top: -230px;
+  bottom: 30px;
   border-radius: 2px;
   background-color: #ffffff;
   box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.2);

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkSharePanel.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkSharePanel.tsx
@@ -118,65 +118,63 @@ export class ArtworkSharePanel extends React.Component<
 
     return (
       <ArtworkPopoutPanel title="Share" onClose={this.props.onClose}>
-        <>
-          <Flex flexDirection="row" mb={1}>
-            <SansGrow size={["3", "2"]} color="black60" mr={4}>
-              <URLInput
-                type="text"
-                readOnly
-                value={url}
-                innerRef={input => (this.input = input)}
-                onClick={this.handleCopy}
-              />
-            </SansGrow>
-            <Sans size={["3", "2"]} weight="medium" color="black60">
-              <a onClick={this.handleCopy}>{this.state.copyLabelText}</a>
-            </Sans>
-          </Flex>
-          <Separator />
-          <Flex flexDirection="row" flexWrap="wrap">
-            {this.renderShareButton({
-              service: "facebook",
-              label: "Facebook",
-              message: "Post to Facebook",
-              url: `https://www.facebook.com/sharer/sharer.php?u=${url}`,
-            })}
-            {this.renderShareButton({
-              service: "twitter",
-              label: "Twitter",
-              message: "Share on Twitter",
-              url: `https://twitter.com/intent/tweet?original_referer=${url}&text=${share}&url=${url}&via=artsy`,
-            })}
+        <Flex flexDirection="row" mb={1}>
+          <SansGrow size={["3", "2"]} color="black60" mr={4}>
+            <URLInput
+              type="text"
+              readOnly
+              value={url}
+              innerRef={input => (this.input = input)}
+              onClick={this.handleCopy}
+            />
+          </SansGrow>
+          <Sans size={["3", "2"]} weight="medium" color="black60">
+            <a onClick={this.handleCopy}>{this.state.copyLabelText}</a>
+          </Sans>
+        </Flex>
+        <Separator />
+        <Flex flexDirection="row" flexWrap="wrap">
+          {this.renderShareButton({
+            service: "facebook",
+            label: "Facebook",
+            message: "Post to Facebook",
+            url: `https://www.facebook.com/sharer/sharer.php?u=${url}`,
+          })}
+          {this.renderShareButton({
+            service: "twitter",
+            label: "Twitter",
+            message: "Share on Twitter",
+            url: `https://twitter.com/intent/tweet?original_referer=${url}&text=${share}&url=${url}&via=artsy`,
+          })}
 
-            {/*
+          {/*
               NOTE: Safari requires direct user interaction.
               See: https://developer.apple.com/safari/technology-preview/release-notes/#r15
             */}
-            <Flex flexDirection="row" flexBasis="50%" mt={2}>
-              <Icon name="mail" color="black" />
-              <Sans size="3" color="black60">
-                <UnstyledLink
-                  href={`mailto:?subject=${share}&body=${share} on Artsy: ${url}`}
-                >
-                  Mail
-                </UnstyledLink>
-              </Sans>
-            </Flex>
-
-            {this.renderShareButton({
-              service: "pinterest",
-              label: "Pinterest",
-              message: "Pin It on Pinterest",
-              url: `https://pinterest.com/pin/create/button/?url=${url}&media=${shareImageUrl}&description=${share}`,
-            })}
-            {this.renderShareButton({
-              service: "tumblr",
-              label: "Tumblr",
-              message: "",
-              url: `https://www.tumblr.com/share/photo?source=${shareImageUrl}&caption=${share}&clickthru=${url}`,
-            })}
+          <Flex flexDirection="row" flexBasis="50%" mt={2}>
+            <Icon name="mail" color="black" />
+            <Sans size="3" color="black60">
+              <UnstyledLink
+                href={`mailto:?subject=${share}&body=${share} on Artsy: ${url}`}
+              >
+                Mail
+              </UnstyledLink>
+            </Sans>
           </Flex>
-        </>
+
+          {this.renderShareButton({
+            service: "pinterest",
+            label: "Pinterest",
+            message: "Pin It on Pinterest",
+            url: `https://pinterest.com/pin/create/button/?url=${url}&media=${shareImageUrl}&description=${share}`,
+          })}
+          {this.renderShareButton({
+            service: "tumblr",
+            label: "Tumblr",
+            message: "",
+            url: `https://www.tumblr.com/share/photo?source=${shareImageUrl}&caption=${share}&clickthru=${url}`,
+          })}
+        </Flex>
       </ArtworkPopoutPanel>
     )
   }

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkSharePanel.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkSharePanel.tsx
@@ -1,10 +1,11 @@
-import { Box, color, Flex, media, Sans, Separator, space } from "@artsy/palette"
+import { color, Flex, media, Sans, Separator } from "@artsy/palette"
 import { ArtworkSharePanel_artwork } from "__generated__/ArtworkSharePanel_artwork.graphql"
 import Icon from "Components/Icon"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
+import { ArtworkPopoutPanel } from "./ArtworkPopoutPanel"
 
 interface ArtworkSharePanelProps {
   artwork: ArtworkSharePanel_artwork
@@ -116,16 +117,8 @@ export class ArtworkSharePanel extends React.Component<
     const url = sd.APP_URL + href
 
     return (
-      <Container>
-        <Box position="absolute" top={space(1)} right={space(1)}>
-          <CloseIcon name="close" onClick={this.props.onClose} />
-        </Box>
-        <Flex flexDirection="column" p={2}>
-          <Flex flexDirection="row" mb={2}>
-            <Sans size="3" weight="medium" color="black100">
-              Share
-            </Sans>
-          </Flex>
+      <ArtworkPopoutPanel title="Share" onClose={this.props.onClose}>
+        <>
           <Flex flexDirection="row" mb={1}>
             <SansGrow size={["3", "2"]} color="black60" mr={4}>
               <URLInput
@@ -183,8 +176,8 @@ export class ArtworkSharePanel extends React.Component<
               url: `https://www.tumblr.com/share/photo?source=${shareImageUrl}&caption=${share}&clickthru=${url}`,
             })}
           </Flex>
-        </Flex>
-      </Container>
+        </>
+      </ArtworkPopoutPanel>
     )
   }
 }
@@ -203,23 +196,6 @@ export const ArtworkSharePanelFragmentContainer = createFragmentContainer(
     }
   `
 )
-
-// TODO: We need to figure out if this is going to be a new re-usable panel type
-//       in which I wouldn’t want to add this into Share
-const Container = styled.div`
-  position: absolute;
-  width: 300px;
-  top: -230px;
-  border-radius: 2px;
-  background-color: #ffffff;
-  box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.2);
-`
-
-const CloseIcon = styled(Icon)`
-  color: ${color("black30")};
-  cursor: pointer;
-  font-size: 12px;
-`
 
 const SansGrow = styled(Sans)`
   display: flex;

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__stories__/ArtworkActions.story.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__stories__/ArtworkActions.story.tsx
@@ -9,6 +9,7 @@ import { ArtworkActions } from "../ArtworkActions"
 
 const ArtworkActionsAuctionFixture = cloneDeep(ArtworkActionsFixture)
 ArtworkActionsAuctionFixture.artwork.sale.is_closed = false
+ArtworkActionsAuctionFixture.artwork.sale.is_auction = true
 
 storiesOf("Apps/Artwork Page/Components/ArtworkImageBrowser", module).add(
   "ArtworkActions",

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__stories__/ArtworkActions.story.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__stories__/ArtworkActions.story.tsx
@@ -11,6 +11,9 @@ const ArtworkActionsAuctionFixture = cloneDeep(ArtworkActionsFixture)
 ArtworkActionsAuctionFixture.artwork.sale.is_closed = false
 ArtworkActionsAuctionFixture.artwork.sale.is_auction = true
 
+const ArtworkActionsNonAdminFixture = cloneDeep(ArtworkActionsFixture)
+ArtworkActionsNonAdminFixture.user.type = "User"
+
 storiesOf("Apps/Artwork Page/Components/ArtworkImageBrowser", module).add(
   "ArtworkActions",
   () => (
@@ -26,6 +29,13 @@ storiesOf("Apps/Artwork Page/Components/ArtworkImageBrowser", module).add(
         <Flex justifyContent="center" alignItems="flex-end" height="200px">
           <RelayStubProvider>
             <ArtworkActions {...ArtworkActionsAuctionFixture as any} />
+          </RelayStubProvider>
+        </Flex>
+      </Section>
+      <Section title="Non-admin">
+        <Flex justifyContent="center" alignItems="flex-end" height="200px">
+          <RelayStubProvider>
+            <ArtworkActions {...ArtworkActionsNonAdminFixture as any} />
           </RelayStubProvider>
         </Flex>
       </Section>

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.test.tsx
@@ -14,7 +14,7 @@ describe("ArtworkActions", () => {
     )
   }
 
-  it("renders proper components", () => {
+  it.only("renders proper components", () => {
     const wrapper = getWrapper()
     expect(wrapper.find("Heart").length).toBe(1)
     expect(wrapper.find("Share").length).toBe(1)

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.test.tsx
@@ -1,4 +1,6 @@
+import { Breakpoint } from "@artsy/palette"
 import { ArtworkActionsFixture } from "Apps/__tests__/Fixtures/Artwork/ArtworkActions.fixture"
+import { MockBoot } from "DevTools"
 import { RelayStubProvider } from "DevTools/RelayStubProvider"
 import { mount } from "enzyme"
 import { cloneDeep } from "lodash"
@@ -6,25 +8,48 @@ import React from "react"
 import { ArtworkActionsFragmentContainer } from "../ArtworkActions"
 
 describe("ArtworkActions", () => {
-  const getWrapper = (props = ArtworkActionsFixture) => {
+  const getWrapper = (
+    breakpoint: Breakpoint = "lg",
+    data = ArtworkActionsFixture
+  ) => {
     return mount(
-      <RelayStubProvider>
-        <ArtworkActionsFragmentContainer {...props as any} />
-      </RelayStubProvider>
+      <MockBoot breakpoint={breakpoint}>
+        <RelayStubProvider>
+          <ArtworkActionsFragmentContainer {...data as any} />
+        </RelayStubProvider>
+      </MockBoot>
     )
   }
 
-  it.only("renders proper components", () => {
+  it("renders proper components for an admin", () => {
     const wrapper = getWrapper()
     expect(wrapper.find("Heart").length).toBe(1)
     expect(wrapper.find("Share").length).toBe(1)
+    expect(wrapper.find("OpenEye").length).toBe(1)
+    expect(wrapper.find("Download").length).toBe(1)
+    expect(wrapper.find("Edit").length).toBe(1)
+    expect(wrapper.find("Genome").length).toBe(1)
+    expect(wrapper.find("More").length).toBe(0)
+  })
+
+  it("renders proper components for a non-admin", () => {
+    const data = cloneDeep(ArtworkActionsFixture)
+    data.user.type = "User"
+    const wrapper = getWrapper("lg", data)
+    expect(wrapper.find("Heart").length).toBe(1)
+    expect(wrapper.find("Share").length).toBe(1)
+    expect(wrapper.find("OpenEye").length).toBe(0)
+    expect(wrapper.find("Download").length).toBe(1)
+    expect(wrapper.find("Edit").length).toBe(0)
+    expect(wrapper.find("Genome").length).toBe(0)
+    expect(wrapper.find("More").length).toBe(0)
   })
 
   describe("concerning SaveButton states icon states", () => {
     it("renders heart icon when not sale", () => {
       const data = cloneDeep(ArtworkActionsFixture)
       data.artwork.sale = null
-      const wrapper = getWrapper(data)
+      const wrapper = getWrapper("lg", data)
       expect(wrapper.find("Heart").length).toBe(1)
       expect(wrapper.find("Bell").length).toBe(0)
     })
@@ -32,7 +57,7 @@ describe("ArtworkActions", () => {
     it("renders heart icon when sale is closed", () => {
       const data = cloneDeep(ArtworkActionsFixture)
       data.artwork.sale.is_closed = true
-      const wrapper = getWrapper(data)
+      const wrapper = getWrapper("lg", data)
       expect(wrapper.find("Heart").length).toBe(1)
       expect(wrapper.find("Bell").length).toBe(0)
     })
@@ -41,7 +66,7 @@ describe("ArtworkActions", () => {
       const data = cloneDeep(ArtworkActionsFixture)
       data.artwork.sale.is_auction = true
       data.artwork.sale.is_closed = false
-      const wrapper = getWrapper(data)
+      const wrapper = getWrapper("lg", data)
       expect(wrapper.find("Heart").length).toBe(0)
       expect(wrapper.find("Bell").length).toBe(1)
     })
@@ -52,7 +77,7 @@ describe("ArtworkActions", () => {
       const data = cloneDeep(ArtworkActionsFixture)
       data.user.type = "Admin"
       data.artwork.is_hangable = true
-      const wrapper = getWrapper(data)
+      const wrapper = getWrapper("lg", data)
       expect(wrapper.find("OpenEye").length).toBe(1)
     })
 
@@ -60,7 +85,7 @@ describe("ArtworkActions", () => {
       const data = cloneDeep(ArtworkActionsFixture)
       data.user.type = "Admin"
       data.artwork.is_hangable = false
-      const wrapper = getWrapper(data)
+      const wrapper = getWrapper("lg", data)
       expect(wrapper.find("OpenEye").length).toBe(0)
     })
   })
@@ -69,35 +94,61 @@ describe("ArtworkActions", () => {
     describe("download link", () => {
       it("renders link if is_downloadable", () => {
         const data = cloneDeep(ArtworkActionsFixture)
+        data.user.type = "User"
         data.artwork.is_downloadable = true
-        const wrapper = getWrapper(data)
+        const wrapper = getWrapper("lg", data)
         expect(wrapper.find("Download").length).toBe(1)
       })
 
       it("renders link if admin", () => {
         const data = cloneDeep(ArtworkActionsFixture)
         data.user.type = "Admin"
-        const wrapper = getWrapper(data)
+        data.artwork.is_downloadable = false
+        const wrapper = getWrapper("lg", data)
         expect(wrapper.find("Download").length).toBe(1)
       })
 
-      it("hides link if is_downloadable=false", () => {
+      it("hides link if is_downloadable=false and the user is not an admin", () => {
         const data = cloneDeep(ArtworkActionsFixture)
-        data.user.type = "not admin"
+        data.user.type = "User"
         data.artwork.is_downloadable = false
-        const wrapper = getWrapper(data)
+        const wrapper = getWrapper("lg", data)
         expect(wrapper.find("Download").length).toBe(0)
       })
     })
+  })
 
-    describe("admin actions", () => {
-      it("renders genome and edit if admin", () => {
-        const data = cloneDeep(ArtworkActionsFixture)
-        data.user.type = "Admin"
-        const wrapper = getWrapper(data)
-        expect(wrapper.find("Edit").length).toBe(1)
-        expect(wrapper.find("Genome").length).toBe(1)
-      })
+  describe("in the xs breakpoint", () => {
+    it("shows the More icon", () => {
+      const wrapper = getWrapper("xs")
+      expect(wrapper.find("Heart").length).toBe(1)
+      expect(wrapper.find("Share").length).toBe(1)
+      expect(wrapper.find("OpenEye").length).toBe(1)
+      expect(wrapper.find("More").length).toBe(1)
+      expect(wrapper.find("Download").length).toBe(0)
+      expect(wrapper.find("Edit").length).toBe(0)
+      expect(wrapper.find("Genome").length).toBe(0)
+    })
+
+    it("clicking the More icon shows the download link if non-admin", () => {
+      const wrapper = getWrapper("xs")
+      wrapper.find("More").simulate("click")
+      expect(wrapper.find("Download").length).toBe(1)
+      expect(wrapper.find("Edit").length).toBe(1)
+      expect(wrapper.find("Genome").length).toBe(1)
+    })
+
+    it("shows no More icon if there are <= 3 actions", () => {
+      const data = cloneDeep(ArtworkActionsFixture)
+      data.user.type = "User"
+      const wrapper = getWrapper("xs", data)
+      expect(wrapper.find("Heart").length).toBe(1)
+      expect(wrapper.find("Share").length).toBe(1)
+      expect(wrapper.find("Download").length).toBe(1)
+      expect(wrapper.find("OpenEye").length).toBe(0)
+      expect(wrapper.find("Edit").length).toBe(0)
+      expect(wrapper.find("Genome").length).toBe(0)
+      expect(wrapper.find("More").length).toBe(0)
     })
   })
 })


### PR DESCRIPTION
This PR addresses https://artsyproduct.atlassian.net/browse/PURCHASE-814 and https://artsyproduct.atlassian.net/browse/PURCHASE-815

In summary, it:
1. Adds labels to the icons in the `ArtworkActions` component (shows up beneath an artwork on the artwork page)
![image](https://user-images.githubusercontent.com/2081340/51880535-9de11400-2345-11e9-8a2c-edbc06ee27be.png)

2. On mobile web... if there are > 3 actions, hide the "rest" behind a `More` icon, and display them in a panel.
![image](https://user-images.githubusercontent.com/2081340/51880701-41cabf80-2346-11e9-9179-a948f4ff4d51.png)

3. Small refactor. I pulled out `ArtworkPopoutPanel` as a component to serve both the `Share` and the `More` functions.

TODO:
- [ ] Do a final pass with reaction linked in force.

cc @mzikherman 