### PR TITLE
Fix SSR issues on /collect, grid images, tracking and h1 global tags

### DIFF
--- a/src/Apps/Collect/Components/Filters/FilterContainer.tsx
+++ b/src/Apps/Collect/Components/Filters/FilterContainer.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import styled from "styled-components"
 import { Subscribe } from "unstated"
 
 import { FilterState } from "Apps/Collect/FilterState"
@@ -20,6 +21,7 @@ export interface FilterContainerProps {
   mediator: Mediator
   mediums: Array<{ id: string; name: string }>
   timePeriods?: Array<{ name: string }>
+  children?: (filters: FilterState) => JSX.Element
 }
 
 export interface FilterContainerState {
@@ -44,10 +46,6 @@ export class FilterContainer extends React.Component<
 
     return (
       <>
-        <Media greaterThan="xs">
-          <Separator mb={2} mt={-1} />
-        </Media>
-
         <Flex flexDirection="column" alignItems="left" mt={-1} mb={1}>
           <WaysToBuyFilter filters={filters} />
         </Flex>
@@ -86,61 +84,59 @@ export class FilterContainer extends React.Component<
   }
 
   render() {
-    const Filters = ({ filters }) => this.renderFilters(filters)
-
-    // tslint:disable-next-line:ban-types
-    const children: (filters: FilterState) => null =
-      (this.props.children as (filters: FilterState) => null) || (() => null)
-
-    const Mobile = props =>
-      // Mobile
-      this.state.showMobileActionSheet && (
-        <MobileActionSheet onClose={this.hideMobileActionSheet}>
-          <Filters {...props} />
-        </MobileActionSheet>
-      )
-
-    const Desktop = props => (
-      <Box width="25%" mr={2}>
-        <Filters {...props} />
-      </Box>
-    )
-
     return (
       <Subscribe to={[FilterState]}>
         {(filters: FilterState) => {
           return (
-            <Flex>
+            <>
+              {/** Mobile */}
               <Media at="xs">
-                <Mobile filters={filters} />
+                <Mobile>
+                  {this.state.showMobileActionSheet && (
+                    <MobileActionSheet onClose={this.hideMobileActionSheet}>
+                      {this.renderFilters(filters)}
+                    </MobileActionSheet>
+                  )}
+
+                  <span id="jump--collectArtworkGrid" />
+                  <SortFilter
+                    filters={filters}
+                    onShow={() =>
+                      this.setState({ showMobileActionSheet: true })
+                    }
+                  />
+
+                  <Spacer mb={2} />
+                  {this.props.children(filters)}
+                </Mobile>
               </Media>
+
+              {/** Desktop */}
               <Media greaterThan="xs">
-                {(className, renderChildren) =>
-                  renderChildren && (
-                    <Desktop filters={filters} className={className} />
-                  )
-                }
+                <Desktop>
+                  <Box width="25%" mr={2}>
+                    {this.renderFilters(filters)}
+                    <Separator mb={2} mt={-1} />
+                  </Box>
+                  <Box width="75%">
+                    <Separator mb={2} mt={-1} />
+                    <span id="jump--collectArtworkGrid" />
+                    <SortFilter filters={filters} />
+                    <Spacer mb={2} />
+                    {this.props.children(filters)}
+                  </Box>
+                </Desktop>
               </Media>
-              <span id="jump--collectArtworkGrid" />
-
-              <Box width={["100%", "75%"]}>
-                <Media greaterThan="xs">
-                  <Separator mb={2} mt={-1} />
-                </Media>
-
-                <SortFilter
-                  filters={filters}
-                  onShow={() => this.setState({ showMobileActionSheet: true })}
-                />
-
-                <Spacer mb={2} />
-
-                {children(filters)}
-              </Box>
-            </Flex>
+            </>
           )
         }}
       </Subscribe>
     )
   }
 }
+
+const Mobile = styled(Box)``
+const Desktop = styled(Flex)``
+
+Mobile.displayName = "Mobile"
+Desktop.displayName = "Desktop"

