### PR TITLE
Add separator between RelatedArticlesCanvas and CollectionsRail

### DIFF
--- a/src/Components/CollectionsRail/CollectionsRail.tsx
+++ b/src/Components/CollectionsRail/CollectionsRail.tsx
@@ -52,7 +52,7 @@ export class CollectionsRail extends React.Component<CollectionRailsProps> {
     return (
       <RailsWrapper pb={3}>
         <Waypoint onEnter={once(this.trackImpression.bind(this))} />
-        <Sans size="6">Shop artworks from curated collections</Sans>
+        <Sans size={["6", "8"]}>Shop works from curated collections</Sans>
         <Spacer mb={3} />
         <Flex flexWrap="wrap">
           {collections.map((collection, index) => {

--- a/src/Components/CollectionsRail/__tests__/CollectionsRail.test.tsx
+++ b/src/Components/CollectionsRail/__tests__/CollectionsRail.test.tsx
@@ -19,7 +19,7 @@ describe("CollectionsRail", () => {
 
   it("Renders expected fields", () => {
     const component = mount(<CollectionsRail {...props} />)
-    expect(component.text()).toMatch("Shop artworks from curated collections")
+    expect(component.text()).toMatch("Shop works from curated collections")
     expect(component.find(CollectionEntity).length).toBe(4)
     expect(component.text()).toMatch("Jasper Johns: Flags")
     expect(component.text()).toMatch("Works from $1,000")

--- a/src/Components/Publishing/Layouts/Components/CanvasFooter.tsx
+++ b/src/Components/Publishing/Layouts/Components/CanvasFooter.tsx
@@ -1,4 +1,4 @@
-import { color } from "@artsy/palette"
+import { color, Separator } from "@artsy/palette"
 import { CollectionsRailContent } from "Components/CollectionsRail"
 import {
   ArticleData,
@@ -30,7 +30,12 @@ export const CanvasFooter: React.SFC<CanvasFooterProps> = props => {
         />
       )}
 
-      {props.showCollectionsRail && <CollectionsRailContent {...props} />}
+      {props.showCollectionsRail && (
+        <div>
+          <Separator mb={4} />
+          <CollectionsRailContent {...props} />
+        </div>
+      )}
 
       {display && (
         <DisplayContainer hasBorder={relatedArticles ? true : false}>

--- a/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
@@ -62,8 +62,7 @@ const getTitle = vertical => {
   if (vertical) {
     return (
       <Title size={["6", "8"]}>
-        Further reading in{" "}
-        <VerticalSpan>{vertical.name.toLowerCase()}</VerticalSpan>
+        Further reading in <VerticalSpan>{vertical.name}</VerticalSpan>
       </Title>
     )
   } else {

--- a/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
@@ -61,12 +61,13 @@ export class RelatedArticlesCanvas extends React.Component<
 const getTitle = vertical => {
   if (vertical) {
     return (
-      <Title size="8">
-        Further Reading in <VerticalSpan>{vertical.name}</VerticalSpan>
+      <Title size={["6", "8"]}>
+        Further reading in{" "}
+        <VerticalSpan>{vertical.name.toLowerCase()}</VerticalSpan>
       </Title>
     )
   } else {
-    return <Title size="8">More from Artsy Editorial</Title>
+    return <Title size={["6", "8"]}>More from Artsy Editorial</Title>
   }
 }
 

--- a/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
@@ -1,4 +1,4 @@
-import { Sans } from "@artsy/palette"
+import { Flex, Sans } from "@artsy/palette"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { RelatedArticleCanvasData } from "Components/Publishing/Typings"
@@ -40,7 +40,7 @@ export class RelatedArticlesCanvas extends React.Component<
     const { articles, isMobile, vertical } = this.props
 
     return (
-      <RelatedArticlesContainer>
+      <Flex flexDirection="column" maxWidth={1250} mx="auto" mt={4} mb={6}>
         {getTitle(vertical)}
         <Waypoint onEnter={once(this.trackRelatedImpression.bind(this))} />
         <ArticlesWrapper isMobile={isMobile}>
@@ -53,7 +53,7 @@ export class RelatedArticlesCanvas extends React.Component<
             )
           })}
         </ArticlesWrapper>
-      </RelatedArticlesContainer>
+      </Flex>
     )
   }
 }
@@ -69,13 +69,6 @@ const getTitle = vertical => {
     return <Title size="8">More from Artsy Editorial</Title>
   }
 }
-
-const RelatedArticlesContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  max-width: 1250px;
-  margin: 40px auto 80px auto;
-`
 
 const Title = styled(Sans)`
   margin-bottom: 20px;

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticlesCanvas.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticlesCanvas.test.tsx
@@ -29,7 +29,7 @@ describe("RelatedArticlesCanvas", () => {
 
   it("renders the vertical name if there is one", () => {
     const component = getWrapper(testProps)
-    expect(component.html()).toMatch("Art Market")
+    expect(component.text()).toMatch("Further reading in Art Market")
   })
 
   it("renders a default message if there is no vertical", () => {

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
 
 .c2 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
+  font-size: 22px;
+  line-height: 30px;
 }
 
 .c8 {
@@ -132,6 +132,18 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   margin-right: 0;
 }
 
+@media screen and (min-width:40em) {
+  .c2 {
+    font-size: 28px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c2 {
+    line-height: 36px;
+  }
+}
+
 @media (max-width:720px) {
   .c5 {
     width: 225px;
@@ -189,9 +201,14 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   <div
     className="c1 c2"
     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
-    fontSize="28px"
+    fontSize={
+      Array [
+        "22px",
+        "28px",
+      ]
+    }
   >
-    Further Reading in 
+    Further reading in 
     <span
       className="c3"
     >

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
@@ -1,6 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 128px;
+  margin-top: 32px;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1250px;
+}
+
 .c2 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-size: 28px;
@@ -87,18 +102,6 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   height: 185px;
   margin-bottom: 10px;
   object-fit: cover;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  max-width: 1250px;
-  margin: 40px auto 80px auto;
 }
 
 .c1 {

--- a/src/Components/Publishing/__stories__/ArticleStandard.story.tsx
+++ b/src/Components/Publishing/__stories__/ArticleStandard.story.tsx
@@ -130,6 +130,7 @@ story.add(`Multiple articles`, () => {
           display={Display("slideshow")}
           relatedArticlesForPanel={RelatedPanel}
           relatedArticlesForCanvas={RelatedCanvas}
+          showCollectionsRail
         />
         <Article
           article={article}


### PR DESCRIPTION
- Adds separator and updates margins between articles and collections rail per spec here- https://app.zeplin.io/project/5aabc5e0786bbb29b6e3dc7f/screen/5c59c0e1135eaf355f77a1a1

- Matches font size of `RelatedArticlesCanvas` and `CollectionsRail` titles
- Adds a slight font size bump down for mobile on titles
- Removes capitalization in related articles title 
- Changes 'artworks' to 'works' in collections rail title