### PR TITLE
[Lib] Update react-line-ellipses

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "react-head": "^3.0.0",
     "react-html-parser": "^2.0.2",
     "react-lazy-load-image-component": "^1.1.1",
-    "react-lines-ellipsis": "xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a",
+    "react-lines-ellipsis": "^0.14.0",
     "react-markdown": "^2.5.0",
     "react-oembed-container": "^0.3.0",
     "react-overlays": "^0.8.3",

--- a/src/Components/Truncator.tsx
+++ b/src/Components/Truncator.tsx
@@ -41,7 +41,7 @@ export const Truncator: React.SFC<Props> = ({
     <ErrorBoundary>
       <HTMLEllipsis
         unsafeHTML={html}
-        maxLine={maxLineCount || 2}
+        maxLine={String(maxLineCount || 2)}
         ellipsis={ellipsis}
         ellipsisHTML={readMoreHTML}
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11412,9 +11412,10 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
-  version "0.13.0"
-  resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
+react-lines-ellipsis@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-lines-ellipsis/-/react-lines-ellipsis-0.14.0.tgz#954459e68d8f9fc5a40498cabc5f47d63cbefd21"
+  integrity sha512-zJf+evlugAQ42zwHYbsR/P9SSx2UrT4opWwY8JXPNIZTVVxjqTt2+91Csx3ya0xSesj7E/EgfUbtDfU03uylXQ==
 
 react-live@^1.12.0:
   version "1.12.0"


### PR DESCRIPTION
Updates to the latest. This applies to our `<Truncator>` component. I checked that this worked in the ArtistCard, seemed all good. 

Noticed that there was some weird back and forth involving our lock file for a few months: https://github.com/artsy/force/commit/a7198c55b40150e13be60355922ec112b8d2cd8f#diff-8ee2343978836a779dc9f8d6b794c3b2L12675