### PR TITLE
Randomize collections rail

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -771,6 +771,7 @@ type Artwork implements Node & Searchable & Sellable {
 
   # A type-specific Gravity Mongo Document ID.
   _id: String!
+  cached: Int
   additional_information(format: Format): String
   artist(
     # Use whatever is in the original response instead of making a request
@@ -926,7 +927,6 @@ type Artwork implements Node & Searchable & Sellable {
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
   certificateOfAuthenticity: ArtworkInfoRow
-  cached: Int
 }
 
 enum ArtworkAggregation {
@@ -1616,6 +1616,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # A type-specific Gravity Mongo Document ID.
   _id: String!
+  cached: Int
   additional_information(format: Format): String
   artist(
     # Use whatever is in the original response instead of making a request
@@ -1771,7 +1772,6 @@ type ArtworkItem implements Node & Searchable & Sellable {
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
   certificateOfAuthenticity: ArtworkInfoRow
-  cached: Int
 }
 
 type ArtworkLayer {
@@ -2439,7 +2439,9 @@ type City {
   coordinates: LatLng
   shows(
     sort: PartnerShowSorts
-    status: EventStatus
+
+    # By default we filter shows by current
+    status: EventStatus = CURRENT
 
     # Whether to include local discovery stubs as well as displayable shows
     discoverable: Boolean
@@ -2787,7 +2789,7 @@ input CreateGeminiEntryForAssetInput {
   # The S3 bucket where the file was uploaded
   source_bucket: String!
 
-  # Additional JSON data to pass through gemini, should deiinitely contain an `id` and a `_type`
+  # Additional JSON data to pass through gemini, should definitely contain an `id` and a `_type`
   metadata: JSON!
   clientMutationId: String
 }
@@ -3378,6 +3380,9 @@ type FairExhibitor {
 
   # Exhibitors id
   id: String
+
+  # Exhibitors _id
+  partner_id: String
 
   # Partner default profile id
   profile_id: String
@@ -4288,7 +4293,7 @@ type HomePage {
     # ID of followed artist to target for related artist rails
     followed_artist_id: String
 
-    # ID of generic gene rail to target
+    # [DEPRECATED: Favor more specific `generic_gene_id`] ID of generic gene rail to target
     generic_gene_id: String
 
     # ID of generic gene rail to target
@@ -4357,14 +4362,15 @@ type HomePageArtworkModule implements Node {
 }
 
 enum HomePageArtworkModuleTypes {
+  FOLLOWED_GENES
+  GENERIC_GENES
   ACTIVE_BIDS
   CURRENT_FAIRS
   FOLLOWED_ARTIST
   FOLLOWED_ARTISTS
   FOLLOWED_GALLERIES
-  FOLLOWED_GENES
-  GENERIC_GENES
   LIVE_AUCTIONS
+  POPULAR_ARTISTS
   RECOMMENDED_WORKS
   RELATED_ARTISTS
   SAVED_WORKS
@@ -7286,7 +7292,7 @@ type Query {
     # Entities to include in search. Default: [ARTIST, ARTWORK].
     entities: [SearchEntity]
 
-    # Mode of search to exceute. Default: SITE.
+    # Mode of search to execute. Default: SITE.
     mode: SearchMode
     after: String
     first: Int
@@ -7398,6 +7404,7 @@ type Query {
   # Find partners by ID
   _unused_gravity_partners(ids: [ID]!): [DoNotUseThisPartner]
   marketingCollections(
+    randomize: Boolean
     size: Int
     showOnEditorial: Boolean
     artistID: String
@@ -8301,7 +8308,9 @@ type Show implements Node {
   # Shows that are near (~75km) from this show
   nearbyShows(
     sort: PartnerShowSorts
-    status: EventStatus
+
+    # By default show only current shows
+    status: EventStatus = CURRENT
 
     # Whether to include local discovery stubs as well as displayable shows
     discoverable: Boolean
@@ -9209,7 +9218,7 @@ type Viewer {
     # Entities to include in search. Default: [ARTIST, ARTWORK].
     entities: [SearchEntity]
 
-    # Mode of search to exceute. Default: SITE.
+    # Mode of search to execute. Default: SITE.
     mode: SearchMode
     after: String
     first: Int

--- a/src/Components/CollectionsRail/index.tsx
+++ b/src/Components/CollectionsRail/index.tsx
@@ -19,12 +19,18 @@ export const CollectionsRailContent: React.SFC<Props> = () => {
             variables={{
               showOnEditorial: true,
               size: 4,
+              randomize: true,
             }}
             query={graphql`
-              query CollectionsRailQuery {
+              query CollectionsRailQuery(
+                $showOnEditorial: Boolean
+                $size: Int
+                $randomize: Boolean
+              ) {
                 collections: marketingCollections(
-                  showOnEditorial: true
-                  size: 4
+                  showOnEditorial: $showOnEditorial
+                  size: $size
+                  randomize: $randomize
                 ) {
                   ...CollectionsRail_collections
                 }

--- a/src/__generated__/CollectionsRailQuery.graphql.ts
+++ b/src/__generated__/CollectionsRailQuery.graphql.ts
@@ -2,7 +2,11 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { CollectionsRail_collections$ref } from "./CollectionsRail_collections.graphql";
-export type CollectionsRailQueryVariables = {};
+export type CollectionsRailQueryVariables = {
+    readonly showOnEditorial?: boolean | null;
+    readonly size?: number | null;
+    readonly randomize?: boolean | null;
+};
 export type CollectionsRailQueryResponse = {
     readonly collections: ReadonlyArray<{
         readonly " $fragmentRefs": CollectionsRail_collections$ref;
@@ -16,8 +20,12 @@ export type CollectionsRailQuery = {
 
 
 /*
-query CollectionsRailQuery {
-  collections: marketingCollections(showOnEditorial: true, size: 4) {
+query CollectionsRailQuery(
+  $showOnEditorial: Boolean
+  $size: Int
+  $randomize: Boolean
+) {
+  collections: marketingCollections(showOnEditorial: $showOnEditorial, size: $size, randomize: $randomize) {
     ...CollectionsRail_collections
     __id: id
   }
@@ -41,19 +49,45 @@ fragment CollectionEntity_collection on MarketingCollection {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "kind": "Literal",
+    "kind": "LocalArgument",
     "name": "showOnEditorial",
-    "value": true,
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "size",
+    "type": "Int",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "randomize",
+    "type": "Boolean",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "randomize",
+    "variableName": "randomize",
     "type": "Boolean"
   },
   {
-    "kind": "Literal",
+    "kind": "Variable",
+    "name": "showOnEditorial",
+    "variableName": "showOnEditorial",
+    "type": "Boolean"
+  },
+  {
+    "kind": "Variable",
     "name": "size",
-    "value": 4,
+    "variableName": "size",
     "type": "Int"
   }
 ],
-v1 = {
+v2 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
@@ -65,21 +99,21 @@ return {
   "operationKind": "query",
   "name": "CollectionsRailQuery",
   "id": null,
-  "text": "query CollectionsRailQuery {\n  collections: marketingCollections(showOnEditorial: true, size: 4) {\n    ...CollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment CollectionsRail_collections on MarketingCollection {\n  ...CollectionEntity_collection\n  __id: id\n}\n\nfragment CollectionEntity_collection on MarketingCollection {\n  slug\n  headerImage\n  title\n  price_guidance\n  show_on_editorial\n  __id: id\n}\n",
+  "text": "query CollectionsRailQuery(\n  $showOnEditorial: Boolean\n  $size: Int\n  $randomize: Boolean\n) {\n  collections: marketingCollections(showOnEditorial: $showOnEditorial, size: $size, randomize: $randomize) {\n    ...CollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment CollectionsRail_collections on MarketingCollection {\n  ...CollectionEntity_collection\n  __id: id\n}\n\nfragment CollectionEntity_collection on MarketingCollection {\n  slug\n  headerImage\n  title\n  price_guidance\n  show_on_editorial\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
     "name": "CollectionsRailQuery",
     "type": "Query",
     "metadata": null,
-    "argumentDefinitions": [],
+    "argumentDefinitions": v0,
     "selections": [
       {
         "kind": "LinkedField",
         "alias": "collections",
         "name": "marketingCollections",
-        "storageKey": "marketingCollections(showOnEditorial:true,size:4)",
-        "args": v0,
+        "storageKey": null,
+        "args": v1,
         "concreteType": "MarketingCollection",
         "plural": true,
         "selections": [
@@ -88,7 +122,7 @@ return {
             "name": "CollectionsRail_collections",
             "args": null
           },
-          v1
+          v2
         ]
       }
     ]
@@ -96,14 +130,14 @@ return {
   "operation": {
     "kind": "Operation",
     "name": "CollectionsRailQuery",
-    "argumentDefinitions": [],
+    "argumentDefinitions": v0,
     "selections": [
       {
         "kind": "LinkedField",
         "alias": "collections",
         "name": "marketingCollections",
-        "storageKey": "marketingCollections(showOnEditorial:true,size:4)",
-        "args": v0,
+        "storageKey": null,
+        "args": v1,
         "concreteType": "MarketingCollection",
         "plural": true,
         "selections": [
@@ -142,12 +176,12 @@ return {
             "args": null,
             "storageKey": null
           },
-          v1
+          v2
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = '9ee28f8d83eeabe7160d78de0db00e88';
+(node as any).hash = '566ba8777f4ede125598df15a4907d1f';
 export default node;


### PR DESCRIPTION
Addresses: [GROW-1145](https://artsyproduct.atlassian.net/browse/GROW-1145)

This address the last bit of Collections Rail UI by adding the `randomize` argument to the collections query.

![screen shot 2019-02-27 at 10 59 42 am](https://user-images.githubusercontent.com/5201004/53503825-d9731900-3a7e-11e9-8e89-6495551067ec.png)
