### PR TITLE
Prevent body from intercepting scroll events when modal is not open (GALL-1430, DISCO-683)

### DIFF
--- a/src/Components/Authentication/__tests__/Desktop/ModalManager.test.tsx
+++ b/src/Components/Authentication/__tests__/Desktop/ModalManager.test.tsx
@@ -57,7 +57,7 @@ describe("ModalManager", () => {
     const wrapper = getWrapper()
     const manager = wrapper.instance() as ModalManager
 
-    expect(document.body.style.overflowY).toEqual("auto")
+    expect(document.body.style.overflowY).toEqual("visible")
 
     manager.openModal({
       mode: ModalType.login,

--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -96,7 +96,7 @@ export class ModalWrapper extends React.Component<
     if (this.props.show) {
       document.body.style.overflowY = "hidden"
     } else {
-      document.body.style.overflowY = "auto"
+      document.body.style.overflowY = "visible"
     }
   }
 


### PR DESCRIPTION
Follow up on https://github.com/artsy/reaction/pull/1858

Fixes https://artsyproduct.atlassian.net/browse/DISCO-683, https://artsyproduct.atlassian.net/browse/GALL-1430

### Problem
This issue was surfaced by a broken infinite scrolling experience. Setting `overflow-y` to `auto` on `body` (+ [other requirements](https://drafts.csswg.org/cssom-view/#viewport)) makes it scrollable when the content overflows. Since [scroll events don't bubble on elements](https://drafts.csswg.org/cssom-view/#scrolling-events), they get intercepted by `body`, and that causes `window` that typically [listens to scroll events](https://github.com/artsy/jquery-on-infinite-scroll/blob/ca95a69d30e26443c431f790ba7b9ee8f2a5f781/index.js#L23) to not receive them. Therefore, the infinite scrolling broke. See this [JSFiddle](https://jsfiddle.net/8h9xbt0j/1/) for demonstration.

### Solution
This PR sets the `overflow-y` to `visible` which is the default.

### Why is this only reproducible on Firefox?
We specify `overflow-x: hidden` on `html` only for [Firefox](https://github.com/artsy/force/blob/7d769ecf961bffa49f0a0ee930a16a19a79d205d/src/desktop/components/main_layout/stylesheets/index.styl#L51-L52), and _I think_ that's one of the requirements to make `body` [scrollable](https://drafts.csswg.org/cssom-view/#viewport) and receive scroll events.