### PR TITLE
@pepopowitz => [Autosuggest] Ensure full width on initial load, and correct name prop on input

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -236,6 +236,7 @@ export class SearchBar extends Component<Props, State> {
       onBlur: this.onBlur,
       placeholder: xs ? "" : PLACEHOLDER,
       value: term,
+      name: "term",
     }
 
     const firstSuggestionPlaceholder = {
@@ -336,7 +337,13 @@ export const SearchBarQueryRenderer: React.SFC = () => {
               if (props) {
                 return <SearchBarRefetchContainer viewer={props.viewer} />
               } else {
-                return <Input placeholder={PLACEHOLDER} />
+                return (
+                  <Input
+                    name="term"
+                    style={{ width: "100%" }}
+                    placeholder={PLACEHOLDER}
+                  />
+                )
               }
             }}
           />


### PR DESCRIPTION
Pretty minor, this sets the same width as the fully enabled `Input` component to avoid that last bit of flash upon hydration (the component would resize slightly).

Also, this adds `name="term"` to the correspondingly rendered `<input>` component, so when wrapped in a `<form action='/search'>` container in Force, works with just hitting 'Enter' (and no JS needed).