### PR TITLE
@mzikherman => [Autosuggest] Hook up event dispatch for analytics tracking

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -22,6 +22,7 @@ import {
   RelayRefetchProp,
 } from "react-relay"
 import styled from "styled-components"
+import Events from "Utils/Events"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
@@ -105,7 +106,9 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
   )
 }
 
-@track()
+@track(null, {
+  dispatch: data => Events.postEvent(data),
+})
 export class SearchBar extends Component<Props, State> {
   public input: HTMLInputElement
   private containerRef: Node

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -66,12 +66,12 @@ const DefaultSuggestion = ({ display, label, query }) => {
 
 const HighlightIcon = () => (
   <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg">
-    <g fill="none" fill-rule="evenodd">
+    <g fill="none" fillRule="evenodd">
       <path fill="none" d="M0 0h18v18H0z" />
       <path
         d="M4.883 11.244l3.108 3.068-.693.688L3 10.758l4.299-4.23.692.689-3.106 3.056h9.134V3H15v8.244H4.883z"
         fill="#000"
-        fill-rule="nonzero"
+        fillRule="nonzero"
       />
     </g>
   </svg>


### PR DESCRIPTION
Thanks @damassi for the tip, noticed these weren't actually firing outside of storybooks (usually we use `<Boot>` to wrap up apps which gives us this).