### PR TITLE
Add back access to the innerRef for Input

### DIFF
--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -10,6 +10,7 @@ export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   block?: boolean
   description?: string
   error?: string
+  innerRef?: React.RefObject<HTMLInputElement>
   title?: string
 }
 


### PR DESCRIPTION
Over on https://github.com/artsy/reaction/pull/1969 @pepopowitz and I removed access to the `innerRef` for `Input` because we thought it wasn't being used - we were wrong!

https://github.com/artsy/positron/blob/010b5d09e27996c997e6b7e6b5d14337dbd59e42/src/client/components/autocomplete2/index.tsx#L205

So here I'm just adding it back to the prop interface so that Positron won't be blocked from bumping Reaction.

Per @damassi, there is some incompatibility with `innerRef` and styled-components so we will have to revisit this at some point. Better to do that work with intention rather than having this PR drop support so suddenly. My thought is to drop that support as we move `Input` over to Palette, but open to other thoughts! ❤️ 