### PR TITLE
Fix link styles in Collections header

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -107,10 +107,19 @@ export class CollectionHeader extends Component<Props> {
                     <Overlay />
                     <MetaContainer>
                       <SubtitlesContainer>
-                        <Sans size={["2", "3"]} color="white100">
+                        <Sans
+                          size={["2", "3"]}
+                          weight="medium"
+                          color="white100"
+                        >
                           <a href={categoryTarget}>{collection.category}</a>
                         </Sans>
-                        <Sans size={["2", "3"]} color="white100" ml="auto">
+                        <Sans
+                          size={["2", "3"]}
+                          weight="medium"
+                          color="white100"
+                          ml="auto"
+                        >
                           <a href="/collect">View all artworks</a>
                         </Sans>
                       </SubtitlesContainer>
@@ -191,9 +200,21 @@ const DescriptionContainer = styled(Flex)``
 
 const SubtitlesContainer = styled(Box)`
   display: flex;
+  color: white;
+
+  a,
+  a:hover {
+    color: inherit;
+  }
 
   ${Sans} {
     text-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
+
+    &:last-child {
+      a {
+        text-decoration: underline;
+      }
+    }
   }
 `
 


### PR DESCRIPTION
Looks like we have a style somewhere that is automatically turning links black, but not sure what side-effects it would result in changing from the top. 

Added a declaration for links in the header to inherit color from their parent, and also added underline/weight based on the spec here: https://app.zeplin.io/project/5b8437e1d4b17846b691835d/screen/5bd228c91311fc09c269bbde 