### PR TITLE
DISCO-751: Support more breakpoints for new search bar

### DIFF
--- a/src/Components/Search/Previews/Grids/ArtistSearch/MarketingCollections.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/MarketingCollections.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { crop } from "Utils/resizer"
+import { Media } from "Utils/Responsive"
 
 interface MarketingCollectionsPreviewProps {
   marketingCollections: MarketingCollectionsPreview_marketingCollections
@@ -78,9 +79,18 @@ export const MarketingCollectionsPreview: React.SFC<
       <Sans size="3" weight="medium" color="black100" mb={2}>
         Artist Collections
       </Sans>
-      <Flex alignItems="flex-start" flexWrap="wrap">
-        {items}
-      </Flex>
+
+      <Media lessThan="lg">
+        <Flex alignItems="flex-start" flexWrap="wrap">
+          {items.slice(0, 3)}
+        </Flex>
+      </Media>
+
+      <Media greaterThan="md">
+        <Flex alignItems="flex-start" flexWrap="wrap">
+          {items}
+        </Flex>
+      </Media>
     </>
   )
 }

--- a/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
@@ -2,6 +2,7 @@ import { Box, Flex, Sans } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
+import { Media } from "Utils/Responsive"
 
 import { RelatedArtworksPreview_viewer } from "__generated__/RelatedArtworksPreview_viewer.graphql"
 import { PreviewGridItemFragmentContainer as PreviewGridItem } from "../PreviewGridItem"
@@ -19,7 +20,7 @@ export const RelatedArtworksPreview: React.SFC<RelatedArtworksPreviewProps> = ({
   ).map(x => x.node)
 
   const relatedArtworks = artworks.map((artwork, i) => (
-    <Box width="50%" key={i}>
+    <Box width={["0%", "100%", "100%", "50%"]} key={i}>
       <PreviewGridItem artwork={artwork} emphasizeArtist />
     </Box>
   ))
@@ -29,9 +30,17 @@ export const RelatedArtworksPreview: React.SFC<RelatedArtworksPreviewProps> = ({
         Related Artworks
       </Sans>
 
-      <Flex alignItems="flex-start" flexWrap="wrap">
-        {relatedArtworks}
-      </Flex>
+      <Media lessThan="lg">
+        <Flex alignItems="flex-start" flexWrap="wrap">
+          {relatedArtworks.slice(0, 5)}
+        </Flex>
+      </Media>
+
+      <Media greaterThan="md">
+        <Flex alignItems="flex-start" flexWrap="wrap">
+          {relatedArtworks}
+        </Flex>
+      </Media>
     </Box>
   )
 }

--- a/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
@@ -7,6 +7,7 @@ import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { ContextConsumer, ContextProps } from "Artsy/SystemContext"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { get } from "Utils/get"
+import { Media } from "Utils/Responsive"
 import { PreviewGridItemFragmentContainer as PreviewGridItem } from "./PreviewGridItem"
 
 interface MerchandisableArtworksPreviewProps {
@@ -23,7 +24,7 @@ const MerchandisableArtworksPreview: React.SFC<
   ).map(x => x.node)
 
   const merchandisableItems = artworks.map((artwork, i) => (
-    <Box width="50%">
+    <Box width={["0%", "100%", "100%", "50%"]}>
       <PreviewGridItem artwork={artwork} key={i} />
     </Box>
   ))
@@ -34,9 +35,17 @@ const MerchandisableArtworksPreview: React.SFC<
         Now Available for Buy Now/ Make Offer
       </Sans>
 
-      <Flex alignItems="flex-start" flexWrap="wrap">
-        {merchandisableItems}
-      </Flex>
+      <Media lessThan="lg">
+        <Flex alignItems="flex-start" flexWrap="wrap">
+          {merchandisableItems.slice(0, 5)}
+        </Flex>
+      </Media>
+
+      <Media greaterThan="md">
+        <Flex alignItems="flex-start" flexWrap="wrap">
+          {merchandisableItems}
+        </Flex>
+      </Media>
     </Box>
   )
 }

--- a/src/Components/Search/Previews/index.tsx
+++ b/src/Components/Search/Previews/index.tsx
@@ -8,7 +8,7 @@ export interface SearchPreviewProps {
   entityType: string
 }
 
