### PR TITLE
[Lib] Point at proper relay-network-modern-build

### DIFF
--- a/src/Artsy/Relay/createRelaySSREnvironment.ts
+++ b/src/Artsy/Relay/createRelaySSREnvironment.ts
@@ -3,8 +3,8 @@ import "regenerator-runtime/runtime"
 
 import { isEmpty } from "lodash"
 import { version as ReactionVersion } from "package.json"
-import RelayClientSSR from "react-relay-network-modern-ssr/lib/client"
-import RelayServerSSR from "react-relay-network-modern-ssr/lib/server"
+import RelayClientSSR from "react-relay-network-modern-ssr/node8/client"
+import RelayServerSSR from "react-relay-network-modern-ssr/node8/server"
 import { Environment, RecordSource, RelayNetwork, Store } from "relay-runtime"
 import { data as sd } from "sharify"
 import { NetworkError } from "Utils/errors"
@@ -15,7 +15,7 @@ import {
   loggerMiddleware,
   RelayNetworkLayer,
   urlMiddleware,
-} from "react-relay-network-modern"
+} from "react-relay-network-modern/node8"
 
 const isServer = typeof window === "undefined"
 const isDevelopment =


### PR DESCRIPTION
Since all of our apps are Node 8 and above realized we could update this: 

https://github.com/relay-tools/react-relay-network-modern#different-builds