### PR TITLE
@jonallured  => [Artist] Add price filtering to artist page

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterRefetch.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterRefetch.tsx
@@ -86,6 +86,7 @@ export const ArtworkFilterRefetchContainer = createRefetchContainer(
           inquireable_only: { type: "Boolean" }
           sort: { type: "String", defaultValue: "-decayed_merch" }
           offerable: { type: "Boolean" }
+          price_range: { type: "String", defaultValue: "*-*" }
         ) {
         __id
         grid: filtered_artworks(
@@ -100,6 +101,7 @@ export const ArtworkFilterRefetchContainer = createRefetchContainer(
           offerable: $offerable
           size: 0
           sort: $sort
+          price_range: $price_range
         ) {
           ...ArtworkFilterArtworkGrid_filtered_artworks
         }
@@ -118,6 +120,7 @@ export const ArtworkFilterRefetchContainer = createRefetchContainer(
       $inquireable_only: Boolean
       $for_sale: Boolean
       $sort: String
+      $price_range: String
     ) {
       node(__id: $artistNodeID) {
         ... on Artist {
@@ -132,6 +135,7 @@ export const ArtworkFilterRefetchContainer = createRefetchContainer(
               acquireable: $acquireable
               offerable: $offerable
               inquireable_only: $inquireable_only
+              price_range: $price_range
             )
         }
       }

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/PriceRangeFilter.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/PriceRangeFilter.tsx
@@ -1,0 +1,30 @@
+import { PriceRange } from "@artsy/palette"
+import { FilterState } from "Apps/Artist/Routes/Overview/state"
+import { ContextConsumer } from "Artsy/SystemContext"
+import React from "react"
+
+export const PriceRangeFilter: React.SFC<{
+  filters: FilterState
+}> = ({ filters }) => {
+  const [initialMin, initialMax] = filters.priceRangeToTuple()
+  return (
+    <ContextConsumer>
+      {({ mediator }) => (
+        <PriceRange
+          allowCross={false}
+          min={FilterState.MIN_PRICE}
+          max={FilterState.MAX_PRICE}
+          step={50}
+          defaultValue={[initialMin, initialMax]}
+          disabled={filters.state.at_auction}
+          onAfterChange={([min, max]) => {
+            const minStr = min === FilterState.MIN_PRICE ? "*" : min
+            const maxStr = max === FilterState.MAX_PRICE ? "*" : max
+
+            filters.setFilter("price_range", `${minStr}-${maxStr}`, mediator)
+          }}
+        />
+      )}
+    </ContextConsumer>
+  )
+}

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -10,6 +10,7 @@ import { Subscribe } from "unstated"
 import { Media } from "Utils/Responsive"
 import { ArtworkFilterRefetchContainer as ArtworkFilter } from "./ArtworkFilterRefetch"
 import { MobileActionSheet } from "./MobileActionSheet"
+import { PriceRangeFilter } from "./PriceRangeFilter"
 
 import {
   Box,
@@ -82,6 +83,14 @@ class Filter extends Component<Props> {
             counts: mediumAggregation.counts,
             mediator,
           })}
+        </Toggle>
+        <Toggle
+          label="Price"
+          expanded={filterState.state.price_range !== "*-*"}
+        >
+          <Flex flexDirection="column" alignItems="left" my={1}>
+            <PriceRangeFilter filters={filterState} />
+          </Flex>
         </Toggle>
         <Toggle
           expanded={filterState.state.partner_id && !this.showZeroState}
@@ -381,6 +390,7 @@ export const ArtworkFilterFragmentContainer = createFragmentContainer(
           defaultValue: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]
         }
         sort: { type: "String", defaultValue: "-decayed_merch" }
+        price_range: { type: "String", defaultValue: "*-*" }
       ) {
       id
       name
@@ -413,6 +423,7 @@ export const ArtworkFilterFragmentContainer = createFragmentContainer(
           acquireable: $acquireable
           at_auction: $at_auction
           inquireable_only: $inquireable_only
+          price_range: $price_range
         )
 
       ...FollowArtistButton_artist

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -176,6 +176,7 @@ export const OverviewRouteFragmentContainer = createFragmentContainer(
           type: "[String]"
           defaultValue: ["blue-chip", "top-established", "top-emerging"]
         }
+        price_range: { type: "String", defaultValue: "*-*" }
       ) {
       ...ArtistBio_bio
       ...CurrentEvent_artist
@@ -193,6 +194,7 @@ export const OverviewRouteFragmentContainer = createFragmentContainer(
           acquireable: $acquireable
           inquireable_only: $inquireable_only
           offerable: $offerable
+          price_range: $price_range
         )
       id
       counts {

--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -13,6 +13,7 @@ interface State {
   acquireable?: boolean
   at_auction?: boolean
   inquireable_only?: boolean
+  price_range?: string
 
   // UI
   selectedFilters: string[]
@@ -33,6 +34,7 @@ export const initialState = {
   offerable: null,
   at_auction: null,
   inquireable_only: null,
+  price_range: "*-*",
   selectedFilters: [],
   showActionSheet: false,
   showZeroState: false,
@@ -40,6 +42,9 @@ export const initialState = {
 
 export class FilterState extends Container<State> {
   state = cloneDeep(initialState)
+
+  static MIN_PRICE = 50
+  static MAX_PRICE = 50000
 
   constructor(props: State) {
     super()
@@ -134,6 +139,17 @@ export class FilterState extends Container<State> {
     })
   }
 
+  priceRangeToTuple(): [number, number] {
+    let minStr: string
+    let maxStr: string
+    let min: number
+    let max: number
+    ;[minStr, maxStr] = this.state.price_range.split("-")
+    min = minStr === "*" ? FilterState.MIN_PRICE : Number(minStr)
+    max = maxStr === "*" ? FilterState.MAX_PRICE : Number(maxStr)
+    return [min, max]
+  }
+
   setFilter(filter, value, mediator) {
     let { selectedFilters } = this.state
 
@@ -145,9 +161,19 @@ export class FilterState extends Container<State> {
         medium: "*",
       }
     } else if (filter === "partner_id") {
-      newPartialState = { major_periods: [], partner_id: value, medium: "*" }
+      newPartialState = {
+        major_periods: [],
+        partner_id: value,
+        medium: "*",
+      }
     } else if (filter === "medium") {
-      newPartialState = { medium: value, partner_id: null, major_periods: [] }
+      newPartialState = {
+        medium: value,
+        partner_id: null,
+        major_periods: [],
+      }
+    } else if (filter === "price_range") {
+      newPartialState[filter] = value
     } else if (
       [
         "for_sale",

--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -89,6 +89,7 @@ export const routes: RouteConfig[] = [
             $acquireable: Boolean
             $offerable: Boolean
             $inquireable_only: Boolean
+            $price_range: String
           ) {
             artist(id: $artistID) {
               ...Overview_artist
@@ -102,6 +103,7 @@ export const routes: RouteConfig[] = [
                   acquireable: $acquireable
                   inquireable_only: $inquireable_only
                   offerable: $offerable
+                  price_range: $price_range
                 )
             }
           }

--- a/src/__generated__/ArtworkFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkFilterRefetchQuery.graphql.ts
@@ -13,6 +13,7 @@ export type ArtworkFilterRefetchQueryVariables = {
     readonly inquireable_only?: boolean | null;
     readonly for_sale?: boolean | null;
     readonly sort?: string | null;
+    readonly price_range?: string | null;
 };
 export type ArtworkFilterRefetchQueryResponse = {
     readonly node: ({
@@ -38,19 +39,20 @@ query ArtworkFilterRefetchQuery(
   $inquireable_only: Boolean
   $for_sale: Boolean
   $sort: String
+  $price_range: String
 ) {
   node(__id: $artistNodeID) {
     __typename
     ... on Artist {
-      ...ArtworkFilterRefetch_artist_3OfsJD
+      ...ArtworkFilterRefetch_artist_3C9Euq
     }
     __id
   }
 }
 
-fragment ArtworkFilterRefetch_artist_3OfsJD on Artist {
+fragment ArtworkFilterRefetch_artist_3C9Euq on Artist {
   __id
-  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, inquireable_only: $inquireable_only, offerable: $offerable, size: 0, sort: $sort) {
+  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, inquireable_only: $inquireable_only, offerable: $offerable, size: 0, sort: $sort, price_range: $price_range) {
     ...ArtworkFilterArtworkGrid_filtered_artworks
     __id
   }
@@ -274,6 +276,12 @@ var v0 = [
     "name": "sort",
     "type": "String",
     "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "price_range",
+    "type": "String",
+    "defaultValue": null
   }
 ],
 v1 = [
@@ -350,7 +358,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkFilterRefetchQuery",
   "id": null,
-  "text": "query ArtworkFilterRefetchQuery(\n  $artistNodeID: ID!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $acquireable: Boolean\n  $at_auction: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $for_sale: Boolean\n  $sort: String\n) {\n  node(__id: $artistNodeID) {\n    __typename\n    ... on Artist {\n      ...ArtworkFilterRefetch_artist_3OfsJD\n    }\n    __id\n  }\n}\n\nfragment ArtworkFilterRefetch_artist_3OfsJD on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, inquireable_only: $inquireable_only, offerable: $offerable, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 24, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query ArtworkFilterRefetchQuery(\n  $artistNodeID: ID!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $acquireable: Boolean\n  $at_auction: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $for_sale: Boolean\n  $sort: String\n  $price_range: String\n) {\n  node(__id: $artistNodeID) {\n    __typename\n    ... on Artist {\n      ...ArtworkFilterRefetch_artist_3C9Euq\n    }\n    __id\n  }\n}\n\nfragment ArtworkFilterRefetch_artist_3C9Euq on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, inquireable_only: $inquireable_only, offerable: $offerable, size: 0, sort: $sort, price_range: $price_range) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 24, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -423,6 +431,12 @@ return {
                     "kind": "Variable",
                     "name": "partner_id",
                     "variableName": "partner_id",
+                    "type": null
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "price_range",
+                    "variableName": "price_range",
                     "type": null
                   },
                   {
@@ -526,6 +540,12 @@ return {
                     "name": "partner_id",
                     "variableName": "partner_id",
                     "type": "ID"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "price_range",
+                    "variableName": "price_range",
+                    "type": "String"
                   },
                   {
                     "kind": "Literal",
@@ -954,5 +974,5 @@ return {
   }
 };
 })();
-(node as any).hash = '494e65886c1a1fa90bdd79bc04173440';
+(node as any).hash = '83c93cce8a458b1520e08b975356c97d';
 export default node;

--- a/src/__generated__/ArtworkFilterRefetch_artist.graphql.ts
+++ b/src/__generated__/ArtworkFilterRefetch_artist.graphql.ts
@@ -81,6 +81,12 @@ return {
       "name": "offerable",
       "type": "Boolean",
       "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "price_range",
+      "type": "String",
+      "defaultValue": "*-*"
     }
   ],
   "selections": [
@@ -148,6 +154,12 @@ return {
           "type": "ID"
         },
         {
+          "kind": "Variable",
+          "name": "price_range",
+          "variableName": "price_range",
+          "type": "String"
+        },
+        {
           "kind": "Literal",
           "name": "size",
           "value": 0,
@@ -174,5 +186,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '2147f6c0a04d64072e36638c68460fbc';
+(node as any).hash = '8dd29625ea0a7f1a1ecf8168464322ad';
 export default node;

--- a/src/__generated__/ArtworkFilter_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkFilter_Test_Query.graphql.ts
@@ -45,14 +45,14 @@ fragment ArtworkFilter_artist on Artist {
     }
     __id
   }
-  ...ArtworkFilterRefetch_artist_28VjLb
+  ...ArtworkFilterRefetch_artist_J8QSd
   ...FollowArtistButton_artist
   __id
 }
 
-fragment ArtworkFilterRefetch_artist_28VjLb on Artist {
+fragment ArtworkFilterRefetch_artist_J8QSd on Artist {
   __id
-  grid: filtered_artworks(aggregations: [TOTAL], medium: "*", size: 0, sort: "-decayed_merch") {
+  grid: filtered_artworks(aggregations: [TOTAL], medium: "*", size: 0, sort: "-decayed_merch", price_range: "*-*") {
     ...ArtworkFilterArtworkGrid_filtered_artworks
     __id
   }
@@ -312,7 +312,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkFilter_Test_Query",
   "id": null,
-  "text": "query ArtworkFilter_Test_Query {\n  artist(id: \"andy-warhol\") {\n    ...ArtworkFilter_artist\n    __id\n  }\n}\n\nfragment ArtworkFilter_artist on Artist {\n  id\n  name\n  is_followed\n  counts {\n    for_sale_artworks\n    ecommerce_artworks\n    auction_artworks\n    artworks\n    has_make_offer_artworks\n  }\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_28VjLb\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_28VjLb on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-decayed_merch\") {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 24, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query ArtworkFilter_Test_Query {\n  artist(id: \"andy-warhol\") {\n    ...ArtworkFilter_artist\n    __id\n  }\n}\n\nfragment ArtworkFilter_artist on Artist {\n  id\n  name\n  is_followed\n  counts {\n    for_sale_artworks\n    ecommerce_artworks\n    auction_artworks\n    artworks\n    has_make_offer_artworks\n  }\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_J8QSd\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_J8QSd on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-decayed_merch\", price_range: \"*-*\") {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 24, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -479,7 +479,7 @@ return {
             "kind": "LinkedField",
             "alias": "grid",
             "name": "filtered_artworks",
-            "storageKey": "filtered_artworks(aggregations:[\"TOTAL\"],medium:\"*\",size:0,sort:\"-decayed_merch\")",
+            "storageKey": "filtered_artworks(aggregations:[\"TOTAL\"],medium:\"*\",price_range:\"*-*\",size:0,sort:\"-decayed_merch\")",
             "args": [
               {
                 "kind": "Literal",
@@ -493,6 +493,12 @@ return {
                 "kind": "Literal",
                 "name": "medium",
                 "value": "*",
+                "type": "String"
+              },
+              {
+                "kind": "Literal",
+                "name": "price_range",
+                "value": "*-*",
                 "type": "String"
               },
               v4,

--- a/src/__generated__/ArtworkFilter_artist.graphql.ts
+++ b/src/__generated__/ArtworkFilter_artist.graphql.ts
@@ -125,6 +125,12 @@ return {
       "name": "sort",
       "type": "String",
       "defaultValue": "-decayed_merch"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "price_range",
+      "type": "String",
+      "defaultValue": "*-*"
     }
   ],
   "selections": [
@@ -294,6 +300,12 @@ return {
         },
         {
           "kind": "Variable",
+          "name": "price_range",
+          "variableName": "price_range",
+          "type": null
+        },
+        {
+          "kind": "Variable",
           "name": "sort",
           "variableName": "sort",
           "type": null
@@ -309,5 +321,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '5f9c312bd6b9c7197d1b491d7c52ef83';
+(node as any).hash = '379731c794a70e9040dfd5dd879d1cfd';
 export default node;

--- a/src/__generated__/Overview_artist.graphql.ts
+++ b/src/__generated__/Overview_artist.graphql.ts
@@ -138,6 +138,12 @@ return {
         "top-established",
         "top-emerging"
       ]
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "price_range",
+      "type": "String",
+      "defaultValue": "*-*"
     }
   ],
   "selections": [
@@ -218,6 +224,12 @@ return {
           "kind": "Variable",
           "name": "partner_id",
           "variableName": "partner_id",
+          "type": null
+        },
+        {
+          "kind": "Variable",
+          "name": "price_range",
+          "variableName": "price_range",
           "type": null
         },
         {
@@ -480,5 +492,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '49bbaacc4883ab3cebebe746ea9bb1a6';
+(node as any).hash = 'd3c2803548d99eddce4f393c519db8b5';
 export default node;

--- a/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/routes_OverviewQueryRendererQuery.graphql.ts
@@ -13,6 +13,7 @@ export type routes_OverviewQueryRendererQueryVariables = {
     readonly acquireable?: boolean | null;
     readonly offerable?: boolean | null;
     readonly inquireable_only?: boolean | null;
+    readonly price_range?: string | null;
 };
 export type routes_OverviewQueryRendererQueryResponse = {
     readonly artist: ({
@@ -38,20 +39,21 @@ query routes_OverviewQueryRendererQuery(
   $acquireable: Boolean
   $offerable: Boolean
   $inquireable_only: Boolean
+  $price_range: String
 ) {
   artist(id: $artistID) {
-    ...Overview_artist_3OfsJD
+    ...Overview_artist_3C9Euq
     __id
   }
 }
 
-fragment Overview_artist_3OfsJD on Artist {
+fragment Overview_artist_3C9Euq on Artist {
   ...ArtistBio_bio
   ...CurrentEvent_artist
   ...MarketInsightsArtistPage_artist
   ...SelectedCareerAchievementsArtistPage_artist
   ...Genes_artist
-  ...ArtworkFilter_artist_3OfsJD
+  ...ArtworkFilter_artist_3C9Euq
   id
   counts {
     partner_shows
@@ -207,7 +209,7 @@ fragment Genes_artist on Artist {
   __id
 }
 
-fragment ArtworkFilter_artist_3OfsJD on Artist {
+fragment ArtworkFilter_artist_3C9Euq on Artist {
   id
   name
   is_followed
@@ -229,14 +231,14 @@ fragment ArtworkFilter_artist_3OfsJD on Artist {
     }
     __id
   }
-  ...ArtworkFilterRefetch_artist_3OfsJD
+  ...ArtworkFilterRefetch_artist_3C9Euq
   ...FollowArtistButton_artist
   __id
 }
 
-fragment ArtworkFilterRefetch_artist_3OfsJD on Artist {
+fragment ArtworkFilterRefetch_artist_3C9Euq on Artist {
   __id
-  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, inquireable_only: $inquireable_only, offerable: $offerable, size: 0, sort: $sort) {
+  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, inquireable_only: $inquireable_only, offerable: $offerable, size: 0, sort: $sort, price_range: $price_range) {
     ...ArtworkFilterArtworkGrid_filtered_artworks
     __id
   }
@@ -469,6 +471,12 @@ var v0 = [
     "name": "inquireable_only",
     "type": "Boolean",
     "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "price_range",
+    "type": "String",
+    "defaultValue": null
   }
 ],
 v1 = [
@@ -572,7 +580,7 @@ return {
   "operationKind": "query",
   "name": "routes_OverviewQueryRendererQuery",
   "id": null,
-  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_3OfsJD\n    __id\n  }\n}\n\nfragment Overview_artist_3OfsJD on Artist {\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsightsArtistPage_artist\n  ...SelectedCareerAchievementsArtistPage_artist\n  ...Genes_artist\n  ...ArtworkFilter_artist_3OfsJD\n  id\n  counts {\n    partner_shows\n  }\n  href\n  is_consignable\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  currentEvent {\n    name\n  }\n  related {\n    genes {\n      edges {\n        node {\n          id\n          __id\n        }\n      }\n    }\n  }\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        __id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n  __id\n}\n\nfragment MarketInsightsArtistPage_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment SelectedCareerAchievementsArtistPage_artist on Artist {\n  _id\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilter_artist_3OfsJD on Artist {\n  id\n  name\n  is_followed\n  counts {\n    for_sale_artworks\n    ecommerce_artworks\n    auction_artworks\n    artworks\n    has_make_offer_artworks\n  }\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_3OfsJD\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_3OfsJD on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, inquireable_only: $inquireable_only, offerable: $offerable, size: 0, sort: $sort) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 24, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_OverviewQueryRendererQuery(\n  $artistID: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_3C9Euq\n    __id\n  }\n}\n\nfragment Overview_artist_3C9Euq on Artist {\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsightsArtistPage_artist\n  ...SelectedCareerAchievementsArtistPage_artist\n  ...Genes_artist\n  ...ArtworkFilter_artist_3C9Euq\n  id\n  counts {\n    partner_shows\n  }\n  href\n  is_consignable\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  currentEvent {\n    name\n  }\n  related {\n    genes {\n      edges {\n        node {\n          id\n          __id\n        }\n      }\n    }\n  }\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        __id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n  __id\n}\n\nfragment MarketInsightsArtistPage_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment SelectedCareerAchievementsArtistPage_artist on Artist {\n  _id\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilter_artist_3C9Euq on Artist {\n  id\n  name\n  is_followed\n  counts {\n    for_sale_artworks\n    ecommerce_artworks\n    auction_artworks\n    artworks\n    has_make_offer_artworks\n  }\n  filtered_artworks(aggregations: [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...ArtworkFilterRefetch_artist_3C9Euq\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment ArtworkFilterRefetch_artist_3C9Euq on Artist {\n  __id\n  grid: filtered_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, inquireable_only: $inquireable_only, offerable: $offerable, size: 0, sort: $sort, price_range: $price_range) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 24, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -640,6 +648,12 @@ return {
                 "kind": "Variable",
                 "name": "partner_id",
                 "variableName": "partner_id",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "price_range",
+                "variableName": "price_range",
                 "type": null
               },
               {
@@ -1254,6 +1268,12 @@ return {
                 "variableName": "partner_id",
                 "type": "ID"
               },
+              {
+                "kind": "Variable",
+                "name": "price_range",
+                "variableName": "price_range",
+                "type": "String"
+              },
               v8,
               {
                 "kind": "Variable",
@@ -1664,5 +1684,5 @@ return {
   }
 };
 })();
-(node as any).hash = '677ea8fb1388d146f283dc23c788730f';
+(node as any).hash = '971501a0aa44fb8562eb58a53110f5da';
 export default node;


### PR DESCRIPTION
This adds price filtering to the artist page.

<img width="621" alt="screen shot 2019-01-31 at 2 14 17 pm" src="https://user-images.githubusercontent.com/1457859/52078967-8763d400-2562-11e9-84bb-fdd52b6cb4d4.png">

The annoyance here is between the artist page filter, and the collect page filter....we haven't found any great way to actually reuse/share that code. They have separate wrappers, state implementations, etc. So there's a bit of 🍝 as well as paperwork here!