### PR TITLE
DISCO-761: Match comp for suggestion spacing

### DIFF
--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -2,6 +2,7 @@ import { Box, color, Flex, Link, Sans, Serif } from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import React, { SFC } from "react"
+import styled from "styled-components"
 
 interface Props {
   display: string
@@ -22,15 +23,28 @@ export const SuggestionItem: SFC<Props> = props => {
     <Box bg={isHighlighted ? "black5" : "white100"}>
       <Link color="black100" href={href} noUnderline>
         <SuggestionWrapper>
-          <Flex flexDirection="column" flexGrow="1" justifyContent="center">
+          <InnerWrapper
+            flexDirection="column"
+            flexGrow="1"
+            justifyContent="center"
+          >
             <Suggestion {...props} />
-          </Flex>
-          {isHighlighted && <HighlightIcon />}
+          </InnerWrapper>
+          {isHighlighted && (
+            <Flex flexGrow="0" px={2}>
+              <HighlightIcon />
+            </Flex>
+          )}
         </SuggestionWrapper>
       </Link>
     </Box>
   )
 }
+
+const InnerWrapper = styled(Flex)`
+  overflow: hidden;
+  white-space: nowrap;
+`
 
 export const PLACEHOLDER = "Search by artist, gallery, style, theme, tag, etc."
 
@@ -39,7 +53,7 @@ export const EmptySuggestion = () => (
 )
 
 const SuggestionWrapper = props => (
-  <Flex alignItems="center" flexDirection="row" height="62px" px={3}>
+  <Flex alignItems="center" flexDirection="row" height="62px" pl={3}>
     {props.children}
   </Flex>
 )
@@ -56,13 +70,18 @@ const DefaultSuggestion = ({ display, label, query }) => {
 
   return (
     <>
-      <Serif size="3">{partTags}</Serif>
+      <SuggestionTitle size="3">{partTags}</SuggestionTitle>
       <Sans color={color("black60")} size="2">
         {label}
       </Sans>
     </>
   )
 }
+
+const SuggestionTitle = styled(Serif)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
 
 const HighlightIcon = () => (
   <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg">

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -94,14 +94,14 @@ storiesOf("Components/Search/SuggestionItems", module).add("Some items", () => (
       query="a query"
     />
     <SuggestionItem
-      display="display two"
+      display="display two aklsdfjalkdfj alksdjf alkdfjs lakjds flkajsd flkajs dflkaj sdflkja sdfklja sdflk asdklfj aklsdjf lakdjsf lkajds flkajsd flkajs flkajsd flkajdf alksdjalksjdfalsdfk j"
       href="/"
       isHighlighted
       label="label two"
       query="a query"
     />
     <SuggestionItem
-      display="display three"
+      display="display three aklsdfj alksdjf alksdj falkdjsf alkjds flakjdsflakjds flakjsdflajs dflkajsf"
       href="/"
       isHighlighted={false}
       label="label three"


### PR DESCRIPTION
This PR aims to match the comp for suggestion spacing. We have properly spaced the suggestion title and the enter icon so that the former grows and shrinks, but the latter stays static. If the text of the suggestion title is too long it'll be truncated with ellipses. Here are some pictures for your scrapbook:

<img width="1335" alt="screen shot 2019-02-25 at 5 22 51 pm" src="https://user-images.githubusercontent.com/79799/53375849-065de980-3922-11e9-8485-d117973ac945.png">
<img width="1335" alt="screen shot 2019-02-25 at 5 22 57 pm" src="https://user-images.githubusercontent.com/79799/53375850-065de980-3922-11e9-8e5c-3421d3ee4802.png">
