### PR TITLE
DISCO-760: Add an "empty" preview for artists without collections or artworks

### DIFF
--- a/src/Components/Search/Previews/Grids/ArtistSearch/NoResults.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/NoResults.tsx
@@ -1,10 +1,46 @@
 import { Flex, Serif } from "@artsy/palette"
 import React from "react"
 
+const ArtworkIcon: React.SFC = () => {
+  return (
+    <svg width="18px" height="18px" viewBox="2 2 14 14" version="1.1">
+      <title>Artwork</title>
+      <desc>Artwork icon</desc>
+      <g
+        id="Indicator/Artwork/Md"
+        stroke="none"
+        strokeWidth="1"
+        fill="none"
+        fillRule="evenodd"
+      >
+        <path
+          d="M5.68794719,6 L9.04687494,2.24412276 L12.3137773,6 L15,6 L15,15 L3,15 L3,6 L5.68794719,6 Z M7.02951148,6 L10.9884205,6 L9.03645839,3.75587724 L7.02951148,6 Z M4,7 L4,14 L14,14 L14,7 L4,7 Z M6,9 L6,12 L12,12 L12,9 L6,9 Z M5,8 L13,8 L13,13 L5,13 L5,8 Z"
+          id="Combined-Shape"
+          fill="#000000"
+          fillRule="nonzero"
+        />
+      </g>
+    </svg>
+  )
+}
+
 export const NoResultsPreview: React.SFC = () => {
   return (
-    <Flex>
-      <Serif size="2" color="black100">
+    <Flex
+      justifyContent="center"
+      alignItems="center"
+      flexDirection="column"
+      my={140}
+      pr={3}
+    >
+      <ArtworkIcon />
+      <Serif
+        size="2"
+        color="black100"
+        mt={1}
+        mx={[0, 2, 2, "115px"]}
+        textAlign="center"
+      >
         This artist does not have any work on Artsy yet.
       </Serif>
     </Flex>

--- a/src/Components/Search/Previews/Grids/ArtistSearch/NoResults.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/NoResults.tsx
@@ -1,0 +1,12 @@
+import { Flex, Serif } from "@artsy/palette"
+import React from "react"
+
+export const NoResultsPreview: React.SFC = () => {
+  return (
+    <Flex>
+      <Serif size="2" color="black100">
+        This artist does not have any work on Artsy yet.
+      </Serif>
+    </Flex>
+  )
+}

--- a/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
@@ -6,6 +6,7 @@ import { Media } from "Utils/Responsive"
 
 import { RelatedArtworksPreview_viewer } from "__generated__/RelatedArtworksPreview_viewer.graphql"
 import { PreviewGridItemFragmentContainer as PreviewGridItem } from "../PreviewGridItem"
+import { NoResultsPreview } from "./NoResults"
 
 interface RelatedArtworksPreviewProps {
   viewer: RelatedArtworksPreview_viewer
@@ -18,6 +19,10 @@ export const RelatedArtworksPreview: React.SFC<RelatedArtworksPreviewProps> = ({
     x => x.filter_artworks.artworks_connection.edges,
     []
   ).map(x => x.node)
+
+  if (artworks.length === 0) {
+    return <NoResultsPreview />
+  }
 
   const relatedArtworks = artworks.map((artwork, i) => (
     <Box width={["0%", "100%", "100%", "50%"]} key={i}>

--- a/src/Components/Search/Previews/Grids/ArtistSearch/__tests__/index.test.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import { graphql } from "react-relay"
 import { PreviewGridItem } from "../../PreviewGridItem"
 import { ArtistSearchPreviewFragmentContainer } from "../index"
 import { MarketingCollectionsPreview } from "../MarketingCollections"
+import { NoResultsPreview } from "../NoResults"
 import { RelatedArtworksPreview } from "../RelatedArtworks"
 
 jest.unmock("react-relay")
@@ -39,7 +40,7 @@ const getWrapper = (viewer, breakpoint = "xl") => {
 
 const buildArtworksConnection: any = (numberOfItems: number) => {
   const edges = Array(numberOfItems)
-    .fill(1)
+    .fill(undefined)
     .map((_, i) => ({
       node: buildNode(i),
     }))
@@ -97,7 +98,24 @@ describe("ArtistSearchPreviewFragmentContainer", () => {
       })
 
       describe("an artist with no related artworks", () => {
-        // it("renders an empty preview", async() => {})
+        it("renders an empty preview", async () => {
+          const viewer = {
+            artist: {
+              id: "andy-warhol",
+              marketingCollections: [],
+            },
+            filter_artworks: {
+              artworks_connection: buildArtworksConnection(0),
+            },
+          }
+
+          const wrapper = await getWrapper(viewer, "md")
+
+          expect(wrapper.find(NoResultsPreview).length).toEqual(1)
+          expect(wrapper.text()).toEqual(
+            "This artist does not have any work on Artsy yet."
+          )
+        })
       })
     })
   })

--- a/src/Components/Search/Previews/Grids/ArtistSearch/__tests__/index.test.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/__tests__/index.test.tsx
@@ -73,14 +73,28 @@ describe("ArtistSearchPreviewFragmentContainer", () => {
           },
         }
 
-        const wrapper = await getWrapper(viewer)
+        const wrapper = await getWrapper(viewer, "lg")
 
         expect(wrapper.find(MarketingCollectionsPreview).length).toEqual(0)
         expect(wrapper.find(RelatedArtworksPreview).length).toEqual(1)
         expect(wrapper.find(PreviewGridItem).length).toEqual(10)
       })
 
-      // it("renders 5 artworks at md", async() => {})
+      it("renders 5 artworks at md", async () => {
+        const viewer = {
+          artist: {
+            id: "andy-warhol",
+            marketingCollections: [],
+          },
+          filter_artworks: {
+            artworks_connection: buildArtworksConnection(10),
+          },
+        }
+
+        const wrapper = await getWrapper(viewer, "md")
+
+        expect(wrapper.find(PreviewGridItem).length).toEqual(5)
+      })
 
       describe("an artist with no related artworks", () => {
         // it("renders an empty preview", async() => {})

--- a/src/Components/Search/Previews/Grids/ArtistSearch/__tests__/index.test.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/__tests__/index.test.tsx
@@ -37,45 +37,54 @@ const getWrapper = (viewer, breakpoint = "xl") => {
   })
 }
 
+const buildArtworksConnection: any = (numberOfItems: number) => {
+  const edges = Array(numberOfItems)
+    .fill(1)
+    .map((_, i) => ({
+      node: buildNode(i),
+    }))
+
+  return {
+    edges,
+  }
+}
+
+const buildNode: any = (nodeIndex: number) => ({
+  artist_names: "Andy Warhol",
+  date: "tomorrow",
+  href: `http://artsy.net/artwork/ugly-flower-${nodeIndex}`,
+  image: {
+    cropped: { url: "http://path/to/ugly-image.jpg" },
+  },
+  title: `Ugly Flower-${nodeIndex}`,
+})
+
 describe("ArtistSearchPreviewFragmentContainer", () => {
   describe("an artist with no marketing collections", () => {
-    it("renders related artworks", async () => {
-      const viewer = {
-        artist: {
-          id: "andy-warhol",
-          marketingCollections: [],
-        },
-        filter_artworks: {
-          artworks_connection: {
-            edges: [
-              {
-                node: {
-                  artist_names: "Andy Warhol",
-                  date: "yesterday",
-                  href: "http://artsy.net/artwork/pretty-flower",
-                  image: { cropped: { url: "http://path/to/image.jpg" } },
-                  title: "Pretty Flower",
-                },
-              },
-              {
-                node: {
-                  artist_names: "Andy Warhol",
-                  date: "tomorrow",
-                  href: "http://artsy.net/artwork/ugly-flower",
-                  image: { cropped: { url: "http://path/to/ugly-image.jpg" } },
-                  title: "Ugly Flower",
-                },
-              },
-            ],
+    describe("an artist with related artworks", () => {
+      it("renders 10 related artworks at lg", async () => {
+        const viewer = {
+          artist: {
+            id: "andy-warhol",
+            marketingCollections: [],
           },
-        },
-      }
+          filter_artworks: {
+            artworks_connection: buildArtworksConnection(10),
+          },
+        }
 
-      const wrapper = await getWrapper(viewer)
+        const wrapper = await getWrapper(viewer)
 
-      expect(wrapper.find(MarketingCollectionsPreview).length).toEqual(0)
-      expect(wrapper.find(RelatedArtworksPreview).length).toEqual(1)
-      expect(wrapper.find(PreviewGridItem).length).toEqual(2)
+        expect(wrapper.find(MarketingCollectionsPreview).length).toEqual(0)
+        expect(wrapper.find(RelatedArtworksPreview).length).toEqual(1)
+        expect(wrapper.find(PreviewGridItem).length).toEqual(10)
+      })
+
+      // it("renders 5 artworks at md", async() => {})
+
+      describe("an artist with no related artworks", () => {
+        // it("renders an empty preview", async() => {})
+      })
     })
   })
 

--- a/src/Components/Search/Previews/Grids/ArtistSearch/__tests__/index.test.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/__tests__/index.test.tsx
@@ -112,7 +112,7 @@ describe("ArtistSearchPreviewFragmentContainer", () => {
           const wrapper = await getWrapper(viewer, "md")
 
           expect(wrapper.find(NoResultsPreview).length).toEqual(1)
-          expect(wrapper.text()).toEqual(
+          expect(wrapper.text()).toContain(
             "This artist does not have any work on Artsy yet."
           )
         })

--- a/src/Components/__stories__/Search.story.tsx
+++ b/src/Components/__stories__/Search.story.tsx
@@ -125,6 +125,16 @@ storiesOf("Components/Search/Previews/Artist", module)
       </ContextProvider>
     </Box>
   ))
+  .add("An artist with neither collections nor related artworks", () => (
+    <Box width="450px" p={2}>
+      <ContextProvider>
+        <SearchPreview
+          entityID="miguel-angel-angel-rojas"
+          entityType="Artist"
+        />
+      </ContextProvider>
+    </Box>
+  ))
 
 storiesOf("Components/Search/Previews/MerchandisableArtworks", module).add(
   "No query",


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-760.

Some artists in the search suggestions do not have marketing collections or artworks. Previously, we were showing the title "Related Artworks" in the right pane, with no actual artworks. 

Now, we'll show this instead: 

![image](https://user-images.githubusercontent.com/1627089/53444611-41205a00-39d4-11e9-9532-b520ca828a63.png)

There are a couple small things that I'll follow up with in other PR's - I'll point them out in the code.