### PR TITLE
@mzikherman => [AuctionTimer] Make sure to display the minute portion in label

### DIFF
--- a/src/Components/v2/AuctionTimer.tsx
+++ b/src/Components/v2/AuctionTimer.tsx
@@ -41,7 +41,7 @@ export class AuctionTimer extends React.Component<Props> {
   }
 
   labelWithTimeRemaining() {
-    const display = moment(this.endDate).format("MMM D, ha")
+    const display = moment(this.endDate).format("MMM D, h:ma")
     if (this.liveStartAt) {
       return `Live ${display}`
     } else {


### PR DESCRIPTION
Noticing some auctions that don't end (or have the live portion start) on the hour weren't displaying that labeling (although the countdown timer was correctly calculated). Just a moment formatting issue.