### PR TITLE
@jonallured => [Autosuggest] Always render Input

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -297,7 +297,7 @@ export const SearchBarQueryRenderer: React.SFC = () => {
               if (props) {
                 return <SearchBarRefetchContainer viewer={props.viewer} />
               } else {
-                return null
+                return <Input placeholder={PLACEHOLDER} />
               }
             }}
           />


### PR DESCRIPTION
This makes sure there's no visible flashing of any input components, along with https://github.com/artsy/reaction/pull/2039

With that latter mentioned PR, we have the network layer being able to return immediately (but still requiring a `Promise.resolve`). Theoretically then the `SearchBar` component can be rendered in its final state immediately, but it's likely there's another render pass to _actually_ do so.

So with this PR, we make sure to always render an `Input`. That way, even in the base case of having JS disabled, a proper `Input` will show up, and then in Force since we'll have a form wrapping it, a user will still be able to type something and get to the search results (even if they're not actually using the autosuggest).