### PR TITLE
Refactor Input component in preparation for moving to Palette

### DIFF
--- a/src/Apps/Order/Components/OfferInput.tsx
+++ b/src/Apps/Order/Components/OfferInput.tsx
@@ -9,8 +9,6 @@ export interface OfferInputProps {
 }
 
 export class OfferInput extends React.Component<OfferInputProps> {
-  inputRef = React.createRef<HTMLInputElement>()
-
   render() {
     const { id, showError, onFocus } = this.props
 
@@ -20,7 +18,6 @@ export class OfferInput extends React.Component<OfferInputProps> {
         title="Your offer"
         type="text"
         pattern="[0-9]"
-        innerRef={this.inputRef}
         defaultValue={null}
         error={showError ? "Offer amount missing or invalid." : null}
         onFocus={onFocus}

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -233,8 +233,6 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
     this.setState({ isCommittingMutation: false })
   }
 
-  inputRef = React.createRef<HTMLInputElement>()
-
   render() {
     const { order } = this.props
     const { isCommittingMutation } = this.state

--- a/src/Components/Authentication/Desktop/ForgotPasswordForm.tsx
+++ b/src/Components/Authentication/Desktop/ForgotPasswordForm.tsx
@@ -7,7 +7,7 @@ import {
   FormContainer as Form,
   SubmitButton,
 } from "Components/Authentication/commonElements"
-import Input from "Components/Input"
+import QuickInput from "Components/QuickInput"
 import { FormProps, InputValues, ModalType } from "../Types"
 import { ForgotPasswordValidator } from "../Validators"
 
@@ -49,9 +49,8 @@ export class ForgotPasswordForm extends Component<
 
           return (
             <Form onSubmit={handleSubmit} height={180}>
-              <Input
+              <QuickInput
                 block
-                quick
                 error={touched.email && errors.email}
                 placeholder="Enter your email address"
                 name="email"

--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -15,6 +15,7 @@ import {
   ModalType,
 } from "Components/Authentication/Types"
 import { LoginValidator } from "Components/Authentication/Validators"
+import PasswordInput from "Components/PasswordInput"
 import QuickInput from "Components/QuickInput"
 
 const Row = styled.div`
@@ -73,13 +74,12 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
                 onBlur={handleBlur}
                 autoFocus
               />
-              <QuickInput
+              <PasswordInput
                 block
                 error={touched.password && errors.password}
                 placeholder="Enter your password"
                 name="password"
                 label="Password"
-                type="password"
                 value={values.password}
                 onChange={handleChange}
                 onBlur={handleBlur}

--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -15,7 +15,7 @@ import {
   ModalType,
 } from "Components/Authentication/Types"
 import { LoginValidator } from "Components/Authentication/Validators"
-import Input from "Components/Input"
+import QuickInput from "Components/QuickInput"
 
 const Row = styled.div`
   display: flex;
@@ -61,9 +61,8 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
 
           return (
             <Form onSubmit={handleSubmit} height={320}>
-              <Input
+              <QuickInput
                 block
-                quick
                 error={touched.email && errors.email}
                 placeholder="Enter your email address"
                 name="email"
@@ -74,9 +73,8 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
                 onBlur={handleBlur}
                 autoFocus
               />
-              <Input
+              <QuickInput
                 block
-                quick
                 error={touched.password && errors.password}
                 placeholder="Enter your password"
                 name="password"

--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -14,6 +14,7 @@ import {
   ModalType,
 } from "Components/Authentication/Types"
 import { SignUpValidator } from "Components/Authentication/Validators"
+import PasswordInput from "Components/PasswordInput"
 import QuickInput from "Components/QuickInput"
 
 export interface SignUpFormState {
@@ -64,13 +65,12 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
                 onBlur={handleBlur}
                 autoFocus
               />
-              <QuickInput
+              <PasswordInput
                 block
                 error={touched.password && errors.password}
                 placeholder="Enter a password"
                 name="password"
                 label="Password"
-                type="password"
                 value={values.password}
                 onChange={handleChange}
                 onBlur={handleBlur}

--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -14,7 +14,7 @@ import {
   ModalType,
 } from "Components/Authentication/Types"
 import { SignUpValidator } from "Components/Authentication/Validators"
-import Input from "Components/Input"
+import QuickInput from "Components/QuickInput"
 
 export interface SignUpFormState {
   error?: string
@@ -52,9 +52,8 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
 
           return (
             <Form onSubmit={handleSubmit} height={430}>
-              <Input
+              <QuickInput
                 block
-                quick
                 error={touched.email && errors.email}
                 placeholder="Enter your email address"
                 name="email"
@@ -65,9 +64,8 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
                 onBlur={handleBlur}
                 autoFocus
               />
-              <Input
+              <QuickInput
                 block
-                quick
                 error={touched.password && errors.password}
                 placeholder="Enter a password"
                 name="password"
@@ -78,9 +76,8 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
                 onBlur={handleBlur}
                 showPasswordMessage
               />
-              <Input
+              <QuickInput
                 block
-                quick
                 error={touched.name && errors.name}
                 placeholder="Enter your full name"
                 name="name"

--- a/src/Components/Authentication/Mobile/ForgotPasswordForm.tsx
+++ b/src/Components/Authentication/Mobile/ForgotPasswordForm.tsx
@@ -7,7 +7,7 @@ import {
   MobileInnerWrapper,
   SubmitButton,
 } from "Components/Authentication/commonElements"
-import Input from "Components/Input"
+import QuickInput from "Components/QuickInput"
 import { Formik, FormikProps } from "formik"
 import React from "react"
 import { FormComponentType, InputValues } from "../Types"
@@ -36,9 +36,8 @@ export const MobileForgotPasswordForm: FormComponentType = props => {
             <MobileInnerWrapper>
               <Form onSubmit={handleSubmit} height={270}>
                 <MobileHeader>Reset your password</MobileHeader>
-                <Input
+                <QuickInput
                   block
-                  quick
                   error={errors.email}
                   placeholder="Enter your email address"
                   name="email"

--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -3,6 +3,7 @@ import { checkEmail } from "Components/Authentication/helpers"
 import React, { Component, Fragment } from "react"
 import styled from "styled-components"
 import Icon from "../../Icon"
+import PasswordInput from "../../PasswordInput"
 import { ProgressIndicator } from "../../ProgressIndicator"
 import QuickInput from "../../QuickInput"
 import { Step, Wizard } from "../../Wizard"
@@ -80,13 +81,12 @@ export class MobileLoginForm extends Component<FormProps> {
           },
         }) => (
           <Fragment>
-            <QuickInput
+            <PasswordInput
               block
               error={errors.password}
               name="password"
               label="Password"
               placeholder="Password"
-              type="password"
               value={values.password}
               onChange={handleChange}
               onBlur={handleBlur}

--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -3,8 +3,8 @@ import { checkEmail } from "Components/Authentication/helpers"
 import React, { Component, Fragment } from "react"
 import styled from "styled-components"
 import Icon from "../../Icon"
-import Input from "../../Input"
 import { ProgressIndicator } from "../../ProgressIndicator"
+import QuickInput from "../../QuickInput"
 import { Step, Wizard } from "../../Wizard"
 import {
   BackButton,
@@ -51,7 +51,7 @@ export class MobileLoginForm extends Component<FormProps> {
             setTouched,
           },
         }) => (
-          <Input
+          <QuickInput
             block
             error={errors.email}
             placeholder="Enter your email address"
@@ -64,7 +64,6 @@ export class MobileLoginForm extends Component<FormProps> {
             setTouched={setTouched}
             touchedOnChange={false}
             autoFocus
-            quick
           />
         )}
       </Step>,
@@ -81,7 +80,7 @@ export class MobileLoginForm extends Component<FormProps> {
           },
         }) => (
           <Fragment>
-            <Input
+            <QuickInput
               block
               error={errors.password}
               name="password"
@@ -93,7 +92,6 @@ export class MobileLoginForm extends Component<FormProps> {
               onBlur={handleBlur}
               setTouched={setTouched}
               touchedOnChange={false}
-              quick
             />
             <Row>
               <ForgotPassword onClick={() => (location.href = "/forgot")} />

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -15,8 +15,8 @@ import { checkEmail } from "Components/Authentication/helpers"
 import { FormProps } from "Components/Authentication/Types"
 import { MobileSignUpValidator } from "Components/Authentication/Validators"
 import Icon from "Components/Icon"
-import Input from "Components/Input"
 import { ProgressIndicator } from "Components/ProgressIndicator"
+import QuickInput from "Components/QuickInput"
 import { Step, Wizard } from "Components/Wizard"
 import React, { Component, Fragment } from "react"
 
@@ -76,7 +76,7 @@ export class MobileSignUpForm extends Component<
           form: { errors, values, handleChange, handleBlur, setTouched },
         }) => (
           <Fragment>
-            <Input
+            <QuickInput
               block
               error={!this.state.isSocialSignUp && errors.email}
               placeholder="Enter your email address"
@@ -89,7 +89,6 @@ export class MobileSignUpForm extends Component<
               setTouched={setTouched}
               touchedOnChange={false}
               autoFocus
-              quick
             />
             <TermsOfServiceCheckbox
               error={errors.accepted_terms_of_service}
@@ -108,7 +107,7 @@ export class MobileSignUpForm extends Component<
           wizard,
           form: { errors, values, handleChange, handleBlur, setTouched },
         }) => (
-          <Input
+          <QuickInput
             block
             error={errors.password}
             name="password"
@@ -120,7 +119,6 @@ export class MobileSignUpForm extends Component<
             onBlur={handleBlur}
             setTouched={setTouched}
             touchedOnChange={false}
-            quick
             showPasswordMessage
           />
         )}
@@ -130,7 +128,7 @@ export class MobileSignUpForm extends Component<
           wizard,
           form: { errors, values, handleChange, handleBlur, setTouched },
         }) => (
-          <Input
+          <QuickInput
             block
             error={errors.name}
             name="name"
@@ -142,7 +140,6 @@ export class MobileSignUpForm extends Component<
             onBlur={handleBlur}
             setTouched={setTouched}
             touchedOnChange={false}
-            quick
           />
         )}
       </Step>,

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -15,6 +15,7 @@ import { checkEmail } from "Components/Authentication/helpers"
 import { FormProps } from "Components/Authentication/Types"
 import { MobileSignUpValidator } from "Components/Authentication/Validators"
 import Icon from "Components/Icon"
+import PasswordInput from "Components/PasswordInput"
 import { ProgressIndicator } from "Components/ProgressIndicator"
 import QuickInput from "Components/QuickInput"
 import { Step, Wizard } from "Components/Wizard"
