### PR TITLE
@pepopowitz => [AutoSuggest] Rough implementation of artist handling for previews

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -21,6 +21,9 @@ input AddInitialOfferToOrderInput {
 
   # Offer price
   offerPrice: MoneyInput
+
+  # Offer note
+  note: String
   clientMutationId: String
 }
 
@@ -112,7 +115,7 @@ enum ArticleSorts {
   PUBLISHED_AT_DESC
 }
 
-type Artist implements Node {
+type Artist implements Node & Searchable {
   # A globally unique ID.
   __id: ID!
 
@@ -258,6 +261,7 @@ type Artist implements Node {
   has_metadata: Boolean
   hometown: String
   image: Image
+  imageUrl: String
   initials(length: Int = 3): String
   insights: [ArtistInsight]
   is_consignable: Boolean
@@ -267,6 +271,7 @@ type Artist implements Node {
   is_followed: Boolean
   is_public: Boolean
   is_shareable: Boolean
+  displayLabel: String
   location: String
   meta: ArtistMeta
   nationality: String
@@ -342,6 +347,7 @@ type Artist implements Node {
   statuses: ArtistStatuses
   highlights: ArtistHighlights
   years: String
+  marketingCollections: [MarketingCollection]
 }
 
 enum ArtistArtworksFilters {
@@ -448,7 +454,7 @@ type ArtistInsight {
   entities: [String]
 }
 
-type ArtistItem implements Node {
+type ArtistItem implements Node & Searchable {
   # A globally unique ID.
   __id: ID!
 
@@ -594,6 +600,7 @@ type ArtistItem implements Node {
   has_metadata: Boolean
   hometown: String
   image: Image
+  imageUrl: String
   initials(length: Int = 3): String
   insights: [ArtistInsight]
   is_consignable: Boolean
@@ -603,6 +610,7 @@ type ArtistItem implements Node {
   is_followed: Boolean
   is_public: Boolean
   is_shareable: Boolean
+  displayLabel: String
   location: String
   meta: ArtistMeta
   nationality: String
@@ -748,7 +756,7 @@ type ArtistStatuses {
   shows: Boolean
 }
 
-type Artwork implements Node & Sellable {
+type Artwork implements Node & Searchable & Sellable {
   # A globally unique ID.
   __id: ID!
 
@@ -800,6 +808,7 @@ type Artwork implements Node & Sellable {
   highlights: [Highlighted]
   href: String
   image: Image
+  imageUrl: String
   image_rights: String
   image_title: String
   images(size: Int): [Image]
@@ -849,6 +858,7 @@ type Artwork implements Node & Sellable {
   is_shareable: Boolean
   is_sold: Boolean
   is_unique: Boolean
+  displayLabel: String
   layer(id: String): ArtworkLayer
   layers: [ArtworkLayer]
   literature(format: Format): String
@@ -1581,7 +1591,7 @@ type ArtworkInquiryEdge {
   cursor: String!
 }
 
-type ArtworkItem implements Node & Sellable {
+type ArtworkItem implements Node & Searchable & Sellable {
   # A globally unique ID.
   __id: ID!
 
@@ -1633,6 +1643,7 @@ type ArtworkItem implements Node & Sellable {
   highlights: [Highlighted]
   href: String
   image: Image
+  imageUrl: String
   image_rights: String
   image_title: String
   images(size: Int): [Image]
@@ -1682,6 +1693,7 @@ type ArtworkItem implements Node & Sellable {
   is_shareable: Boolean
   is_sold: Boolean
   is_unique: Boolean
+  displayLabel: String
   layer(id: String): ArtworkLayer
   layers: [ArtworkLayer]
   literature(format: Format): String
@@ -2129,6 +2141,9 @@ input buyerCounterOfferInput {
 
   # Offer price
   offerPrice: MoneyInput
+
+  # Offer note
+  note: String
   clientMutationId: String
 }
 
@@ -5593,6 +5608,9 @@ type Offer {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # Offer note
+  note: String
 }
 
 # A connection to a list of items.
@@ -6041,6 +6059,8 @@ type OrderConnection {
   # A list of edges.
   edges: [OrderEdge]
   totalCount: Int
+  totalPages: Int
+  pageCursors: PageCursors
 }
 
 # An edge in a connection.
@@ -6774,6 +6794,12 @@ type Query {
     id: String!
   ): Artwork
 
+  # A subset of the metadata for an artwork at a specific time
+  artworkVersion(
+    # The ID of the ArtworkVersion
+    id: String!
+  ): ArtworkVersion
+
   # A list of Artworks
   artworks(ids: [String]): [Artwork]
 
@@ -7168,6 +7194,22 @@ type Query {
     sort: SaleSorts
   ): [Sale]
 
+  # Global search
+  search(
+    # Search query to perform. Required.
+    query: String!
+
+    # Entities to include in search. Default: [ARTIST, ARTWORK].
+    entities: [SearchEntity]
+
+    # Mode of search to exceute. Default: SITE.
+    mode: SearchMode
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): SearchableConnection
+
   # The schema for difference micro-service settings
   services: Services
 
@@ -7202,6 +7244,9 @@ type Query {
   user(
     # Email to search for user by
     email: String
+
+    # ID of the user
+    id: String
   ): User
 
   # A list of Users
@@ -7268,7 +7313,7 @@ type Query {
 
   # Find partners by ID
   _unused_gravity_partners(ids: [ID]!): [DoNotUseThisPartner]
-  marketingCollections: [MarketingCollection!]!
+  marketingCollections(artistID: String): [MarketingCollection!]!
   marketingCategories: [MarketingCollectionCategory!]!
   marketingCollection(slug: String!): MarketingCollection
 }
@@ -7774,6 +7819,51 @@ type SaveArtworkPayload {
   clientMutationId: String
 }
 
+# An object that may be searched for
+interface Searchable {
+  displayLabel: String
+  imageUrl: String
+  href: String
+}
+
+# A connection to a list of items.
+type SearchableConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [SearchableEdge]
+  pageCursors: PageCursors
+  totalCount: Int
+}
+
+# An edge in a connection.
+type SearchableEdge {
+  # The item at the end of the edge
+  node: Searchable
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
+type SearchableItem implements Node & Searchable {
+  __id: ID!
+  displayLabel: String
+  imageUrl: String
+  href: String
+  searchableType: String
+}
+
+enum SearchEntity {
+  ARTWORK
+  ARTIST
+}
+
+enum SearchMode {
+  AUTOSUGGEST
+  SITE
+}
+
 # A piece that can be sold
 interface Sellable {
   dimensions: dimensions
@@ -7807,6 +7897,9 @@ input sellerCounterOfferInput {
 
   # Offer price
   offerPrice: MoneyInput
+
+  # Offer note
+  note: String
   clientMutationId: String
 }
 
@@ -8593,6 +8686,12 @@ type Viewer {
     id: String!
   ): Artwork
 
+  # A subset of the metadata for an artwork at a specific time
+  artworkVersion(
+    # The ID of the ArtworkVersion
+    id: String!
+  ): ArtworkVersion
+
   # A list of Artworks
   artworks(ids: [String]): [Artwork]
 
@@ -8987,6 +9086,22 @@ type Viewer {
     sort: SaleSorts
   ): [Sale]
 
+  # Global search
+  search(
+    # Search query to perform. Required.
+    query: String!
+
+    # Entities to include in search. Default: [ARTIST, ARTWORK].
+    entities: [SearchEntity]
+
+    # Mode of search to exceute. Default: SITE.
+    mode: SearchMode
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): SearchableConnection
+
   # The schema for difference micro-service settings
   services: Services
 
@@ -9021,6 +9136,9 @@ type Viewer {
   user(
     # Email to search for user by
     email: String
+
+    # ID of the user
+    id: String
   ): User
 
   # A list of Users

--- a/src/Components/Search/Previews/Grids/Artist.tsx
+++ b/src/Components/Search/Previews/Grids/Artist.tsx
@@ -1,0 +1,82 @@
+import { ArtistSearchPreview_artist } from "__generated__/ArtistSearchPreview_artist.graphql"
+import { ArtistSearchPreviewQuery } from "__generated__/ArtistSearchPreviewQuery.graphql"
+import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { ContextConsumer } from "Artsy/SystemContext"
+import ArtworkGrid from "Components/ArtworkGrid"
+import React from "react"
+import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+
+interface ArtistSearchPreviewProps {
+  artist: ArtistSearchPreview_artist
+}
+
+export class ArtistSearchPreview extends React.Component<
+  ArtistSearchPreviewProps
+> {
+  render() {
+    const { marketingCollections, artworks_connection } = this.props.artist
+
+    if (marketingCollections.length > 0) {
+      return (
+        <>
+          <h1>Collections</h1>
+          {marketingCollections.map(({ title }, index) => {
+            return <div>{title}</div>
+          })}
+        </>
+      )
+    }
+
+    return (
+      <ArtworkGrid artworks={artworks_connection} columnCount={[2, 3, 4]} />
+    )
+  }
+}
+
+export const ArtistSearchPreviewFragmentContainer = createFragmentContainer(
+  ArtistSearchPreview,
+  graphql`
+    fragment ArtistSearchPreview_artist on Artist {
+      id
+      marketingCollections {
+        title
+      }
+      artworks_connection(
+        first: 8
+        filter: [IS_FOR_SALE]
+        sort: PUBLISHED_AT_DESC
+      ) {
+        ...ArtworkGrid_artworks
+      }
+    }
+  `
+)
+
+export const ArtistSearchPreviewQueryRenderer: React.SFC<{
+  entityID: string
+}> = ({ entityID }) => {
+  return (
+    <ContextConsumer>
+      {({ relayEnvironment }) => {
+        return (
+          <QueryRenderer<ArtistSearchPreviewQuery>
+            environment={relayEnvironment}
+            variables={{
+              entityID,
+            }}
+            query={graphql`
+              query ArtistSearchPreviewQuery($entityID: String!) {
+                artist(id: $entityID) {
+                  ...ArtistSearchPreview_artist
+                }
+              }
+            `}
+            render={renderWithLoadProgress(
+              ArtistSearchPreviewFragmentContainer
+            )}
+          />
+        )
+      }}
+    </ContextConsumer>
+  )
+}

--- a/src/Components/Search/Previews/index.tsx
+++ b/src/Components/Search/Previews/index.tsx
@@ -1,0 +1,25 @@
+import React, { SFC } from "react"
+import { ArtistSearchPreviewQueryRenderer as ArtistSearchPreview } from "./Grids/Artist"
+
+export interface SearchPreviewProps {
+  entityID: string
+  entityType: string
+}
+
+export const SearchPreview: SFC<SearchPreviewProps> = ({
+  entityID,
+  entityType,
+}) => {
+  switch (entityType) {
+    case "Sale": {
+      return <div>Sale Context Not Implemented</div>
+    }
+    case "Fair": {
+      return <div>Fair Context Not Implemented</div>
+    }
+    case "Artist": {
+      return <ArtistSearchPreview entityID={entityID} />
+    }
+    // And so forth...
+  }
+}

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -1,0 +1,23 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+
+import { ContextProvider } from "Artsy/SystemContext"
+import { SearchPreview } from "Components/Search/Previews"
+
+storiesOf("Components/Search/Previews/Artist", module)
+  .add("An artist with collections", () => (
+    <ContextProvider>
+      <SearchPreview entityID="kaws" entityType="Artist" />
+    </ContextProvider>
+  ))
+  .add("An artist without collections", () => (
+    <ContextProvider>
+      <SearchPreview entityID="douglas-gordon" entityType="Artist" />
+    </ContextProvider>
+  ))
+
+storiesOf("Components/Search/Previews/Sale", module).add("A sale", () => (
+  <ContextProvider>
+    <SearchPreview entityID="phillips" entityType="Sale" />
+  </ContextProvider>
+))

--- a/src/__generated__/ArtistSearchPreviewQuery.graphql.ts
+++ b/src/__generated__/ArtistSearchPreviewQuery.graphql.ts
@@ -1,0 +1,612 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { ArtistSearchPreview_artist$ref } from "./ArtistSearchPreview_artist.graphql";
+export type ArtistSearchPreviewQueryVariables = {
+    readonly entityID: string;
+};
+export type ArtistSearchPreviewQueryResponse = {
+    readonly artist: ({
+        readonly " $fragmentRefs": ArtistSearchPreview_artist$ref;
+    }) | null;
+};
+export type ArtistSearchPreviewQuery = {
+    readonly response: ArtistSearchPreviewQueryResponse;
+    readonly variables: ArtistSearchPreviewQueryVariables;
+};
+
+
+
+/*
+query ArtistSearchPreviewQuery(
+  $entityID: String!
+) {
+  artist(id: $entityID) {
+    ...ArtistSearchPreview_artist
+    __id
+  }
+}
+
+fragment ArtistSearchPreview_artist on Artist {
+  id
+  marketingCollections {
+    title
+    __id: id
+  }
+  artworks_connection(first: 8, filter: [IS_FOR_SALE], sort: PUBLISHED_AT_DESC) {
+    ...ArtworkGrid_artworks
+  }
+  __id
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnection {
+  edges {
+    node {
+      __id
+      image {
+        aspect_ratio
+      }
+      ...GridItem_artwork
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  _id
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio
+  }
+  is_biddable
+  sale {
+    is_preview
+    __id
+  }
+  is_acquireable
+  is_offerable
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  __id
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+  __id
+}
+
+fragment Save_artwork on Artwork {
+  __id
+  _id
+  id
+  is_saved
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message
+  cultural_maker
+  artists(shallow: true) {
+    __id
+    href
+    name
+  }
+  collecting_institution
+  partner(shallow: true) {
+    name
+    href
+    __id
+  }
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    display_timely_at
+    __id
+  }
+  sale_artwork {
+    highest_bid {
+      display
+      __id: id
+    }
+    opening_bid {
+      display
+    }
+    __id
+  }
+  __id
+}
+
+fragment Contact_artwork on Artwork {
+  _id
+  href
+  is_inquireable
+  sale {
+    is_auction
+    is_live_open
+    is_open
+    is_closed
+    __id
+  }
+  partner(shallow: true) {
+    type
+    __id
+  }
+  sale_artwork {
+    highest_bid {
+      display
+      __id: id
+    }
+    opening_bid {
+      display
+    }
+    counts {
+      bidder_positions
+    }
+    __id
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "entityID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "entityID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "display",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "ArtistSearchPreviewQuery",
+  "id": null,
+  "text": "query ArtistSearchPreviewQuery(\n  $entityID: String!\n) {\n  artist(id: $entityID) {\n    ...ArtistSearchPreview_artist\n    __id\n  }\n}\n\nfragment ArtistSearchPreview_artist on Artist {\n  id\n  marketingCollections {\n    title\n    __id: id\n  }\n  artworks_connection(first: 8, filter: [IS_FOR_SALE], sort: PUBLISHED_AT_DESC) {\n    ...ArtworkGrid_artworks\n  }\n  __id\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistSearchPreviewQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistSearchPreview_artist",
+            "args": null
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistSearchPreviewQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          v3,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "marketingCollections",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "MarketingCollection",
+            "plural": true,
+            "selections": [
+              v4,
+              v5
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artworks_connection",
+            "storageKey": "artworks_connection(filter:[\"IS_FOR_SALE\"],first:8,sort:\"PUBLISHED_AT_DESC\")",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "filter",
+                "value": [
+                  "IS_FOR_SALE"
+                ],
+                "type": "[ArtistArtworksFilters]"
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 8,
+                "type": "Int"
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "PUBLISHED_AT_DESC",
+                "type": "ArtworkSorts"
+              }
+            ],
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v2,
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "_id",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "is_biddable",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_preview",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          v2,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_auction",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_live_open",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_open",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "is_closed",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "display_timely_at",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "is_acquireable",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "is_offerable",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v6,
+                      v4,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspect_ratio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "placeholder",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large",
+                                "type": "[String]"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "sale_message",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "cultural_maker",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artists",
+                        "storageKey": "artists(shallow:true)",
+                        "args": v7,
+                        "concreteType": "Artist",
+                        "plural": true,
+                        "selections": [
+                          v2,
+                          v6,
+                          v8
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "collecting_institution",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": "partner(shallow:true)",
+                        "args": v7,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          v8,
+                          v6,
+                          v2,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "type",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale_artwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "highest_bid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "plural": false,
+                            "selections": [
+                              v9,
+                              v5
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "opening_bid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "plural": false,
+                            "selections": [
+                              v9
+                            ]
+                          },
+                          v2,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "counts",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "bidder_positions",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "is_inquireable",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v3,
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "is_saved",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '57281ba518b5ca3e111812779fde836f';
+export default node;

--- a/src/__generated__/ArtistSearchPreview_artist.graphql.ts
+++ b/src/__generated__/ArtistSearchPreview_artist.graphql.ts
@@ -1,0 +1,106 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+import { ArtworkGrid_artworks$ref } from "./ArtworkGrid_artworks.graphql";
+declare const _ArtistSearchPreview_artist$ref: unique symbol;
+export type ArtistSearchPreview_artist$ref = typeof _ArtistSearchPreview_artist$ref;
+export type ArtistSearchPreview_artist = {
+    readonly id: string;
+    readonly marketingCollections: ReadonlyArray<({
+        readonly title: string;
+    }) | null> | null;
+    readonly artworks_connection: ({
+        readonly " $fragmentRefs": ArtworkGrid_artworks$ref;
+    }) | null;
+    readonly " $refType": ArtistSearchPreview_artist$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSearchPreview_artist",
+  "type": "Artist",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "marketingCollections",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "MarketingCollection",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "title",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": "__id",
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artworks_connection",
+      "storageKey": "artworks_connection(filter:[\"IS_FOR_SALE\"],first:8,sort:\"PUBLISHED_AT_DESC\")",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "filter",
+          "value": [
+            "IS_FOR_SALE"
+          ],
+          "type": "[ArtistArtworksFilters]"
+        },
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 8,
+          "type": "Int"
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "PUBLISHED_AT_DESC",
+          "type": "ArtworkSorts"
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "FragmentSpread",
+          "name": "ArtworkGrid_artworks",
+          "args": null
+        }
+      ]
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "__id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '1d51e53e51e7d745b05f1f966b004490';
+export default node;

--- a/src/__generated__/OfferMutation.graphql.ts
+++ b/src/__generated__/OfferMutation.graphql.ts
@@ -5,6 +5,7 @@ export type OrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type AddInitialOfferToOrderInput = {
     readonly orderId: string;
     readonly offerPrice?: MoneyInput | null;
+    readonly note?: string | null;
     readonly clientMutationId?: string | null;
 };
 export type MoneyInput = {

--- a/src/__generated__/RespondCounterOfferMutation.graphql.ts
+++ b/src/__generated__/RespondCounterOfferMutation.graphql.ts
@@ -5,6 +5,7 @@ import { Respond_order$ref } from "./Respond_order.graphql";
 export type buyerCounterOfferInput = {
     readonly offerId: string;
     readonly offerPrice?: MoneyInput | null;
+    readonly note?: string | null;
     readonly clientMutationId?: string | null;
 };
 export type MoneyInput = {


### PR DESCRIPTION
Here's an example of how we might start to organize the components for the RHS 'additional context' stuff for autosuggest.

Here's the folder structure: https://github.com/mzikherman/reaction-force/tree/search_context/src/Components/SearchAutoSuggest

This is totally unstyled for now! 😅 