### PR TITLE
@pepopowitz => [Search] Add suggestions component

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -1,0 +1,104 @@
+import { Spacer, Spinner } from "@artsy/palette"
+import { SearchBarQuery } from "__generated__/SearchBarQuery.graphql"
+import { ContextConsumer, ContextProps } from "Artsy"
+import Input from "Components/Input"
+import { SearchSuggestionsFragmentContainer as SearchSuggestions } from "Components/Search/Suggestions"
+import { throttle } from "lodash"
+import React, { Component } from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import styled from "styled-components"
+
+export interface Props extends ContextProps {
+  term?: string
+}
+
+interface State {
+  term: string
+  input: string
+  searched: boolean
+}
+
+export class SearchBar extends Component<Props, State> {
+  state = {
+    searched: false,
+    term: null,
+    input: null,
+  }
+
+  throttledTextChange = term => {
+    this.setState({ term })
+  }
+
+  componentDidMount() {
+    this.throttledTextChange = throttle(this.throttledTextChange, 500, {
+      leading: true,
+    })
+  }
+
+  searchTextChanged = e => {
+    const input = e.target.value
+    this.setState({ input })
+    this.throttledTextChange(input)
+  }
+
+  resultsForTerm(term: string) {
+    if (term && term.length > 0) {
+      return (
+        <ContextConsumer>
+          {({ relayEnvironment }) => {
+            return (
+              <QueryRenderer<SearchBarQuery>
+                environment={relayEnvironment}
+                query={graphql`
+                  query SearchBarQuery($term: String!) {
+                    viewer {
+                      ...SuggestionsSearch_viewer @arguments(term: $term)
+                    }
+                  }
+                `}
+                variables={{ term }}
+                render={({ props }) => {
+                  if (props) {
+                    return (
+                      <SearchSuggestions term={term} viewer={props.viewer} />
+                    )
+                  } else {
+                    return (
+                      <SpinnerContainer>
+                        <Spinner />
+                      </SpinnerContainer>
+                    )
+                  }
+                }}
+              />
+            )
+          }}
+        </ContextConsumer>
+      )
+    }
+  }
+
+  render() {
+    const { term } = this.state
+
+    return (
+      <>
+        <Input
+          block
+          onInput={this.searchTextChanged.bind(this)}
+          onPaste={this.searchTextChanged.bind(this)}
+          onCut={this.searchTextChanged.bind(this)}
+          autoFocus
+        />
+        <Spacer />
+        {this.resultsForTerm(term)}
+      </>
+    )
+  }
+}
+
+const SpinnerContainer = styled.div`
+  width: 100%;
+  height: 100px;
+  position: relative;
+`

--- a/src/Components/Search/Suggestions/index.tsx
+++ b/src/Components/Search/Suggestions/index.tsx
@@ -25,10 +25,11 @@ export const SearchSuggestions: React.SFC<Props> = ({ viewer }) => {
   return <>no suggestions</>
 }
 
