### PR TITLE
Avoid endlessly requesting further pages of followed artists' artworks

### DIFF
--- a/src/Apps/WorksForYou/WorksForYouFeed.tsx
+++ b/src/Apps/WorksForYou/WorksForYouFeed.tsx
@@ -52,7 +52,7 @@ export class WorksForYouFeed extends Component<Props, State> {
 
   maybeLoadMore() {
     const threshold = window.innerHeight + window.scrollY
-    const el = ReactDOM.findDOMNode(this) as Element
+    const el = ReactDOM.findDOMNode(this).parentElement as Element
     if (threshold >= el.clientHeight + el.scrollTop) {
       this.loadMoreArtworks()
     }


### PR DESCRIPTION
When users scroll down even slightly on the `/works-for-you` page, the page kicks off a sequence of exhaustive, paginated requests for every published work ever by followed artists. This can mean thousands of API requests, and we frequently observe server-side errors (timeouts) trying to load the `n`th page of results for users who follow prolific artists. 

Related: [PLATFORM-1237](https://artsyproduct.atlassian.net/browse/PLATFORM-1237)

Upon investigation [and with @mzikherman's help], it seemed like the element whose `clientHeight` we're using to calculate offset was actually one artist's row, not the overall feed as intended. We confirmed that this "fixed" the issue locally but I wonder if there's a better solution or a more fundamental bug causing `this` to correspond to one row rather than the whole `WorksForYouFeed`. Any suggestions are welcome.