### PR TITLE
Add showCollectionsRail prop to Articles

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -36,6 +36,7 @@ export interface ArticleProps {
   marginTop?: string | null
   display?: DisplayData
   showTooltips?: boolean
+  showCollectionsRail?: boolean
   slideIndex?: number
   tracking?: TrackingProp
   closeViewer?: () => void

--- a/src/Components/Publishing/Layouts/Components/CanvasFooter.tsx
+++ b/src/Components/Publishing/Layouts/Components/CanvasFooter.tsx
@@ -14,6 +14,7 @@ export interface CanvasFooterProps {
   relatedArticles?: RelatedArticleCanvasData[]
   article: ArticleData
   renderTime?: number
+  showCollectionsRail?: boolean
 }
 
 export const CanvasFooter: React.SFC<CanvasFooterProps> = props => {

--- a/src/Components/Publishing/Layouts/FeatureLayout.tsx
+++ b/src/Components/Publishing/Layouts/FeatureLayout.tsx
@@ -22,6 +22,7 @@ export const FeatureLayout: React.SFC<ArticleProps> = props => {
     relatedArticlesForCanvas,
     renderTime,
     showTooltips,
+    showCollectionsRail,
   } = props
   const { seriesArticle } = article
 
@@ -65,6 +66,7 @@ export const FeatureLayout: React.SFC<ArticleProps> = props => {
             display={display}
             relatedArticles={relatedArticlesForCanvas}
             renderTime={renderTime}
+            showCollectionsRail={showCollectionsRail}
           />
         )}
     </FeatureLayoutContainer>

--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -19,6 +19,7 @@ interface Props {
   onExpand?: () => void
   relatedArticlesForCanvas?: RelatedArticleCanvasData[]
   renderTime?: number
+  showCollectionsRail?: boolean
   tracking?: TrackingProp
 }
 
@@ -79,6 +80,7 @@ export class NewsLayout extends Component<Props, State> {
       isMobile,
       relatedArticlesForCanvas,
       renderTime,
+      showCollectionsRail,
     } = this.props
     const { isTruncated, isHovered } = this.state
 
@@ -120,6 +122,7 @@ export class NewsLayout extends Component<Props, State> {
             display={display}
             relatedArticles={relatedArticlesForCanvas}
             renderTime={renderTime}
+            showCollectionsRail={showCollectionsRail}
           />
         )}
       </NewsContainer>

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -72,6 +72,7 @@ export class StandardLayout extends React.Component<
       relatedArticlesForPanel,
       renderTime,
       showTooltips,
+      showCollectionsRail,
       isSuper,
     } = this.props
     const { isTruncated } = this.state
@@ -137,6 +138,7 @@ export class StandardLayout extends React.Component<
                     display={display}
                     relatedArticles={relatedArticlesForCanvas}
                     renderTime={renderTime}
+                    showCollectionsRail={showCollectionsRail}
                   />
                 )}
             </ArticleWrapper>


### PR DESCRIPTION
- Adds boolean prop `showCollectionsRail` to `ArticleProps`
- Passes `showCollectionsRail` to `CanvasFooter` for standard, feature and news articles