@@ -107,13 +108,12 @@ export class MobileSignUpForm extends Component<
           wizard,
           form: { errors, values, handleChange, handleBlur, setTouched },
         }) => (
-          <QuickInput
+          <PasswordInput
             block
             error={errors.password}
             name="password"
             label="Password"
             placeholder="Password"
-            type="password"
             value={values.password}
             onChange={handleChange}
             onBlur={handleBlur}

--- a/src/Components/Authentication/__tests__/Mobile/LoginForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Mobile/LoginForm.test.tsx
@@ -1,5 +1,5 @@
 import { MobileLoginForm } from "Components/Authentication/Mobile/LoginForm"
-import Input from "Components/Input"
+import QuickInput from "Components/QuickInput"
 import { mount } from "enzyme"
 import React from "react"
 
@@ -16,7 +16,7 @@ describe("MobileLoginForm", () => {
 
   it("renders the first step", () => {
     const wrapper = getWrapper({})
-    const input = wrapper.find(Input)
+    const input = wrapper.find(QuickInput)
     expect(input.length).toBe(1)
     expect(input.props().type).toEqual("email")
   })

--- a/src/Components/Authentication/__tests__/Mobile/ResetPasswordForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Mobile/ResetPasswordForm.test.tsx
@@ -1,5 +1,5 @@
 import { MobileForgotPasswordForm } from "Components/Authentication/Mobile/ForgotPasswordForm"
-import Input from "Components/Input"
+import QuickInput from "Components/QuickInput"
 import { mount } from "enzyme"
 import React from "react"
 
@@ -16,7 +16,7 @@ describe("MobileLoginForm", () => {
 
   it("renders the email input", () => {
     const wrapper = getWrapper({})
-    const input = wrapper.find(Input)
+    const input = wrapper.find(QuickInput)
     expect(input.length).toBe(1)
     expect(input.props().type).toEqual("email")
   })

--- a/src/Components/Authentication/__tests__/Mobile/SignUpForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Mobile/SignUpForm.test.tsx
@@ -1,5 +1,5 @@
 import { MobileSignUpForm } from "Components/Authentication/Mobile/SignUpForm"
-import Input from "Components/Input"
+import QuickInput from "Components/QuickInput"
 import { mount } from "enzyme"
 import React from "react"
 
@@ -17,7 +17,7 @@ describe("MobileSignUpForm", () => {
 
   it("renders the first step", () => {
     const wrapper = getWrapper({})
-    const input = wrapper.find(Input)
+    const input = wrapper.find(QuickInput)
     expect(input.length).toBe(1)
     expect(input.props().type).toEqual("email")
     expect(wrapper.text()).toContain("Sign up for Artsy")

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -12,7 +12,6 @@ export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   error?: string
   title?: string
   touchedOnChange?: boolean
-  innerRef?: React.RefObject<HTMLInputElement>
 }
 
 export interface InputState {

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -1,6 +1,4 @@
-import { space } from "@artsy/palette"
-import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
-import { fadeIn, fadeOut, growAndFadeIn } from "Assets/Animations"
+import { growAndFadeIn } from "Assets/Animations"
 import Colors from "Assets/Colors"
 import { garamond, unica } from "Assets/Fonts"
 import React from "react"
@@ -12,54 +10,25 @@ export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   block?: boolean
   description?: string
   error?: string
-  label?: string
   leftView?: JSX.Element
   rightView?: JSX.Element
-  setTouched?: (fields: { [field: string]: boolean }) => void
-  showPasswordMessage?: boolean
   title?: string
-  quick?: boolean
   touchedOnChange?: boolean
   innerRef?: React.RefObject<HTMLInputElement>
 }
 
 export interface InputState {
-  focused: boolean
   value: string
-  showPassword: boolean
 }
 
 /**
- * Configurable input field. It comes in two modes, standard & quick.
- * In standard mode, the `title` and `description` props are rendered above
- * the input. In quick mode, `title` and `description` are ignored, only
- * `label` is rendered inside the input.
+ * Standard input field.
+ * The `title` and `description` props are rendered above the input.
  *
- * @example
- *
- * ```javascript
- *  // Quick mode
- *  <Input
- *    quick
- *    label="Name"
- *    type="text"
- *    placeholder="Enter you name"
- *  />
- *  ```
- *
- * ```
- *  // Standard mode
- *  <Input
- *    title="Name"
- *    description="Your full name."
- *    type="text"
- *  />
  */
 export class Input extends React.Component<InputProps, InputState> {
   state = {
-    focused: false,
     value: (this.props.value as string) || "",
-    showPassword: false,
     touchedOnChange: true,
   }
 
@@ -72,32 +41,18 @@ export class Input extends React.Component<InputProps, InputState> {
   }
 
   onFocus = e => {
-    this.setState({
-      focused: true,
-    })
-
     if (this.props.onFocus) {
       this.props.onFocus(e)
     }
   }
 
   onBlur = e => {
-    if (this.props.setTouched) {
-      this.props.setTouched({ [this.props.name]: true })
-    }
-    this.setState({
-      focused: false,
-    })
-
     if (this.props.onBlur) {
       this.props.onBlur(e)
     }
   }
 
   onChange = e => {
-    if (this.props.touchedOnChange && this.props.setTouched) {
-      this.props.setTouched({ [this.props.name]: true })
-    }
     this.setState({
       value: e.currentTarget.value,
     })
@@ -107,86 +62,8 @@ export class Input extends React.Component<InputProps, InputState> {
     }
   }
 
-  getRightViewForPassword() {
-    const icon = this.state.showPassword ? (
-      <ClosedEyeIcon onClick={this.toggleShowPassword} />
-    ) : (
-      <OpenEyeIcon onClick={this.toggleShowPassword} />
-    )
-
-    return <Eye onClick={this.toggleShowPassword}>{icon}</Eye>
-  }
-
-  toggleShowPassword = () => {
-    this.setState({
-      showPassword: !this.state.showPassword,
-    })
-  }
-
-  get convertedType() {
-    const { type } = this.props
-    if (this.state.showPassword && type === "password") {
-      return "text"
-    }
-    return type
-  }
-
   render() {
-    const { error, quick } = this.props
-
-    if (quick) {
-      // prettier-ignore
-      const {
-        className,
-        label,
-        leftView,
-        ref: _ref,
-        rightView,
-        showPasswordMessage,
-        type,
-        onChange,
-        setTouched,
-        ...newProps
-      } = this.props
-      const showLabel = (!!this.state.focused || !!this.state.value) && !!label
-      const isPassword = type === "password"
-
-      return (
-        <Container>
-          <InputContainer
-            hasLabel={!!label}
-            hasError={!!error}
-            className={this.state.focused ? "focused" : ""}
-          >
-            <Label out={!showLabel}>{label}</Label>
-            {!!leftView && leftView}
-            <InputComponent
-              innerRef={this.props.innerRef}
-              {...newProps}
-              onFocus={this.onFocus}
-              onBlur={this.onBlur}
-              onChange={this.onChange}
-              value={this.state.value}
-              type={this.convertedType}
-              showLabel={showLabel}
-            />
-            {isPassword
-              ? this.getRightViewForPassword()
-              : !!rightView && rightView}
-          </InputContainer>
-          {!error && showPasswordMessage ? (
-            <PasswordMessage>
-              Password must be at least 8 characters.
-            </PasswordMessage>
-          ) : (
-            ""
-          )}
-          <Error show={!!error}>{error}</Error>
-        </Container>
-      )
-    }
-
-    const { title, description, ref, ...rest } = this.props
+    const { error, title, description, ref, ...rest } = this.props
     return (
       <Container>
         {title && <Title>{title}</Title>}
@@ -207,50 +84,6 @@ export const StyledInput = styled.input`
   ${block(24)};
 `
 
-const InputComponent = styled.input.attrs<{ showLabel: boolean }>({})`
-  ${garamond("s17")};
-  border: 0;
-  font-size: 17px;
-  outline: none;
-  flex: 1;
-  transition: all 0.25s;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  padding: 0 ${space(1)}px;
-  line-height: initial;
-  ${props => props.showLabel && "padding: 10px 10px 0 10px"};
-`
-
-const InputContainer = styled.div.attrs<{
-  hasLabel?: boolean
-  hasError: boolean
-}>({})`
-  ${borderedInput};
-  margin-right: 0;
-  margin-top: 5px;
-  margin-bottom: 10px;
-  display: flex;
-  position: relative;
-  height: ${p => (p.hasLabel ? "40px" : "20px")};
-  flex-direction: row;
-  align-items: center;
-  box-sizing: content-box;
-`
-
-const Label = styled.label.attrs<{ out: boolean }>({})`
-  ${unica("s12", "medium")};
-  position: absolute;
-  left: 10px;
-  top: 7px;
-  visibility: ${p => (p.out ? "hidden" : "visible")};
-  animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
-  transition: visibility 0.2s linear;
-  z-index: 1;
-`
-
 export const Title = styled.div`
   ${garamond("s17")};
 `
@@ -269,19 +102,6 @@ const Error = styled.div.attrs<{ show: boolean }>({})`
   transition: visibility 0.2s linear;
   animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
   height: ${p => (p.show ? "16px" : "0")};
-`
-
-const PasswordMessage = styled.div`
-  ${unica("s12")};
-  margin-top: 10px;
-  color: ${Colors.graySemibold};
-  height: 16px;
-`
-
-const Eye = styled.span`
-  position: absolute;
-  right: 10px;
-  z-index: 1;
 `
 
 export default Input

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -66,7 +66,7 @@ export class Input extends React.Component<InputProps, InputState> {
         {title && <Title>{title}</Title>}
         {description && <Description>{description}</Description>}
         <StyledInput hasError={!!error} {...rest} />
-        <Error show={!!error}>{error}</Error>
+        {error && <Error>{error}</Error>}
       </Container>
     )
   }
@@ -91,14 +91,13 @@ const Description = styled.div`
   margin: 3px 0 0;
 `
 
-const Error = styled.div.attrs<{ show: boolean }>({})`
+const Error = styled.div`
   ${unica("s12")};
-  margin-top: ${p => (p.show ? "10px" : "0")};
+  margin-top: 10px;
   color: ${Colors.redMedium};
-  visibility: ${p => (p.show ? "visible" : "hidden")};
   transition: visibility 0.2s linear;
-  animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
-  height: ${p => (p.show ? "16px" : "0")};
+  animation: ${growAndFadeIn("16px")} 0.25s linear;
+  height: 16px;
 `
 
 export default Input

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -11,7 +11,6 @@ export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   description?: string
   error?: string
   title?: string
-  touchedOnChange?: boolean
 }
 
 export interface InputState {
@@ -24,41 +23,6 @@ export interface InputState {
  *
  */
 export class Input extends React.Component<InputProps, InputState> {
-  state = {
-    value: (this.props.value as string) || "",
-    touchedOnChange: true,
-  }
-
-  componentWillReceiveProps(newProps) {
-    if (this.props.name !== newProps.name) {
-      this.setState({
-        value: "",
-      })
-    }
-  }
-
-  onFocus = e => {
-    if (this.props.onFocus) {
-      this.props.onFocus(e)
-    }
-  }
-
-  onBlur = e => {
-    if (this.props.onBlur) {
-      this.props.onBlur(e)
-    }
-  }
-
-  onChange = e => {
-    this.setState({
-      value: e.currentTarget.value,
-    })
-
-    if (this.props.onChange) {
-      this.props.onChange(e)
-    }
-  }
-
   render() {
     const { error, title, description, ref, ...rest } = this.props
     return (

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -10,8 +10,6 @@ export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   block?: boolean
   description?: string
   error?: string
-  leftView?: JSX.Element
-  rightView?: JSX.Element
   title?: string
   touchedOnChange?: boolean
   innerRef?: React.RefObject<HTMLInputElement>

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -66,7 +66,7 @@ export class Input extends React.Component<InputProps, InputState> {
         {title && <Title>{title}</Title>}
         {description && <Description>{description}</Description>}
         <StyledInput hasError={!!error} {...rest} />
-        {error && <Error>{error}</Error>}
+        {error && <InputError>{error}</InputError>}
       </Container>
     )
   }
@@ -91,7 +91,7 @@ const Description = styled.div`
   margin: 3px 0 0;
 `
 
-const Error = styled.div`
+export const InputError = styled.div`
   ${unica("s12")};
   margin-top: 10px;
   color: ${Colors.redMedium};

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -1,5 +1,5 @@
+import { color, space } from "@artsy/palette"
 import { growAndFadeIn } from "Assets/Animations"
-import Colors from "Assets/Colors"
 import { garamond, unica } from "Assets/Fonts"
 import React, { SFC } from "react"
 import styled from "styled-components"
@@ -36,7 +36,7 @@ export const Input: SFC<InputProps> = ({
 }
 
 const Container = styled.div`
-  padding-bottom: 5px;
+  padding-bottom: ${space(0.5)}px;
 `
 
 export const StyledInput = styled.input`
@@ -50,14 +50,14 @@ export const Title = styled.div`
 
 const Description = styled.div`
   ${garamond("s15")};
-  color: ${Colors.graySemibold};
-  margin: 3px 0 0;
+  color: ${color("black60")};
+  margin: ${space(0.3)}px 0 0;
 `
 
 export const InputError = styled.div`
   ${unica("s12")};
-  margin-top: 10px;
-  color: ${Colors.redMedium};
+  margin-top: ${space(1)}px;
+  color: ${color("red100")};
   transition: visibility 0.2s linear;
   animation: ${growAndFadeIn("16px")} 0.25s linear;
   height: 16px;

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -1,7 +1,7 @@
 import { growAndFadeIn } from "Assets/Animations"
 import Colors from "Assets/Colors"
 import { garamond, unica } from "Assets/Fonts"
-import React from "react"
+import React, { SFC } from "react"
 import styled from "styled-components"
 import { block } from "./Helpers"
 import { borderedInput } from "./Mixins"
@@ -13,27 +13,26 @@ export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   title?: string
 }
 
-export interface InputState {
-  value: string
-}
-
 /**
  * Standard input field.
  * The `title` and `description` props are rendered above the input.
  *
  */
-export class Input extends React.Component<InputProps, InputState> {
-  render() {
-    const { error, title, description, ref, ...rest } = this.props
-    return (
-      <Container>
-        {title && <Title>{title}</Title>}
-        {description && <Description>{description}</Description>}
-        <StyledInput hasError={!!error} {...rest} />
-        {error && <InputError>{error}</InputError>}
-      </Container>
-    )
-  }
+export const Input: SFC<InputProps> = ({
+  error,
+  title,
+  description,
+  ref,
+  ...rest
+}) => {
+  return (
+    <Container>
+      {title && <Title>{title}</Title>}
+      {description && <Description>{description}</Description>}
+      <StyledInput hasError={!!error} {...rest} />
+      {error && <InputError>{error}</InputError>}
+    </Container>
+  )
 }
 
 const Container = styled.div`

--- a/src/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/Components/Onboarding/Steps/Artists/index.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import styled from "styled-components"
 
 import Colors from "../../../../Assets/Colors"
-import Icon from "../../../Icon"
 import Input from "../../../Input"
 
 import { MultiButtonState } from "../../../Buttons/MultiStateButton"
@@ -86,7 +85,6 @@ export default class Artists extends React.Component<StepProps, State> {
         <OnboardingSearchBox>
           <Input
             placeholder={"Search artists..."}
-            leftView={<Icon name="search" color={Colors.graySemibold} />}
             block
             onInput={this.searchTextChanged.bind(this)}
             onPaste={this.searchTextChanged.bind(this)}

--- a/src/Components/Onboarding/Steps/Genes/index.tsx
+++ b/src/Components/Onboarding/Steps/Genes/index.tsx
@@ -3,7 +3,6 @@ import * as React from "react"
 import styled from "styled-components"
 
 import Colors from "../../../../Assets/Colors"
-import Icon from "../../../Icon"
 import Input from "../../../Input"
 
 import { MultiButtonState } from "../../../Buttons/MultiStateButton"
@@ -80,16 +79,6 @@ export default class Genes extends React.Component<StepProps, State> {
         <OnboardingSearchBox>
           <Input
             placeholder={"Search categories..."}
-            leftView={<Icon name="search" color={Colors.graySemibold} />}
-            rightView={
-              this.state.inputText.length ? (
-                <Icon
-                  name="close"
-                  color={Colors.graySemibold}
-                  onClick={this.clearSearch.bind(this)}
-                />
-              ) : null
-            }
             block
             onInput={this.searchTextChanged}
             onPaste={this.searchTextChanged}

--- a/src/Components/PasswordInput.tsx
+++ b/src/Components/PasswordInput.tsx
@@ -1,26 +1,14 @@
-import { space } from "@artsy/palette"
 import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
-import { fadeIn, fadeOut } from "Assets/Animations"
-import Colors from "Assets/Colors"
-import { garamond, unica } from "Assets/Fonts"
 import React from "react"
 import styled from "styled-components"
-import { borderedInput } from "./Mixins"
 
-import { InputError } from "./Input"
+import QuickInput, { QuickInputProps } from "./QuickInput"
 
-export interface PasswordInputProps extends React.HTMLProps<HTMLInputElement> {
-  block?: boolean
-  error?: string
-  label?: string
-  setTouched?: (fields: { [field: string]: boolean }) => void
+export interface PasswordInputProps extends QuickInputProps {
   showPasswordMessage?: boolean
-  touchedOnChange?: boolean
 }
 
 export interface PasswordInputState {
-  focused: boolean
-  value: string
   showPassword: boolean
 }
 
@@ -34,54 +22,7 @@ export class PasswordInput extends React.Component<
   PasswordInputState
 > {
   state = {
-    focused: false,
-    value: (this.props.value as string) || "",
     showPassword: false,
-    touchedOnChange: true,
-  }
-
-  componentWillReceiveProps(newProps) {
-    if (this.props.name !== newProps.name) {
-      this.setState({
-        value: "",
-      })
-    }
-  }
-
-  onFocus = e => {
-    this.setState({
-      focused: true,
-    })
-
-    if (this.props.onFocus) {
-      this.props.onFocus(e)
-    }
-  }
-
-  onBlur = e => {
-    if (this.props.setTouched) {
-      this.props.setTouched({ [this.props.name]: true })
-    }
-    this.setState({
-      focused: false,
-    })
-
-    if (this.props.onBlur) {
-      this.props.onBlur(e)
-    }
-  }
-
-  onChange = e => {
-    if (this.props.touchedOnChange && this.props.setTouched) {
-      this.props.setTouched({ [this.props.name]: true })
-    }
-    this.setState({
-      value: e.currentTarget.value,
-    })
-
-    if (this.props.onChange) {
-      this.props.onChange(e)
-    }
   }
 
   getRightViewForPassword() {
@@ -100,109 +41,24 @@ export class PasswordInput extends React.Component<
     })
   }
 
-  get convertedType() {
-    return this.state.showPassword ? "text" : "password"
-  }
-
   render() {
-    const {
-      error,
-      className,
-      label,
-      ref: _ref,
-      showPasswordMessage,
-      onChange,
-      setTouched,
-      ...newProps
-    } = this.props
-    const showLabel = (!!this.state.focused || !!this.state.value) && !!label
+    const { error, showPasswordMessage, ref, ...newProps } = this.props
+
+    const type = this.state.showPassword ? "text" : "password"
+    const note =
+      !error && showPasswordMessage && "Password must be at least 8 characters."
 
     return (
-      <Container>
-        <InputContainer
-          hasLabel={!!label}
-          hasError={!!error}
-          className={this.state.focused ? "focused" : ""}
-        >
-          <Label out={!showLabel}>{label}</Label>
-          <InputComponent
-            {...newProps}
-            onFocus={this.onFocus}
-            onBlur={this.onBlur}
-            onChange={this.onChange}
-            value={this.state.value}
-            type={this.convertedType}
-            showLabel={showLabel}
-          />
-          {this.getRightViewForPassword()}
-        </InputContainer>
-        {!error && showPasswordMessage && <PasswordRequirements />}
-        {error && <InputError>{error}</InputError>}
-      </Container>
+      <QuickInput
+        {...newProps}
+        error={error}
+        type={type}
+        rightAddOn={this.getRightViewForPassword()}
+        note={note}
+      />
     )
   }
 }
-
-const Container = styled.div`
-  padding-bottom: 5px;
-`
-
-const InputComponent = styled.input.attrs<{ showLabel: boolean }>({})`
-  ${garamond("s17")};
-  border: 0;
-  font-size: 17px;
-  outline: none;
-  flex: 1;
-  transition: all 0.25s;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  padding: 0 ${space(1)}px;
-  line-height: initial;
-  ${props => props.showLabel && "padding: 10px 10px 0 10px"};
-`
-
-const InputContainer = styled.div.attrs<{
-  hasLabel?: boolean
-  hasError: boolean
-}>({})`
-  ${borderedInput};
-  margin-right: 0;
-  margin-top: 5px;
-  margin-bottom: 10px;
-  display: flex;
-  position: relative;
-  height: ${p => (p.hasLabel ? "40px" : "20px")};
-  flex-direction: row;
-  align-items: center;
-  box-sizing: content-box;
-`
-
-const Label = styled.label.attrs<{ out: boolean }>({})`
-  ${unica("s12", "medium")};
-  position: absolute;
-  left: 10px;
-  top: 7px;
-  visibility: ${p => (p.out ? "hidden" : "visible")};
-  animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
-  transition: visibility 0.2s linear;
-  z-index: 1;
-`
-
-const PasswordRequirements = () => (
-  <PasswordMessage>
-    Password must be at least 8 characters.
-  </PasswordMessage>
-)
-
-const PasswordMessage = styled.div`
-  ${unica("s12")};
-  margin-top: 10px;
-  color: ${Colors.graySemibold};
-  height: 16px;
-`
 
 const Eye = styled.span`
   position: absolute;

--- a/src/Components/PasswordInput.tsx
+++ b/src/Components/PasswordInput.tsx
@@ -14,7 +14,6 @@ export interface PasswordInputProps extends React.HTMLProps<HTMLInputElement> {
   setTouched?: (fields: { [field: string]: boolean }) => void
   showPasswordMessage?: boolean
   touchedOnChange?: boolean
-  innerRef?: React.RefObject<HTMLInputElement>
 }
 
 export interface PasswordInputState {
@@ -125,7 +124,6 @@ export class PasswordInput extends React.Component<
         >
           <Label out={!showLabel}>{label}</Label>
           <InputComponent
-            innerRef={this.props.innerRef}
             {...newProps}
             onFocus={this.onFocus}
             onBlur={this.onBlur}

--- a/src/Components/PasswordInput.tsx
+++ b/src/Components/PasswordInput.tsx
@@ -1,11 +1,13 @@
 import { space } from "@artsy/palette"
 import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
-import { fadeIn, fadeOut, growAndFadeIn } from "Assets/Animations"
+import { fadeIn, fadeOut } from "Assets/Animations"
 import Colors from "Assets/Colors"
 import { garamond, unica } from "Assets/Fonts"
 import React from "react"
 import styled from "styled-components"
 import { borderedInput } from "./Mixins"
+
+import { InputError } from "./Input"
 
 export interface PasswordInputProps extends React.HTMLProps<HTMLInputElement> {
   block?: boolean
@@ -135,7 +137,7 @@ export class PasswordInput extends React.Component<
           {this.getRightViewForPassword()}
         </InputContainer>
         {!error && showPasswordMessage && <PasswordRequirements />}
-        {error && <Error>{error}</Error>}
+        {error && <InputError>{error}</InputError>}
       </Container>
     )
   }
@@ -187,15 +189,6 @@ const Label = styled.label.attrs<{ out: boolean }>({})`
   animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
   transition: visibility 0.2s linear;
   z-index: 1;
-`
-
-const Error = styled.div`
-  ${unica("s12")};
-  margin-top: 10px;
-  color: ${Colors.redMedium};
-  transition: visibility 0.2s linear;
-  animation: ${growAndFadeIn("16px")} 0.25s linear;
-  height: 16px;
 `
 
 const PasswordRequirements = () => (

--- a/src/Components/PasswordInput.tsx
+++ b/src/Components/PasswordInput.tsx
@@ -134,14 +134,8 @@ export class PasswordInput extends React.Component<
           />
           {this.getRightViewForPassword()}
         </InputContainer>
-        {!error && showPasswordMessage ? (
-          <PasswordMessage>
-            Password must be at least 8 characters.
-          </PasswordMessage>
-        ) : (
-          ""
-        )}
-        <Error show={!!error}>{error}</Error>
+        {!error && showPasswordMessage && <PasswordRequirements />}
+        {error && <Error>{error}</Error>}
       </Container>
     )
   }
@@ -195,15 +189,20 @@ const Label = styled.label.attrs<{ out: boolean }>({})`
   z-index: 1;
 `
 
-const Error = styled.div.attrs<{ show: boolean }>({})`
+const Error = styled.div`
   ${unica("s12")};
-  margin-top: ${p => (p.show ? "10px" : "0")};
+  margin-top: 10px;
   color: ${Colors.redMedium};
-  visibility: ${p => (p.show ? "visible" : "hidden")};
   transition: visibility 0.2s linear;
-  animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
-  height: ${p => (p.show ? "16px" : "0")};
+  animation: ${growAndFadeIn("16px")} 0.25s linear;
+  height: 16px;
 `
+
+const PasswordRequirements = () => (
+  <PasswordMessage>
+    Password must be at least 8 characters.
+  </PasswordMessage>
+)
 
 const PasswordMessage = styled.div`
   ${unica("s12")};

--- a/src/Components/PasswordInput.tsx
+++ b/src/Components/PasswordInput.tsx
@@ -1,4 +1,4 @@
-import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
+import { ClosedEyeIcon, OpenEyeIcon, space } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 
@@ -62,7 +62,7 @@ export class PasswordInput extends React.Component<
 
 const Eye = styled.span`
   position: absolute;
-  right: 10px;
+  right: ${space(1)}px;
   z-index: 1;
 `
 

--- a/src/Components/PasswordInput.tsx
+++ b/src/Components/PasswordInput.tsx
@@ -1,0 +1,223 @@
+import { space } from "@artsy/palette"
+import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
+import { fadeIn, fadeOut, growAndFadeIn } from "Assets/Animations"
+import Colors from "Assets/Colors"
+import { garamond, unica } from "Assets/Fonts"
+import React from "react"
+import styled from "styled-components"
+import { borderedInput } from "./Mixins"
+
+export interface PasswordInputProps extends React.HTMLProps<HTMLInputElement> {
+  block?: boolean
+  error?: string
+  label?: string
+  setTouched?: (fields: { [field: string]: boolean }) => void
+  showPasswordMessage?: boolean
+  touchedOnChange?: boolean
+  innerRef?: React.RefObject<HTMLInputElement>
+}
+
+export interface PasswordInputState {
+  focused: boolean
+  value: string
+  showPassword: boolean
+}
+
+/**
+ * Password input.
+ * Renders the label inside of the textbox; shows/hides the password.
+ *
+ */
+export class PasswordInput extends React.Component<
+  PasswordInputProps,
+  PasswordInputState
+> {
+  state = {
+    focused: false,
+    value: (this.props.value as string) || "",
+    showPassword: false,
+    touchedOnChange: true,
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (this.props.name !== newProps.name) {
+      this.setState({
+        value: "",
+      })
+    }
+  }
+
+  onFocus = e => {
+    this.setState({
+      focused: true,
+    })
+
+    if (this.props.onFocus) {
+      this.props.onFocus(e)
+    }
+  }
+
+  onBlur = e => {
+    if (this.props.setTouched) {
+      this.props.setTouched({ [this.props.name]: true })
+    }
+    this.setState({
+      focused: false,
+    })
+
+    if (this.props.onBlur) {
+      this.props.onBlur(e)
+    }
+  }
+
+  onChange = e => {
+    if (this.props.touchedOnChange && this.props.setTouched) {
+      this.props.setTouched({ [this.props.name]: true })
+    }
+    this.setState({
+      value: e.currentTarget.value,
+    })
+
+    if (this.props.onChange) {
+      this.props.onChange(e)
+    }
+  }
+
+  getRightViewForPassword() {
+    const icon = this.state.showPassword ? (
+      <ClosedEyeIcon onClick={this.toggleShowPassword} />
+    ) : (
+      <OpenEyeIcon onClick={this.toggleShowPassword} />
+    )
+
+    return <Eye onClick={this.toggleShowPassword}>{icon}</Eye>
+  }
+
+  toggleShowPassword = () => {
+    this.setState({
+      showPassword: !this.state.showPassword,
+    })
+  }
+
+  get convertedType() {
+    return this.state.showPassword ? "text" : "password"
+  }
+
+  render() {
+    const {
+      error,
+      className,
+      label,
+      ref: _ref,
+      showPasswordMessage,
+      onChange,
+      setTouched,
+      ...newProps
+    } = this.props
+    const showLabel = (!!this.state.focused || !!this.state.value) && !!label
+
+    return (
+      <Container>
+        <InputContainer
+          hasLabel={!!label}
+          hasError={!!error}
+          className={this.state.focused ? "focused" : ""}
+        >
+          <Label out={!showLabel}>{label}</Label>
+          <InputComponent
+            innerRef={this.props.innerRef}
+            {...newProps}
+            onFocus={this.onFocus}
+            onBlur={this.onBlur}
+            onChange={this.onChange}
+            value={this.state.value}
+            type={this.convertedType}
+            showLabel={showLabel}
+          />
+          {this.getRightViewForPassword()}
+        </InputContainer>
+        {!error && showPasswordMessage ? (
+          <PasswordMessage>
+            Password must be at least 8 characters.
+          </PasswordMessage>
+        ) : (
+          ""
+        )}
+        <Error show={!!error}>{error}</Error>
+      </Container>
+    )
+  }
+}
+
+const Container = styled.div`
+  padding-bottom: 5px;
+`
+
+const InputComponent = styled.input.attrs<{ showLabel: boolean }>({})`
+  ${garamond("s17")};
+  border: 0;
+  font-size: 17px;
+  outline: none;
+  flex: 1;
+  transition: all 0.25s;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0 ${space(1)}px;
+  line-height: initial;
+  ${props => props.showLabel && "padding: 10px 10px 0 10px"};
+`
+
+const InputContainer = styled.div.attrs<{
+  hasLabel?: boolean
+  hasError: boolean
+}>({})`
+  ${borderedInput};
+  margin-right: 0;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  display: flex;
+  position: relative;
+  height: ${p => (p.hasLabel ? "40px" : "20px")};
+  flex-direction: row;
+  align-items: center;
+  box-sizing: content-box;
+`
+
+const Label = styled.label.attrs<{ out: boolean }>({})`
+  ${unica("s12", "medium")};
+  position: absolute;
+  left: 10px;
+  top: 7px;
+  visibility: ${p => (p.out ? "hidden" : "visible")};
+  animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
+  transition: visibility 0.2s linear;
+  z-index: 1;
+`
+
+const Error = styled.div.attrs<{ show: boolean }>({})`
+  ${unica("s12")};
+  margin-top: ${p => (p.show ? "10px" : "0")};
+  color: ${Colors.redMedium};
+  visibility: ${p => (p.show ? "visible" : "hidden")};
+  transition: visibility 0.2s linear;
+  animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
+  height: ${p => (p.show ? "16px" : "0")};
+`
+
+const PasswordMessage = styled.div`
+  ${unica("s12")};
+  margin-top: 10px;
+  color: ${Colors.graySemibold};
+  height: 16px;
+`
+
+const Eye = styled.span`
+  position: absolute;
+  right: 10px;
+  z-index: 1;
+`
+
+export default PasswordInput

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -1,10 +1,11 @@
 import { space } from "@artsy/palette"
-import { fadeIn, fadeOut, growAndFadeIn } from "Assets/Animations"
-import Colors from "Assets/Colors"
+import { fadeIn, fadeOut } from "Assets/Animations"
 import { garamond, unica } from "Assets/Fonts"
 import React from "react"
 import styled from "styled-components"
 import { borderedInput } from "./Mixins"
+
+import { InputError } from "./Input"
 
 export interface QuickInputProps extends React.HTMLProps<HTMLInputElement> {
   block?: boolean
@@ -107,7 +108,7 @@ export class QuickInput extends React.Component<
             showLabel={showLabel}
           />
         </InputContainer>
-        {error && <Error>{error}</Error>}
+        {error && <InputError>{error}</InputError>}
       </Container>
     )
   }
@@ -159,15 +160,6 @@ const Label = styled.label.attrs<{ out: boolean }>({})`
   animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
   transition: visibility 0.2s linear;
   z-index: 1;
-`
-
-const Error = styled.div`
-  ${unica("s12")};
-  margin-top: 10px;
-  color: ${Colors.redMedium};
-  transition: visibility 0.2s linear;
-  animation: ${growAndFadeIn("16px")} 0.25s linear;
-  height: 16px;
 `
 
 export default QuickInput

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -1,5 +1,4 @@
 import { space } from "@artsy/palette"
-import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
 import { fadeIn, fadeOut, growAndFadeIn } from "Assets/Animations"
 import Colors from "Assets/Colors"
 import { garamond, unica } from "Assets/Fonts"
@@ -12,7 +11,6 @@ export interface QuickInputProps extends React.HTMLProps<HTMLInputElement> {
   error?: string
   label?: string
   setTouched?: (fields: { [field: string]: boolean }) => void
-  showPasswordMessage?: boolean
   touchedOnChange?: boolean
   innerRef?: React.RefObject<HTMLInputElement>
 }
@@ -20,7 +18,6 @@ export interface QuickInputProps extends React.HTMLProps<HTMLInputElement> {
 export interface QuickInputState {
   focused: boolean
   value: string
-  showPassword: boolean
 }
 
 /**
@@ -34,7 +31,6 @@ export class QuickInput extends React.Component<
   state = {
     focused: false,
     value: (this.props.value as string) || "",
-    showPassword: false,
     touchedOnChange: true,
   }
 
@@ -82,44 +78,18 @@ export class QuickInput extends React.Component<
     }
   }
 
-  getRightViewForPassword() {
-    const icon = this.state.showPassword ? (
-      <ClosedEyeIcon onClick={this.toggleShowPassword} />
-    ) : (
-      <OpenEyeIcon onClick={this.toggleShowPassword} />
-    )
-
-    return <Eye onClick={this.toggleShowPassword}>{icon}</Eye>
-  }
-
-  toggleShowPassword = () => {
-    this.setState({
-      showPassword: !this.state.showPassword,
-    })
-  }
-
-  get convertedType() {
-    const { type } = this.props
-    if (this.state.showPassword && type === "password") {
-      return "text"
-    }
-    return type
-  }
-
   render() {
     const {
       error,
       className,
       label,
       ref: _ref,
-      showPasswordMessage,
       type,
       onChange,
       setTouched,
       ...newProps
     } = this.props
     const showLabel = (!!this.state.focused || !!this.state.value) && !!label
-    const isPassword = type === "password"
 
     return (
       <Container>
@@ -136,18 +106,9 @@ export class QuickInput extends React.Component<
             onBlur={this.onBlur}
             onChange={this.onChange}
             value={this.state.value}
-            type={this.convertedType}
             showLabel={showLabel}
           />
-          {isPassword && this.getRightViewForPassword()}
         </InputContainer>
-        {!error && showPasswordMessage ? (
-          <PasswordMessage>
-            Password must be at least 8 characters.
-          </PasswordMessage>
-        ) : (
-          ""
-        )}
         <Error show={!!error}>{error}</Error>
       </Container>
     )
@@ -210,19 +171,6 @@ const Error = styled.div.attrs<{ show: boolean }>({})`
   transition: visibility 0.2s linear;
   animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
   height: ${p => (p.show ? "16px" : "0")};
-`
-
-const PasswordMessage = styled.div`
-  ${unica("s12")};
-  margin-top: 10px;
-  color: ${Colors.graySemibold};
-  height: 16px;
-`
-
-const Eye = styled.span`
-  position: absolute;
-  right: 10px;
-  z-index: 1;
 `
 
 export default QuickInput

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -12,7 +12,6 @@ export interface QuickInputProps extends React.HTMLProps<HTMLInputElement> {
   label?: string
   setTouched?: (fields: { [field: string]: boolean }) => void
   touchedOnChange?: boolean
-  innerRef?: React.RefObject<HTMLInputElement>
 }
 
 export interface QuickInputState {
@@ -100,7 +99,6 @@ export class QuickInput extends React.Component<
         >
           <Label out={!showLabel}>{label}</Label>
           <InputComponent
-            innerRef={this.props.innerRef}
             {...newProps}
             onFocus={this.onFocus}
             onBlur={this.onBlur}

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -121,13 +121,12 @@ export class QuickInput extends React.Component<
 }
 
 const Container = styled.div`
-  padding-bottom: 5px;
+  padding-bottom: ${space(0.5)}px;
 `
 
 const InputComponent = styled.input.attrs<{ showLabel: boolean }>({})`
   ${garamond("s17")};
   border: 0;
-  font-size: 17px;
   outline: none;
   flex: 1;
   transition: all 0.25s;
@@ -138,7 +137,8 @@ const InputComponent = styled.input.attrs<{ showLabel: boolean }>({})`
   height: 100%;
   padding: 0 ${space(1)}px;
   line-height: initial;
-  ${props => props.showLabel && "padding: 10px 10px 0 10px"};
+  ${props =>
+    props.showLabel && `padding: ${space(1)}px ${space(1)}px 0 ${space(1)}px`};
 `
 
 const InputContainer = styled.div.attrs<{
@@ -147,11 +147,11 @@ const InputContainer = styled.div.attrs<{
 }>({})`
   ${borderedInput};
   margin-right: 0;
-  margin-top: 5px;
-  margin-bottom: 10px;
+  margin-top: ${space(0.5)}px;
+  margin-bottom: ${space(1)}px;
   display: flex;
   position: relative;
-  height: ${p => (p.hasLabel ? "40px" : "20px")};
+  height: ${p => (p.hasLabel ? `${space(4)}px` : `${space(2)}px`)};
   flex-direction: row;
   align-items: center;
   box-sizing: content-box;
@@ -160,8 +160,8 @@ const InputContainer = styled.div.attrs<{
 const Label = styled.label.attrs<{ out: boolean }>({})`
   ${unica("s12", "medium")};
   position: absolute;
-  left: 10px;
-  top: 7px;
+  left: ${space(1)}px;
+  top: ${space(1)}px;
   visibility: ${p => (p.out ? "hidden" : "visible")};
   animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
   transition: visibility 0.2s linear;
@@ -170,7 +170,7 @@ const Label = styled.label.attrs<{ out: boolean }>({})`
 
 const InputNote = styled.div`
   ${unica("s12")};
-  margin-top: 10px;
+  margin-top: ${space(1)}px;
   color: ${Colors.graySemibold};
   height: 16px;
 `

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -9,15 +9,12 @@ import { borderedInput } from "./Mixins"
 
 export interface QuickInputProps extends React.HTMLProps<HTMLInputElement> {
   block?: boolean
-  description?: string
   error?: string
   label?: string
   leftView?: JSX.Element
   rightView?: JSX.Element
   setTouched?: (fields: { [field: string]: boolean }) => void
   showPasswordMessage?: boolean
-  title?: string
-  quick?: boolean
   touchedOnChange?: boolean
   innerRef?: React.RefObject<HTMLInputElement>
 }
@@ -112,21 +109,19 @@ export class QuickInput extends React.Component<
   }
 
   render() {
-    const { error } = this.props
-
-    // prettier-ignore
     const {
-        className,
-        label,
-        leftView,
-        ref: _ref,
-        rightView,
-        showPasswordMessage,
-        type,
-        onChange,
-        setTouched,
-        ...newProps
-      } = this.props
+      error,
+      className,
+      label,
+      leftView,
+      ref: _ref,
+      rightView,
+      showPasswordMessage,
+      type,
+      onChange,
+      setTouched,
+      ...newProps
+    } = this.props
     const showLabel = (!!this.state.focused || !!this.state.value) && !!label
     const isPassword = type === "password"
 
@@ -212,10 +207,6 @@ const Label = styled.label.attrs<{ out: boolean }>({})`
   animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
   transition: visibility 0.2s linear;
   z-index: 1;
-`
-
-export const Title = styled.div`
-  ${garamond("s17")};
 `
 
 const Error = styled.div.attrs<{ show: boolean }>({})`

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -11,8 +11,6 @@ export interface QuickInputProps extends React.HTMLProps<HTMLInputElement> {
   block?: boolean
   error?: string
   label?: string
-  leftView?: JSX.Element
-  rightView?: JSX.Element
   setTouched?: (fields: { [field: string]: boolean }) => void
   showPasswordMessage?: boolean
   touchedOnChange?: boolean
@@ -113,9 +111,7 @@ export class QuickInput extends React.Component<
       error,
       className,
       label,
-      leftView,
       ref: _ref,
-      rightView,
       showPasswordMessage,
       type,
       onChange,
@@ -133,7 +129,6 @@ export class QuickInput extends React.Component<
           className={this.state.focused ? "focused" : ""}
         >
           <Label out={!showLabel}>{label}</Label>
-          {!!leftView && leftView}
           <InputComponent
             innerRef={this.props.innerRef}
             {...newProps}
@@ -144,9 +139,7 @@ export class QuickInput extends React.Component<
             type={this.convertedType}
             showLabel={showLabel}
           />
-          {isPassword
-            ? this.getRightViewForPassword()
-            : !!rightView && rightView}
+          {isPassword && this.getRightViewForPassword()}
         </InputContainer>
         {!error && showPasswordMessage ? (
           <PasswordMessage>

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -107,7 +107,7 @@ export class QuickInput extends React.Component<
             showLabel={showLabel}
           />
         </InputContainer>
-        <Error show={!!error}>{error}</Error>
+        {error && <Error>{error}</Error>}
       </Container>
     )
   }
@@ -161,14 +161,13 @@ const Label = styled.label.attrs<{ out: boolean }>({})`
   z-index: 1;
 `
 
-const Error = styled.div.attrs<{ show: boolean }>({})`
+const Error = styled.div`
   ${unica("s12")};
-  margin-top: ${p => (p.show ? "10px" : "0")};
+  margin-top: 10px;
   color: ${Colors.redMedium};
-  visibility: ${p => (p.show ? "visible" : "hidden")};
   transition: visibility 0.2s linear;
-  animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
-  height: ${p => (p.show ? "16px" : "0")};
+  animation: ${growAndFadeIn("16px")} 0.25s linear;
+  height: 16px;
 `
 
 export default QuickInput

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -1,5 +1,6 @@
 import { space } from "@artsy/palette"
 import { fadeIn, fadeOut } from "Assets/Animations"
+import Colors from "Assets/Colors"
 import { garamond, unica } from "Assets/Fonts"
 import React from "react"
 import styled from "styled-components"
@@ -11,6 +12,8 @@ export interface QuickInputProps extends React.HTMLProps<HTMLInputElement> {
   block?: boolean
   error?: string
   label?: string
+  note?: string
+  rightAddOn?: JSX.Element
   setTouched?: (fields: { [field: string]: boolean }) => void
   touchedOnChange?: boolean
 }
@@ -84,9 +87,10 @@ export class QuickInput extends React.Component<
       className,
       label,
       ref: _ref,
-      type,
       onChange,
       setTouched,
+      rightAddOn,
+      note,
       ...newProps
     } = this.props
     const showLabel = (!!this.state.focused || !!this.state.value) && !!label
@@ -107,7 +111,9 @@ export class QuickInput extends React.Component<
             value={this.state.value}
             showLabel={showLabel}
           />
+          {rightAddOn}
         </InputContainer>
+        {note && <InputNote>{note}</InputNote>}
         {error && <InputError>{error}</InputError>}
       </Container>
     )
@@ -160,6 +166,13 @@ const Label = styled.label.attrs<{ out: boolean }>({})`
   animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
   transition: visibility 0.2s linear;
   z-index: 1;
+`
+
+const InputNote = styled.div`
+  ${unica("s12")};
+  margin-top: 10px;
+  color: ${Colors.graySemibold};
+  height: 16px;
 `
 
 export default QuickInput

--- a/src/Components/QuickInput.tsx
+++ b/src/Components/QuickInput.tsx
@@ -1,0 +1,244 @@
+import { space } from "@artsy/palette"
+import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
+import { fadeIn, fadeOut, growAndFadeIn } from "Assets/Animations"
+import Colors from "Assets/Colors"
+import { garamond, unica } from "Assets/Fonts"
+import React from "react"
+import styled from "styled-components"
+import { borderedInput } from "./Mixins"
+
+export interface QuickInputProps extends React.HTMLProps<HTMLInputElement> {
+  block?: boolean
+  description?: string
+  error?: string
+  label?: string
+  leftView?: JSX.Element
+  rightView?: JSX.Element
+  setTouched?: (fields: { [field: string]: boolean }) => void
+  showPasswordMessage?: boolean
+  title?: string
+  quick?: boolean
+  touchedOnChange?: boolean
+  innerRef?: React.RefObject<HTMLInputElement>
+}
+
+export interface QuickInputState {
+  focused: boolean
+  value: string
+  showPassword: boolean
+}
+
+/**
+ * Quick input. Renders the label inside of the textbox.
+ *
+ */
+export class QuickInput extends React.Component<
+  QuickInputProps,
+  QuickInputState
+> {
+  state = {
+    focused: false,
+    value: (this.props.value as string) || "",
+    showPassword: false,
+    touchedOnChange: true,
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (this.props.name !== newProps.name) {
+      this.setState({
+        value: "",
+      })
+    }
+  }
+
+  onFocus = e => {
+    this.setState({
+      focused: true,
+    })
+
+    if (this.props.onFocus) {
+      this.props.onFocus(e)
+    }
+  }
+
+  onBlur = e => {
+    if (this.props.setTouched) {
+      this.props.setTouched({ [this.props.name]: true })
+    }
+    this.setState({
+      focused: false,
+    })
+
+    if (this.props.onBlur) {
+      this.props.onBlur(e)
+    }
+  }
+
+  onChange = e => {
+    if (this.props.touchedOnChange && this.props.setTouched) {
+      this.props.setTouched({ [this.props.name]: true })
+    }
+    this.setState({
+      value: e.currentTarget.value,
+    })
+
+    if (this.props.onChange) {
+      this.props.onChange(e)
+    }
+  }
+
+  getRightViewForPassword() {
+    const icon = this.state.showPassword ? (
+      <ClosedEyeIcon onClick={this.toggleShowPassword} />
+    ) : (
+      <OpenEyeIcon onClick={this.toggleShowPassword} />
+    )
+
+    return <Eye onClick={this.toggleShowPassword}>{icon}</Eye>
+  }
+
+  toggleShowPassword = () => {
+    this.setState({
+      showPassword: !this.state.showPassword,
+    })
+  }
+
+  get convertedType() {
+    const { type } = this.props
+    if (this.state.showPassword && type === "password") {
+      return "text"
+    }
+    return type
+  }
+
+  render() {
+    const { error } = this.props
+
+    // prettier-ignore
+    const {
+        className,
+        label,
+        leftView,
+        ref: _ref,
+        rightView,
+        showPasswordMessage,
+        type,
+        onChange,
+        setTouched,
+        ...newProps
+      } = this.props
+    const showLabel = (!!this.state.focused || !!this.state.value) && !!label
+    const isPassword = type === "password"
+
+    return (
+      <Container>
+        <InputContainer
+          hasLabel={!!label}
+          hasError={!!error}
+          className={this.state.focused ? "focused" : ""}
+        >
+          <Label out={!showLabel}>{label}</Label>
+          {!!leftView && leftView}
+          <InputComponent
+            innerRef={this.props.innerRef}
+            {...newProps}
+            onFocus={this.onFocus}
+            onBlur={this.onBlur}
+            onChange={this.onChange}
+            value={this.state.value}
+            type={this.convertedType}
+            showLabel={showLabel}
+          />
+          {isPassword
+            ? this.getRightViewForPassword()
+            : !!rightView && rightView}
+        </InputContainer>
+        {!error && showPasswordMessage ? (
+          <PasswordMessage>
+            Password must be at least 8 characters.
+          </PasswordMessage>
+        ) : (
+          ""
+        )}
+        <Error show={!!error}>{error}</Error>
+      </Container>
+    )
+  }
+}
+
+const Container = styled.div`
+  padding-bottom: 5px;
+`
+
+const InputComponent = styled.input.attrs<{ showLabel: boolean }>({})`
+  ${garamond("s17")};
+  border: 0;
+  font-size: 17px;
+  outline: none;
+  flex: 1;
+  transition: all 0.25s;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0 ${space(1)}px;
+  line-height: initial;
+  ${props => props.showLabel && "padding: 10px 10px 0 10px"};
+`
+
+const InputContainer = styled.div.attrs<{
+  hasLabel?: boolean
+  hasError: boolean
+}>({})`
+  ${borderedInput};
+  margin-right: 0;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  display: flex;
+  position: relative;
+  height: ${p => (p.hasLabel ? "40px" : "20px")};
+  flex-direction: row;
+  align-items: center;
+  box-sizing: content-box;
+`
+
+const Label = styled.label.attrs<{ out: boolean }>({})`
+  ${unica("s12", "medium")};
+  position: absolute;
+  left: 10px;
+  top: 7px;
+  visibility: ${p => (p.out ? "hidden" : "visible")};
+  animation: ${p => (p.out ? fadeOut : fadeIn)} 0.2s linear;
+  transition: visibility 0.2s linear;
+  z-index: 1;
+`
+
+export const Title = styled.div`
+  ${garamond("s17")};
+`
+
+const Error = styled.div.attrs<{ show: boolean }>({})`
+  ${unica("s12")};
+  margin-top: ${p => (p.show ? "10px" : "0")};
+  color: ${Colors.redMedium};
+  visibility: ${p => (p.show ? "visible" : "hidden")};
+  transition: visibility 0.2s linear;
+  animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
+  height: ${p => (p.show ? "16px" : "0")};
+`
+
+const PasswordMessage = styled.div`
+  ${unica("s12")};
+  margin-top: 10px;
+  color: ${Colors.graySemibold};
+  height: 16px;
+`
+
+const Eye = styled.span`
+  position: absolute;
+  right: 10px;
+  z-index: 1;
+`
+
+export default QuickInput

--- a/src/Components/__stories__/Input.story.tsx
+++ b/src/Components/__stories__/Input.story.tsx
@@ -9,6 +9,7 @@ import Button from "../Buttons/Inverted"
 import { Checkbox } from "../Checkbox"
 import Icon from "../Icon"
 import Input from "../Input"
+import QuickInput from "../QuickInput"
 import TextArea from "../TextArea"
 
 const Title = styled.h1`
@@ -94,19 +95,17 @@ storiesOf("Components/Input", module)
       <Subtitle>Used for short/simple forms</Subtitle>
 
       <div style={{ padding: 10 }}>
-        <Input
+        <QuickInput
           placeholder="Enter your email address"
           label="Email"
           block
-          quick
         />
-        <Input
+        <QuickInput
           type="password"
           placeholder="Enter your password"
           label="Password"
           rightView={<Icon name="search" color={colors.graySemibold} />}
           block
-          quick
         />
       </div>
     </div>

--- a/src/Components/__stories__/Input.story.tsx
+++ b/src/Components/__stories__/Input.story.tsx
@@ -83,6 +83,31 @@ storiesOf("Components/Input", module)
               value="Content"
               block
             />
+
+            <QuickInput
+              placeholder="Placeholder"
+              label="Title"
+              error={on ? "There was a problem" : null}
+              value="Content"
+              block
+            />
+
+            <PasswordInput
+              placeholder="Placeholder"
+              label="Title"
+              error={on ? "There was a problem" : null}
+              value="Content"
+              block
+            />
+
+            <PasswordInput
+              placeholder="Placeholder"
+              label="Title"
+              error={on ? "There was a problem" : null}
+              value="Content"
+              block
+              showPasswordMessage
+            />
           </section>
         </div>
       )}
@@ -103,6 +128,12 @@ storiesOf("Components/Input", module)
           placeholder="Enter your password"
           label="Password"
           block
+        />
+        <PasswordInput
+          placeholder="Enter your password"
+          label="Password"
+          block
+          showPasswordMessage
         />
       </div>
     </div>

--- a/src/Components/__stories__/Input.story.tsx
+++ b/src/Components/__stories__/Input.story.tsx
@@ -4,10 +4,8 @@ import React from "react"
 import styled from "styled-components"
 
 import { Toggle } from "react-powerplug"
-import colors from "../../Assets/Colors"
 import Button from "../Buttons/Inverted"
 import { Checkbox } from "../Checkbox"
-import Icon from "../Icon"
 import Input from "../Input"
 import QuickInput from "../QuickInput"
 import TextArea from "../TextArea"
@@ -104,7 +102,6 @@ storiesOf("Components/Input", module)
           type="password"
           placeholder="Enter your password"
           label="Password"
-          rightView={<Icon name="search" color={colors.graySemibold} />}
           block
         />
       </div>

--- a/src/Components/__stories__/Input.story.tsx
+++ b/src/Components/__stories__/Input.story.tsx
@@ -19,7 +19,7 @@ const Subtitle = styled.h2`
 `
 
 storiesOf("Components/Input", module)
-  .add("Default Input", () => (
+  .add("Input", () => (
     <div style={{ padding: 10 }}>
       <Title>Input</Title>
       <Subtitle>Our default input style. Title is optional.</Subtitle>
@@ -61,9 +61,7 @@ storiesOf("Components/Input", module)
       {({ on, toggle }) => (
         <div style={{ padding: 10 }}>
           <Title>Input with error</Title>
-          <Subtitle>
-            Used when greater context is needed beyond the title.
-          </Subtitle>
+          <Subtitle>Our default input style. Title is optional.</Subtitle>
 
           <Button onClick={toggle}>Toggle errors</Button>
 
@@ -83,7 +81,35 @@ storiesOf("Components/Input", module)
               value="Content"
               block
             />
+          </section>
+        </div>
+      )}
+    </Toggle>
+  ))
+  .add("QuickInput", () => (
+    <div style={{ padding: 10 }}>
+      <Title>QuickInput</Title>
+      <Subtitle>Used for short/simple forms</Subtitle>
 
+      <div style={{ padding: 10 }}>
+        <QuickInput
+          placeholder="Enter your email address"
+          label="Email"
+          block
+        />
+      </div>
+    </div>
+  ))
+  .add("QuickInput with Error", () => (
+    <Toggle initial>
+      {({ on, toggle }) => (
+        <div style={{ padding: 10 }}>
+          <Title>QuickInput with error</Title>
+          <Subtitle>Used for short/simple forms</Subtitle>
+
+          <Button onClick={toggle}>Toggle errors</Button>
+
+          <section style={{ padding: 10 }}>
             <QuickInput
               placeholder="Placeholder"
               label="Title"
@@ -91,10 +117,44 @@ storiesOf("Components/Input", module)
               value="Content"
               block
             />
+          </section>
+        </div>
+      )}
+    </Toggle>
+  ))
+  .add("PasswordInput", () => (
+    <div style={{ padding: 10 }}>
+      <Title>PasswordInput</Title>
+      <Subtitle>A specialized QuickInput for password entry</Subtitle>
 
+      <div style={{ padding: 10 }}>
+        <PasswordInput
+          placeholder="Enter your password"
+          label="Password"
+          block
+        />
+        <PasswordInput
+          placeholder="Enter your password"
+          label="Password (with requirements)"
+          block
+          showPasswordMessage
+        />
+      </div>
+    </div>
+  ))
+  .add("PasswordInput with Error", () => (
+    <Toggle initial>
+      {({ on, toggle }) => (
+        <div style={{ padding: 10 }}>
+          <Title>PasswordInput with error</Title>
+          <Subtitle>A specialized QuickInput for password entry</Subtitle>
+
+          <Button onClick={toggle}>Toggle errors</Button>
+
+          <section style={{ padding: 10 }}>
             <PasswordInput
               placeholder="Placeholder"
-              label="Title"
+              label="Password"
               error={on ? "There was a problem" : null}
               value="Content"
               block
@@ -102,7 +162,7 @@ storiesOf("Components/Input", module)
 
             <PasswordInput
               placeholder="Placeholder"
-              label="Title"
+              label="Password (with requirements)"
               error={on ? "There was a problem" : null}
               value="Content"
               block
@@ -112,31 +172,6 @@ storiesOf("Components/Input", module)
         </div>
       )}
     </Toggle>
-  ))
-  .add("Input with Label", () => (
-    <div style={{ padding: 10 }}>
-      <Title>Input with label</Title>
-      <Subtitle>Used for short/simple forms</Subtitle>
-
-      <div style={{ padding: 10 }}>
-        <QuickInput
-          placeholder="Enter your email address"
-          label="Email"
-          block
-        />
-        <PasswordInput
-          placeholder="Enter your password"
-          label="Password"
-          block
-        />
-        <PasswordInput
-          placeholder="Enter your password"
-          label="Password"
-          block
-          showPasswordMessage
-        />
-      </div>
-    </div>
   ))
   .add("Text Areas", () => (
     <div>

--- a/src/Components/__stories__/Input.story.tsx
+++ b/src/Components/__stories__/Input.story.tsx
@@ -7,6 +7,7 @@ import { Toggle } from "react-powerplug"
 import Button from "../Buttons/Inverted"
 import { Checkbox } from "../Checkbox"
 import Input from "../Input"
+import PasswordInput from "../PasswordInput"
 import QuickInput from "../QuickInput"
 import TextArea from "../TextArea"
 
@@ -98,8 +99,7 @@ storiesOf("Components/Input", module)
           label="Email"
           block
         />
-        <QuickInput
-          type="password"
+        <PasswordInput
           placeholder="Enter your password"
           label="Password"
           block
@@ -154,7 +154,7 @@ storiesOf("Components/Input", module)
   .add("Form w/ Button", () => (
     <div style={{ padding: 10 }}>
       <Input placeholder="Email" block />
-      <Input type="password" placeholder="Password" block />
+      <PasswordInput placeholder="Password" block />
       <Button block>Submit</Button>
     </div>
   ))

--- a/src/Components/__tests__/Input.test.tsx
+++ b/src/Components/__tests__/Input.test.tsx
@@ -1,0 +1,36 @@
+import { mount } from "enzyme"
+import React from "react"
+
+import Input from "../Input"
+
+describe("Input", () => {
+  it("renders an input with no metadata", () => {
+    const wrapper = mount(<Input />)
+
+    expect(wrapper.find("input").length).toEqual(1)
+  })
+
+  it("passes supported props through to input", () => {
+    const wrapper = mount(<Input type="password" placeholder="a placeholder" />)
+
+    const inputProps = wrapper.find("input").props()
+
+    expect(inputProps.type).toEqual("password")
+    expect(inputProps.placeholder).toEqual("a placeholder")
+  })
+
+  it("renders the input metadata", () => {
+    const wrapper = mount(
+      <Input
+        title="hello"
+        description="This is a field"
+        error="But something went wrong!"
+      />
+    )
+
+    const actual = wrapper.text()
+    expect(actual).toContain("hello")
+    expect(actual).toContain("This is a field")
+    expect(actual).toContain("But something went wrong!")
+  })
+})

--- a/src/Components/__tests__/Input.test.tsx
+++ b/src/Components/__tests__/Input.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme"
+import "jest-styled-components"
 import React from "react"
+import renderer from "react-test-renderer"
 
 import Input from "../Input"
 
@@ -32,5 +34,20 @@ describe("Input", () => {
     expect(actual).toContain("hello")
     expect(actual).toContain("This is a field")
     expect(actual).toContain("But something went wrong!")
+  })
+
+  it("renders as a snapshot", () => {
+    const component = renderer
+      .create(
+        <Input
+          type="password"
+          placeholder="a placeholder"
+          title="hello"
+          description="This is a field"
+          error="But something went wrong!"
+        />
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
   })
 })

--- a/src/Components/__tests__/PasswordInput.test.tsx
+++ b/src/Components/__tests__/PasswordInput.test.tsx
@@ -1,6 +1,7 @@
-// import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
 import { mount } from "enzyme"
+import "jest-styled-components"
 import React from "react"
+import renderer from "react-test-renderer"
 
 import PasswordInput from "../PasswordInput"
 
@@ -18,6 +19,12 @@ describe("PasswordInput", () => {
     expect(wrapper.find('input[type="text"]').length).toEqual(0)
   })
 
+  it("renders masked as a snapshot", () => {
+    const component = renderer.create(<PasswordInput />).toJSON()
+
+    expect(component).toMatchSnapshot()
+  })
+
   it("renders unmasked if you click on the eye", () => {
     const wrapper = mount(<PasswordInput />)
 
@@ -26,6 +33,16 @@ describe("PasswordInput", () => {
 
     expect(wrapper.find('input[type="password"]').length).toEqual(0)
     expect(wrapper.find('input[type="text"]').length).toEqual(1)
+  })
+
+  it("renders unmasked as a snapshot", () => {
+    const component = renderer.create(<PasswordInput />)
+
+    const root = component.root
+    const input = root.find(element => element.type === "svg")
+    input.props.onClick()
+
+    expect(component.toJSON()).toMatchSnapshot()
   })
 
   it("shows error instead of note when error exists", () => {

--- a/src/Components/__tests__/PasswordInput.test.tsx
+++ b/src/Components/__tests__/PasswordInput.test.tsx
@@ -1,0 +1,40 @@
+// import { ClosedEyeIcon, OpenEyeIcon } from "@artsy/palette"
+import { mount } from "enzyme"
+import React from "react"
+
+import PasswordInput from "../PasswordInput"
+
+describe("PasswordInput", () => {
+  it("renders a PasswordInput", () => {
+    const wrapper = mount(<PasswordInput />)
+
+    expect(wrapper.find("input").length).toEqual(1)
+  })
+
+  it("renders masked by default", () => {
+    const wrapper = mount(<PasswordInput />)
+
+    expect(wrapper.find('input[type="password"]').length).toEqual(1)
+    expect(wrapper.find('input[type="text"]').length).toEqual(0)
+  })
+
+  it("renders unmasked if you click on the eye", () => {
+    const wrapper = mount(<PasswordInput />)
+
+    const icon = wrapper.find("svg")
+    icon.simulate("click")
+
+    expect(wrapper.find('input[type="password"]').length).toEqual(0)
+    expect(wrapper.find('input[type="text"]').length).toEqual(1)
+  })
+
+  it("shows error instead of note when error exists", () => {
+    const wrapper = mount(
+      <PasswordInput note="This is a note" error="But this is an error" />
+    )
+
+    const text = wrapper.text()
+    expect(text).not.toContain("This is a note")
+    expect(text).toContain("But this is an error")
+  })
+})

--- a/src/Components/__tests__/QuickInput.test.tsx
+++ b/src/Components/__tests__/QuickInput.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from "enzyme"
+import "jest-styled-components"
 import React from "react"
+import renderer from "react-test-renderer"
 
 import QuickInput from "../QuickInput"
 
@@ -27,5 +29,38 @@ describe("QuickInput", () => {
     expect(actual).toContain("an error")
     expect(actual).toContain("some label")
     expect(actual).toContain("right side")
+  })
+
+  it("renders an unfocused QuickInput as a snapshot", () => {
+    const rightAddOn = <div>right side</div>
+    const component = renderer
+      .create(
+        <QuickInput
+          error="an error"
+          label="some label"
+          note="a note"
+          rightAddOn={rightAddOn}
+        />
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
+
+  it("renders a focused QuickInput as a snapshot", () => {
+    const rightAddOn = <div>right side</div>
+    const component = renderer.create(
+      <QuickInput
+        error="an error"
+        label="some label"
+        note="a note"
+        rightAddOn={rightAddOn}
+      />
+    )
+
+    const root = component.root
+    const input = root.find(element => element.type === "input")
+    input.props.onFocus()
+
+    expect(component.toJSON()).toMatchSnapshot()
   })
 })

--- a/src/Components/__tests__/QuickInput.test.tsx
+++ b/src/Components/__tests__/QuickInput.test.tsx
@@ -1,0 +1,31 @@
+import { mount } from "enzyme"
+import React from "react"
+
+import QuickInput from "../QuickInput"
+
+describe("QuickInput", () => {
+  it("renders a QuickInput", () => {
+    const wrapper = mount(<QuickInput />)
+
+    expect(wrapper.find("input").length).toEqual(1)
+  })
+
+  it("renders a QuickInput with metadata", () => {
+    const rightAddOn = <div>right side</div>
+
+    const wrapper = mount(
+      <QuickInput
+        error="an error"
+        label="some label"
+        note="a note"
+        rightAddOn={rightAddOn}
+      />
+    )
+
+    const actual = wrapper.text()
+    expect(actual).toContain("a note")
+    expect(actual).toContain("an error")
+    expect(actual).toContain("some label")
+    expect(actual).toContain("right side")
+  })
+})

--- a/src/Components/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/Input.test.tsx.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input renders as a snapshot 1`] = `
+.c0 {
+  padding-bottom: 5px;
+}
+
+.c3 {
+  padding: 10px;
+  box-shadow: none;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 10px;
+  resize: none;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 1px solid #f7625a;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+}
+
+.c3::-webkit-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c3::-moz-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c3:-ms-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c3::placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c3:hover,
+.c3:focus,
+.c3.focused {
+  border-color: #f7625a;
+  outline: 0;
+}
+
+.c3:disabled {
+  border: 2px dotted #e5e5e5;
+}
+
+.c1 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 15px;
+  line-height: 1.25em;
+  -webkit-font-smoothing: antialiased;
+  color: #666;
+  margin: 3px 0 0;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  margin-top: 10px;
+  color: #F7625A;
+  -webkit-transition: visibility 0.2s linear;
+  transition: visibility 0.2s linear;
+  -webkit-animation: eBtoLo 0.25s linear;
+  animation: eBtoLo 0.25s linear;
+  height: 16px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    hello
+  </div>
+  <div
+    className="c2"
+  >
+    This is a field
+  </div>
+  <input
+    className="c3"
+    placeholder="a placeholder"
+    type="password"
+  />
+  <div
+    className="c4"
+  >
+    But something went wrong!
+  </div>
+</div>
+`;

--- a/src/Components/__tests__/__snapshots__/PasswordInput.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/PasswordInput.test.tsx.snap
@@ -1,0 +1,347 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PasswordInput renders masked as a snapshot 1`] = `
+.c0 {
+  padding-bottom: 5px;
+}
+
+.c3 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 0;
+  outline: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-transition: all 0.25s;
+  transition: all 0.25s;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0 10px;
+  line-height: initial;
+}
+
+.c1 {
+  padding: 10px;
+  box-shadow: none;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 10px;
+  resize: none;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 1px solid #e5e5e5;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 0;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  height: 20px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: content-box;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1::-moz-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1:-ms-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1::placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.focused {
+  border-color: #6e1fff;
+  outline: 0;
+}
+
+.c1:disabled {
+  border: 2px dotted #e5e5e5;
+}
+
+.c2 {
+  font-family: Unica77LLWebMedium,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  visibility: hidden;
+  -webkit-animation: hSsjZP 0.2s linear;
+  animation: hSsjZP 0.2s linear;
+  -webkit-transition: visibility 0.2s linear;
+  transition: visibility 0.2s linear;
+  z-index: 1;
+}
+
+.c4 {
+  position: absolute;
+  right: 10px;
+  z-index: 1;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2"
+    />
+    <input
+      className="c3"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="password"
+      value=""
+    />
+    <span
+      className="c4"
+      onClick={[Function]}
+    >
+      <svg
+        height="18"
+        onClick={[Function]}
+        viewBox="0 0 18 18"
+        width="18"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <title>
+          Action/View/Md
+        </title>
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <g
+            fill="#000"
+            fillRule="nonzero"
+            transform="translate(1.000000, 3.000000)"
+          >
+            <path
+              d="M1.24869667,5.4620914 C1.1373218,5.64932065 1.14382667,5.88199751 1.26548624,6.06299904 C3.17245723,8.89988278 5.40646346,10.2857143 7.99932611,10.2857143 C10.5928102,10.2857143 12.8272789,8.89921208 14.7345474,6.06094369 C14.8558101,5.88048859 14.8626517,5.6486384 14.752249,5.46166626 C13.0384933,2.5598384 10.8078954,1.14285714 8.01017583,1.14285714 C5.2122393,1.14285714 2.97495646,2.56012332 1.24869667,5.4620914 Z M0.237631667,4.88772843 C2.1625973,1.65172138 4.7699889,0 8.01017583,0 C11.2513166,0 13.8530677,1.65275534 15.7651716,4.89043749 C16.0964091,5.45140384 16.0758859,6.14690631 15.7120998,6.68826823 C13.6031161,9.8267157 11.0215865,11.4285714 7.99932611,11.4285714 C4.97777755,11.4285714 2.39673899,9.82746374 0.288018499,6.69044965 C-0.0769779696,6.14741861 -0.0964918559,5.44941434 0.237631667,4.88772843 Z"
+            />
+            <path
+              d="M8,8.57142857 C6.42204357,8.57142857 5.14285714,7.29224214 5.14285714,5.71428571 C5.14285714,4.13632929 6.42204357,2.85714286 8,2.85714286 C9.57795643,2.85714286 10.8571429,4.13632929 10.8571429,5.71428571 C10.8571429,7.29224214 9.57795643,8.57142857 8,8.57142857 Z M8,7.42857143 C8.94677386,7.42857143 9.71428571,6.66105957 9.71428571,5.71428571 C9.71428571,4.76751186 8.94677386,4 8,4 C7.05322614,4 6.28571429,4.76751186 6.28571429,5.71428571 C6.28571429,6.66105957 7.05322614,7.42857143 8,7.42857143 Z"
+            />
+          </g>
+        </g>
+      </svg>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`PasswordInput renders unmasked as a snapshot 1`] = `
+.c5 {
+  vertical-align: middle;
+}
+
+.c0 {
+  padding-bottom: 5px;
+}
+
+.c3 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 0;
+  outline: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-transition: all 0.25s;
+  transition: all 0.25s;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0 10px;
+  line-height: initial;
+}
+
+.c1 {
+  padding: 10px;
+  box-shadow: none;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 10px;
+  resize: none;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 1px solid #e5e5e5;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 0;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  height: 20px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: content-box;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1::-moz-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1:-ms-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1::placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.focused {
+  border-color: #6e1fff;
+  outline: 0;
+}
+
+.c1:disabled {
+  border: 2px dotted #e5e5e5;
+}
+
+.c2 {
+  font-family: Unica77LLWebMedium,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  visibility: hidden;
+  -webkit-animation: hSsjZP 0.2s linear;
+  animation: hSsjZP 0.2s linear;
+  -webkit-transition: visibility 0.2s linear;
+  transition: visibility 0.2s linear;
+  z-index: 1;
+}
+
+.c4 {
+  position: absolute;
+  right: 10px;
+  z-index: 1;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2"
+    />
+    <input
+      className="c3"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="text"
+      value=""
+    />
+    <span
+      className="c4"
+      onClick={[Function]}
+    >
+      <svg
+        className="c5"
+        height={20}
+        viewBox="0 0 12 12"
+        width={20}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5,6s0,0,0,.08L6.07,4.51H6A1.5,1.5,0,0,0,4.5,6Z"
+          fill="#c2c2c2"
+        />
+        <path
+          d="M3.68,6.91A2.54,2.54,0,0,1,3.5,6,2.5,2.5,0,0,1,6,3.5a2.54,2.54,0,0,1,.91.18L8.19,2.4A6.14,6.14,0,0,0,6,2,6.75,6.75,0,0,0,0,6,7.9,7.9,0,0,0,2,8.56Z"
+          fill="#c2c2c2"
+        />
+        <path
+          d="M9.57,3.14l.78-.79-.7-.7-8,8,.7.7,1-1A6.08,6.08,0,0,0,6,10a6.75,6.75,0,0,0,6-4A7.67,7.67,0,0,0,9.57,3.14ZM6,8.5a2.46,2.46,0,0,1-1.37-.42l.73-.73a1.49,1.49,0,0,0,2-2l.73-.73A2.46,2.46,0,0,1,8.5,6,2.5,2.5,0,0,1,6,8.5Z"
+          fill="#c2c2c2"
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;

--- a/src/Components/__tests__/__snapshots__/QuickInput.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/QuickInput.test.tsx.snap
@@ -1,0 +1,348 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QuickInput renders a focused QuickInput as a snapshot 1`] = `
+.c5 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  margin-top: 10px;
+  color: #F7625A;
+  -webkit-transition: visibility 0.2s linear;
+  transition: visibility 0.2s linear;
+  -webkit-animation: eBtoLo 0.25s linear;
+  animation: eBtoLo 0.25s linear;
+  height: 16px;
+}
+
+.c0 {
+  padding-bottom: 5px;
+}
+
+.c3 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 0;
+  outline: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-transition: all 0.25s;
+  transition: all 0.25s;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0 10px;
+  line-height: initial;
+  padding: 10px 10px 0 10px;
+}
+
+.c1 {
+  padding: 10px;
+  box-shadow: none;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 10px;
+  resize: none;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 1px solid #f7625a;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 0;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  height: 40px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: content-box;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1::-moz-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1:-ms-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1::placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.focused {
+  border-color: #f7625a;
+  outline: 0;
+}
+
+.c1:disabled {
+  border: 2px dotted #e5e5e5;
+}
+
+.c2 {
+  font-family: Unica77LLWebMedium,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  visibility: visible;
+  -webkit-animation: eMLfYp 0.2s linear;
+  animation: eMLfYp 0.2s linear;
+  -webkit-transition: visibility 0.2s linear;
+  transition: visibility 0.2s linear;
+  z-index: 1;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  margin-top: 10px;
+  color: #666666;
+  height: 16px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="focused c1"
+  >
+    <label
+      className="c2"
+    >
+      some label
+    </label>
+    <input
+      className="c3"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      value=""
+    />
+    <div>
+      right side
+    </div>
+  </div>
+  <div
+    className="c4"
+  >
+    a note
+  </div>
+  <div
+    className="c5"
+  >
+    an error
+  </div>
+</div>
+`;
+
+exports[`QuickInput renders an unfocused QuickInput as a snapshot 1`] = `
+.c5 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  margin-top: 10px;
+  color: #F7625A;
+  -webkit-transition: visibility 0.2s linear;
+  transition: visibility 0.2s linear;
+  -webkit-animation: eBtoLo 0.25s linear;
+  animation: eBtoLo 0.25s linear;
+  height: 16px;
+}
+
+.c0 {
+  padding-bottom: 5px;
+}
+
+.c3 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 0;
+  outline: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-transition: all 0.25s;
+  transition: all 0.25s;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0 10px;
+  line-height: initial;
+}
+
+.c1 {
+  padding: 10px;
+  box-shadow: none;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 10px;
+  resize: none;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 17px;
+  line-height: 1.1em;
+  -webkit-font-smoothing: antialiased;
+  border: 1px solid #f7625a;
+  -webkit-transition: border-color 0.25s;
+  transition: border-color 0.25s;
+  margin-right: 0;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  height: 40px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: content-box;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1::-moz-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1:-ms-input-placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1::placeholder {
+  color: #cccccc;
+  text-overflow: ellipsis;
+  line-height: normal;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.focused {
+  border-color: #f7625a;
+  outline: 0;
+}
+
+.c1:disabled {
+  border: 2px dotted #e5e5e5;
+}
+
+.c2 {
+  font-family: Unica77LLWebMedium,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  visibility: hidden;
+  -webkit-animation: hSsjZP 0.2s linear;
+  animation: hSsjZP 0.2s linear;
+  -webkit-transition: visibility 0.2s linear;
+  transition: visibility 0.2s linear;
+  z-index: 1;
+}
+
+.c4 {
+  font-family: Unica77LLWebRegular,Arial,serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 1.4em;
+  margin-top: 10px;
+  color: #666666;
+  height: 16px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2"
+    >
+      some label
+    </label>
+    <input
+      className="c3"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      value=""
+    />
+    <div>
+      right side
+    </div>
+  </div>
+  <div
+    className="c4"
+  >
+    a note
+  </div>
+  <div
+    className="c5"
+  >
+    an error
+  </div>
+</div>
+`;


### PR DESCRIPTION
This is ready for review! I'm leaving it as a WIP for now, in case we want to wait until we get more specs from design for the palette version of the inputs.

Collaboration with @jonallured.

## Goal of this PR

We noticed that the "text input" fields were in Reaction, but they feel like something that could belong in palette. Our main goal was to make the text inputs easier to extract into palette. [An issue has been created in palette for the extraction](https://github.com/artsy/palette/issues/253).

While trying to understand how the text inputs worked, we noticed 3 variants of text input - a standard input, a "quick" input where the label for the field is inside the textbox, and a password input where the value is masked rom the user. [Zeplin affirms this](https://app.zeplin.io/project/5acd19ff49a1429169c3128b/screen/5ace5b9019e07a581ca7fa17). We found it easier to understand the code of these variants by breaking them into 3 separate components - [Input](https://github.com/artsy/reaction/pull/1969/files#diff-8034249d0768be96ad9c8106abdd5be2), [QuickInput](https://github.com/artsy/reaction/pull/1969/files#diff-f735be8094a599c1dd8ad5ab9d16cbc5), and [PasswordInput](https://github.com/artsy/reaction/pull/1969/files#diff-8b8ef0b1cfc4b81b3ba43664428b72a8). Those are the meat of this PR.

## Things worth mentioning

### Some components were passing props to the Input component that did nothing

[Onboarding/Steps/Artists](https://github.com/artsy/reaction/pull/1969/files#diff-3149367c8afe1b23417b66476758cfd4) and [Onboarding/Steps/Genes](https://github.com/artsy/reaction/pull/1969/files#diff-77a43f31cb80f21de24f6909b31356f3) were passing `leftView` and `rightView` props into the old version of `Input` - but that didn't actually do anything. Those props were only displayed if the `quick` prop was also passed in, and in this case it wasn't.

The intention of these props was to show an `X` to cancel out of the search. This is currently not showing in production; and when we hacked things to make the `X` show up, it didn't look at all correct. For now, we've removed these unused props. We'll raise this issue to our PM, and find a way to address this regression.

### We removed the `inputRef` prop

It appears to have been used for a short period of time by some work on "make offer". With the refactoring @ds300 has done there recently, it doesn't appear to be used anymore. [So, we removed it entirely](https://github.com/artsy/reaction/pull/1969/files#diff-4e60cf6afb78e5c1ef30cdae9d322bd3).

### Not all styles are "palette-friendly" yet

For instance, [font-sizes are still using the reaction font sizes](https://github.com/artsy/reaction/pull/1969/files#diff-8034249d0768be96ad9c8106abdd5be2R48). The existing text input fields are based on Garamond 17px/15px. Palette [doesn't define a 17px or 15px serif font](https://github.com/artsy/palette/blob/master/tokens.json#L171).

We think the answer to this is to change the text inputs to use 16px (size 3). However, this would change the way forms in reaction look. Any forms that have text inputs along with other types of inputs would look wacky - some things in 16px, some in 17px. We'd have to modify other form inputs in reaction to *also* use 16px with those changes.

We think that this dichotomy should be addressed when the inputs have been moved to palette (as 16px), and reaction is updated to point at them. 