### PR TITLE
@pepopowitz => [Search] Prototype for loading previews w/ suggestions

### DIFF
--- a/src/__generated__/SearchBarQuery.graphql.ts
+++ b/src/__generated__/SearchBarQuery.graphql.ts
@@ -32,6 +32,10 @@ fragment SuggestionsSearch_viewer_4hh6ED on Viewer {
       node {
         __typename
         displayLabel
+        href
+        ... on SearchableItem {
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -55,7 +59,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarQuery",
   "id": null,
-  "text": "query SearchBarQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer_4hh6ED\n  }\n}\n\nfragment SuggestionsSearch_viewer_4hh6ED on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer_4hh6ED\n  }\n}\n\nfragment SuggestionsSearch_viewer_4hh6ED on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -166,9 +170,29 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "__id",
                         "args": null,
                         "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/SuggestionsSearchQuery.graphql.ts
+++ b/src/__generated__/SuggestionsSearchQuery.graphql.ts
@@ -32,6 +32,10 @@ fragment SuggestionsSearch_viewer_4hh6ED on Viewer {
       node {
         __typename
         displayLabel
+        href
+        ... on SearchableItem {
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -55,7 +59,7 @@ return {
   "operationKind": "query",
   "name": "SuggestionsSearchQuery",
   "id": null,
-  "text": "query SuggestionsSearchQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer_4hh6ED\n  }\n}\n\nfragment SuggestionsSearch_viewer_4hh6ED on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SuggestionsSearchQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer_4hh6ED\n  }\n}\n\nfragment SuggestionsSearch_viewer_4hh6ED on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -166,9 +170,29 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "__id",
                         "args": null,
                         "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/SuggestionsSearch_viewer.graphql.ts
+++ b/src/__generated__/SuggestionsSearch_viewer.graphql.ts
@@ -8,6 +8,8 @@ export type SuggestionsSearch_viewer = {
         readonly edges: ReadonlyArray<({
             readonly node: ({
                 readonly displayLabel: string | null;
+                readonly href: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -86,9 +88,29 @@ const node: ConcreteFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
+                  "name": "href",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
                   "name": "__id",
                   "args": null,
                   "storageKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
                 }
               ]
             }
@@ -98,5 +120,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '4c09909c73d7aec4186c1a5a705fe6a9';
+(node as any).hash = 'b2d4eb6ae95ade92e1a3ade95a81c702';
 export default node;


### PR DESCRIPTION
cc @jonallured 

![search](https://user-images.githubusercontent.com/1457859/52378555-fc894a80-2a35-11e9-92e7-c5b956c016f6.gif)

This builds upon https://github.com/artsy/reaction/pull/1994 to start roughing in the preview component alongside suggestions. With some minimal `Flex` and widths, and it's starting to look more reasonable (+ responsiveness).