### PR TITLE
Fix style injection

### DIFF
--- a/src/Artsy/Router/Components/Boot.tsx
+++ b/src/Artsy/Router/Components/Boot.tsx
@@ -11,7 +11,6 @@ import { data as sd } from "sharify"
 import { Provider as StateProvider } from "unstated"
 import { BreakpointVisualizer } from "Utils/BreakpointVisualizer"
 import Events from "Utils/Events"
-import { createMediaStyle } from "Utils/Responsive"
 
 import {
   MatchingMediaQueries,
@@ -29,9 +28,6 @@ export interface BootProps {
   headTags?: JSX.Element[]
 }
 
-// Build global responsive styles
-const reactResponsiveStyles = createMediaStyle()
-
 // FIXME: When we update to latest @types/styled-components `suppressMultiMountWarning`
 // issue will be fixed
 const { GlobalStyles } = injectGlobalStyles<{
@@ -44,8 +40,6 @@ const { GlobalStyles } = injectGlobalStyles<{
     font-size: inherit;
     margin: 0;
   }
-
-  ${reactResponsiveStyles}
 `)
 
 @track(null, {

--- a/src/__stories__/config.js
+++ b/src/__stories__/config.js
@@ -10,12 +10,9 @@ function loadStories() {
 }
 
 // Add RRM styles to Storybooks head
-const reactResponsiveStyles = createMediaStyle()
-document.head.innerHTML += `
-  <style>
-    ${reactResponsiveStyles}
-  </style>
-`
+const rrmStyle = document.createElement("style")
+rrmStyle.innerHTML = createMediaStyle()
+document.head.appendChild(rrmStyle)
 
 addDecorator(
   withOptions({

--- a/src/__stories__/config.js
+++ b/src/__stories__/config.js
@@ -1,12 +1,21 @@
 import Events from "../Utils/Events"
 import { addDecorator, configure } from "@storybook/react"
 import { withOptions } from "@storybook/addon-options"
+import { createMediaStyle } from "Utils/Responsive"
 
 const req = require.context("../", true, /\.story\.tsx$/)
 
 function loadStories() {
   req.keys().forEach(filename => req(filename))
 }
+
+// Add RRM styles to Storybooks head
+const reactResponsiveStyles = createMediaStyle()
+document.head.innerHTML += `
+  <style>
+    ${reactResponsiveStyles}
+  </style>
+`
 
 addDecorator(
   withOptions({


### PR DESCRIPTION
During SC4 upgrade we no longer had a way to directly inject styles into a head that lacks a react tree, so our RRM styles weren't being injected. I added it to the Boot global styles, leading to a little duplication since its already being passed via SSR. Should always be handled by consumers. 