### PR TITLE
@pepopowitz => [Autosuggest] Implement analytics tracking, replicating existing tracking...approximately

### DIFF
--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -96,6 +96,8 @@ export enum ActionType {
   // MO speedbumps
   ViewedOfferTooLow = "Viewed offer too low",
   ViewedOfferHigherThanListPrice = "Viewed offer higher than listed price",
+
+  FocusedOnAutosuggestInput = "Focused on header auto-suggest input",
 }
 
 /**

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -97,7 +97,10 @@ export enum ActionType {
   ViewedOfferTooLow = "Viewed offer too low",
   ViewedOfferHigherThanListPrice = "Viewed offer higher than listed price",
 
-  FocusedOnAutosuggestInput = "Focused on header auto-suggest input",
+  FocusedOnAutosuggestInput = "Focused on search input",
+  SelectedItemFromSearch = "Selected item from search",
+  SearchedAutosuggestWithResults = "Searched from header with results",
+  SearchedAutosuggestWithoutResults = "Searched from header with no results",
 }
 
 /**


### PR DESCRIPTION
This implements the existing autosuggest tracking in the new component, but I very loosely followed the exact schema. This should be mergeable (and does record all the needed data), but will QA with @cavvia to make sure it's workable. I suspect we don't _need_ to match the exact schema from Force, but we can QA this on staging and any tweaks should be straightforward (🤞 )

Tracks:
- on 'focus' into the autosuggest input
- selecting an item from the suggestions (including the first item which takes you to `/search` and isnt a 'real' item)
- performing a fetch based on a new input- this includes whether or not results are returned