### PR TITLE
@alloy => [Autosuggest] Allow QueryRenderer to return w/o fetching

### DIFF
--- a/src/Artsy/Relay/createRelaySSREnvironment.ts
+++ b/src/Artsy/Relay/createRelaySSREnvironment.ts
@@ -78,7 +78,7 @@ export function createRelaySSREnvironment(config: Config = {}) {
       // or further refactoring to extract `addMiddlewareToEnvironment(environment)`,
       // to be used in the SearchBar QueryRenderer (for example).
       next => req => {
-        if (req.variables.term === "")
+        if (req.id === "SearchBarSuggestQuery" && req.variables.term === "")
           return Promise.resolve({ data: { viewer: {} } })
         return next(req)
       },

--- a/src/Artsy/Relay/createRelaySSREnvironment.ts
+++ b/src/Artsy/Relay/createRelaySSREnvironment.ts
@@ -74,6 +74,14 @@ export function createRelaySSREnvironment(config: Config = {}) {
   const network =
     relayNetwork ||
     new RelayNetworkLayer([
+      // TODO: Better introspection around if this is a SearchBar query,
+      // or further refactoring to extract `addMiddlewareToEnvironment(environment)`,
+      // to be used in the SearchBar QueryRenderer (for example).
+      next => req => {
+        if (req.variables.term === "")
+          return Promise.resolve({ data: { viewer: {} } })
+        return next(req)
+      },
       urlMiddleware({
         url: METAPHYSICS_ENDPOINT,
         headers: !!user

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
       color="#000"
     >
       <div
-        className="PartnerInline PartnerInline__PartnerInlineContainer-soorph-0 kTrDuE"
+        className="PartnerInline PartnerInline__PartnerInlineContainer-soorph-0 gyUhml"
       >
         <a
           href="/"
         >
           <div
-            className="Icon-s13f8sed-0 eScAls"
+            className="Icon-sc-13f8sed-0 cEKJrA"
           >
             
           </div>
@@ -122,10 +122,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
       className="Eoy2018Artists__ArticleContent-apetgy-2 dvYCoX"
     >
       <div
-        className="Eoy2018Artists__IntroSection-apetgy-6 jkuGpk"
+        className="Eoy2018Artists__IntroSection-apetgy-6 kRsgop"
       >
         <div
-          className="Byline Byline__BylineContainer-s1iqb1j2-0 dGLzes"
+          className="Byline Byline__BylineContainer-sc-1iqb1j2-0 lnQvdw"
           color="black"
         >
           <div
@@ -146,7 +146,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="Date__DateContainer-s1u78l60-0 cqHYNi"
+            className="Date__DateContainer-sc-1u78l60-0 kgTcUj"
           >
             <div
               className="Typography-sc-1pie2ao-0 ehDCiu sc-EHOje fXsUty"
@@ -162,10 +162,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="Share__ShareContainer-s1y1t686-0 PaPVw"
+            className="Share__ShareContainer-sc-1y1t686-0 czsizs"
           >
             <a
-              className="Share__IconWrapper-s1y1t686-1 hTPohU"
+              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018"
               onClick={[Function]}
               target="_blank"
@@ -191,7 +191,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="Share__IconWrapper-s1y1t686-1 hTPohU"
+              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018&text=The Most Influential Artists of 2018&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -217,7 +217,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="Share__IconWrapper-s1y1t686-1 hTPohU"
+              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
               href="mailto:?subject=The Most Influential Artists of 2018&body=Check out The Most Influential Artists of 2018 on Artsy: https://www.artsy.net/article/artsy-editorial-influential-artists-2018"
               onClick={[Function]}
               target="_blank"
@@ -248,12 +248,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           className="sc-htoDjs grMeOB"
         >
           <div
-            className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+            className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
             fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
             fontSize="22px"
           >
             <div
-              className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+              className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
               color="black"
             >
               <div
@@ -302,12 +302,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -321,13 +321,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -436,11 +436,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Kerry James Marshall"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FX8Ew_Hp2QurfxBx4A_hOJQ%252Fd7hftxdivxxvm.cloudfront-4.jpg&width=800&quality=80"
             />
           </div>
@@ -450,12 +450,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -503,12 +503,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -522,13 +522,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -637,11 +637,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Adrian Piper"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F8CIBxY3JyP8Cw4g1piRRTQ%252Fadrian2.jpg&width=800&quality=80"
             />
           </div>
@@ -651,12 +651,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -704,12 +704,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -723,13 +723,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -838,11 +838,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Maurizio Cattelan"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FrFQMyKzr0rr2J2dyE8Z_CQ%252FMaurizio-Cattelan%252C-Untitled%252C-2018.jpg&width=800&quality=80"
             />
           </div>
@@ -852,12 +852,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -905,12 +905,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -924,13 +924,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -1039,11 +1039,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Judy Chicago"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FokvgJtWoMGOcqu8jQPM-rg%252F04-Judy-Chicago---Purple-Atmosphere-%25281%2529.jpg&width=800&quality=80"
             />
           </div>
@@ -1053,12 +1053,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1106,12 +1106,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1125,13 +1125,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -1240,11 +1240,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Alex Da Corte"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fm2oi5n0W8HGvQX6E7nqC0w%252Fadc4.jpg&width=800&quality=80"
             />
           </div>
@@ -1254,12 +1254,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1307,12 +1307,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1326,13 +1326,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -1441,11 +1441,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Bruce Nauman"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FrUujNsJxqofZl_aUDfqFRw%252Fl_nauman_greenhorses_1988_02.jpg&width=800&quality=80"
             />
           </div>
@@ -1455,12 +1455,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1508,12 +1508,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1527,13 +1527,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -1642,11 +1642,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Cao Fei"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FkYwGX2zgLX0azm8Nw1D5XQ%252FCao-fei.jpg&width=800&quality=80"
             />
           </div>
@@ -1656,12 +1656,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1709,12 +1709,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1728,13 +1728,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -1843,11 +1843,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Simone Leigh"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fj88zDN6TeQRfRIEoxRkQrg%252FHLA_Plinth_Leigh_Schenck_horizontal.jpg&width=800&quality=80"
             />
           </div>
@@ -1857,12 +1857,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1910,12 +1910,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -1929,13 +1929,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -2044,11 +2044,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="David Hockney"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FN6Ppl6hCbWSi4sSlg8JTWw%252Fhockney.jpg&width=800&quality=80"
             />
           </div>
@@ -2058,12 +2058,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2111,12 +2111,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2130,13 +2130,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -2245,11 +2245,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Wu Tsang"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBR-Vvj7daJkMh130NjyJng%252Fwu1.jpg&width=800&quality=80"
             />
           </div>
@@ -2259,12 +2259,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2312,12 +2312,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2331,13 +2331,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -2446,11 +2446,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Tomás Saraceno"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FuZs7UwgzctSiTGbBaiubaA%252F56_18FRA_PdT_Press_36_AR.jpg&width=800&quality=80"
             />
           </div>
@@ -2460,12 +2460,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2513,12 +2513,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2532,13 +2532,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -2647,11 +2647,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Takashi Murakami"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4vfQ9iy4VgbAQa_8IY_Lqw%252FMurakami-10-web.jpg&width=800&quality=80"
             />
           </div>
@@ -2661,12 +2661,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2714,12 +2714,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2733,13 +2733,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -2848,11 +2848,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Joan Mitchell"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FxRgeOh2cJK2HzWbUVpa4-A%252Fjm1.jpg&width=800&quality=80"
             />
           </div>
@@ -2862,12 +2862,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2915,12 +2915,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -2934,13 +2934,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -3049,11 +3049,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Forensic Architecture"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FTm1l55s5WWabhlGEEN7sYg%252Ffm6.jpg&width=800&quality=80"
             />
           </div>
@@ -3063,12 +3063,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3116,12 +3116,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3135,13 +3135,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -3250,11 +3250,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Wolfgang Tillmans"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FHSAs4GGSc-K_1ZiXvuv-kA%252FTillmans5.jpg&width=800&quality=80"
             />
           </div>
@@ -3264,12 +3264,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3317,12 +3317,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3336,13 +3336,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -3451,11 +3451,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Charline von Heyl"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fm6lI89fEesw43gExCb1HeA%252Fc3.jpg&width=800&quality=80"
             />
           </div>
@@ -3465,12 +3465,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3518,12 +3518,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3537,13 +3537,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -3652,11 +3652,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Charles White"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FV9ah8w3raEYKYCoVweBjLQ%252Fz6.jpg&width=800&quality=80"
             />
           </div>
@@ -3666,12 +3666,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3719,12 +3719,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3738,13 +3738,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -3853,11 +3853,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Andrea Fraser"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco209l53g3nK9mfoMO3cpQ%252Fandrea2.jpg&width=800&quality=80"
             />
           </div>
@@ -3867,12 +3867,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3920,12 +3920,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -3939,13 +3939,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -4054,11 +4054,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="John Bock"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGNsez6zKrcmqu-HvUGDxbw%252Fb1.jpg&width=800&quality=80"
             />
           </div>
@@ -4068,12 +4068,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -4121,12 +4121,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -4140,13 +4140,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
         >
           <div
-            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
             onClick={[Function]}
           >
             <div
@@ -4255,11 +4255,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
           >
             <img
               alt="Kehinde Wiley"
-              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FzyXvajTSQIlmSwD5vitxGQ%252FKehinde3.jpg&width=800&quality=80"
             />
           </div>
@@ -4269,12 +4269,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -4291,12 +4291,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
+            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
             color="black"
           >
             <div
@@ -4315,13 +4315,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
     className="sc-htoDjs dhOLBP"
   >
     <div
-      className="Eoy2018Artists__RelatedArticleWrapper-apetgy-11 ilRGPE"
+      className="Eoy2018Artists__RelatedArticleWrapper-apetgy-11 fAPIhx"
     >
       <div
         className="sc-htoDjs dYiTnf"
       >
         <div
-          className="ArticleCards__ArticlesWrapper-s128ki95-0 iUWMmH"
+          className="ArticleCards__ArticlesWrapper-sc-128ki95-0 hmyaEK"
         >
           <a
             className="ArticleCard ArticleCard__ArticleCardContainer-nqsvxw-2 cVVhNQ"
@@ -4374,7 +4374,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  className="Date__DateContainer-s1u78l60-0 cqHYNi"
+                  className="Date__DateContainer-sc-1u78l60-0 kgTcUj"
                 >
                   <div
                     className="Typography-sc-1pie2ao-0 ehDCiu sc-EHOje fXsUty"
@@ -4417,7 +4417,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 
 exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 <div
-  className="Eoy2018Culture__ArticleWrapper-s14ga9qk-0 fEDjEY"
+  className="Eoy2018Culture__ArticleWrapper-sc-14ga9qk-0 jCdWEv"
 >
   <div>
     <div
@@ -4425,13 +4425,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       color="black"
     >
       <div
-        className="PartnerInline PartnerInline__PartnerInlineContainer-soorph-0 kTrDuE"
+        className="PartnerInline PartnerInline__PartnerInlineContainer-soorph-0 gyUhml"
       >
         <a
           href="/"
         >
           <div
-            className="Icon-s13f8sed-0 dJXNnw"
+            className="Icon-sc-13f8sed-0 gRUzdu"
           >
             
           </div>
@@ -4469,10 +4469,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__SectionWrapper-s14ga9qk-2 hySMjA"
+    className="Eoy2018Culture__SectionWrapper-sc-14ga9qk-2 fNacTa"
   >
     <div
-      className="Eoy2018Culture__ArticleTitle-s14ga9qk-4 WKtvY sc-EHOje iIggoL"
+      className="Eoy2018Culture__ArticleTitle-sc-14ga9qk-4 iyjJQn sc-EHOje iIggoL"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4489,12 +4489,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <img
-      className="Eoy2018Culture__HeaderImg-s14ga9qk-6 gZdkPP"
+      className="Eoy2018Culture__HeaderImg-sc-14ga9qk-6 djOjRI"
       src="https://artsy-media-uploads.s3.amazonaws.com/-XyBoU_ZEbnlyKfjNyu1zA%2Fblack-panther-header.jpg"
     />
   </div>
   <div
-    className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+    className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
   >
     <div
       className="sc-htoDjs dXICTI"
@@ -4513,10 +4513,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           }
         >
           <div
-            className="Share__ShareContainer-s1y1t686-0 PaPVw"
+            className="Share__ShareContainer-sc-1y1t686-0 czsizs"
           >
             <a
-              className="Share__IconWrapper-s1y1t686-1 hTPohU"
+              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018"
               onClick={[Function]}
               target="_blank"
@@ -4542,7 +4542,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="Share__IconWrapper-s1y1t686-1 hTPohU"
+              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018&text=The Year In Culture 2018&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -4568,7 +4568,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="Share__IconWrapper-s1y1t686-1 hTPohU"
+              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
               href="mailto:?subject=The Year In Culture 2018&body=Check out The Year In Culture 2018 on Artsy: https://www.artsy.net/article/artsy-editorial-year-culture-2018"
               onClick={[Function]}
               target="_blank"
@@ -4623,7 +4623,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="Date__DateContainer-s1u78l60-0 cqHYNi"
+            className="Date__DateContainer-sc-1u78l60-0 kgTcUj"
           >
             <div
               className="Typography-sc-1pie2ao-0 ehDCiu sc-EHOje fXsUty"
@@ -4668,7 +4668,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -4678,7 +4678,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -4689,7 +4689,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -4701,17 +4701,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="A still from Donald Glover’s “This Is America” video. Courtesy of the artist."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FcFYhEkcOH68HfFsRha83yA%252Fthis-is-america.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -4766,10 +4766,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -4785,7 +4785,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -4803,7 +4803,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -4818,13 +4818,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -4914,18 +4914,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Donald Glover and Hiro Murai"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FKLtrAvpKSBrd3eeop2N_tw%252FATL_EP209_0048.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -4943,7 +4943,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -4966,7 +4966,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -4976,7 +4976,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -4987,7 +4987,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -4999,17 +4999,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Detail of Amy Sherald, Michelle LaVaughn Robinson Obama, 2018. Courtesy of the National Portrait Gallery, Smithsonian Institution."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FPs8YXbW8eqEo1pn9tWmtUw%252FMichelle-Obama-2-3.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -5064,10 +5064,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -5083,7 +5083,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5101,7 +5101,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -5116,13 +5116,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -5212,18 +5212,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Amy Sherald"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FhTe5F1xOYgvc49JSF86xHQ%252FAmy-Sherald.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5241,7 +5241,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -5264,7 +5264,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -5274,7 +5274,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -5285,7 +5285,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -5297,17 +5297,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Installation view of teamLab, “Borderless,” 2018, at Mori Building Digital Art Museum, Odaiba, Tokyo. © teamLab. Courtesy of Pace Gallery."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FMSmO8KUrvWXG89xkuYTXcQ%252FTeam-Lab-1.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -5362,10 +5362,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -5381,7 +5381,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5399,7 +5399,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -5414,13 +5414,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -5510,18 +5510,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="teamLab"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9Uurw-CkPYfKMpbXOFOaVQ%252F01_Universe-of-Water-Particles-on-a-Rock-where-People-Gather_02.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5539,7 +5539,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -5562,7 +5562,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -5572,7 +5572,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -5583,7 +5583,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -5595,17 +5595,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Photo of Nan Goldin during a protest at the Harvard Art Museums. Photo by TW Collins. Courtesy of P.A.I.N. Sackler. "
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FVGqbgOtSAwLIh4b1i6qUjg%252FNan-Goldin.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -5660,10 +5660,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -5679,7 +5679,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5697,7 +5697,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -5712,13 +5712,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -5808,18 +5808,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Nan Goldin"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fg8dtyJ6h_73di_mnbQNDcA%252FPAIN-Met-Thom-Pavia.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5837,7 +5837,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -5860,7 +5860,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -5870,7 +5870,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -5881,7 +5881,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -5893,17 +5893,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Illustrations by Tim O’Brien for Time. Courtesy of Time."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FyswckDIxtxpMOJVUn0buTA%252Ftrump-cover.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -5958,10 +5958,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -5977,7 +5977,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5995,7 +5995,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -6010,13 +6010,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -6106,18 +6106,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="D.W. Pine"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FE0kxF5gFOcTHmZ7eJkV6qw%252Fdwnewsroom2bw.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6135,7 +6135,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -6158,7 +6158,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -6168,7 +6168,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -6179,7 +6179,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -6191,17 +6191,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Portrait of Virgil Abloh at the Louis Vuitton headquarters © Alex Majoli/Magnum Photos. Courtesy of Magnum Photos."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FB5TJX7T9KhipmIMQNa89UQ%252FVirgilAbloh1.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -6256,10 +6256,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -6275,7 +6275,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6293,7 +6293,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -6308,13 +6308,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -6404,18 +6404,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Virgil Abloh"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FLmo6qr-T4qcliTd5Da00cg%252FVA6.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6433,7 +6433,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -6456,7 +6456,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -6466,7 +6466,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -6477,7 +6477,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -6489,17 +6489,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Photo by Nicolas McComber via Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FqhospIkboXNNaKstMepR8Q%252Fgettyimages-497948239-1024x1024.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -6554,10 +6554,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -6573,7 +6573,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6591,7 +6591,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -6606,13 +6606,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -6702,18 +6702,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="James Monsees and Adam Bowen "
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Flsmscwlt8G99eYm_2ClTDg%252Fcustom-Custom_Size___custom-Custom_Size____Q4A0076.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6731,7 +6731,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -6754,7 +6754,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -6764,7 +6764,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -6775,7 +6775,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -6787,17 +6787,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="A demonstration of SenseTime surveillance software identifying details about people and vehicles. Image by REUTERS/Thomas Peter."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9x64dDN-rzDGvP1I_2_LIA%252FRTS1JOE1.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -6852,10 +6852,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -6871,7 +6871,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6889,7 +6889,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -6904,7 +6904,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6922,7 +6922,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -6945,7 +6945,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -6955,7 +6955,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -6966,7 +6966,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -6978,17 +6978,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Chromat’s “Pool Rules” campaign, 2018. Courtesy of Chromat."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FP60eLGMR2gw-28uv0_HqHg%252FAll-Body-Hair_SQUARE.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -7043,10 +7043,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -7062,7 +7062,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7080,7 +7080,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -7095,13 +7095,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -7191,18 +7191,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Becca McCharen-Tran"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAVsEZBxGBlrimU7CjHLFjA%252Fgiphy%2B%25283%2529.gif&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7220,7 +7220,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -7243,7 +7243,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -7253,7 +7253,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -7264,7 +7264,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -7276,17 +7276,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Detail of Artemisia Gentileschi, Judith and Holofernes, ca. 1620. Courtesy of Uffizi Gallery, Florence."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fi2CYazJvF5wLXzyNKYvieg%252FAG.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -7341,10 +7341,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -7360,7 +7360,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7378,7 +7378,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -7393,7 +7393,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7411,7 +7411,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -7434,7 +7434,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -7444,7 +7444,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -7455,7 +7455,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -7467,17 +7467,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Tyler Mitchell’s portraits of Beyoncé on the September cover of Vogue, 2018. Courtesy of the artist. "
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FLuFZ75Fw5Y3o3ykPG4GlHA%252FTyler-Mitchell.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -7532,10 +7532,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -7551,7 +7551,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7569,7 +7569,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -7584,13 +7584,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -7680,18 +7680,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Tyler Mitchell"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9T0iJeeEigiyxNReF0QfwA%252FTyler-Mitchell-2.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7709,7 +7709,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -7732,7 +7732,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -7742,7 +7742,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -7753,7 +7753,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -7765,17 +7765,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Courtesy of Nike."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fz_OfNx3FevCzKtM5mpladg%252FKaep_Twitter_original.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -7830,10 +7830,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -7849,7 +7849,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7867,7 +7867,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -7882,10 +7882,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__SectionWrapper-s14ga9qk-2 iBCRkf"
+      className="Eoy2018Culture__SectionWrapper-sc-14ga9qk-2 iJmafn"
     />
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7903,7 +7903,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -7926,7 +7926,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -7936,7 +7936,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -7947,7 +7947,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -7959,17 +7959,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Frida Escobedo in the Serpentine Pavilion 2018. Photo by Yui Mok/PA Images via Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FZOqOihulahiEyNTAUIC-KQ%252FFrida.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -8024,10 +8024,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8043,7 +8043,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8061,7 +8061,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -8076,13 +8076,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -8172,18 +8172,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Frida Escobedo"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FFjRmnOVSStJA1gKZTGPFhg%252Fserpentine.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8201,7 +8201,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -8224,7 +8224,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -8234,7 +8234,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8245,7 +8245,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -8257,17 +8257,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="The Peoples Vote March For The Future, October 20, 2018 in London, United Kingdom. Photo by Richard Baker/In Pictures via Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FHFx9YigVAntD6nEK2RsKUA%252FEU-flag.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -8322,10 +8322,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8341,7 +8341,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8359,7 +8359,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -8374,10 +8374,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__SectionWrapper-s14ga9qk-2 iBCRkf"
+      className="Eoy2018Culture__SectionWrapper-sc-14ga9qk-2 iJmafn"
     />
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8395,7 +8395,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -8418,7 +8418,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -8428,7 +8428,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8439,7 +8439,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -8451,17 +8451,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Banksy, Love is in the Bin, 2018. Photo by Ben Stansall/AFP/Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-befF7qZAmHJkDWB2xJkgg%252Fbanksy.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -8516,10 +8516,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8535,7 +8535,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8553,7 +8553,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -8568,16 +8568,16 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__SectionWrapper-s14ga9qk-2 iBCRkf"
+      className="Eoy2018Culture__SectionWrapper-sc-14ga9qk-2 iJmafn"
     />
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -8667,18 +8667,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Banksy"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FnKLf0gK4wyZqXVRABztjMg%252FScreen%2BShot%2B2018-12-18%2Bat%2B5.51.43%2BPM%2Bcopy.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8696,7 +8696,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -8719,7 +8719,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -8729,7 +8729,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8740,7 +8740,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -8752,17 +8752,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Robin Hammond’s photo for the cover of National Geographic’sRace Issue, 2018. Courtesy of the artist."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FTv5WK-OU5YcfcC91v4vMmg%252FRH2.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -8817,10 +8817,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8836,7 +8836,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8854,7 +8854,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -8869,13 +8869,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -8965,18 +8965,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Robin Hammond"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FsrC1j1nSPLkPjq5AnJ_wCw%252FMM8590_170730_005205-2.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8994,7 +8994,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -9017,7 +9017,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -9027,7 +9027,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9038,7 +9038,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -9050,17 +9050,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Meryl Streep, Ai-jen Poo, Natalie Portman, Tarana Burke, Michelle Williams, America Ferrera, Jessica Chastain, Amy Poehler, and activist Saru Jayaraman attend 19th Annual Post-Golden Globes Party, 2018. Photo by Frazer Harrison/Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FbkvGvE6tp2EP19kqnFcpZg%252FTimes-Up.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -9115,10 +9115,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9134,7 +9134,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9152,7 +9152,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -9167,13 +9167,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -9263,18 +9263,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="The Women of Time’s Up"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBe0Sn_Sw53_E6MQoMLGHiQ%252Fwwwb.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9292,7 +9292,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -9315,7 +9315,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -9325,7 +9325,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9336,7 +9336,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -9348,17 +9348,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Icon&#x27;s 3-D Home and Vulcan Printer. Courtesy of New Story."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FonTeTCjr_e83ByifcMtXbw%252F3d.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -9413,10 +9413,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9432,7 +9432,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9450,7 +9450,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -9465,7 +9465,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9483,7 +9483,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -9506,7 +9506,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -9516,7 +9516,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9527,7 +9527,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -9539,17 +9539,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Still from Marvel Studios’ Black Panther, featuring M’Baku (Winston Duke). Photo by Film Frame. Courtesy of and ©Marvel Studios 2018."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F_l1KjIyqKDM91G16jKyaXw%252FRET0780_v130_1081.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -9604,10 +9604,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9623,7 +9623,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9641,7 +9641,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -9656,13 +9656,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -9752,18 +9752,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Ruth E. Carter"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FdaecYc_R6lkMny_y75k0gg%252FMBB7040_v044.1008-%25281%2529.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9781,7 +9781,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -9804,7 +9804,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -9814,7 +9814,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9825,7 +9825,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -9837,17 +9837,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Photo by John Moore/Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4shupex2D9w9PWXdTmAMzA%252FJohn-Moore.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -9902,10 +9902,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9921,7 +9921,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9939,7 +9939,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -9954,13 +9954,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -10050,18 +10050,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="John Moore"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-abSduBjHqXS9GUQF3d77g%252FGettyImages-1052458070-%25281%2529.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10079,7 +10079,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -10102,7 +10102,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -10112,7 +10112,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10123,7 +10123,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -10135,17 +10135,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Film still from Crazy Rich Asians. © 2018 Warner Bros. Entertainment Inc. and Kimmel Distribution, LLC. Photo courtesy of Warner Bros. Pictures. "
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FkpnNQ1PlOLDm36GE6hs-cg%252FCRA3.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -10200,10 +10200,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10219,7 +10219,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10237,7 +10237,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -10252,13 +10252,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -10348,18 +10348,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Jon M. Chu"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FfgsmCOJQ0x-CHwAUG9d-GQ%252FCra30.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10377,7 +10377,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -10400,7 +10400,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -10410,7 +10410,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10421,7 +10421,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -10433,17 +10433,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Millicent Fawcett, 2018. Photo by Garry Knight, via Flickr. "
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FXhJSikVVXBGXnzCgeCM1aQ%252FMF.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -10498,10 +10498,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10517,7 +10517,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10535,7 +10535,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -10550,7 +10550,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10568,7 +10568,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -10591,7 +10591,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -10601,7 +10601,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10612,7 +10612,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -10624,17 +10624,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Portrait of Sean Combs by Kevin Mazur/WireImage."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FQuNflQwi_NT0JbQT5tdnUg%252FSean-Combs.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -10689,10 +10689,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10708,7 +10708,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10726,7 +10726,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -10741,13 +10741,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -10837,18 +10837,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Sean Combs"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAtL5eJG3iSkwG3Kqx3u3wg%252FSean-Combs.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10866,7 +10866,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -10889,7 +10889,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
   >
     <span
       style={
@@ -10899,7 +10899,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10910,7 +10910,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -10922,17 +10922,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Red Antler&#x27;s branding designs for Burrow on the New York subway. Courtesy of Red Antler."
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FfUmNBMo9PJ2XTbLGd0bunw%252FBurrow4.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -10987,10 +10987,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -11006,7 +11006,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11024,7 +11024,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -11039,13 +11039,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -11135,18 +11135,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Emily Heyward, JB Osborne, and Simon Endres"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FQBYknGwt3MpId7Omep3oSQ%252Fcasper.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11164,7 +11164,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
+            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
             color="#000"
           >
             <div
@@ -11187,7 +11187,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
+    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
   >
     <span
       style={
@@ -11197,7 +11197,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
+      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
     >
       <div
         dangerouslySetInnerHTML={
@@ -11208,7 +11208,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
+      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -11220,17 +11220,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
+              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
             >
               <img
                 alt="Make America Great Again with Spider Martin in Pearl, MS, 2016. Courtesy of Wyatt Gallery/For Freedoms. "
-                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
+                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FG7L_BaQLUPAo6Er5_SqQjw%252Ffor-freedoms.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
+                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -11285,10 +11285,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
+              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
             >
               <div
-                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
+                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -11304,7 +11304,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11322,7 +11322,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -11337,13 +11337,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
+      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
+        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
       >
         <div
-          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
+          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
           onClick={[Function]}
         >
           <div
@@ -11433,18 +11433,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
+          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
         >
           <img
             alt="Hank Willis Thomas and Eric Gottesman"
-            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
+            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F51DvSBZIfkbuWp8rkvHNtQ%252FUNC_Greensboro_LawnSignActivation.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11462,7 +11462,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div
@@ -11477,7 +11477,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
+      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11495,7 +11495,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
+            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
             color="white"
           >
             <div

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
       color="#000"
     >
       <div
-        className="PartnerInline PartnerInline__PartnerInlineContainer-soorph-0 gyUhml"
+        className="PartnerInline PartnerInline__PartnerInlineContainer-soorph-0 kTrDuE"
       >
         <a
           href="/"
         >
           <div
-            className="Icon-sc-13f8sed-0 cEKJrA"
+            className="Icon-s13f8sed-0 eScAls"
           >
             
           </div>
@@ -122,10 +122,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
       className="Eoy2018Artists__ArticleContent-apetgy-2 dvYCoX"
     >
       <div
-        className="Eoy2018Artists__IntroSection-apetgy-6 kRsgop"
+        className="Eoy2018Artists__IntroSection-apetgy-6 jkuGpk"
       >
         <div
-          className="Byline Byline__BylineContainer-sc-1iqb1j2-0 lnQvdw"
+          className="Byline Byline__BylineContainer-s1iqb1j2-0 dGLzes"
           color="black"
         >
           <div
@@ -146,7 +146,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="Date__DateContainer-sc-1u78l60-0 kgTcUj"
+            className="Date__DateContainer-s1u78l60-0 cqHYNi"
           >
             <div
               className="Typography-sc-1pie2ao-0 ehDCiu sc-EHOje fXsUty"
@@ -162,10 +162,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="Share__ShareContainer-sc-1y1t686-0 czsizs"
+            className="Share__ShareContainer-s1y1t686-0 PaPVw"
           >
             <a
-              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
+              className="Share__IconWrapper-s1y1t686-1 hTPohU"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018"
               onClick={[Function]}
               target="_blank"
@@ -191,7 +191,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
+              className="Share__IconWrapper-s1y1t686-1 hTPohU"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018&text=The Most Influential Artists of 2018&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -217,7 +217,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
+              className="Share__IconWrapper-s1y1t686-1 hTPohU"
               href="mailto:?subject=The Most Influential Artists of 2018&body=Check out The Most Influential Artists of 2018 on Artsy: https://www.artsy.net/article/artsy-editorial-influential-artists-2018"
               onClick={[Function]}
               target="_blank"
@@ -248,12 +248,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           className="sc-htoDjs grMeOB"
         >
           <div
-            className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+            className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
             fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
             fontSize="22px"
           >
             <div
-              className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+              className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
               color="black"
             >
               <div
@@ -302,12 +302,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -321,13 +321,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -436,11 +436,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Kerry James Marshall"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FX8Ew_Hp2QurfxBx4A_hOJQ%252Fd7hftxdivxxvm.cloudfront-4.jpg&width=800&quality=80"
             />
           </div>
@@ -450,12 +450,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -503,12 +503,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -522,13 +522,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -637,11 +637,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Adrian Piper"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F8CIBxY3JyP8Cw4g1piRRTQ%252Fadrian2.jpg&width=800&quality=80"
             />
           </div>
@@ -651,12 +651,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -704,12 +704,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -723,13 +723,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -838,11 +838,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Maurizio Cattelan"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FrFQMyKzr0rr2J2dyE8Z_CQ%252FMaurizio-Cattelan%252C-Untitled%252C-2018.jpg&width=800&quality=80"
             />
           </div>
@@ -852,12 +852,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -905,12 +905,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -924,13 +924,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -1039,11 +1039,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Judy Chicago"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FokvgJtWoMGOcqu8jQPM-rg%252F04-Judy-Chicago---Purple-Atmosphere-%25281%2529.jpg&width=800&quality=80"
             />
           </div>
@@ -1053,12 +1053,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1106,12 +1106,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1125,13 +1125,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -1240,11 +1240,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Alex Da Corte"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fm2oi5n0W8HGvQX6E7nqC0w%252Fadc4.jpg&width=800&quality=80"
             />
           </div>
@@ -1254,12 +1254,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1307,12 +1307,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1326,13 +1326,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -1441,11 +1441,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Bruce Nauman"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FrUujNsJxqofZl_aUDfqFRw%252Fl_nauman_greenhorses_1988_02.jpg&width=800&quality=80"
             />
           </div>
@@ -1455,12 +1455,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1508,12 +1508,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1527,13 +1527,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -1642,11 +1642,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Cao Fei"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FkYwGX2zgLX0azm8Nw1D5XQ%252FCao-fei.jpg&width=800&quality=80"
             />
           </div>
@@ -1656,12 +1656,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1709,12 +1709,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1728,13 +1728,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -1843,11 +1843,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Simone Leigh"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fj88zDN6TeQRfRIEoxRkQrg%252FHLA_Plinth_Leigh_Schenck_horizontal.jpg&width=800&quality=80"
             />
           </div>
@@ -1857,12 +1857,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1910,12 +1910,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -1929,13 +1929,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -2044,11 +2044,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="David Hockney"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FN6Ppl6hCbWSi4sSlg8JTWw%252Fhockney.jpg&width=800&quality=80"
             />
           </div>
@@ -2058,12 +2058,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2111,12 +2111,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2130,13 +2130,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -2245,11 +2245,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Wu Tsang"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBR-Vvj7daJkMh130NjyJng%252Fwu1.jpg&width=800&quality=80"
             />
           </div>
@@ -2259,12 +2259,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2312,12 +2312,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2331,13 +2331,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -2446,11 +2446,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Tomás Saraceno"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FuZs7UwgzctSiTGbBaiubaA%252F56_18FRA_PdT_Press_36_AR.jpg&width=800&quality=80"
             />
           </div>
@@ -2460,12 +2460,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2513,12 +2513,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2532,13 +2532,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -2647,11 +2647,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Takashi Murakami"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4vfQ9iy4VgbAQa_8IY_Lqw%252FMurakami-10-web.jpg&width=800&quality=80"
             />
           </div>
@@ -2661,12 +2661,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2714,12 +2714,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2733,13 +2733,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -2848,11 +2848,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Joan Mitchell"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FxRgeOh2cJK2HzWbUVpa4-A%252Fjm1.jpg&width=800&quality=80"
             />
           </div>
@@ -2862,12 +2862,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2915,12 +2915,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -2934,13 +2934,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -3049,11 +3049,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Forensic Architecture"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FTm1l55s5WWabhlGEEN7sYg%252Ffm6.jpg&width=800&quality=80"
             />
           </div>
@@ -3063,12 +3063,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3116,12 +3116,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3135,13 +3135,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -3250,11 +3250,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Wolfgang Tillmans"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FHSAs4GGSc-K_1ZiXvuv-kA%252FTillmans5.jpg&width=800&quality=80"
             />
           </div>
@@ -3264,12 +3264,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3317,12 +3317,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3336,13 +3336,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -3451,11 +3451,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Charline von Heyl"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fm6lI89fEesw43gExCb1HeA%252Fc3.jpg&width=800&quality=80"
             />
           </div>
@@ -3465,12 +3465,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3518,12 +3518,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3537,13 +3537,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -3652,11 +3652,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Charles White"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FV9ah8w3raEYKYCoVweBjLQ%252Fz6.jpg&width=800&quality=80"
             />
           </div>
@@ -3666,12 +3666,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3719,12 +3719,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3738,13 +3738,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -3853,11 +3853,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Andrea Fraser"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco209l53g3nK9mfoMO3cpQ%252Fandrea2.jpg&width=800&quality=80"
             />
           </div>
@@ -3867,12 +3867,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3920,12 +3920,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -3939,13 +3939,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -4054,11 +4054,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="John Bock"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGNsez6zKrcmqu-HvUGDxbw%252Fb1.jpg&width=800&quality=80"
             />
           </div>
@@ -4068,12 +4068,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -4121,12 +4121,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 iIxALY sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 hkxbVg sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -4140,13 +4140,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 hAkxpi"
+        className="Eoy2018Artists__ImageSetWrapper-apetgy-10 eQUhbC"
       >
         <div
-          className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+          className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
         >
           <div
-            className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+            className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
             onClick={[Function]}
           >
             <div
@@ -4255,11 +4255,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+            className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
           >
             <img
               alt="Kehinde Wiley"
-              className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+              className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FzyXvajTSQIlmSwD5vitxGQ%252FKehinde3.jpg&width=800&quality=80"
             />
           </div>
@@ -4269,12 +4269,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -4291,12 +4291,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="sc-htoDjs grMeOB"
       >
         <div
-          className="Eoy2018Artists__TextSection-apetgy-7 dolsGf sc-EHOje dJpJwb"
+          className="Eoy2018Artists__TextSection-apetgy-7 kpVGib sc-EHOje dJpJwb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 fueZGM"
+            className="article__text-section StyledText-s1ysl1h-0 fSYeZy"
             color="black"
           >
             <div
@@ -4315,13 +4315,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
     className="sc-htoDjs dhOLBP"
   >
     <div
-      className="Eoy2018Artists__RelatedArticleWrapper-apetgy-11 fAPIhx"
+      className="Eoy2018Artists__RelatedArticleWrapper-apetgy-11 ilRGPE"
     >
       <div
         className="sc-htoDjs dYiTnf"
       >
         <div
-          className="ArticleCards__ArticlesWrapper-sc-128ki95-0 hmyaEK"
+          className="ArticleCards__ArticlesWrapper-s128ki95-0 iUWMmH"
         >
           <a
             className="ArticleCard ArticleCard__ArticleCardContainer-nqsvxw-2 cVVhNQ"
@@ -4374,7 +4374,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  className="Date__DateContainer-sc-1u78l60-0 kgTcUj"
+                  className="Date__DateContainer-s1u78l60-0 cqHYNi"
                 >
                   <div
                     className="Typography-sc-1pie2ao-0 ehDCiu sc-EHOje fXsUty"
@@ -4417,7 +4417,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 
 exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 <div
-  className="Eoy2018Culture__ArticleWrapper-sc-14ga9qk-0 jCdWEv"
+  className="Eoy2018Culture__ArticleWrapper-s14ga9qk-0 fEDjEY"
 >
   <div>
     <div
@@ -4425,13 +4425,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       color="black"
     >
       <div
-        className="PartnerInline PartnerInline__PartnerInlineContainer-soorph-0 gyUhml"
+        className="PartnerInline PartnerInline__PartnerInlineContainer-soorph-0 kTrDuE"
       >
         <a
           href="/"
         >
           <div
-            className="Icon-sc-13f8sed-0 gRUzdu"
+            className="Icon-s13f8sed-0 dJXNnw"
           >
             
           </div>
@@ -4469,10 +4469,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__SectionWrapper-sc-14ga9qk-2 fNacTa"
+    className="Eoy2018Culture__SectionWrapper-s14ga9qk-2 hySMjA"
   >
     <div
-      className="Eoy2018Culture__ArticleTitle-sc-14ga9qk-4 iyjJQn sc-EHOje iIggoL"
+      className="Eoy2018Culture__ArticleTitle-s14ga9qk-4 WKtvY sc-EHOje iIggoL"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4489,12 +4489,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <img
-      className="Eoy2018Culture__HeaderImg-sc-14ga9qk-6 djOjRI"
+      className="Eoy2018Culture__HeaderImg-s14ga9qk-6 gZdkPP"
       src="https://artsy-media-uploads.s3.amazonaws.com/-XyBoU_ZEbnlyKfjNyu1zA%2Fblack-panther-header.jpg"
     />
   </div>
   <div
-    className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+    className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
   >
     <div
       className="sc-htoDjs dXICTI"
@@ -4513,10 +4513,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           }
         >
           <div
-            className="Share__ShareContainer-sc-1y1t686-0 czsizs"
+            className="Share__ShareContainer-s1y1t686-0 PaPVw"
           >
             <a
-              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
+              className="Share__IconWrapper-s1y1t686-1 hTPohU"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018"
               onClick={[Function]}
               target="_blank"
@@ -4542,7 +4542,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
+              className="Share__IconWrapper-s1y1t686-1 hTPohU"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018&text=The Year In Culture 2018&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -4568,7 +4568,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="Share__IconWrapper-sc-1y1t686-1 iIadxt"
+              className="Share__IconWrapper-s1y1t686-1 hTPohU"
               href="mailto:?subject=The Year In Culture 2018&body=Check out The Year In Culture 2018 on Artsy: https://www.artsy.net/article/artsy-editorial-year-culture-2018"
               onClick={[Function]}
               target="_blank"
@@ -4623,7 +4623,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="Date__DateContainer-sc-1u78l60-0 kgTcUj"
+            className="Date__DateContainer-s1u78l60-0 cqHYNi"
           >
             <div
               className="Typography-sc-1pie2ao-0 ehDCiu sc-EHOje fXsUty"
@@ -4668,7 +4668,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -4678,7 +4678,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -4689,7 +4689,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -4701,17 +4701,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="A still from Donald Glover’s “This Is America” video. Courtesy of the artist."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FcFYhEkcOH68HfFsRha83yA%252Fthis-is-america.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -4766,10 +4766,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -4785,7 +4785,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -4803,7 +4803,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -4818,13 +4818,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -4914,18 +4914,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Donald Glover and Hiro Murai"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FKLtrAvpKSBrd3eeop2N_tw%252FATL_EP209_0048.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -4943,7 +4943,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -4966,7 +4966,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -4976,7 +4976,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -4987,7 +4987,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -4999,17 +4999,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Detail of Amy Sherald, Michelle LaVaughn Robinson Obama, 2018. Courtesy of the National Portrait Gallery, Smithsonian Institution."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FPs8YXbW8eqEo1pn9tWmtUw%252FMichelle-Obama-2-3.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -5064,10 +5064,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -5083,7 +5083,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5101,7 +5101,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -5116,13 +5116,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -5212,18 +5212,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Amy Sherald"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FhTe5F1xOYgvc49JSF86xHQ%252FAmy-Sherald.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5241,7 +5241,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -5264,7 +5264,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -5274,7 +5274,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -5285,7 +5285,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -5297,17 +5297,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Installation view of teamLab, “Borderless,” 2018, at Mori Building Digital Art Museum, Odaiba, Tokyo. © teamLab. Courtesy of Pace Gallery."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FMSmO8KUrvWXG89xkuYTXcQ%252FTeam-Lab-1.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -5362,10 +5362,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -5381,7 +5381,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5399,7 +5399,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -5414,13 +5414,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -5510,18 +5510,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="teamLab"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9Uurw-CkPYfKMpbXOFOaVQ%252F01_Universe-of-Water-Particles-on-a-Rock-where-People-Gather_02.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5539,7 +5539,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -5562,7 +5562,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -5572,7 +5572,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -5583,7 +5583,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -5595,17 +5595,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Photo of Nan Goldin during a protest at the Harvard Art Museums. Photo by TW Collins. Courtesy of P.A.I.N. Sackler. "
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FVGqbgOtSAwLIh4b1i6qUjg%252FNan-Goldin.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -5660,10 +5660,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -5679,7 +5679,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5697,7 +5697,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -5712,13 +5712,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -5808,18 +5808,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Nan Goldin"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fg8dtyJ6h_73di_mnbQNDcA%252FPAIN-Met-Thom-Pavia.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5837,7 +5837,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -5860,7 +5860,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -5870,7 +5870,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -5881,7 +5881,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -5893,17 +5893,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Illustrations by Tim O’Brien for Time. Courtesy of Time."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FyswckDIxtxpMOJVUn0buTA%252Ftrump-cover.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -5958,10 +5958,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -5977,7 +5977,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -5995,7 +5995,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -6010,13 +6010,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -6106,18 +6106,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="D.W. Pine"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FE0kxF5gFOcTHmZ7eJkV6qw%252Fdwnewsroom2bw.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6135,7 +6135,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -6158,7 +6158,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -6168,7 +6168,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -6179,7 +6179,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -6191,17 +6191,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Portrait of Virgil Abloh at the Louis Vuitton headquarters © Alex Majoli/Magnum Photos. Courtesy of Magnum Photos."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FB5TJX7T9KhipmIMQNa89UQ%252FVirgilAbloh1.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -6256,10 +6256,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -6275,7 +6275,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6293,7 +6293,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -6308,13 +6308,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -6404,18 +6404,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Virgil Abloh"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FLmo6qr-T4qcliTd5Da00cg%252FVA6.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6433,7 +6433,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -6456,7 +6456,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -6466,7 +6466,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -6477,7 +6477,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -6489,17 +6489,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Photo by Nicolas McComber via Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FqhospIkboXNNaKstMepR8Q%252Fgettyimages-497948239-1024x1024.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -6554,10 +6554,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -6573,7 +6573,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6591,7 +6591,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -6606,13 +6606,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -6702,18 +6702,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="James Monsees and Adam Bowen "
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Flsmscwlt8G99eYm_2ClTDg%252Fcustom-Custom_Size___custom-Custom_Size____Q4A0076.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6731,7 +6731,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -6754,7 +6754,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -6764,7 +6764,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -6775,7 +6775,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -6787,17 +6787,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="A demonstration of SenseTime surveillance software identifying details about people and vehicles. Image by REUTERS/Thomas Peter."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9x64dDN-rzDGvP1I_2_LIA%252FRTS1JOE1.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -6852,10 +6852,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -6871,7 +6871,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6889,7 +6889,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -6904,7 +6904,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -6922,7 +6922,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -6945,7 +6945,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -6955,7 +6955,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -6966,7 +6966,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -6978,17 +6978,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Chromat’s “Pool Rules” campaign, 2018. Courtesy of Chromat."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FP60eLGMR2gw-28uv0_HqHg%252FAll-Body-Hair_SQUARE.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -7043,10 +7043,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -7062,7 +7062,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7080,7 +7080,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -7095,13 +7095,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -7191,18 +7191,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Becca McCharen-Tran"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAVsEZBxGBlrimU7CjHLFjA%252Fgiphy%2B%25283%2529.gif&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7220,7 +7220,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -7243,7 +7243,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -7253,7 +7253,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -7264,7 +7264,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -7276,17 +7276,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Detail of Artemisia Gentileschi, Judith and Holofernes, ca. 1620. Courtesy of Uffizi Gallery, Florence."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fi2CYazJvF5wLXzyNKYvieg%252FAG.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -7341,10 +7341,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -7360,7 +7360,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7378,7 +7378,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -7393,7 +7393,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7411,7 +7411,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -7434,7 +7434,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -7444,7 +7444,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -7455,7 +7455,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -7467,17 +7467,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Tyler Mitchell’s portraits of Beyoncé on the September cover of Vogue, 2018. Courtesy of the artist. "
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FLuFZ75Fw5Y3o3ykPG4GlHA%252FTyler-Mitchell.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -7532,10 +7532,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -7551,7 +7551,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7569,7 +7569,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -7584,13 +7584,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -7680,18 +7680,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Tyler Mitchell"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9T0iJeeEigiyxNReF0QfwA%252FTyler-Mitchell-2.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7709,7 +7709,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -7732,7 +7732,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -7742,7 +7742,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -7753,7 +7753,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -7765,17 +7765,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Courtesy of Nike."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fz_OfNx3FevCzKtM5mpladg%252FKaep_Twitter_original.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -7830,10 +7830,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -7849,7 +7849,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7867,7 +7867,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -7882,10 +7882,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__SectionWrapper-sc-14ga9qk-2 iJmafn"
+      className="Eoy2018Culture__SectionWrapper-s14ga9qk-2 iBCRkf"
     />
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -7903,7 +7903,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -7926,7 +7926,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -7936,7 +7936,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -7947,7 +7947,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -7959,17 +7959,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Frida Escobedo in the Serpentine Pavilion 2018. Photo by Yui Mok/PA Images via Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FZOqOihulahiEyNTAUIC-KQ%252FFrida.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -8024,10 +8024,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8043,7 +8043,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8061,7 +8061,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -8076,13 +8076,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -8172,18 +8172,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Frida Escobedo"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FFjRmnOVSStJA1gKZTGPFhg%252Fserpentine.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8201,7 +8201,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -8224,7 +8224,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -8234,7 +8234,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8245,7 +8245,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -8257,17 +8257,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="The Peoples Vote March For The Future, October 20, 2018 in London, United Kingdom. Photo by Richard Baker/In Pictures via Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FHFx9YigVAntD6nEK2RsKUA%252FEU-flag.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -8322,10 +8322,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8341,7 +8341,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8359,7 +8359,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -8374,10 +8374,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__SectionWrapper-sc-14ga9qk-2 iJmafn"
+      className="Eoy2018Culture__SectionWrapper-s14ga9qk-2 iBCRkf"
     />
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8395,7 +8395,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -8418,7 +8418,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -8428,7 +8428,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8439,7 +8439,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -8451,17 +8451,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Banksy, Love is in the Bin, 2018. Photo by Ben Stansall/AFP/Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-befF7qZAmHJkDWB2xJkgg%252Fbanksy.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -8516,10 +8516,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8535,7 +8535,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8553,7 +8553,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -8568,16 +8568,16 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__SectionWrapper-sc-14ga9qk-2 iJmafn"
+      className="Eoy2018Culture__SectionWrapper-s14ga9qk-2 iBCRkf"
     />
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -8667,18 +8667,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Banksy"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FnKLf0gK4wyZqXVRABztjMg%252FScreen%2BShot%2B2018-12-18%2Bat%2B5.51.43%2BPM%2Bcopy.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8696,7 +8696,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -8719,7 +8719,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -8729,7 +8729,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8740,7 +8740,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -8752,17 +8752,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Robin Hammond’s photo for the cover of National Geographic’sRace Issue, 2018. Courtesy of the artist."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FTv5WK-OU5YcfcC91v4vMmg%252FRH2.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -8817,10 +8817,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8836,7 +8836,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8854,7 +8854,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -8869,13 +8869,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -8965,18 +8965,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Robin Hammond"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FsrC1j1nSPLkPjq5AnJ_wCw%252FMM8590_170730_005205-2.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -8994,7 +8994,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -9017,7 +9017,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -9027,7 +9027,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9038,7 +9038,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -9050,17 +9050,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Meryl Streep, Ai-jen Poo, Natalie Portman, Tarana Burke, Michelle Williams, America Ferrera, Jessica Chastain, Amy Poehler, and activist Saru Jayaraman attend 19th Annual Post-Golden Globes Party, 2018. Photo by Frazer Harrison/Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FbkvGvE6tp2EP19kqnFcpZg%252FTimes-Up.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -9115,10 +9115,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9134,7 +9134,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9152,7 +9152,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -9167,13 +9167,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -9263,18 +9263,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="The Women of Time’s Up"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBe0Sn_Sw53_E6MQoMLGHiQ%252Fwwwb.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9292,7 +9292,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -9315,7 +9315,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -9325,7 +9325,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9336,7 +9336,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -9348,17 +9348,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Icon&#x27;s 3-D Home and Vulcan Printer. Courtesy of New Story."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FonTeTCjr_e83ByifcMtXbw%252F3d.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -9413,10 +9413,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9432,7 +9432,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9450,7 +9450,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -9465,7 +9465,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9483,7 +9483,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -9506,7 +9506,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -9516,7 +9516,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9527,7 +9527,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -9539,17 +9539,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Still from Marvel Studios’ Black Panther, featuring M’Baku (Winston Duke). Photo by Film Frame. Courtesy of and ©Marvel Studios 2018."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F_l1KjIyqKDM91G16jKyaXw%252FRET0780_v130_1081.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -9604,10 +9604,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9623,7 +9623,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9641,7 +9641,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -9656,13 +9656,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -9752,18 +9752,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Ruth E. Carter"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FdaecYc_R6lkMny_y75k0gg%252FMBB7040_v044.1008-%25281%2529.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9781,7 +9781,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -9804,7 +9804,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -9814,7 +9814,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9825,7 +9825,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -9837,17 +9837,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Photo by John Moore/Getty Images."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4shupex2D9w9PWXdTmAMzA%252FJohn-Moore.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -9902,10 +9902,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9921,7 +9921,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -9939,7 +9939,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -9954,13 +9954,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -10050,18 +10050,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="John Moore"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-abSduBjHqXS9GUQF3d77g%252FGettyImages-1052458070-%25281%2529.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10079,7 +10079,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -10102,7 +10102,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -10112,7 +10112,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10123,7 +10123,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -10135,17 +10135,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Film still from Crazy Rich Asians. © 2018 Warner Bros. Entertainment Inc. and Kimmel Distribution, LLC. Photo courtesy of Warner Bros. Pictures. "
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FkpnNQ1PlOLDm36GE6hs-cg%252FCRA3.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -10200,10 +10200,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10219,7 +10219,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10237,7 +10237,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -10252,13 +10252,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -10348,18 +10348,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Jon M. Chu"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FfgsmCOJQ0x-CHwAUG9d-GQ%252FCra30.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10377,7 +10377,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -10400,7 +10400,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -10410,7 +10410,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10421,7 +10421,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -10433,17 +10433,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Millicent Fawcett, 2018. Photo by Garry Knight, via Flickr. "
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FXhJSikVVXBGXnzCgeCM1aQ%252FMF.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -10498,10 +10498,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10517,7 +10517,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10535,7 +10535,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -10550,7 +10550,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10568,7 +10568,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -10591,7 +10591,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -10601,7 +10601,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10612,7 +10612,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -10624,17 +10624,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Portrait of Sean Combs by Kevin Mazur/WireImage."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FQuNflQwi_NT0JbQT5tdnUg%252FSean-Combs.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -10689,10 +10689,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10708,7 +10708,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10726,7 +10726,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -10741,13 +10741,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -10837,18 +10837,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Sean Combs"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAtL5eJG3iSkwG3Kqx3u3wg%252FSean-Combs.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -10866,7 +10866,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -10889,7 +10889,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 cAYGsm"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 kxvhOA"
   >
     <span
       style={
@@ -10899,7 +10899,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10910,7 +10910,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -10922,17 +10922,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Red Antler&#x27;s branding designs for Burrow on the New York subway. Courtesy of Red Antler."
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FfUmNBMo9PJ2XTbLGd0bunw%252FBurrow4.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -10987,10 +10987,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -11006,7 +11006,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11024,7 +11024,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -11039,13 +11039,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -11135,18 +11135,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Emily Heyward, JB Osborne, and Simon Endres"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FQBYknGwt3MpId7Omep3oSQ%252Fcasper.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11164,7 +11164,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 kghsGz"
+            className="article__text-section StyledText-s1ysl1h-0 hxcNnb"
             color="#000"
           >
             <div
@@ -11187,7 +11187,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="Eoy2018Culture__ChapterWrapper-sc-14ga9qk-1 isnIvf"
+    className="Eoy2018Culture__ChapterWrapper-s14ga9qk-1 bOBEkK"
   >
     <span
       style={
@@ -11197,7 +11197,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="Eoy2018Culture__SectionHeader-sc-14ga9qk-5 iqCEJt"
+      className="Eoy2018Culture__SectionHeader-s14ga9qk-5 jgZaUH"
     >
       <div
         dangerouslySetInnerHTML={
@@ -11208,7 +11208,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="Eoy2018Culture__ImageWrapper-sc-14ga9qk-7 gQkAPp"
+      className="Eoy2018Culture__ImageWrapper-s14ga9qk-7 ejgeec"
     >
       <div
         className="ImageCollection__ImageCollectionContainer-begb1k-0 gAZlUz"
@@ -11220,17 +11220,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article-image"
           >
             <div
-              className="ImageWrapper__StyledImageWrapper-sc-87c4qo-1 cLMWhb"
+              className="ImageWrapper__StyledImageWrapper-s87c4qo-1 cLoUGY"
             >
               <img
                 alt="Make America Great Again with Spider Martin in Pearl, MS, 2016. Courtesy of Wyatt Gallery/For Freedoms. "
-                className="BlockImage__container ImageWrapper__BlockImage-sc-87c4qo-2 bsOwzN"
+                className="BlockImage__container ImageWrapper__BlockImage-s87c4qo-2 gMPGCs"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FG7L_BaQLUPAo6Er5_SqQjw%252Ffor-freedoms.jpg&width=1200&quality=80"
                 width="100%"
               />
               <div
-                className="ImageWrapper__Fullscreen-sc-87c4qo-0 iEvuFu"
+                className="ImageWrapper__Fullscreen-s87c4qo-0 FniyA"
               >
                 <div
                   className="ViewFullscreen__ViewFullscreenLink-g6oqwx-0 dVFxUj"
@@ -11285,10 +11285,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="Caption__CaptionContainer-sc-1c6ztax-0 hViexZ"
+              className="Caption__CaptionContainer-s1c6ztax-0 dIEkoq"
             >
               <div
-                className="Caption__Figcaption-sc-1c6ztax-1 gfGWzf"
+                className="Caption__Figcaption-s1c6ztax-1 elHbuT"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -11304,7 +11304,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11322,7 +11322,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -11337,13 +11337,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__ImageSetWrapper-sc-14ga9qk-8 ibbnfq"
+      className="Eoy2018Culture__ImageSetWrapper-s14ga9qk-8 eoiCxj"
     >
       <div
-        className="ImageSetPreview__ImageSetContainer-sc-1pp4y1-0 hIuyQc"
+        className="ImageSetPreview__ImageSetContainer-s1pp4y1-0 bkAlRb"
       >
         <div
-          className="ImageSetPreview__FullLabel-sc-1pp4y1-1 bLyWbd"
+          className="ImageSetPreview__FullLabel-s1pp4y1-1 imvxad"
           onClick={[Function]}
         >
           <div
@@ -11433,18 +11433,18 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ImageSetPreview__ImgContainer-sc-1pp4y1-3 hVRqis"
+          className="ImageSetPreview__ImgContainer-s1pp4y1-3 cXixQr"
         >
           <img
             alt="Hank Willis Thomas and Eric Gottesman"
-            className="ImageSetPreview__Img-sc-1pp4y1-2 iiHvkk"
+            className="ImageSetPreview__Img-s1pp4y1-2 kYtGoI"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F51DvSBZIfkbuWp8rkvHNtQ%252FUNC_Greensboro_LawnSignActivation.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11462,7 +11462,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div
@@ -11477,7 +11477,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="Eoy2018Culture__TextContainer-sc-14ga9qk-3 ktZCSI"
+      className="Eoy2018Culture__TextContainer-s14ga9qk-3 dMHmzE"
     >
       <div
         className="sc-htoDjs eoYKwy"
@@ -11495,7 +11495,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <div
-            className="article__text-section StyledText-sc-1ysl1h-0 dCQqJm"
+            className="article__text-section StyledText-s1ysl1h-0 hQFqsY"
             color="white"
           >
             <div


### PR DESCRIPTION
This allows the SearchBar to start off initially w/o making an unnecessary round trip to MP (requesting `viewer {}`), since that's unneeded for the initial state.

This was based off of a discussion in the [Relay Slack chat](https://graphql.slack.com/archives/C0BEXJLKG/p1550598752174300), with this solution (modifying the network layer) seeming to be the most workable.