### PR TITLE
@jonallured => [Autosuggest] More roughing in of UI, introduction of special first item

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -27,6 +27,7 @@ const AutosuggestContainer = styled(Box)`
       ul {
         list-style-type: none;
         padding: 0;
+        margin: 0;
       }
     }
   }
@@ -41,7 +42,7 @@ const PLACEHOLDER = "Search by artist, gallery, style, theme, tag, etc."
 
 interface State {
   /* Holds current input */
-  input: string
+  term: string
   /* For preview generation of selected items */
   entityID: string
   entityType: string
@@ -52,24 +53,22 @@ export class SearchBar extends Component<Props, State> {
   public input: HTMLInputElement
 
   state = {
-    input: "",
+    term: "",
     entityID: null,
     entityType: null,
     focused: false,
   }
 
-  storeInputReference = autosuggest => {
-    if (autosuggest != null) {
-      this.input = autosuggest.input
-    }
-  }
-
   // Throttled method to toggle previews.
   throttledOnSuggestionHighlighted = ({ suggestion }) => {
-    if (!suggestion) return null
+    if (!suggestion) return
+
     const {
       node: { searchableType: entityType, id: entityID },
     } = suggestion
+
+    if (entityType === "FirstItem") return
+
     this.setState({ entityType, entityID })
   }
 
@@ -98,8 +97,8 @@ export class SearchBar extends Component<Props, State> {
     )
   }
 
-  searchTextChanged = (_e, { newValue: input }) => {
-    this.setState({ input })
+  searchTextChanged = (_e, { newValue: term }) => {
+    this.setState({ term })
   }
 
   onFocus = () => {
@@ -111,7 +110,7 @@ export class SearchBar extends Component<Props, State> {
   }
 
   onSuggestionsClearRequested = () => {
-    this.setState({ input: "", entityID: null, entityType: null })
+    this.setState({ term: "", entityID: null, entityType: null })
   }
 
   // Navigate to selected search item.
@@ -127,29 +126,32 @@ export class SearchBar extends Component<Props, State> {
   }
 
   renderPreview() {
-    const { entityID, entityType } = this.state
-    if (entityID && entityType) {
-      return <SearchPreview entityID={entityID} entityType={entityType} />
-    }
+    const { entityID, entityType, focused } = this.state
+    if (!focused) return
+
+    return <SearchPreview entityID={entityID} entityType={entityType} />
   }
 
-  renderSuggestionsContainer = ({ containerProps, children, query }) => {
+  renderSuggestionsContainer = (
+    { containerProps, children, query },
+    { xs }
+  ) => {
     const { focused } = this.state
 
-    let firstItem = null
-    if (query) {
-      firstItem = <Box>Search "{query}"</Box>
-    } else if (focused) {
-      firstItem = <Box>{PLACEHOLDER}</Box>
+    let emptyState = null
+    if (!xs && !query && focused) {
+      emptyState = (
+        <Box pb={3} pl={3}>
+          {PLACEHOLDER}
+        </Box>
+      )
     }
     return (
       <Box {...containerProps}>
         <Flex flexDirection={["column", "row"]}>
           <Box width={["100%", "50%"]}>
             <Flex flexDirection="column">
-              <Box mt={3} pl={3}>
-                {firstItem}
-              </Box>
+              {emptyState}
               {children}
             </Flex>
           </Box>
@@ -157,6 +159,10 @@ export class SearchBar extends Component<Props, State> {
         </Flex>
       </Box>
     )
+  }
+
+  getSuggestionValue = ({ node: { displayLabel } }) => {
+    return displayLabel
   }
 
   renderSuggestion = (
@@ -175,38 +181,46 @@ export class SearchBar extends Component<Props, State> {
   }
 
   renderInputComponent = inputProps => (
-    <Box>
-      <Input style={{ width: "100%" }} {...inputProps} />
-    </Box>
+    <Input style={{ width: "100%" }} {...inputProps} />
   )
 
   renderAutosuggestComponent({ xs }) {
-    const { input } = this.state
+    const { term } = this.state
     const { viewer } = this.props
-    const edges = get(viewer, v => v.search.edges, [])
 
     const inputProps = {
       onChange: this.searchTextChanged,
       onFocus: this.onFocus,
       onBlur: this.onBlur,
       placeholder: xs ? "" : PLACEHOLDER,
-      value: input,
+      value: term,
     }
 
+    const firstSuggestionPlaceholder = {
+      node: {
+        searchableType: "FirstItem",
+        displayLabel: term,
+        href: `/search?q={input}`,
+      },
+    }
+
+    const edges = get(viewer, v => v.search.edges, [])
+    const suggestions = xs ? edges : [firstSuggestionPlaceholder, ...edges]
     return (
       <AutosuggestContainer>
         <Autosuggest
-          suggestions={edges}
+          suggestions={suggestions}
           onSuggestionsClearRequested={this.onSuggestionsClearRequested}
           onSuggestionHighlighted={this.throttledOnSuggestionHighlighted}
           onSuggestionsFetchRequested={this.throttledFetch}
-          getSuggestionValue={({ node: { displayLabel } }) => displayLabel}
+          getSuggestionValue={this.getSuggestionValue}
           renderSuggestion={this.renderSuggestion}
-          renderSuggestionsContainer={this.renderSuggestionsContainer}
+          renderSuggestionsContainer={props => {
+            return this.renderSuggestionsContainer(props, { xs })
+          }}
           inputProps={inputProps}
           onSuggestionSelected={this.onSuggestionSelected}
           renderInputComponent={this.renderInputComponent}
-          ref={this.storeInputReference}
         />
       </AutosuggestContainer>
     )
@@ -233,7 +247,7 @@ export const SearchBarRefetchContainer = createRefetchContainer(
           term: { type: "String!", defaultValue: "" }
           hasTerm: { type: "Boolean!", defaultValue: false }
         ) {
-        search(query: $term, mode: AUTOSUGGEST, first: 10)
+        search(query: $term, mode: AUTOSUGGEST, first: 7)
           @include(if: $hasTerm) {
           edges {
             node {

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,4 +1,4 @@
-import { color, Flex, Sans, Serif } from "@artsy/palette"
+import { Box, color, Flex, Sans, Serif } from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import React, { SFC } from "react"
@@ -9,9 +9,18 @@ interface Props {
 }
 
 export const SuggestionItem: SFC<Props> = ({ display, label, query }) => {
+  if (label === "FirstItem") {
+    return (
+      <Box pl={3} pb={3}>
+        Search "{query}"
+      </Box>
+    )
+  }
+
   const matches = match(display, query)
   const parts = parse(display, matches)
 
+  // TODO: Center text vertically
   return (
     <Flex pl={3} pb={3} justifyContent="center" flexDirection="column">
       <Serif size="2">

--- a/src/Components/Search/__tests__/SearchBar.test.tsx
+++ b/src/Components/Search/__tests__/SearchBar.test.tsx
@@ -23,6 +23,12 @@ const searchResults = {
       },
     ],
   },
+
+  filter_artworks: {
+    artworks_connection: {
+      edges: [],
+    },
+  },
 }
 
 const simulateTyping = (wrapper: ReactWrapper, text: string) => {
@@ -101,5 +107,14 @@ describe("SearchBar", () => {
     await flushPromiseQueue()
 
     expect(component.html()).toContain("<strong>Perc</strong>y Z")
+  })
+
+  it("displays merchandisable artworks", async () => {
+    const component = await getWrapper(searchResults)
+
+    simulateTyping(component, "blah") // Any text of non-zero length.
+    await flushPromiseQueue()
+
+    expect(component.text()).toContain("Now Available for Buy Now/ Make Offer")
   })
 })

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -1,10 +1,9 @@
-import React from "react"
-import { storiesOf } from "storybook/storiesOf"
-
 import { ContextProvider } from "Artsy/SystemContext"
 import { SearchPreview } from "Components/Search/Previews"
 import { SearchBarQueryRenderer as SearchBar } from "Components/Search/SearchBar"
 import { SearchSuggestionsQueryRenderer as SearchSuggestions } from "Components/Search/Suggestions"
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
 
 storiesOf("Components/Search/SearchBar", module).add("Input", () => (
   <ContextProvider>

--- a/src/__generated__/SearchBarRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchBarRefetchQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarRefetchQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarRefetchQuery",
   "id": null,
-  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 10,
+                    "value": 7,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBarSuggestQuery.graphql.ts
+++ b/src/__generated__/SearchBarSuggestQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarSuggestQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarSuggestQuery",
   "id": null,
-  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 10,
+                    "value": 7,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBarTestQuery.graphql.ts
+++ b/src/__generated__/SearchBarTestQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarTestQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarTestQuery",
   "id": null,
-  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 10,
+                    "value": 7,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBar_viewer.graphql.ts
+++ b/src/__generated__/SearchBar_viewer.graphql.ts
@@ -53,7 +53,7 @@ const node: ConcreteFragment = {
             {
               "kind": "Literal",
               "name": "first",
-              "value": 10,
+              "value": 7,
               "type": "Int"
             },
             {
@@ -141,5 +141,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '1d1401a81558c8538abb9c09129418d5';
+(node as any).hash = 'd5c878b4c5fc01c702d6fe74e63075b9';
 export default node;


### PR DESCRIPTION
![search](https://user-images.githubusercontent.com/1457859/52748169-d0307980-2fb3-11e9-835d-a27a41c74991.gif)

The main thing here is the introduction of a special 'synthetic' first item. This is b/c, based on the comps, the first item that appears when you type in a term: `Search "andy"` for example, _is_ actually pretty much an item in our suggestions. As in, it's selectable/scrollable/clickable, and selecting it should take you to the search results page `/search?q=andy`.

So this PR adds that, and it sort of behaves well! It's kind of a weird idea, but I suspect that trying to handle it 'like' it's an actual suggestion (so you can navigate to it in the list) w/o it _actually_ being a suggestion is going to be even weirder and more of a headache!