### PR TITLE
Use `label` prop in BorderedRadio and Radio

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -154,9 +154,8 @@ class Filter extends Component<Props> {
                 }
               }}
               key={index}
-            >
-              {count.name}
-            </Radio>
+              label={count.name}
+            />
           )
         })}
       </Flex>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -105,8 +105,8 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             }}
             selected={this.state.selectedEditionSet === editionSet}
             disabled={!editionEcommerceAvailable}
+            label={editionFragment}
           />
-          {editionFragment}
         </Row>
       )
     } else {

--- a/src/Apps/Collect/Components/Filters/MediumFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/MediumFilter.tsx
@@ -30,9 +30,8 @@ export const MediumFilter: React.SFC<{
                 }
               }}
               key={index}
-            >
-              {medium.name}
-            </Radio>
+              label={medium.name}
+            />
           )
         })
       }

--- a/src/Apps/Collect/Components/Filters/TimePeriodFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/TimePeriodFilter.tsx
@@ -32,9 +32,8 @@ export const TimePeriodFilter: React.SFC<{
                 }
               }}
               key={index}
-            >
-              {timePeriod}
-            </Radio>
+              label={timePeriod}
+            />
           )
         })
     }

--- a/src/Apps/Comparables/Filter/MediumFilter.tsx
+++ b/src/Apps/Comparables/Filter/MediumFilter.tsx
@@ -35,9 +35,8 @@ export const MediumFilter: React.SFC = () => {
                             }
                           }}
                           key={index}
-                        >
-                          {category}
-                        </Radio>
+                          label={category}
+                        />
                       )
                     }
                   )}

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -280,12 +280,12 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
                   }
                   defaultValue={this.state.responseOption}
                 >
-                  <BorderedRadio value="ACCEPT">
-                    Accept seller's offer
-                  </BorderedRadio>
-
-                  <BorderedRadio value="COUNTER" position="relative">
-                    Send counteroffer
+                  <BorderedRadio value="ACCEPT" label="Accept seller's offer" />
+                  <BorderedRadio
+                    value="COUNTER"
+                    position="relative"
+                    label="Send counteroffer"
+                  >
                     <Collapse open={this.state.responseOption === "COUNTER"}>
                       <Spacer mb={2} />
                       <OfferInput
@@ -316,15 +316,20 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
                       )}
                     </Collapse>
                   </BorderedRadio>
-                  <BorderedRadio value="DECLINE" position="relative">
-                    Decline seller's offer
-                    <Collapse open={this.state.responseOption === "DECLINE"}>
-                      <Spacer mb={1} />
-                      <Sans size="2" color="black60">
-                        Declining an offer will end the negotiation process on
-                        this offer.
-                      </Sans>
-                    </Collapse>
+                  <BorderedRadio
+                    value="DECLINE"
+                    position="relative"
+                    label="Decline seller's offer"
+                  >
+                    <Flex position="relative">
+                      <Collapse open={this.state.responseOption === "DECLINE"}>
+                        <Spacer mb={1} />
+                        <Sans size="2" color="black60">
+                          Declining an offer will end the negotiation process on
+                          this offer.
+                        </Sans>
+                      </Collapse>
+                    </Flex>
                   </BorderedRadio>
                 </RadioGroup>
                 <Spacer mb={[2, 3]} />

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -332,12 +332,15 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                       onSelect={this.onSelectShippingOption.bind(this)}
                       defaultValue={this.state.shippingOption}
                     >
-                      <BorderedRadio value="SHIP">
-                        Add shipping address
-                      </BorderedRadio>
+                      <BorderedRadio
+                        value="SHIP"
+                        label="Add shipping address"
+                      />
 
-                      <BorderedRadio value="PICKUP">
-                        Arrange for pickup (free)
+                      <BorderedRadio
+                        value="PICKUP"
+                        label="Arrange for pickup (free)"
+                      >
                         <Collapse open={this.state.shippingOption === "PICKUP"}>
                           <Sans size="2" color="black60">
                             After your order is confirmed, a specialist will


### PR DESCRIPTION
Refactors BorderedRadio and Radio usages to use the new `label` prop (see artsy/palette#290)

In doing so, fixes https://artsyproduct.atlassian.net/browse/PURCHASE-875

![good-focusing-holmes](https://user-images.githubusercontent.com/1242537/52808415-bfe8cf00-3085-11e9-9c05-e4b9629b2cb8.gif)