-const SearchSuggestionsFragmentContainer = createFragmentContainer(
+export const SearchSuggestionsFragmentContainer = createFragmentContainer(
   SearchSuggestions,
   graphql`
-    fragment SuggestionsSearch_viewer on Viewer {
+    fragment SuggestionsSearch_viewer on Viewer
+      @argumentDefinitions(term: { type: "String!", defaultValue: "" }) {
       search(query: $term, mode: AUTOSUGGEST, first: 10) {
         edges {
           node {
@@ -52,7 +53,7 @@ export const SearchSuggestionsQueryRenderer: React.SFC<{
             query={graphql`
               query SuggestionsSearchQuery($term: String!) {
                 viewer {
-                  ...SuggestionsSearch_viewer
+                  ...SuggestionsSearch_viewer @arguments(term: $term)
                 }
               }
             `}

--- a/src/Components/Search/Suggestions/index.tsx
+++ b/src/Components/Search/Suggestions/index.tsx
@@ -1,0 +1,77 @@
+import { SuggestionsSearch_viewer } from "__generated__/SuggestionsSearch_viewer.graphql"
+import { SuggestionsSearchQuery } from "__generated__/SuggestionsSearchQuery.graphql"
+import { ContextConsumer } from "Artsy/SystemContext"
+import * as React from "react"
+import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { get } from "Utils/get"
+
+interface Props {
+  term: string
+  viewer: SuggestionsSearch_viewer
+}
+
+export const SearchSuggestions: React.SFC<Props> = ({ viewer }) => {
+  const edges = get(viewer, v => v.search.edges)
+  if (edges.length > 0) {
+    return (
+      <>
+        <h1>Suggestions</h1>
+        {edges.map(({ node }) => {
+          return <div>{node.displayLabel}</div>
+        })}
+      </>
+    )
+  }
+  return <>no suggestions</>
+}
+
+const SearchSuggestionsFragmentContainer = createFragmentContainer(
+  SearchSuggestions,
+  graphql`
+    fragment SuggestionsSearch_viewer on Viewer {
+      search(query: $term, mode: AUTOSUGGEST, first: 10) {
+        edges {
+          node {
+            displayLabel
+          }
+        }
+      }
+    }
+  `
+)
+
+export const SearchSuggestionsQueryRenderer: React.SFC<{
+  term: string
+}> = ({ term }) => {
+  return (
+    <ContextConsumer>
+      {({ relayEnvironment }) => {
+        return (
+          <QueryRenderer<SuggestionsSearchQuery>
+            environment={relayEnvironment}
+            query={graphql`
+              query SuggestionsSearchQuery($term: String!) {
+                viewer {
+                  ...SuggestionsSearch_viewer
+                }
+              }
+            `}
+            variables={{ term }}
+            render={({ error, props }) => {
+              if (props) {
+                return (
+                  <SearchSuggestionsFragmentContainer
+                    viewer={props.viewer}
+                    term={term}
+                  />
+                )
+              } else {
+                return null
+              }
+            }}
+          />
+        )
+      }}
+    </ContextConsumer>
+  )
+}

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -3,6 +3,19 @@ import React from "react"
 
 import { ContextProvider } from "Artsy/SystemContext"
 import { SearchPreview } from "Components/Search/Previews"
+import { SearchSuggestionsQueryRenderer as SearchSuggestions } from "Components/Search/Suggestions"
+
+storiesOf("Components/Search/Suggestions", module).add("Term: Andy", () => (
+  <ContextProvider>
+    <SearchSuggestions term="andy" />
+  </ContextProvider>
+))
+
+storiesOf("Components/Search/Previews/Sale", module).add("A sale", () => (
+  <ContextProvider>
+    <SearchPreview entityID="phillips" entityType="Sale" />
+  </ContextProvider>
+))
 
 storiesOf("Components/Search/Previews/Artist", module)
   .add("An artist with collections", () => (

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -3,7 +3,14 @@ import React from "react"
 
 import { ContextProvider } from "Artsy/SystemContext"
 import { SearchPreview } from "Components/Search/Previews"
+import { SearchBar } from "Components/Search/SearchBar"
 import { SearchSuggestionsQueryRenderer as SearchSuggestions } from "Components/Search/Suggestions"
+
+storiesOf("Components/Search/SearchBar", module).add("Input", () => (
+  <ContextProvider>
+    <SearchBar />
+  </ContextProvider>
+))
 
 storiesOf("Components/Search/Suggestions", module).add("Term: Andy", () => (
   <ContextProvider>

--- a/src/__generated__/SearchBarQuery.graphql.ts
+++ b/src/__generated__/SearchBarQuery.graphql.ts
@@ -2,23 +2,23 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { SuggestionsSearch_viewer$ref } from "./SuggestionsSearch_viewer.graphql";
-export type SuggestionsSearchQueryVariables = {
+export type SearchBarQueryVariables = {
     readonly term: string;
 };
-export type SuggestionsSearchQueryResponse = {
+export type SearchBarQueryResponse = {
     readonly viewer: ({
         readonly " $fragmentRefs": SuggestionsSearch_viewer$ref;
     }) | null;
 };
-export type SuggestionsSearchQuery = {
-    readonly response: SuggestionsSearchQueryResponse;
-    readonly variables: SuggestionsSearchQueryVariables;
+export type SearchBarQuery = {
+    readonly response: SearchBarQueryResponse;
+    readonly variables: SearchBarQueryVariables;
 };
 
 
 
 /*
-query SuggestionsSearchQuery(
+query SearchBarQuery(
   $term: String!
 ) {
   viewer {
@@ -53,13 +53,13 @@ var v0 = [
 return {
   "kind": "Request",
   "operationKind": "query",
-  "name": "SuggestionsSearchQuery",
+  "name": "SearchBarQuery",
   "id": null,
-  "text": "query SuggestionsSearchQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer_4hh6ED\n  }\n}\n\nfragment SuggestionsSearch_viewer_4hh6ED on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer_4hh6ED\n  }\n}\n\nfragment SuggestionsSearch_viewer_4hh6ED on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
-    "name": "SuggestionsSearchQuery",
+    "name": "SearchBarQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": v0,
@@ -91,7 +91,7 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "SuggestionsSearchQuery",
+    "name": "SearchBarQuery",
     "argumentDefinitions": v0,
     "selections": [
       {
@@ -191,5 +191,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'cd65ab07788e0ea140e2befeb2d49787';
+(node as any).hash = 'b852043c30769d6f0612c3b0d9e4fb7a';
 export default node;

--- a/src/__generated__/SuggestionsSearchQuery.graphql.ts
+++ b/src/__generated__/SuggestionsSearchQuery.graphql.ts
@@ -1,0 +1,188 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { SuggestionsSearch_viewer$ref } from "./SuggestionsSearch_viewer.graphql";
+export type SuggestionsSearchQueryVariables = {
+    readonly term: string;
+};
+export type SuggestionsSearchQueryResponse = {
+    readonly viewer: ({
+        readonly " $fragmentRefs": SuggestionsSearch_viewer$ref;
+    }) | null;
+};
+export type SuggestionsSearchQuery = {
+    readonly response: SuggestionsSearchQueryResponse;
+    readonly variables: SuggestionsSearchQueryVariables;
+};
+
+
+
+/*
+query SuggestionsSearchQuery(
+  $term: String!
+) {
+  viewer {
+    ...SuggestionsSearch_viewer
+  }
+}
+
+fragment SuggestionsSearch_viewer on Viewer {
+  search(query: $term, mode: AUTOSUGGEST, first: 10) {
+    edges {
+      node {
+        __typename
+        displayLabel
+        ... on Node {
+          __id
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "term",
+    "type": "String!",
+    "defaultValue": null
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "SuggestionsSearchQuery",
+  "id": null,
+  "text": "query SuggestionsSearchQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer\n  }\n}\n\nfragment SuggestionsSearch_viewer on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "SuggestionsSearchQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "viewer",
+        "name": "__viewer_viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "SuggestionsSearch_viewer",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "SuggestionsSearchQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "search",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10,
+                "type": "Int"
+              },
+              {
+                "kind": "Literal",
+                "name": "mode",
+                "value": "AUTOSUGGEST",
+                "type": "SearchMode"
+              },
+              {
+                "kind": "Variable",
+                "name": "query",
+                "variableName": "term",
+                "type": "String!"
+              }
+            ],
+            "concreteType": "SearchableConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "SearchableEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": null,
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "displayLabel",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__id",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedHandle",
+        "alias": null,
+        "name": "viewer",
+        "args": null,
+        "handle": "viewer",
+        "key": "",
+        "filters": null
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '842837234e01043c66e7d22542b0535a';
+export default node;

--- a/src/__generated__/SuggestionsSearch_viewer.graphql.ts
+++ b/src/__generated__/SuggestionsSearch_viewer.graphql.ts
@@ -1,0 +1,101 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+declare const _SuggestionsSearch_viewer$ref: unique symbol;
+export type SuggestionsSearch_viewer$ref = typeof _SuggestionsSearch_viewer$ref;
+export type SuggestionsSearch_viewer = {
+    readonly search: ({
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly displayLabel: string | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+    readonly " $refType": SuggestionsSearch_viewer$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "SuggestionsSearch_viewer",
+  "type": "Viewer",
+  "metadata": null,
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "term",
+      "type": "String!"
+    }
+  ],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "search",
+      "storageKey": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10,
+          "type": "Int"
+        },
+        {
+          "kind": "Literal",
+          "name": "mode",
+          "value": "AUTOSUGGEST",
+          "type": "SearchMode"
+        },
+        {
+          "kind": "Variable",
+          "name": "query",
+          "variableName": "term",
+          "type": "String!"
+        }
+      ],
+      "concreteType": "SearchableConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "SearchableEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": null,
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "displayLabel",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__id",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '1fc10f86dc22565bec4c56b3db091b0c';
+export default node;

--- a/src/__generated__/SuggestionsSearch_viewer.graphql.ts
+++ b/src/__generated__/SuggestionsSearch_viewer.graphql.ts
@@ -23,9 +23,10 @@ const node: ConcreteFragment = {
   "metadata": null,
   "argumentDefinitions": [
     {
-      "kind": "RootArgument",
+      "kind": "LocalArgument",
       "name": "term",
-      "type": "String!"
+      "type": "String!",
+      "defaultValue": ""
     }
   ],
   "selections": [
@@ -97,5 +98,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '1fc10f86dc22565bec4c56b3db091b0c';
+(node as any).hash = '4c09909c73d7aec4186c1a5a705fe6a9';
 export default node;


### PR DESCRIPTION
cc @jonallured 

This adds a fragment container/query renderer for the suggestions component. Namely, it can fetch and render results from an auto-suggest query.

Looking like:

<img width="177" alt="screen shot 2019-02-06 at 12 53 18 pm" src="https://user-images.githubusercontent.com/1457859/52362275-3181a700-2a0e-11e9-9157-099a5befc6e4.png">


This is mergeable, but I left it as a WIP. I'm adding a `SearchBar` component that includes an `Input` and wraps it up with suggestions, to hopefully have a reasonable example of some composition of the components.