-const map = {
+const previewComponents = {
   Artist: ArtistSearchPreview,
   default: MerchandisableArtworksPreview
 }
@@ -17,7 +17,7 @@ export const SearchPreview: SFC<SearchPreviewProps> = ({
   entityID,
   entityType,
 }) => {
-  const Preview = map[entityType] || map.default
+  const Preview = previewComponents[entityType] || previewComponents.default
 
   return (
     <Media greaterThan="xs">

--- a/src/Components/Search/Previews/index.tsx
+++ b/src/Components/Search/Previews/index.tsx
@@ -1,4 +1,5 @@
 import React, { SFC } from "react"
+import { Media } from "Utils/Responsive"
 import { ArtistSearchPreviewQueryRenderer as ArtistSearchPreview } from "./Grids/ArtistSearch"
 import { MerchandisableArtworksPreviewQueryRenderer as MerchandisableArtworksPreview } from "./Grids/MerchandisableArtworks"
 
@@ -7,16 +8,20 @@ export interface SearchPreviewProps {
   entityType: string
 }
 
+const map = {
+  Artist: ArtistSearchPreview,
+  default: MerchandisableArtworksPreview
+}
+
 export const SearchPreview: SFC<SearchPreviewProps> = ({
   entityID,
   entityType,
 }) => {
-  switch (entityType) {
-    case "Artist": {
-      return <ArtistSearchPreview entityID={entityID} />
-    }
-    default: {
-      return <MerchandisableArtworksPreview />
-    }
-  }
+  const Preview = map[entityType] || map.default
+
+  return (
+    <Media greaterThan="xs">
+      <Preview entityID={entityID} />
+    </Media>
+  )
 }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -75,7 +75,7 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
     >
       <ResultsWrapper
         width={[
-          "0px",
+          "100%",
           "calc(100% + 250px)",
           "calc(100% + 250px)",
           "calc(100% + 450px)",
@@ -84,7 +84,7 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
       >
         <SuggestionsWrapper
           width={[
-            "0px",
+            "100%",
             "calc(100% - 250px)",
             "calc(100% - 250px)",
             "calc(100% - 450px)",
@@ -94,7 +94,7 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
             {children}
           </Flex>
         </SuggestionsWrapper>
-        <Box width={["0px", "240px", "240px", "450px"]} pl={3} py={2}>
+        <Box width={["0px", "240px", "240px", "450px"]} pl={[0, 3]} py={[0, 2]}>
           {preview}
         </Box>
       </ResultsWrapper>

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -56,7 +56,6 @@ const AutosuggestWrapper = styled(Box)`
 `
 
 const ResultsWrapper = styled(Box)`
-  width: calc(100% + 450px);
   background-color: ${colors.white};
   display: flex;
   border: 1px solid ${colors.grayRegular};
@@ -74,13 +73,28 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
       flexDirection={["column", "row"]}
       {...containerProps}
     >
-      <ResultsWrapper mt={0.5}>
-        <SuggestionsWrapper width="calc(100% - 450px)">
+      <ResultsWrapper
+        width={[
+          "0px",
+          "calc(100% + 250px)",
+          "calc(100% + 250px)",
+          "calc(100% + 450px)",
+        ]}
+        mt={0.5}
+      >
+        <SuggestionsWrapper
+          width={[
+            "0px",
+            "calc(100% - 250px)",
+            "calc(100% - 250px)",
+            "calc(100% - 450px)",
+          ]}
+        >
           <Flex flexDirection="column" width="100%">
             {children}
           </Flex>
         </SuggestionsWrapper>
-        <Box width="450px" pl={3} py={2}>
+        <Box width={["0px", "240px", "240px", "450px"]} pl={3} py={2}>
           {preview}
         </Box>
       </ResultsWrapper>


### PR DESCRIPTION
This PR aims to improve the support for more breakpoints, here's some pretty pictures:

<img width="294" alt="screen shot 2019-02-22 at 4 00 52 pm" src="https://user-images.githubusercontent.com/79799/53273970-3e172800-36bb-11e9-8fc1-7707604bbccb.png">
<img width="641" alt="screen shot 2019-02-22 at 4 01 57 pm" src="https://user-images.githubusercontent.com/79799/53273978-3fe0eb80-36bb-11e9-823e-87126b7bb396.png">
<img width="1009" alt="screen shot 2019-02-22 at 4 02 04 pm" src="https://user-images.githubusercontent.com/79799/53273982-41aaaf00-36bb-11e9-87db-a0cbe01f42fd.png">

There's still work to be done here at XS because I'm simply turning off previews for that breakpoint, but we're supposed to show the default decayed merch preview on focus and on exact match we can show some previews too, but I'm less clear on that.