### PR TITLE
@pepopowitz => [Autosuggest] Use react-autosuggest and start roughing in functionality

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -7848,6 +7848,12 @@ type SearchableEdge {
 
 type SearchableItem implements Node & Searchable {
   __id: ID!
+
+  # A type-specific ID.
+  id: String!
+
+  # A type-specific Gravity Mongo Document ID.
+  _id: String!
   displayLabel: String
   imageUrl: String
   href: String
@@ -7855,8 +7861,17 @@ type SearchableItem implements Node & Searchable {
 }
 
 enum SearchEntity {
-  ARTWORK
   ARTIST
+  ARTWORK
+  ARTICLE
+  CITY
+  COLLECTION
+  FAIR
+  FEATURE
+  GENE
+  PROFILE
+  SALE
+  TAG
 }
 
 enum SearchMode {
@@ -8185,6 +8200,9 @@ type Show implements Node {
 
   # An image representing the show, or a sharable image from an artwork in the show
   meta_image: Image
+
+  # Is the user following this show
+  is_followed: Boolean
 
   # The exhibition title
   name: String

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "prop-types": "^15.5.10",
     "qs": "^6.5.0",
     "rc-slider": "^8.6.2",
+    "react-autosuggest": "^9.4.3",
     "react-css-transition-replace": "^3.0.2",
     "react-head": "^3.0.0",
     "react-html-parser": "^2.0.2",

--- a/src/Components/Search/Previews/index.tsx
+++ b/src/Components/Search/Previews/index.tsx
@@ -11,14 +11,11 @@ export const SearchPreview: SFC<SearchPreviewProps> = ({
   entityType,
 }) => {
   switch (entityType) {
-    case "Sale": {
-      return <div>Sale Context Not Implemented</div>
-    }
-    case "Fair": {
-      return <div>Fair Context Not Implemented</div>
-    }
     case "Artist": {
       return <ArtistSearchPreview entityID={entityID} />
+    }
+    default: {
+      return <>Featured Artworks here</>
     }
     // And so forth...
   }

--- a/src/Components/Search/Spike/SearchBarSpike.tsx
+++ b/src/Components/Search/Spike/SearchBarSpike.tsx
@@ -1,6 +1,9 @@
+import { Box, Flex } from "@artsy/palette"
 import { SearchBarSpike_viewer } from "__generated__/SearchBarSpike_viewer.graphql"
 import { SearchBarSpikeSuggestQuery } from "__generated__/SearchBarSpikeSuggestQuery.graphql"
 import { ContextConsumer, ContextProps } from "Artsy"
+import Input from "Components/Input"
+import { SearchPreview } from "Components/Search/Previews"
 import { throttle } from "lodash"
 import React, { Component } from "react"
 import Autosuggest from "react-autosuggest"
@@ -18,15 +21,31 @@ export interface Props extends ContextProps {
 }
 
 interface State {
+  /* Holds current input */
   input: string
+  /* For preview generation of selected items */
+  entityID: string
+  entityType: string
 }
 
 export class SearchBarSpike extends Component<Props, State> {
   state = {
     input: "",
+    entityID: null,
+    entityType: null,
   }
 
-  throttledFetch = term => {
+  // Throttled method to toggle previews.
+  throttledOnSuggestionHighlighted = ({ suggestion }) => {
+    if (!suggestion) return null
+    const {
+      node: { searchableType: entityType, id: entityID },
+    } = suggestion
+    this.setState({ entityType, entityID })
+  }
+
+  // Throttled method to perform refetch for new suggest query.
+  throttledFetch = ({ value: term }) => {
     this.props.relay.refetch(
       {
         term,
@@ -43,36 +62,94 @@ export class SearchBarSpike extends Component<Props, State> {
     this.throttledFetch = throttle(this.throttledFetch, 500, {
       leading: true,
     })
+    this.throttledOnSuggestionHighlighted = throttle(
+      this.throttledOnSuggestionHighlighted,
+      500,
+      { leading: true }
+    )
   }
 
   searchTextChanged = (_e, { newValue: input }) => {
     this.setState({ input })
   }
 
+  onSuggestionsClearRequested = () => {
+    this.setState({ input: "", entityID: null, entityType: null })
+  }
+
+  // Navigate to selected search item.
+  onSuggestionSelected = (
+    _e,
+    {
+      suggestion: {
+        node: { href },
+      },
+    }
+  ) => {
+    window.location.href = href
+  }
+
+  renderPreview() {
+    const { entityID, entityType } = this.state
+    if (entityID && entityType) {
+      return <SearchPreview entityID={entityID} entityType={entityType} />
+    }
+  }
+
+  renderSuggestionsContainer = ({ containerProps, children, query }) => {
+    if (!query) return null
+    return (
+      <Box {...containerProps}>
+        <Flex flexDirection={["column", "row"]}>
+          <Box width={["100%", "25%"]}>
+            <Flex flexDirection="column">
+              <Box>Search "{query}"</Box>
+              {children}
+            </Flex>
+          </Box>
+          <Box width={["100%", "75%"]}>{this.renderPreview()}</Box>
+        </Flex>
+      </Box>
+    )
+  }
+
+  renderSuggestion = ({ node: { displayLabel } }, { isHighlighted }) => {
+    return (
+      <span style={{ backgroundColor: isHighlighted ? "#ddd" : "#fff" }}>
+        {displayLabel}
+      </span>
+    )
+  }
+
+  renderInputComponent = inputProps => (
+    <Box>
+      <Input style={{ width: "100%" }} {...inputProps} />
+    </Box>
+  )
+
   render() {
     const { viewer } = this.props
+    const { input } = this.state
     const edges = get(viewer, v => v.search.edges, [])
 
     const inputProps = {
       onChange: this.searchTextChanged,
-      placeholder: "Search...",
-      value: this.state.input,
+      placeholder: "Search by artist, gallery, style...",
+      value: input,
     }
 
     return (
       <Autosuggest
         suggestions={edges}
-        onSuggestionsClearRequested={() => {
-          /* */
-        }}
-        onSuggestionsFetchRequested={({ value }) => this.throttledFetch(value)}
-        getSuggestionValue={() => {
-          /* */
-        }}
-        renderSuggestion={({ node }) => {
-          return <span>{node.displayLabel}</span>
-        }}
+        onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+        onSuggestionHighlighted={this.throttledOnSuggestionHighlighted}
+        onSuggestionsFetchRequested={this.throttledFetch}
+        getSuggestionValue={({ node: { displayLabel } }) => displayLabel}
+        renderSuggestion={this.renderSuggestion}
+        renderSuggestionsContainer={this.renderSuggestionsContainer}
         inputProps={inputProps}
+        onSuggestionSelected={this.onSuggestionSelected}
+        renderInputComponent={this.renderInputComponent}
       />
     )
   }
@@ -92,6 +169,11 @@ export const SearchBarRefetchContainer = createRefetchContainer(
           edges {
             node {
               displayLabel
+              href
+              ... on SearchableItem {
+                searchableType
+                id
+              }
             }
           }
         }

--- a/src/Components/Search/Spike/SearchBarSpike.tsx
+++ b/src/Components/Search/Spike/SearchBarSpike.tsx
@@ -1,0 +1,144 @@
+import { SearchBarSpike_viewer } from "__generated__/SearchBarSpike_viewer.graphql"
+import { SearchBarSpikeSuggestQuery } from "__generated__/SearchBarSpikeSuggestQuery.graphql"
+import { ContextConsumer, ContextProps } from "Artsy"
+import { throttle } from "lodash"
+import React, { Component } from "react"
+import Autosuggest from "react-autosuggest"
+import {
+  createRefetchContainer,
+  graphql,
+  QueryRenderer,
+  RelayRefetchProp,
+} from "react-relay"
+import { get } from "Utils/get"
+
+export interface Props extends ContextProps {
+  relay: RelayRefetchProp
+  viewer: SearchBarSpike_viewer
+}
+
+interface State {
+  input: string
+}
+
+export class SearchBarSpike extends Component<Props, State> {
+  state = {
+    input: "",
+  }
+
+  throttledFetch = term => {
+    this.props.relay.refetch(
+      {
+        term,
+        hasTerm: true,
+      },
+      null,
+      error => {
+        if (error) console.error(error)
+      }
+    )
+  }
+
+  componentDidMount() {
+    this.throttledFetch = throttle(this.throttledFetch, 500, {
+      leading: true,
+    })
+  }
+
+  searchTextChanged = (_e, { newValue: input }) => {
+    this.setState({ input })
+  }
+
+  render() {
+    const { viewer } = this.props
+    const edges = get(viewer, v => v.search.edges, [])
+
+    const inputProps = {
+      onChange: this.searchTextChanged,
+      placeholder: "Search...",
+      value: this.state.input,
+    }
+
+    return (
+      <Autosuggest
+        suggestions={edges}
+        onSuggestionsClearRequested={() => {
+          /* */
+        }}
+        onSuggestionsFetchRequested={({ value }) => this.throttledFetch(value)}
+        getSuggestionValue={() => {
+          /* */
+        }}
+        renderSuggestion={({ node }) => {
+          return <span>{node.displayLabel}</span>
+        }}
+        inputProps={inputProps}
+      />
+    )
+  }
+}
+
+export const SearchBarRefetchContainer = createRefetchContainer(
+  SearchBarSpike,
+  {
+    viewer: graphql`
+      fragment SearchBarSpike_viewer on Viewer
+        @argumentDefinitions(
+          term: { type: "String!", defaultValue: "" }
+          hasTerm: { type: "Boolean!", defaultValue: false }
+        ) {
+        search(query: $term, mode: AUTOSUGGEST, first: 10)
+          @include(if: $hasTerm) {
+          edges {
+            node {
+              displayLabel
+            }
+          }
+        }
+      }
+    `,
+  },
+  graphql`
+    query SearchBarSpikeRefetchQuery($term: String!, $hasTerm: Boolean!) {
+      viewer {
+        ...SearchBarSpike_viewer @arguments(term: $term, hasTerm: $hasTerm)
+      }
+    }
+  `
+)
+
+export const SearchBarSpikeQueryRenderer: React.SFC = () => {
+  return (
+    <ContextConsumer>
+      {({ relayEnvironment }) => {
+        return (
+          <QueryRenderer<SearchBarSpikeSuggestQuery>
+            environment={relayEnvironment}
+            query={graphql`
+              query SearchBarSpikeSuggestQuery(
+                $term: String!
+                $hasTerm: Boolean!
+              ) {
+                viewer {
+                  ...SearchBarSpike_viewer
+                    @arguments(term: $term, hasTerm: $hasTerm)
+                }
+              }
+            `}
+            variables={{
+              term: "",
+              hasTerm: false,
+            }}
+            render={({ props }) => {
+              if (props) {
+                return <SearchBarRefetchContainer viewer={props.viewer} />
+              } else {
+                return null
+              }
+            }}
+          />
+        )
+      }}
+    </ContextConsumer>
+  )
+}

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -4,7 +4,14 @@ import React from "react"
 import { ContextProvider } from "Artsy/SystemContext"
 import { SearchPreview } from "Components/Search/Previews"
 import { SearchBar } from "Components/Search/SearchBar"
+import { SearchBarSpikeQueryRenderer as SearchBarSpike } from "Components/Search/Spike/SearchBarSpike"
 import { SearchSuggestionsQueryRenderer as SearchSuggestions } from "Components/Search/Suggestions"
+
+storiesOf("Components/Search/Spike/SearchBarSpike", module).add("Input", () => (
+  <ContextProvider>
+    <SearchBarSpike />
+  </ContextProvider>
+))
 
 storiesOf("Components/Search/SearchBar", module).add("Input", () => (
   <ContextProvider>
@@ -15,12 +22,6 @@ storiesOf("Components/Search/SearchBar", module).add("Input", () => (
 storiesOf("Components/Search/Suggestions", module).add("Term: Andy", () => (
   <ContextProvider>
     <SearchSuggestions term="andy" />
-  </ContextProvider>
-))
-
-storiesOf("Components/Search/Previews/Sale", module).add("A sale", () => (
-  <ContextProvider>
-    <SearchPreview entityID="phillips" entityType="Sale" />
   </ContextProvider>
 ))
 

--- a/src/__generated__/SearchBarSpikeRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchBarSpikeRefetchQuery.graphql.ts
@@ -34,6 +34,11 @@ fragment SearchBarSpike_viewer_2Mejjw on Viewer {
       node {
         __typename
         displayLabel
+        href
+        ... on SearchableItem {
+          searchableType
+          id
+        }
         ... on Node {
           __id
         }
@@ -63,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarSpikeRefetchQuery",
   "id": null,
-  "text": "query SearchBarSpikeRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBarSpike_viewer_2Mejjw\n  }\n}\n\nfragment SearchBarSpike_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarSpikeRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBarSpike_viewer_2Mejjw\n  }\n}\n\nfragment SearchBarSpike_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -185,9 +190,36 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
                             "name": "__id",
                             "args": null,
                             "storageKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "type": "SearchableItem",
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "searchableType",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "id",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
                           }
                         ]
                       }

--- a/src/__generated__/SearchBarSpikeRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchBarSpikeRefetchQuery.graphql.ts
@@ -1,0 +1,216 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { SearchBarSpike_viewer$ref } from "./SearchBarSpike_viewer.graphql";
+export type SearchBarSpikeRefetchQueryVariables = {
+    readonly term: string;
+    readonly hasTerm: boolean;
+};
+export type SearchBarSpikeRefetchQueryResponse = {
+    readonly viewer: ({
+        readonly " $fragmentRefs": SearchBarSpike_viewer$ref;
+    }) | null;
+};
+export type SearchBarSpikeRefetchQuery = {
+    readonly response: SearchBarSpikeRefetchQueryResponse;
+    readonly variables: SearchBarSpikeRefetchQueryVariables;
+};
+
+
+
+/*
+query SearchBarSpikeRefetchQuery(
+  $term: String!
+  $hasTerm: Boolean!
+) {
+  viewer {
+    ...SearchBarSpike_viewer_2Mejjw
+  }
+}
+
+fragment SearchBarSpike_viewer_2Mejjw on Viewer {
+  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {
+    edges {
+      node {
+        __typename
+        displayLabel
+        ... on Node {
+          __id
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "term",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "hasTerm",
+    "type": "Boolean!",
+    "defaultValue": null
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "SearchBarSpikeRefetchQuery",
+  "id": null,
+  "text": "query SearchBarSpikeRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBarSpike_viewer_2Mejjw\n  }\n}\n\nfragment SearchBarSpike_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "SearchBarSpikeRefetchQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "viewer",
+        "name": "__viewer_viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "SearchBarSpike_viewer",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "hasTerm",
+                "variableName": "hasTerm",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "term",
+                "variableName": "term",
+                "type": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "SearchBarSpikeRefetchQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "Condition",
+            "passingValue": true,
+            "condition": "hasTerm",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "search",
+                "storageKey": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 10,
+                    "type": "Int"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "mode",
+                    "value": "AUTOSUGGEST",
+                    "type": "SearchMode"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "query",
+                    "variableName": "term",
+                    "type": "String!"
+                  }
+                ],
+                "concreteType": "SearchableConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "SearchableEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "__typename",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "__id",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedHandle",
+        "alias": null,
+        "name": "viewer",
+        "args": null,
+        "handle": "viewer",
+        "key": "",
+        "filters": null
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'be8b9d751eea6571e73ad688c8d9bbb8';
+export default node;

--- a/src/__generated__/SearchBarSpikeSuggestQuery.graphql.ts
+++ b/src/__generated__/SearchBarSpikeSuggestQuery.graphql.ts
@@ -1,0 +1,216 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { SearchBarSpike_viewer$ref } from "./SearchBarSpike_viewer.graphql";
+export type SearchBarSpikeSuggestQueryVariables = {
+    readonly term: string;
+    readonly hasTerm: boolean;
+};
+export type SearchBarSpikeSuggestQueryResponse = {
+    readonly viewer: ({
+        readonly " $fragmentRefs": SearchBarSpike_viewer$ref;
+    }) | null;
+};
+export type SearchBarSpikeSuggestQuery = {
+    readonly response: SearchBarSpikeSuggestQueryResponse;
+    readonly variables: SearchBarSpikeSuggestQueryVariables;
+};
+
+
+
+/*
+query SearchBarSpikeSuggestQuery(
+  $term: String!
+  $hasTerm: Boolean!
+) {
+  viewer {
+    ...SearchBarSpike_viewer_2Mejjw
+  }
+}
+
+fragment SearchBarSpike_viewer_2Mejjw on Viewer {
+  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {
+    edges {
+      node {
+        __typename
+        displayLabel
+        ... on Node {
+          __id
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "term",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "hasTerm",
+    "type": "Boolean!",
+    "defaultValue": null
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "SearchBarSpikeSuggestQuery",
+  "id": null,
+  "text": "query SearchBarSpikeSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBarSpike_viewer_2Mejjw\n  }\n}\n\nfragment SearchBarSpike_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "SearchBarSpikeSuggestQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "viewer",
+        "name": "__viewer_viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "SearchBarSpike_viewer",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "hasTerm",
+                "variableName": "hasTerm",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "term",
+                "variableName": "term",
+                "type": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "SearchBarSpikeSuggestQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "Condition",
+            "passingValue": true,
+            "condition": "hasTerm",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "search",
+                "storageKey": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 10,
+                    "type": "Int"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "mode",
+                    "value": "AUTOSUGGEST",
+                    "type": "SearchMode"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "query",
+                    "variableName": "term",
+                    "type": "String!"
+                  }
+                ],
+                "concreteType": "SearchableConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "SearchableEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "__typename",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "__id",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedHandle",
+        "alias": null,
+        "name": "viewer",
+        "args": null,
+        "handle": "viewer",
+        "key": "",
+        "filters": null
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '8f96ba3e5a8c63a5c0392860a6c67b5d';
+export default node;

--- a/src/__generated__/SearchBarSpikeSuggestQuery.graphql.ts
+++ b/src/__generated__/SearchBarSpikeSuggestQuery.graphql.ts
@@ -34,6 +34,11 @@ fragment SearchBarSpike_viewer_2Mejjw on Viewer {
       node {
         __typename
         displayLabel
+        href
+        ... on SearchableItem {
+          searchableType
+          id
+        }
         ... on Node {
           __id
         }
@@ -63,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarSpikeSuggestQuery",
   "id": null,
-  "text": "query SearchBarSpikeSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBarSpike_viewer_2Mejjw\n  }\n}\n\nfragment SearchBarSpike_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarSpikeSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBarSpike_viewer_2Mejjw\n  }\n}\n\nfragment SearchBarSpike_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -185,9 +190,36 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
                             "name": "__id",
                             "args": null,
                             "storageKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "type": "SearchableItem",
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "searchableType",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "id",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
                           }
                         ]
                       }

--- a/src/__generated__/SearchBarSpike_viewer.graphql.ts
+++ b/src/__generated__/SearchBarSpike_viewer.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+declare const _SearchBarSpike_viewer$ref: unique symbol;
+export type SearchBarSpike_viewer$ref = typeof _SearchBarSpike_viewer$ref;
+export type SearchBarSpike_viewer = {
+    readonly search?: ({
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly displayLabel: string | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+    readonly " $refType": SearchBarSpike_viewer$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "SearchBarSpike_viewer",
+  "type": "Viewer",
+  "metadata": null,
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "term",
+      "type": "String!",
+      "defaultValue": ""
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "hasTerm",
+      "type": "Boolean!",
+      "defaultValue": false
+    }
+  ],
+  "selections": [
+    {
+      "kind": "Condition",
+      "passingValue": true,
+      "condition": "hasTerm",
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "search",
+          "storageKey": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 10,
+              "type": "Int"
+            },
+            {
+              "kind": "Literal",
+              "name": "mode",
+              "value": "AUTOSUGGEST",
+              "type": "SearchMode"
+            },
+            {
+              "kind": "Variable",
+              "name": "query",
+              "variableName": "term",
+              "type": "String!"
+            }
+          ],
+          "concreteType": "SearchableConnection",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "edges",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "SearchableEdge",
+              "plural": true,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "node",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": null,
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "__id",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '9473c92711a8506af5e744fa95c0b742';
+export default node;

--- a/src/__generated__/SearchBarSpike_viewer.graphql.ts
+++ b/src/__generated__/SearchBarSpike_viewer.graphql.ts
@@ -8,6 +8,9 @@ export type SearchBarSpike_viewer = {
         readonly edges: ReadonlyArray<({
             readonly node: ({
                 readonly displayLabel: string | null;
+                readonly href: string | null;
+                readonly searchableType?: string | null;
+                readonly id?: string;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -97,9 +100,36 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "href",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "__id",
                       "args": null,
                       "storageKey": null
+                    },
+                    {
+                      "kind": "InlineFragment",
+                      "type": "SearchableItem",
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "searchableType",
+                          "args": null,
+                          "storageKey": null
+                        },
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "id",
+                          "args": null,
+                          "storageKey": null
+                        }
+                      ]
                     }
                   ]
                 }
@@ -111,5 +141,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '9473c92711a8506af5e744fa95c0b742';
+(node as any).hash = '297fcf07fa6b24b023f91675e887c1e6';
 export default node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10019,6 +10019,11 @@ object-assign@4.x, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+  integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
+
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -11236,6 +11241,24 @@ react-addons-test-utils@^16.0.0-alpha.3:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
+react-autosuggest@^9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.4.3.tgz#eb46852422a48144ab9f39fb5470319222f26c7c"
+  integrity sha512-wFbp5QpgFQRfw9cwKvcgLR8theikOUkv8PFsuLYqI2PUgVlx186Cz8MYt5bLxculi+jxGGUUVt+h0esaBZZouw==
+  dependencies:
+    prop-types "^15.5.10"
+    react-autowhatever "^10.1.2"
+    shallow-equal "^1.0.0"
+
+react-autowhatever@^10.1.2:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.2.0.tgz#bdd07bf19ddf78acdb8ce7ae162ac13b646874ab"
+  integrity sha512-dqHH4uqiJldPMbL8hl/i2HV4E8FMTDEdVlOIbRqYnJi0kTpWseF9fJslk/KS9pGDnm80JkYzVI+nzFjnOG/u+g==
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
 react-css-transition-replace@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/react-css-transition-replace/-/react-css-transition-replace-3.0.3.tgz#23d3ed17f54e41435c0485300adb75d2e6e24aad"
@@ -11583,6 +11606,13 @@ react-textarea-autosize@^7.0.4:
   integrity sha512-1cC8pFSrIVH92aE+UKxGQ2Gqq43qdIcMscJKScEFeBNemn6gHa+NwKqdXkHxxg5H6uuvW+cPpJPTes6zh90M+A==
   dependencies:
     prop-types "^15.6.0"
+
+react-themeable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
+  integrity sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=
+  dependencies:
+    object-assign "^3.0.0"
 
 react-tracking@^5.6.0:
   version "5.6.0"
@@ -12446,6 +12476,11 @@ scroll-behavior@^0.9.3:
     dom-helpers "^3.2.1"
     invariant "^2.2.2"
 
+section-iterator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
+  integrity sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=
+
 select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
@@ -12570,6 +12605,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.1.0.tgz#cc022f030dcba0d1c198abf658a3c6c744e171ca"
+  integrity sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw==
 
 shallowequal@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
Latest screenshot:

![search](https://user-images.githubusercontent.com/1457859/52461269-4f4d2a00-2b3c-11e9-8e0c-500eedc94496.gif)


This adds `react-autosuggest` and hooks it up in a Relay context (refetch container- finally using that!), and gets some basic functionality in. The motivation and some ad-hoc discussion about whether this library is a worthy addition to Reaction was done in Slack earlier: https://artsy.slack.com/archives/C2TQ4PT8R/p1549570277663300 

I figured this is worth a look-see and PR b/c a lot of the 'meat' of the functionality is present. Further iterative steps revolve more around understanding and using the library fully, UI work and styling, etc.