### PR TITLE
Make @sentry/browser a peer dependency of reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-router": "^4.2.0",
-    "styled-components": "^4"
+    "styled-components": "^4",
+    "@sentry/browser": "^4.2.3"
   },
   "scripts": {
     "clean": "rm -rf dist",
@@ -63,6 +64,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.0.0",
     "@omakase/cli": "^0.0.5",
+    "@sentry/browser": "^4.2.3",
     "@storybook/addon-info": "^4.0.12",
     "@storybook/addon-options": "^4.0.12",
     "@storybook/addons": "^4.0.12",
@@ -154,7 +156,6 @@
   "dependencies": {
     "@artsy/detect-responsive-traits": "^0.0.1",
     "@artsy/react-responsive-media": "^2.0.0-beta.5",
-    "@sentry/browser": "^4.2.3",
     "autosuggest-highlight": "^3.1.1",
     "cheerio": "^1.0.0-rc.2",
     "currency.js": "^1.2.1",


### PR DESCRIPTION
This removes `@sentry/browser` from being a direct dependency of reaction. Libraries like this that are utilized by the parent project shouldn't be direct dependencies. This was causing a duplication in our upstream webpack dependency in force. 

I'll go through and ensure positron, volt, and whoever else depends on reaction has this dependency specified in their projects.  I'm using [this link](https://github.com/search?q=org%3Aartsy+%22%40artsy%2Freaction%22+filename%3Apackage.json&type=Code) to look through the org for things that depend on reaction and ensure they have sentry too. 