### PR TITLE
Keep actions and image dots centered for mobile web as well

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -390,10 +390,10 @@ const UtilButtonContainer = styled(Flex)`
 `
 
 const Container = styled(Flex).attrs({
-  justifyContent: ["left", "center"],
-  mb: [2, 2],
-  ml: [-0.5, 0.5],
-  pt: [2, 3],
+  justifyContent: "center",
+  mb: 2,
+  ml: 0.5,
+  pt: 3,
 })`
   position: relative;
   user-select: none;

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -11,7 +11,6 @@ import {
   Col,
   color,
   Flex,
-  media,
   ResponsiveImage,
   Row,
 } from "@artsy/palette"
@@ -180,14 +179,6 @@ const ArrowButtonContainer = styled(Flex)`
 
 const Container = styled(Box)`
   user-select: none;
-
-  ${media.xs`
-    .slick-dots {
-      bottom: -43px;
-      display: inline-block;
-      text-align: right;
-    }
-  `};
 
   .slick-dots li {
     width: 2px;


### PR DESCRIPTION
Missed this nuance when I was matching the designs!

For mobile web, we also want the image browser dots to appear centered instead of floated to the right, where they may overlap with the labels.

![image](https://user-images.githubusercontent.com/2081340/51992483-10074500-247b-11e9-96d2-33e41f1a7691.png)
