### PR TITLE
[PATCH authentication] pass artist name in query params

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -255,7 +255,7 @@ export class SmallArtistHeader extends Component<Props> {
                 objectId: props.artist.id,
                 signUpIntent: "follow artist",
                 trigger: "click",
-                title: `Sign up to follow ${props.artist.name}`,
+                entityName: props.artist.name,
               })
               const href = `/sign_up?redirect-to=${window.location}&${params}`
 

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -33,6 +33,7 @@ export interface FormProps {
   onTwitterLogin?: (e: Event) => void
   onBackButtonClicked?: (e: Event) => void
   title?: string
+  entityName?: string
 }
 
 interface AfterSignUpAction {


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-1080

Because we moved [away from passing the title as a query param](https://github.com/artsy/force/pull/3449#issuecomment-459503584), the custom title wasn't displaying in the mobile signup modal. This passes the artist name as a query param versus the title to build the the custom title in the force router. Note that there is additional force work that needs to be done to complete this but this PR should be merged first.

![screen shot 2019-02-11 at 10 27 45 am](https://user-images.githubusercontent.com/5201004/52573452-2d77cf80-2de8-11e9-991a-a15dd87f4e94.png)
