### PR TITLE
Update SearchBar to better match comps

### DIFF
--- a/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
@@ -47,7 +47,7 @@ export const RelatedArtworksPreviewFragmentContainer = createFragmentContainer(
         artist_id: $entityID
       ) {
         __id
-        artworks_connection(first: 8) {
+        artworks_connection(first: 10) {
           edges {
             node {
               ...PreviewGridItem_artwork

--- a/src/Components/Search/Previews/Grids/ArtistSearch/index.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/index.tsx
@@ -35,7 +35,7 @@ export const ArtistSearchPreviewFragmentContainer = createFragmentContainer(
       @argumentDefinitions(entityID: { type: "String!" }) {
       artist(id: $entityID) {
         id
-        marketingCollections {
+        marketingCollections(size: 6) {
           title
           ...MarketingCollectionsPreview_marketingCollections
         }

--- a/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
@@ -47,7 +47,7 @@ export const MerchandisableArtworksPreviewFragmentContainer = createFragmentCont
     fragment MerchandisableArtworks_viewer on Viewer {
       filter_artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
         __id
-        artworks_connection(first: 8) {
+        artworks_connection(first: 10) {
           edges {
             node {
               ...PreviewGridItem_artwork

--- a/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
+++ b/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
@@ -12,7 +12,7 @@ interface PreviewGridItemProps {
   emphasizeArtist?: boolean
 }
 
-const Title = styled(Serif).attrs({ italic: true })`
+const OverflowEllipsis = styled(Serif)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -42,12 +42,15 @@ export const PreviewGridItem: React.SFC<PreviewGridItemProps> = ({
       </Link>
       <Link href={artwork.href} noUnderline>
         <Box>
-          <Title size="2">
+          <OverflowEllipsis size="2" italic>
             {artwork.title}, {artwork.date}
-          </Title>
-          <Serif size="2" weight={emphasizeArtist ? "semibold" : "regular"}>
+          </OverflowEllipsis>
+          <OverflowEllipsis
+            size="2"
+            weight={emphasizeArtist ? "semibold" : "regular"}
+          >
             {artwork.artist_names}
-          </Serif>
+          </OverflowEllipsis>
         </Box>
       </Link>
     </Flex>

--- a/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
+++ b/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
@@ -28,17 +28,15 @@ export const PreviewGridItem: React.SFC<PreviewGridItemProps> = ({
   return (
     <Flex mr={2} mb={2}>
       <Link href={artwork.href} noUnderline>
-        {imageUrl ? (
-          <Image
-            mr={2}
-            src={imageUrl}
-            alt={`${artwork.title} by ${artwork.artist_names}`}
-          />
-        ) : (
-          <Box width="40px" height="40px" mr={2}>
-            &nbsp;
-          </Box>
-        )}
+        <Box width="40px" height="40px" mr={2}>
+          {imageUrl && (
+            <Image
+              mr={2}
+              src={imageUrl}
+              alt={`${artwork.title} by ${artwork.artist_names}`}
+            />
+          )}
+        </Box>
       </Link>
       <Link href={artwork.href} noUnderline>
         <Box>

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -287,7 +287,7 @@ export const SearchBarRefetchContainer = createRefetchContainer(
           term: { type: "String!", defaultValue: "" }
           hasTerm: { type: "Boolean!", defaultValue: false }
         ) {
-        search(query: $term, mode: AUTOSUGGEST, first: 7)
+        search(query: $term, mode: AUTOSUGGEST, first: 5)
           @include(if: $hasTerm) {
           edges {
             node {

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -62,6 +62,10 @@ const ResultsWrapper = styled(Box)`
   position: absolute;
 `
 
+const SuggestionsWrapper = styled(Box)`
+  border-right: 1px solid ${colors.grayRegular};
+`
+
 const SuggestionContainer = ({ children, containerProps, preview }) => {
   return (
     <AutosuggestWrapper
@@ -70,11 +74,11 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
       {...containerProps}
     >
       <ResultsWrapper>
-        <Box width="calc(100% - 450px)">
+        <SuggestionsWrapper width="calc(100% - 450px)">
           <Flex flexDirection="column" width="100%">
             {children}
           </Flex>
-        </Box>
+        </SuggestionsWrapper>
         <Box width="450px" pl={3}>
           {preview}
         </Box>

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -79,7 +79,7 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
             {children}
           </Flex>
         </SuggestionsWrapper>
-        <Box width="450px" pl={3}>
+        <Box width="450px" pl={3} py={2}>
           {preview}
         </Box>
       </ResultsWrapper>

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
+import { SuggestionItemContainer } from "./Suggestions/SuggestionItemContainer"
 
 const logger = createLogger("Components/Search/SearchBar")
 
@@ -182,9 +183,7 @@ export class SearchBar extends Component<Props, State> {
     let emptyState = null
     if (!xs && !query && focused) {
       emptyState = (
-        <Box pb={3} pl={3}>
-          {PLACEHOLDER}
-        </Box>
+        <SuggestionItemContainer>{PLACEHOLDER}</SuggestionItemContainer>
       )
     }
 

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -58,7 +58,7 @@ const ResultsWrapper = styled(Box)`
   width: calc(100% + 450px);
   background-color: ${colors.white};
   display: flex;
-  box-shadow: 1px 1px 6px ${colors.black30};
+  border: 1px solid ${colors.grayRegular};
   position: absolute;
 `
 
@@ -73,7 +73,7 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
       flexDirection={["column", "row"]}
       {...containerProps}
     >
-      <ResultsWrapper>
+      <ResultsWrapper mt={0.5}>
         <SuggestionsWrapper width="calc(100% - 450px)">
           <Flex flexDirection="column" width="100%">
             {children}
@@ -175,6 +175,9 @@ export class SearchBar extends Component<Props, State> {
     { xs }
   ) => {
     const { focused } = this.state
+    if (!focused) {
+      return null
+    }
 
     let emptyState = null
     if (!xs && !query && focused) {

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -49,6 +49,43 @@ interface State {
   focused: boolean
 }
 
+const AutosuggestWrapper = styled(Box)`
+  background: red;
+  position: relative;
+`
+
+const SuggestionListWrapper = styled(Box)`
+  background-color: green;
+  position: absolute;
+  left: 0;
+  right: 0;
+`
+
+const PreviewListWrapper = styled(Box)`
+  background-color: blue;
+  position: absolute;
+  left: 100%;
+`
+
+const SuggestionContainer = ({
+  children,
+  containerProps,
+  focused,
+  query,
+  preview,
+}) => {
+  return (
+    <AutosuggestWrapper flexDirection={["column", "row"]} {...containerProps}>
+      <SuggestionListWrapper width={["100%"]}>
+        <Flex flexDirection="column">{children}</Flex>
+      </SuggestionListWrapper>
+      <PreviewListWrapper width={["100%", "50%"]} pl={3}>
+        {preview}
+      </PreviewListWrapper>
+    </AutosuggestWrapper>
+  )
+}
+
 export class SearchBar extends Component<Props, State> {
   public input: HTMLInputElement
 
@@ -146,20 +183,19 @@ export class SearchBar extends Component<Props, State> {
         </Box>
       )
     }
+
+    const props = {
+      children,
+      containerProps,
+      focused,
+      query,
+      preview: this.renderPreview(),
+    }
+
     return (
-      <Box {...containerProps}>
-        <Flex flexDirection={["column", "row"]}>
-          <Box width={["100%", "50%"]}>
-            <Flex flexDirection="column">
-              {emptyState}
-              {children}
-            </Flex>
-          </Box>
-          <Box width={["100%", "50%"]} pl={3}>
-            {this.renderPreview()}
-          </Box>
-        </Flex>
-      </Box>
+      <SuggestionContainer {...props}>
+        {emptyState || children}
+      </SuggestionContainer>
     )
   }
 

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -2,6 +2,7 @@ import { Box, Flex } from "@artsy/palette"
 import { SearchBar_viewer } from "__generated__/SearchBar_viewer.graphql"
 import { SearchBarSuggestQuery } from "__generated__/SearchBarSuggestQuery.graphql"
 import { ContextConsumer, ContextProps } from "Artsy"
+import colors from "Assets/Colors"
 import Input from "Components/Input"
 import { SearchPreview } from "Components/Search/Previews"
 import { SuggestionItem } from "Components/Search/Suggestions/SuggestionItem"
@@ -50,38 +51,34 @@ interface State {
 }
 
 const AutosuggestWrapper = styled(Box)`
-  background: red;
   position: relative;
 `
 
-const SuggestionListWrapper = styled(Box)`
-  background-color: green;
+const ResultsWrapper = styled(Box)`
+  width: calc(100% + 450px);
+  background-color: ${colors.white};
+  display: flex;
+  box-shadow: 1px 1px 6px ${colors.black30};
   position: absolute;
-  left: 0;
-  right: 0;
 `
 
-const PreviewListWrapper = styled(Box)`
-  background-color: blue;
-  position: absolute;
-  left: 100%;
-`
-
-const SuggestionContainer = ({
-  children,
-  containerProps,
-  focused,
-  query,
-  preview,
-}) => {
+const SuggestionContainer = ({ children, containerProps, preview }) => {
   return (
-    <AutosuggestWrapper flexDirection={["column", "row"]} {...containerProps}>
-      <SuggestionListWrapper width={"100%"}>
-        <Flex flexDirection="column">{children}</Flex>
-      </SuggestionListWrapper>
-      <PreviewListWrapper width={"450px"} pl={3}>
-        {preview}
-      </PreviewListWrapper>
+    <AutosuggestWrapper
+      width="100%"
+      flexDirection={["column", "row"]}
+      {...containerProps}
+    >
+      <ResultsWrapper>
+        <Box width="calc(100% - 450px)">
+          <Flex flexDirection="column" width="100%">
+            {children}
+          </Flex>
+        </Box>
+        <Box width="450px" pl={3}>
+          {preview}
+        </Box>
+      </ResultsWrapper>
     </AutosuggestWrapper>
   )
 }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -76,10 +76,10 @@ const SuggestionContainer = ({
 }) => {
   return (
     <AutosuggestWrapper flexDirection={["column", "row"]} {...containerProps}>
-      <SuggestionListWrapper width={["100%"]}>
+      <SuggestionListWrapper width={"100%"}>
         <Flex flexDirection="column">{children}</Flex>
       </SuggestionListWrapper>
-      <PreviewListWrapper width={["100%", "50%"]} pl={3}>
+      <PreviewListWrapper width={"450px"} pl={3}>
         {preview}
       </PreviewListWrapper>
     </AutosuggestWrapper>

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -12,8 +12,11 @@ interface Props {
 
 export const SuggestionItem: SFC<Props> = ({ href, display, label, query }) => {
   if (label === "FirstItem") {
+    // `color="black100"` is misleading.
+    //  The actual color doesn't really matter - the child element controls the displayed color.
+    //  We specify color only because it makes the text not underlined on hover.
     return (
-      <Link noUnderline href={href}>
+      <Link noUnderline href={href} color="black100">
         <SuggestionItemContainer>Search "{query}"</SuggestionItemContainer>
       </Link>
     )
@@ -23,7 +26,10 @@ export const SuggestionItem: SFC<Props> = ({ href, display, label, query }) => {
   const parts = parse(display, matches)
 
   return (
-    <Link noUnderline href={href}>
+    // `color="black100"` is misleading.
+    //  The actual color doesn't really matter - the child elements control the displayed color.
+    //  We specify color only because it makes the text not underlined on hover.
+    <Link noUnderline href={href} color="black100">
       <SuggestionItemContainer>
         <Serif size="3">
           {parts.map(({ highlight, text }, index) => {

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,7 +1,8 @@
-import { Box, color, Flex, Link, Sans, Serif } from "@artsy/palette"
+import { color, Link, Sans, Serif } from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import React, { SFC } from "react"
+import { SuggestionItemContainer } from "./SuggestionItemContainer"
 interface Props {
   display: string
   label: string
@@ -13,9 +14,7 @@ export const SuggestionItem: SFC<Props> = ({ href, display, label, query }) => {
   if (label === "FirstItem") {
     return (
       <Link noUnderline href={href}>
-        <Box pl={3} pb={3}>
-          Search "{query}"
-        </Box>
+        <SuggestionItemContainer>Search "{query}"</SuggestionItemContainer>
       </Link>
     )
   }
@@ -23,19 +22,18 @@ export const SuggestionItem: SFC<Props> = ({ href, display, label, query }) => {
   const matches = match(display, query)
   const parts = parse(display, matches)
 
-  // TODO: Center text vertically
   return (
     <Link noUnderline href={href}>
-      <Flex pl={3} pb={3} justifyContent="center" flexDirection="column">
-        <Serif size="2">
+      <SuggestionItemContainer>
+        <Serif size="3">
           {parts.map(({ highlight, text }, index) => {
             return highlight ? <strong key={index}>{text}</strong> : text
           })}
         </Serif>
-        <Sans color={color("black30")} size="2">
+        <Sans color={color("black60")} size="2">
           {label}
         </Sans>
-      </Flex>
+      </SuggestionItemContainer>
     </Link>
   )
 }

--- a/src/Components/Search/Suggestions/SuggestionItemContainer.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItemContainer.tsx
@@ -2,7 +2,7 @@ import { Flex } from "@artsy/palette"
 import React, { SFC } from "react"
 
 interface Props {
-  children: JSX.Element[] | string[] | string
+  children: React.ReactNode
 }
 
 export const SuggestionItemContainer: SFC<Props> = ({ children }) => (

--- a/src/Components/Search/Suggestions/SuggestionItemContainer.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItemContainer.tsx
@@ -1,0 +1,12 @@
+import { Flex } from "@artsy/palette"
+import React, { SFC } from "react"
+
+interface Props {
+  children: JSX.Element[] | string[] | string
+}
+
+export const SuggestionItemContainer: SFC<Props> = ({ children }) => (
+  <Flex flexDirection="column" justifyContent="center" height="62px" pl={3}>
+    {children}
+  </Flex>
+)

--- a/src/Components/Search/Suggestions/index.tsx
+++ b/src/Components/Search/Suggestions/index.tsx
@@ -73,7 +73,7 @@ export const SearchSuggestionsFragmentContainer = createFragmentContainer(
   graphql`
     fragment SuggestionsSearch_viewer on Viewer
       @argumentDefinitions(term: { type: "String!", defaultValue: "" }) {
-      search(query: $term, mode: AUTOSUGGEST, first: 10) {
+      search(query: $term, mode: AUTOSUGGEST, first: 5) {
         edges {
           node {
             displayLabel

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@artsy/palette"
+import { Box, Flex } from "@artsy/palette"
 import { ContextProvider } from "Artsy/SystemContext"
 import { SearchPreview } from "Components/Search/Previews"
 import { SearchBarQueryRenderer as SearchBar } from "Components/Search/SearchBar"
@@ -7,9 +7,70 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 
 storiesOf("Components/Search/SearchBar", module).add("Input", () => (
-  <ContextProvider>
-    <SearchBar />
-  </ContextProvider>
+  <>
+    <Flex>
+      <Box>Artsy Logo</Box>
+      <Box width="400px">
+        <ContextProvider>
+          <SearchBar />
+        </ContextProvider>
+      </Box>
+      <Box>Nav Item</Box>
+      <Box>Nav Item</Box>
+      <Box>Nav Item</Box>
+    </Flex>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec non nibh
+      quis ex imperdiet tristique eu non nisl. Nullam dignissim ex vel malesuada
+      tristique. Nullam leo urna, eleifend eu porttitor ut, fringilla non nibh.
+      Etiam id suscipit felis, vitae lacinia orci. Sed sagittis scelerisque
+      imperdiet. Sed tempus nulla in nunc malesuada, feugiat hendrerit dui
+      ornare. Sed pharetra erat orci, ac molestie turpis tincidunt non. Ut sit
+      amet lorem at lectus molestie hendrerit. Maecenas a risus vel nibh
+      lobortis bibendum. Fusce facilisis mauris a ex suscipit, in pretium leo
+      aliquam. Donec vitae malesuada metus. Pellentesque odio lacus, imperdiet
+      vel tincidunt dignissim, porttitor vel dui. Proin lacus mauris, tincidunt
+      ac risus ac, consectetur tincidunt lorem.
+    </p>
+    <p>
+      Nulla facilisi. Maecenas bibendum libero et massa euismod suscipit ut ac
+      justo. Vestibulum et ex vel neque ultrices porttitor ultricies id lacus.
+      Integer eget nisl consequat, auctor urna vitae, blandit ante. Sed
+      tincidunt pulvinar enim, non elementum nunc vehicula in. Fusce fermentum
+      mattis nunc pulvinar venenatis. Quisque imperdiet ex ac tellus
+      pellentesque, sed faucibus elit vestibulum. Curabitur et nisl ac massa
+      convallis blandit. Maecenas vitae feugiat ex. Morbi at arcu at arcu congue
+      varius eget in nisi. Aliquam tempor varius dui ut luctus.
+    </p>
+    <p>
+      Donec at lacus finibus tortor facilisis vestibulum vitae quis enim. Proin
+      blandit interdum aliquam. Ut tempus orci ut magna dictum, vitae vulputate
+      sem varius. Praesent at porttitor leo. Aliquam efficitur tincidunt
+      tincidunt. In auctor purus porta suscipit mattis. Aliquam ante tellus,
+      cursus quis augue at, commodo pulvinar ipsum. Aliquam erat volutpat.
+      Praesent nec laoreet tortor, ut congue metus. Nam vitae velit nec erat
+      egestas imperdiet. Vestibulum quam dolor, tempus a neque id, fermentum
+      ultricies tortor.
+    </p>
+    <p>
+      Maecenas aliquam massa non porttitor venenatis. Mauris a ante dictum lorem
+      eleifend pharetra. Integer maximus non nisi sit amet aliquet. Sed
+      consequat lacinia blandit. Aliquam ut maximus diam. Vivamus id eleifend
+      orci, at feugiat libero. Aenean volutpat, ex vel semper tincidunt, magna
+      est lobortis neque, quis cursus est velit sit amet diam. Curabitur in
+      elementum nisi. Etiam quis dui magna. Integer ornare elementum nunc sit
+      amet rutrum. Maecenas nisi mauris, gravida sit amet ipsum nec, rutrum
+      laoreet neque. Praesent nec pellentesque tortor. Cras pharetra ante
+      ullamcorper aliquet vehicula. Donec gravida in ante rutrum pellentesque.
+    </p>
+    <p>
+      Mauris viverra finibus neque. Etiam ac est massa. Pellentesque blandit id
+      ligula quis consectetur. Nunc posuere tempor velit, non semper turpis
+      cursus id. Donec sed vulputate mi, eu gravida nisi. Aenean sit amet
+      malesuada quam. Nulla et est laoreet, malesuada justo in, lacinia tellus.
+      In mattis euismod mattis.
+    </p>
+  </>
 ))
 
 storiesOf("Components/Search/Suggestions", module).add("Term: Andy", () => (

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -5,16 +5,27 @@ import { SearchBarQueryRenderer as SearchBar } from "Components/Search/SearchBar
 import { SearchSuggestionsQueryRenderer as SearchSuggestions } from "Components/Search/Suggestions"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
+import styled from "styled-components"
+
+const SearchBarContainer = styled(Box)`
+  flex-grow: 1;
+`
 
 storiesOf("Components/Search/SearchBar", module).add("Input", () => (
   <>
     <Flex>
       <Box>Artsy Logo</Box>
-      <Box width="400px">
+      <SearchBarContainer>
         <ContextProvider>
           <SearchBar />
         </ContextProvider>
-      </Box>
+      </SearchBarContainer>
+      <Box>Nav Item</Box>
+      <Box>Nav Item</Box>
+      <Box>Nav Item</Box>
+      <Box>Nav Item</Box>
+      <Box>Nav Item</Box>
+      <Box>Nav Item</Box>
       <Box>Nav Item</Box>
       <Box>Nav Item</Box>
       <Box>Nav Item</Box>

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -3,6 +3,7 @@ import { ContextProvider } from "Artsy/SystemContext"
 import { SearchPreview } from "Components/Search/Previews"
 import { SearchBarQueryRenderer as SearchBar } from "Components/Search/SearchBar"
 import { SearchSuggestionsQueryRenderer as SearchSuggestions } from "Components/Search/Suggestions"
+import { SuggestionItem } from "Components/Search/Suggestions/SuggestionItem"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import styled from "styled-components"
@@ -87,6 +88,29 @@ storiesOf("Components/Search/SearchBar", module).add("Input", () => (
 storiesOf("Components/Search/Suggestions", module).add("Term: Andy", () => (
   <ContextProvider>
     <SearchSuggestions term="andy" />
+  </ContextProvider>
+))
+
+storiesOf("Components/Search/SuggestionItems", module).add("Some items", () => (
+  <ContextProvider>
+    <SuggestionItem
+      display="display one"
+      label="FirstItem"
+      query="a query"
+      href="/"
+    />
+    <SuggestionItem
+      display="display two"
+      label="label two"
+      query="a query"
+      href="/"
+    />
+    <SuggestionItem
+      display="display three"
+      label="label three"
+      query="a query"
+      href="/"
+    />
   </ContextProvider>
 ))
 

--- a/src/__generated__/ArtistSearchPreviewQuery.graphql.ts
+++ b/src/__generated__/ArtistSearchPreviewQuery.graphql.ts
@@ -29,7 +29,7 @@ query ArtistSearchPreviewQuery(
 fragment ArtistSearchPreview_viewer_1IQPhv on Viewer {
   artist(id: $entityID) {
     id
-    marketingCollections {
+    marketingCollections(size: 6) {
       title
       ...MarketingCollectionsPreview_marketingCollections
       __id: id
@@ -49,7 +49,7 @@ fragment MarketingCollectionsPreview_marketingCollections on MarketingCollection
 fragment RelatedArtworksPreview_viewer_1IQPhv on Viewer {
   filter_artworks(aggregations: [TOTAL], sort: "-decayed_merch", artist_id: $entityID) {
     __id
-    artworks_connection(first: 8) {
+    artworks_connection(first: 10) {
       edges {
         node {
           ...PreviewGridItem_artwork
@@ -102,7 +102,7 @@ return {
   "operationKind": "query",
   "name": "ArtistSearchPreviewQuery",
   "id": null,
-  "text": "query ArtistSearchPreviewQuery(\n  $entityID: String!\n) {\n  viewer {\n    ...ArtistSearchPreview_viewer_1IQPhv\n  }\n}\n\nfragment ArtistSearchPreview_viewer_1IQPhv on Viewer {\n  artist(id: $entityID) {\n    id\n    marketingCollections {\n      title\n      ...MarketingCollectionsPreview_marketingCollections\n      __id: id\n    }\n    __id\n  }\n  ...RelatedArtworksPreview_viewer_1IQPhv\n}\n\nfragment MarketingCollectionsPreview_marketingCollections on MarketingCollection {\n  title\n  slug\n  headerImage\n  __id: id\n}\n\nfragment RelatedArtworksPreview_viewer_1IQPhv on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: \"-decayed_merch\", artist_id: $entityID) {\n    __id\n    artworks_connection(first: 8) {\n      edges {\n        node {\n          ...PreviewGridItem_artwork\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment PreviewGridItem_artwork on Artwork {\n  href\n  title\n  artist_names\n  image {\n    cropped(width: 40, height: 40) {\n      url\n    }\n  }\n  date\n  __id\n}\n",
+  "text": "query ArtistSearchPreviewQuery(\n  $entityID: String!\n) {\n  viewer {\n    ...ArtistSearchPreview_viewer_1IQPhv\n  }\n}\n\nfragment ArtistSearchPreview_viewer_1IQPhv on Viewer {\n  artist(id: $entityID) {\n    id\n    marketingCollections(size: 6) {\n      title\n      ...MarketingCollectionsPreview_marketingCollections\n      __id: id\n    }\n    __id\n  }\n  ...RelatedArtworksPreview_viewer_1IQPhv\n}\n\nfragment MarketingCollectionsPreview_marketingCollections on MarketingCollection {\n  title\n  slug\n  headerImage\n  __id: id\n}\n\nfragment RelatedArtworksPreview_viewer_1IQPhv on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: \"-decayed_merch\", artist_id: $entityID) {\n    __id\n    artworks_connection(first: 10) {\n      edges {\n        node {\n          ...PreviewGridItem_artwork\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment PreviewGridItem_artwork on Artwork {\n  href\n  title\n  artist_names\n  image {\n    cropped(width: 40, height: 40) {\n      url\n    }\n  }\n  date\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -177,8 +177,15 @@ return {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "marketingCollections",
-                "storageKey": null,
-                "args": null,
+                "storageKey": "marketingCollections(size:6)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "size",
+                    "value": 6,
+                    "type": "Int"
+                  }
+                ],
                 "concreteType": "MarketingCollection",
                 "plural": true,
                 "selections": [
@@ -244,12 +251,12 @@ return {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "artworks_connection",
-                "storageKey": "artworks_connection(first:8)",
+                "storageKey": "artworks_connection(first:10)",
                 "args": [
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 8,
+                    "value": 10,
                     "type": "Int"
                   }
                 ],

--- a/src/__generated__/ArtistSearchPreview_viewer.graphql.ts
+++ b/src/__generated__/ArtistSearchPreview_viewer.graphql.ts
@@ -60,8 +60,15 @@ const node: ConcreteFragment = {
           "kind": "LinkedField",
           "alias": null,
           "name": "marketingCollections",
-          "storageKey": null,
-          "args": null,
+          "storageKey": "marketingCollections(size:6)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "size",
+              "value": 6,
+              "type": "Int"
+            }
+          ],
           "concreteType": "MarketingCollection",
           "plural": true,
           "selections": [
@@ -109,5 +116,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '2fd6cd7a9f843faec6dd4fe0c43ac857';
+(node as any).hash = '75fa320234ceaf45c234aa38bdf9385d';
 export default node;

--- a/src/__generated__/MerchandisableArtworksPreviewQuery.graphql.ts
+++ b/src/__generated__/MerchandisableArtworksPreviewQuery.graphql.ts
@@ -25,7 +25,7 @@ query MerchandisableArtworksPreviewQuery {
 fragment MerchandisableArtworks_viewer on Viewer {
   filter_artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
     __id
-    artworks_connection(first: 8) {
+    artworks_connection(first: 10) {
       edges {
         node {
           ...PreviewGridItem_artwork
@@ -63,7 +63,7 @@ return {
   "operationKind": "query",
   "name": "MerchandisableArtworksPreviewQuery",
   "id": null,
-  "text": "query MerchandisableArtworksPreviewQuery {\n  viewer {\n    ...MerchandisableArtworks_viewer\n  }\n}\n\nfragment MerchandisableArtworks_viewer on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    __id\n    artworks_connection(first: 8) {\n      edges {\n        node {\n          ...PreviewGridItem_artwork\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment PreviewGridItem_artwork on Artwork {\n  href\n  title\n  artist_names\n  image {\n    cropped(width: 40, height: 40) {\n      url\n    }\n  }\n  date\n  __id\n}\n",
+  "text": "query MerchandisableArtworksPreviewQuery {\n  viewer {\n    ...MerchandisableArtworks_viewer\n  }\n}\n\nfragment MerchandisableArtworks_viewer on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    __id\n    artworks_connection(first: 10) {\n      edges {\n        node {\n          ...PreviewGridItem_artwork\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment PreviewGridItem_artwork on Artwork {\n  href\n  title\n  artist_names\n  image {\n    cropped(width: 40, height: 40) {\n      url\n    }\n  }\n  date\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -133,12 +133,12 @@ return {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "artworks_connection",
-                "storageKey": "artworks_connection(first:8)",
+                "storageKey": "artworks_connection(first:10)",
                 "args": [
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 8,
+                    "value": 10,
                     "type": "Int"
                   }
                 ],

--- a/src/__generated__/MerchandisableArtworks_viewer.graphql.ts
+++ b/src/__generated__/MerchandisableArtworks_viewer.graphql.ts
@@ -64,12 +64,12 @@ return {
           "kind": "LinkedField",
           "alias": null,
           "name": "artworks_connection",
-          "storageKey": "artworks_connection(first:8)",
+          "storageKey": "artworks_connection(first:10)",
           "args": [
             {
               "kind": "Literal",
               "name": "first",
-              "value": 8,
+              "value": 10,
               "type": "Int"
             }
           ],
@@ -111,5 +111,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'f1f4bf6587c8e5724373d845ef754f55';
+(node as any).hash = '79905c4eb172da9b968160702df1e1a8';
 export default node;

--- a/src/__generated__/RelatedArtworksPreview_viewer.graphql.ts
+++ b/src/__generated__/RelatedArtworksPreview_viewer.graphql.ts
@@ -77,12 +77,12 @@ return {
           "kind": "LinkedField",
           "alias": null,
           "name": "artworks_connection",
-          "storageKey": "artworks_connection(first:8)",
+          "storageKey": "artworks_connection(first:10)",
           "args": [
             {
               "kind": "Literal",
               "name": "first",
-              "value": 8,
+              "value": 10,
               "type": "Int"
             }
           ],
@@ -124,5 +124,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '43f99049d331104fc425d84e94ef612f';
+(node as any).hash = '11cb0e787561ef8b4422c184212a35f7';
 export default node;

--- a/src/__generated__/SearchBarRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchBarRefetchQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarRefetchQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarRefetchQuery",
   "id": null,
-  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 7,
+                    "value": 5,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBarSuggestQuery.graphql.ts
+++ b/src/__generated__/SearchBarSuggestQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarSuggestQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarSuggestQuery",
   "id": null,
-  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 7,
+                    "value": 5,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBarTestQuery.graphql.ts
+++ b/src/__generated__/SearchBarTestQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarTestQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarTestQuery",
   "id": null,
-  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 7,
+                    "value": 5,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBar_viewer.graphql.ts
+++ b/src/__generated__/SearchBar_viewer.graphql.ts
@@ -53,7 +53,7 @@ const node: ConcreteFragment = {
             {
               "kind": "Literal",
               "name": "first",
-              "value": 7,
+              "value": 5,
               "type": "Int"
             },
             {
@@ -141,5 +141,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'd5c878b4c5fc01c702d6fe74e63075b9';
+(node as any).hash = 'e649d07e62973aefbb0d83d8c32d5031';
 export default node;

--- a/src/__generated__/SuggestionsSearchQuery.graphql.ts
+++ b/src/__generated__/SuggestionsSearchQuery.graphql.ts
@@ -27,7 +27,7 @@ query SuggestionsSearchQuery(
 }
 
 fragment SuggestionsSearch_viewer_4hh6ED on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 10) {
+  search(query: $term, mode: AUTOSUGGEST, first: 5) {
     edges {
       node {
         __typename
@@ -59,7 +59,7 @@ return {
   "operationKind": "query",
   "name": "SuggestionsSearchQuery",
   "id": null,
-  "text": "query SuggestionsSearchQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer_4hh6ED\n  }\n}\n\nfragment SuggestionsSearch_viewer_4hh6ED on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SuggestionsSearchQuery(\n  $term: String!\n) {\n  viewer {\n    ...SuggestionsSearch_viewer_4hh6ED\n  }\n}\n\nfragment SuggestionsSearch_viewer_4hh6ED on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -116,7 +116,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 10,
+                "value": 5,
                 "type": "Int"
               },
               {

--- a/src/__generated__/SuggestionsSearch_viewer.graphql.ts
+++ b/src/__generated__/SuggestionsSearch_viewer.graphql.ts
@@ -41,7 +41,7 @@ const node: ConcreteFragment = {
         {
           "kind": "Literal",
           "name": "first",
-          "value": 10,
+          "value": 5,
           "type": "Int"
         },
         {
@@ -120,5 +120,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'b2d4eb6ae95ade92e1a3ade95a81c702';
+(node as any).hash = '6a778e464a7027583659259597cce94e';
 export default node;

--- a/src/__generated__/TestsQuery.graphql.ts
+++ b/src/__generated__/TestsQuery.graphql.ts
@@ -29,7 +29,7 @@ query TestsQuery(
 fragment ArtistSearchPreview_viewer_1IQPhv on Viewer {
   artist(id: $entityID) {
     id
-    marketingCollections {
+    marketingCollections(size: 6) {
       title
       ...MarketingCollectionsPreview_marketingCollections
       __id: id
@@ -49,7 +49,7 @@ fragment MarketingCollectionsPreview_marketingCollections on MarketingCollection
 fragment RelatedArtworksPreview_viewer_1IQPhv on Viewer {
   filter_artworks(aggregations: [TOTAL], sort: "-decayed_merch", artist_id: $entityID) {
     __id
-    artworks_connection(first: 8) {
+    artworks_connection(first: 10) {
       edges {
         node {
           ...PreviewGridItem_artwork
@@ -102,7 +102,7 @@ return {
   "operationKind": "query",
   "name": "TestsQuery",
   "id": null,
-  "text": "query TestsQuery(\n  $entityID: String!\n) {\n  viewer {\n    ...ArtistSearchPreview_viewer_1IQPhv\n  }\n}\n\nfragment ArtistSearchPreview_viewer_1IQPhv on Viewer {\n  artist(id: $entityID) {\n    id\n    marketingCollections {\n      title\n      ...MarketingCollectionsPreview_marketingCollections\n      __id: id\n    }\n    __id\n  }\n  ...RelatedArtworksPreview_viewer_1IQPhv\n}\n\nfragment MarketingCollectionsPreview_marketingCollections on MarketingCollection {\n  title\n  slug\n  headerImage\n  __id: id\n}\n\nfragment RelatedArtworksPreview_viewer_1IQPhv on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: \"-decayed_merch\", artist_id: $entityID) {\n    __id\n    artworks_connection(first: 8) {\n      edges {\n        node {\n          ...PreviewGridItem_artwork\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment PreviewGridItem_artwork on Artwork {\n  href\n  title\n  artist_names\n  image {\n    cropped(width: 40, height: 40) {\n      url\n    }\n  }\n  date\n  __id\n}\n",
+  "text": "query TestsQuery(\n  $entityID: String!\n) {\n  viewer {\n    ...ArtistSearchPreview_viewer_1IQPhv\n  }\n}\n\nfragment ArtistSearchPreview_viewer_1IQPhv on Viewer {\n  artist(id: $entityID) {\n    id\n    marketingCollections(size: 6) {\n      title\n      ...MarketingCollectionsPreview_marketingCollections\n      __id: id\n    }\n    __id\n  }\n  ...RelatedArtworksPreview_viewer_1IQPhv\n}\n\nfragment MarketingCollectionsPreview_marketingCollections on MarketingCollection {\n  title\n  slug\n  headerImage\n  __id: id\n}\n\nfragment RelatedArtworksPreview_viewer_1IQPhv on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: \"-decayed_merch\", artist_id: $entityID) {\n    __id\n    artworks_connection(first: 10) {\n      edges {\n        node {\n          ...PreviewGridItem_artwork\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment PreviewGridItem_artwork on Artwork {\n  href\n  title\n  artist_names\n  image {\n    cropped(width: 40, height: 40) {\n      url\n    }\n  }\n  date\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -177,8 +177,15 @@ return {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "marketingCollections",
-                "storageKey": null,
-                "args": null,
+                "storageKey": "marketingCollections(size:6)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "size",
+                    "value": 6,
+                    "type": "Int"
+                  }
+                ],
                 "concreteType": "MarketingCollection",
                 "plural": true,
                 "selections": [
@@ -244,12 +251,12 @@ return {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "artworks_connection",
-                "storageKey": "artworks_connection(first:8)",
+                "storageKey": "artworks_connection(first:10)",
                 "args": [
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 8,
+                    "value": 10,
                     "type": "Int"
                   }
                 ],


### PR DESCRIPTION
This PR includes a variety of styling changes, with the goal of matching the auto-suggest search bar to the Zeplin comps.
 
Included:

- [x] Deal with white on white for the border of the suggest area (box-shadow)
- [x] Limit suggestions to 6 items, including the placeholder
- [x] Limit grid preview items to 10 items
- [x] Limit marketing collections to 6 items
- [x] We're missing the line between suggestions and previews
- [x] Fix positioning (in reaction)
- [x] Width hasn't grown into container properly (in reaction)
- [x] Match comp for search suggestions (height, for example)
- [x] Missing padding at top of suggestion/preview panes
- [x] Suggestion item text should have no hover underline
- [x] `overflow: ellipsis` for artist names (search for Fiona Banner, and you'll see)
- [x] Wrap preview images in a <Box> with static width/height to keep things from dancing while loading

Here's what it looks like now!



![kapture 2019-02-20 at 20 19 18](https://user-images.githubusercontent.com/1627089/53138736-ebb7f900-354c-11e9-96bd-bd71f7baab37.gif)
