### PR TITLE
DISCO-759: Add search bar icon

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -26,6 +26,7 @@ import Events from "Utils/Events"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
+import { SearchInputContainer } from "./SearchInputContainer"
 
 const logger = createLogger("Components/Search/SearchBar")
 
@@ -288,9 +289,7 @@ export class SearchBar extends Component<Props, State> {
     )
   }
 
-  renderInputComponent = inputProps => {
-    return <Input style={{ width: "100%" }} {...inputProps} />
-  }
+  renderInputComponent = props => <SearchInputContainer {...props} />
 
   renderAutosuggestComponent({ xs }) {
     const { term } = this.state

--- a/src/Components/Search/SearchInputContainer.tsx
+++ b/src/Components/Search/SearchInputContainer.tsx
@@ -20,7 +20,7 @@ const SearchButton = styled.button`
     border-radius: 50%;
 
     svg > path {
-      fill: #fff;
+      fill: ${color("white100")};
     }
   }
 `
@@ -31,10 +31,11 @@ export const SearchInputContainer = props => {
       <Input style={{ width: "100%" }} {...props} />
       <SearchButton>
         <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg">
+          <title>search</title>
           <path
             d="M11.5 3a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7zm0-1A4.5 4.5 0 1 0 16 6.5 4.49 4.49 0 0 0 11.5 2zM9.442 9.525l-.88-.88L2.06 15.06l.88.88 6.502-6.415z"
             fill="#000"
-            fill-rule="nonzero"
+            fillRule="nonzero"
           />
         </svg>
       </SearchButton>

--- a/src/Components/Search/SearchInputContainer.tsx
+++ b/src/Components/Search/SearchInputContainer.tsx
@@ -25,10 +25,10 @@ const SearchButton = styled.button`
   }
 `
 
-export const SearchInputContainer = props => {
+export const SearchInputContainer: React.ExoticComponent<any> = React.forwardRef((props, ref) => {
   return (
     <Box style={{ position: "relative" }}>
-      <Input style={{ width: "100%" }} {...props} />
+      <Input ref={ref} style={{ width: "100%" }} {...props} />
       <SearchButton>
         <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg">
           <title>search</title>
@@ -41,4 +41,4 @@ export const SearchInputContainer = props => {
       </SearchButton>
     </Box>
   )
-}
+})

--- a/src/Components/Search/SearchInputContainer.tsx
+++ b/src/Components/Search/SearchInputContainer.tsx
@@ -1,0 +1,43 @@
+import { Box, color } from "@artsy/palette"
+import Input from "Components/Input"
+import React from "react"
+import styled from "styled-components"
+
+const SearchButton = styled.button`
+  position: absolute;
+  right: 0;
+  top: 50%;
+  border: none;
+  margin-top: -14px;
+  width: 24px;
+  height: 24px;
+  margin-right: 10px;
+  background: none;
+  padding: 0;
+
+  :focus {
+    background: ${color("purple100")};
+    border-radius: 50%;
+
+    svg > path {
+      fill: #fff;
+    }
+  }
+`
+
+export const SearchInputContainer = props => {
+  return (
+    <Box style={{ position: "relative" }}>
+      <Input style={{ width: "100%" }} {...props} />
+      <SearchButton>
+        <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M11.5 3a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7zm0-1A4.5 4.5 0 1 0 16 6.5 4.49 4.49 0 0 0 11.5 2zM9.442 9.525l-.88-.88L2.06 15.06l.88.88 6.502-6.415z"
+            fill="#000"
+            fill-rule="nonzero"
+          />
+        </svg>
+      </SearchButton>
+    </Box>
+  )
+}


### PR DESCRIPTION
This PR adds the search icon to the search bar. Like on #2061, I'm just adding the icon here in reaction, but ultimately I want to get this into Palette and consume from there - this is on the short list of icons to add when I have a moment. Here are some shots:

<img width="1399" alt="screen shot 2019-02-26 at 9 02 45 am" src="https://user-images.githubusercontent.com/79799/53422750-aa3ca900-39a5-11e9-804f-f14e5a27e4e2.png">
<img width="1399" alt="screen shot 2019-02-26 at 9 02 49 am" src="https://user-images.githubusercontent.com/79799/53422752-ac066c80-39a5-11e9-9d65-0d71b9de8ddd.png">
<img width="1399" alt="screen shot 2019-02-26 at 9 02 52 am" src="https://user-images.githubusercontent.com/79799/53422753-ad379980-39a5-11e9-91fd-fbb5c215aec7.png">