--- a/src/Apps/Collect/Components/Filters/__tests__/FilterContainer.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/FilterContainer.test.tsx
@@ -46,7 +46,11 @@ describe("FilterContainer", () => {
             mediator={mockMediator}
             mediums={mediums}
             user={user}
-          />
+          >
+            {filters => {
+              return <div />
+            }}
+          </FilterContainer>
         </Provider>
       </MockBoot>
     )
@@ -65,7 +69,11 @@ describe("FilterContainer", () => {
             mediator={mockMediator}
             mediums={mediums}
             user={user}
-          />
+          >
+            {filters => {
+              return <div />
+            }}
+          </FilterContainer>
         </Provider>
       </MockBoot>
     )

--- a/src/Artsy/Router/Components/Boot.tsx
+++ b/src/Artsy/Router/Components/Boot.tsx
@@ -28,7 +28,15 @@ export interface BootProps {
   headTags?: JSX.Element[]
 }
 
-const { GlobalStyles } = injectGlobalStyles()
+const { GlobalStyles } = injectGlobalStyles(`
+  h1 {
+    font-style: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    margin: 0;
+  }
+`)
 
 // TODO: Do we want to let Force explicitly inject the analytics code?
 @track(null, {

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -4,6 +4,7 @@ import { Mediator } from "Artsy/SystemContext"
 import { isFunction } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { data as sd } from "sharify"
 import styled from "styled-components"
 import colors from "../../Assets/Colors"
 import Metadata from "./Metadata"
@@ -78,12 +79,10 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
       return null
     }
 
-    const width = 300
+    const width = 400
     const height = Math.floor(width / this.props.artwork.image.aspect_ratio)
     const type = this.props.artwork.image.aspect_ratio ? "fit" : "fill" // Either scale or crop, based on if an aspect ratio is available.
-    const url = `https://d7hftxdivxxvm.cloudfront.net/?resize_to=${type}&width=${width}&height=${height}&quality=${IMAGE_QUALITY}&src=${encodeURIComponent(
-      imageURL
-    )}`
+    const url = `${sd.GEMINI_CLOUDFRONT_URL}/?resize_to=${type}&width=${width}&height=${height}&quality=${IMAGE_QUALITY}&src=${encodeURIComponent(imageURL)}` // prettier-ignore
     return url
   }
 

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -1,12 +1,10 @@
 import { Flex, Sans } from "@artsy/palette"
 import { GridItem_artwork } from "__generated__/GridItem_artwork.graphql"
 import { Mediator } from "Artsy/SystemContext"
-import { pickBy } from "lodash"
+import { isFunction } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { data as sd } from "sharify"
 import styled from "styled-components"
-import { Responsive } from "Utils/Responsive"
 import colors from "../../Assets/Colors"
 import Metadata from "./Metadata"
 import SaveButton from "./Save"
@@ -61,46 +59,32 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
     isMounted: false,
   }
 
+  canHover: boolean
+
   componentDidMount() {
     this.setState({
       isMounted: true,
     })
+
+    // Satisfy test runner. See https://github.com/artsy/reaction/blob/master/src/setup_jest.ts#L28
+    if (isFunction(window.matchMedia)) {
+      this.canHover = !window.matchMedia("(hover: none)").matches
+    }
   }
 
-  getImageUrl(breakpoints) {
+  getImageUrl() {
     const imageURL = this.props.artwork.image.url
-
     if (!imageURL) {
       return null
     }
 
-    if (this.state.isMounted) {
-      const breakpoint = Object.keys(pickBy(breakpoints))[0]
-      const getWidth = () => {
-        switch (breakpoint) {
-          case "xs":
-          case "sm":
-          case "md":
-            return 400
-          case "lg":
-          case "xl":
-          default:
-            return 300
-        }
-      }
-
-      const width = Math.floor(getWidth())
-      const height = Math.floor(width / this.props.artwork.image.aspect_ratio)
-
-      // Either scale or crop, based on if an aspect ratio is available.
-      const type = this.props.artwork.image.aspect_ratio ? "fit" : "fill"
-      // tslint:disable-next-line:max-line-length
-      return `${
-        sd.GEMINI_CLOUDFRONT_URL
-      }/?resize_to=${type}&width=${width}&height=${height}&quality=${IMAGE_QUALITY}&src=${encodeURIComponent(
-        imageURL
-      )}`
-    }
+    const width = 300
+    const height = Math.floor(width / this.props.artwork.image.aspect_ratio)
+    const type = this.props.artwork.image.aspect_ratio ? "fit" : "fill" // Either scale or crop, based on if an aspect ratio is available.
+    const url = `https://d7hftxdivxxvm.cloudfront.net/?resize_to=${type}&width=${width}&height=${height}&quality=${IMAGE_QUALITY}&src=${encodeURIComponent(
+      imageURL
+    )}`
+    return url
   }
 
   renderArtworkBadge({
@@ -146,7 +130,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
 
   get shouldTrackArtworkImpressions() {
     let track = false
-    if (typeof window !== "undefined") {
+    if (this.state.isMounted) {
       track = window.location.pathname.includes("/collect")
     }
     return track
@@ -160,54 +144,49 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
       userSpread = { user }
     }
 
+    // the 'artwork-item' className and data-id={artwork._id} are required to
+    // track Artwork impressions
     const trackableClassName = this.shouldTrackArtworkImpressions
       ? "artwork-item"
       : ""
 
     return (
-      <Responsive>
-        {({ hover, ...breakpoints }) => {
-          return (
-            <div
-              // the 'artwork-item' className and data-id={artwork._id} are required to track Artwork impressions
-              className={`${className} ${trackableClassName}`}
-              style={style}
-              data-id={artwork._id}
-            >
-              <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
-                <a
-                  href={artwork.href}
-                  onClick={() => {
-                    if (this.props.onClick) {
-                      this.props.onClick()
-                    }
-                  }}
-                >
-                  <Image src={this.getImageUrl(breakpoints)} />
-                </a>
-                {this.renderArtworkBadge(artwork)}
-                {/* The undefined check is a fallback for Force code that uses
-                    Reaction code without wrapping the tree in a Responsive
-                    provider component. */}
-                {(hover === undefined || hover) && (
-                  <SaveButton
-                    className="artwork-save"
-                    artwork={artwork}
-                    style={{
-                      position: "absolute",
-                      right: "10px",
-                      bottom: "10px",
-                    }}
-                    {...userSpread}
-                    mediator={this.props.mediator}
-                  />
-                )}
-              </Placeholder>
-              <Metadata artwork={artwork} />
-            </div>
-          )
-        }}
-      </Responsive>
+      <div
+        className={`${className} ${trackableClassName}`}
+        data-id={artwork._id}
+        style={style}
+      >
+        <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
+          <a
+            href={artwork.href}
+            onClick={() => {
+              if (this.props.onClick) {
+                this.props.onClick()
+              }
+            }}
+          >
+            <Image src={this.getImageUrl()} />
+          </a>
+
+          {this.renderArtworkBadge(artwork)}
+
+          {this.canHover && (
+            <SaveButton
+              className="artwork-save"
+              artwork={artwork}
+              style={{
+                position: "absolute",
+                right: "10px",
+                bottom: "10px",
+              }}
+              {...userSpread}
+              mediator={this.props.mediator}
+            />
+          )}
+        </Placeholder>
+
+        <Metadata artwork={artwork} />
+      </div>
     )
   }
 }

--- a/src/Components/Publishing/Header/Layouts/ClassicHeader.tsx
+++ b/src/Components/Publishing/Header/Layouts/ClassicHeader.tsx
@@ -51,14 +51,6 @@ export const Title = styled.div`
   padding-bottom: ${space(3)}px;
   ${garamond("s37")};
 
-  h1 {
-    font-style: inherit;
-    font-family: inherit;
-    font-weight: inherit;
-    font-size: inherit;
-    margin: 0;
-  }
-
   ${pMedia.xs`
     ${garamond("s34")}
   `};

--- a/src/Components/Publishing/Header/Layouts/Components/FeatureInnerContent.tsx
+++ b/src/Components/Publishing/Header/Layouts/Components/FeatureInnerContent.tsx
@@ -52,14 +52,6 @@ export const Title = styled.div.attrs<{ color?: string }>({})`
   margin-bottom: 75px;
   letter-spacing: -0.035em;
 
-  h1 {
-    font-style: inherit;
-    font-family: inherit;
-    font-weight: inherit;
-    font-size: inherit;
-    margin: 0;
-  }
-
   ${pMedia.xl`
     ${unica("s80")}
   `};

--- a/src/Components/Publishing/Header/Layouts/StandardHeader.tsx
+++ b/src/Components/Publishing/Header/Layouts/StandardHeader.tsx
@@ -62,14 +62,6 @@ const Title = styled.div`
   ${garamond("s50")};
   padding-bottom: 50px;
 
-  h1 {
-    font-style: inherit;
-    font-family: inherit;
-    font-weight: inherit;
-    font-size: inherit;
-    margin: 0;
-  }
-
   ${pMedia.sm`
     ${garamond("s34")}
   `};

--- a/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/ClassicHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/ClassicHeader.test.tsx.snap
@@ -50,14 +50,6 @@ exports[`Classic Header Snapshots renders editable props properly 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 h1 {
-  font-style: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  font-size: inherit;
-  margin: 0;
-}
-
 .c2 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 19px;
@@ -187,14 +179,6 @@ exports[`Classic Header Snapshots renders properly 1`] = `
   font-size: 37px;
   line-height: 1.2em;
   -webkit-font-smoothing: antialiased;
-}
-
-.c1 h1 {
-  font-style: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  font-size: inherit;
-  margin: 0;
 }
 
 .c2 {

--- a/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/StandardHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/StandardHeader.test.tsx.snap
@@ -111,14 +111,6 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
   padding-bottom: 50px;
 }
 
-.c5 h1 {
-  font-style: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  font-size: inherit;
-  margin: 0;
-}
-
 .c2 {
   padding-bottom: 10px;
 }
@@ -413,14 +405,6 @@ exports[`Standard Header Snapshots renders properly 1`] = `
   line-height: 1.1em;
   -webkit-font-smoothing: antialiased;
   padding-bottom: 50px;
-}
-
-.c5 h1 {
-  font-style: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  font-size: inherit;
-  margin: 0;
 }
 
 .c2 {

--- a/src/setup_jest.ts
+++ b/src/setup_jest.ts
@@ -14,8 +14,7 @@ jest.mock("Utils/logger")
  * We want each test to have assertions, otherwise it’s too easy to write async
  * tests that never end up making any, leading to false positives.
  *
- * TODO: Find a way to make this not emit after failing tests. It creates a
- * ton of unuseful noise in the console.
+ * TODO: Find a way to make this not emit after failing tests.
  */
 afterEach(() => expect.hasAssertions())
 


### PR DESCRIPTION
This PR fixes a bunch of SSR errors I discovered when debugging https://artsyproduct.atlassian.net/browse/GROW-1094: 

1) Noticed that SSR and mobile layout was broken on `/collect` with JS turned off on mobile: 

<img width="479" alt="screen shot 2019-01-30 at 6 02 00 pm" src="https://user-images.githubusercontent.com/236943/52025486-4794e200-24b9-11e9-8ed0-bc9612246d16.png">

I refactored the view a bit so it's more straightforward and the issue seemed to fix itself. Rather than weaving `<Media at='xs'>` and `<Media greaterThan='xs'>` throughout the same block i made mobile and desktop strictly separate via an acceptable amount of duplication, which allowed us to remove a bunch of intermediate variables for clarity and simplify overall. 

2) Fix SSR rendering on our grid. I've been noticing how pages with grids aways render with grey blocks for a while and tracked that down. With JS turned off: 

Before: 
-----

<img width="930" alt="screen shot 2019-01-30 at 4 52 33 pm" src="https://user-images.githubusercontent.com/236943/52025652-0c46e300-24ba-11e9-8843-14804cc307a8.png">

After:
-----

<img width="1090" alt="screen shot 2019-01-30 at 4 52 41 pm" src="https://user-images.githubusercontent.com/236943/52025674-1668e180-24ba-11e9-8f4e-87884d3e678a.png">


3) Noticed that our scroll tracking was buggy due to SSR page thrashing. I had to explicitly add the scroll tracking after the client mounted, which added the class to the artwork grid. 

![scroll tracking](https://user-images.githubusercontent.com/236943/52026087-7d3aca80-24bb-11e9-912b-bb948f2dca83.gif)

4) Fixes the issue with `h1` tags based on [this slack convo](https://artsy.slack.com/archives/C03J4L2KK/p1548866512185100) and [this PR](https://github.com/artsy/reaction/pull/1951/files#diff-69b9332da53df2687332ba3511aa9699R54)