### PR TITLE
Don't dismiss the search results if the user clicked on a descendant component

### DIFF
--- a/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
@@ -24,8 +24,8 @@ const MerchandisableArtworksPreview: React.SFC<
   ).map(x => x.node)
 
   const merchandisableItems = artworks.map((artwork, i) => (
-    <Box width={["0%", "100%", "100%", "50%"]}>
-      <PreviewGridItem artwork={artwork} key={i} />
+    <Box width={["0%", "100%", "100%", "50%"]} key={i}>
+      <PreviewGridItem artwork={artwork} />
     </Box>
   ))
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-756.

This fixes a timing bug. When a user searches, and they click on a link in the preview pane (right side), the results box closes without going anywhere. This is because the links in the preview pane are removed from the DOM before the browser can follow the link - the `onBlur` event of the search box is triggering a re-render with the clicked link removed.

So, we are grabbing a ref to the container. When the `onBlur` event fires for "leaving" the search box, we check to see if the `relatedTarget` is a descendant of the container ref. If it is, we set a flag indicating to other events that the search results should not dismiss. This allows the browser to actually follow the link. 