### PR TITLE
DISCO-739: Add Tracking to Artwork Page Filters

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -1,6 +1,7 @@
 import { FilterIcon, Toggle } from "@artsy/palette"
 import { ArtworkFilter_artist } from "__generated__/ArtworkFilter_artist.graphql"
 import { FilterState } from "Apps/Artist/Routes/Overview/state"
+import { track } from "Artsy/Analytics"
 import { ContextConsumer, Mediator } from "Artsy/SystemContext"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import React, { Component } from "react"
@@ -33,6 +34,7 @@ interface Props {
   mediator?: Mediator
 }
 
+@track()
 class Filter extends Component<Props> {
   static defaultProps = {
     hideTopBorder: false,
@@ -146,13 +148,9 @@ class Filter extends Component<Props> {
               my={0.3}
               selected={currentFilter === count.id}
               value={count.id}
-              onSelect={({ selected }) => {
-                if (selected) {
-                  return filterState.setFilter(category, count.id, mediator)
-                } else {
-                  return filterState.unsetFilter(category, mediator)
-                }
-              }}
+              onSelect={({ selected }) =>
+                this.handleCategorySelect(selected, category, count)
+              }
               key={index}
               label={count.name}
             />
@@ -160,6 +158,20 @@ class Filter extends Component<Props> {
         })}
       </Flex>
     )
+  }
+
+  @track((_props, _state, [_selected, category, count]) => {
+    const changeProperty = `changed_${category}`
+    return { [changeProperty]: count.id }
+  })
+  handleCategorySelect(selected, category, count) {
+    const { filterState, mediator } = this.props
+
+    if (selected) {
+      return filterState.setFilter(category, count.id, mediator)
+    } else {
+      return filterState.unsetFilter(category, mediator)
+    }
   }
 
   renderWaysToBuy(filterState, mediator, counts) {

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -2,6 +2,7 @@ import { FilterIcon, Toggle } from "@artsy/palette"
 import { ArtworkFilter_artist } from "__generated__/ArtworkFilter_artist.graphql"
 import { FilterState } from "Apps/Artist/Routes/Overview/state"
 import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { ContextConsumer, Mediator } from "Artsy/SystemContext"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import React, { Component } from "react"
@@ -160,9 +161,12 @@ class Filter extends Component<Props> {
     )
   }
 
-  @track((_props, _state, [_selected, category, count]) => {
-    const changeProperty = `changed_${category}`
-    return { [changeProperty]: count.id }
+  @track((props: Props, _state, [_selected, category, count]) => {
+    return {
+      action_type: Schema.ActionType.ClickedCommercialFilter,
+      changed: { [category]: count.id },
+      current: { ...props.filterState.state },
+    }
   })
   handleCategorySelect(selected, category, count) {
     const { filterState, mediator } = this.props

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -54,6 +54,8 @@ export enum ActionType {
    */
   ClickedReadMore = "Clicked read more",
 
+  ClickedCommercialFilter = "Clicked commercial filter params",
+
   /**
    * A/B Test Experiments
    */


### PR DESCRIPTION
This is a bit of a spike after a pairing session with @damassi. First he noticed that we could simplify things quite a bit if we moved the ContextConsumer into the fragment container, so I followed that refactoring through on a9880ff.

Then I added tracking to the selection of categories using the `@track` decorator on 044d02d. I wasn't wild about how this looked because I had to proxy through a factory function in order to get it to work.

That indirection bothered me enough to simplify things with a26e34a. Here I've moved the proxying up into the `onSelect` in the element, which seems better to me.

Finally, with 923cbac I went another direction entirely and switched to tracking the event through the prop that we get from decoration rather than using the decoration function itself. I think I like this best, but it doesn't look like this is the convention in the codebase, so open to thoughts there!!