### PR TITLE
[DO NOT MERGE] New payment page will redirect to /status page unless the order's last transaction has failed

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2357,6 +2357,9 @@ type BuyOrder implements Order {
 
   # Credit card on this order
   creditCard: CreditCard
+
+  # Whether or not the last attempt to charge the buyer failed
+  lastTransactionFailed: Boolean
   lastApprovedAt(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -2450,7 +2453,14 @@ type City {
     before: String
     last: Int
   ): ShowConnection
-  fairs(size: Int, sort: FairSorts, status: EventStatus): [Fair]
+  fairs(
+    sort: FairSorts
+    status: EventStatus
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): FairConnection
 }
 
 type Collection implements Node {
@@ -3351,6 +3361,17 @@ enum FairArtistSorts {
   NAME_DESC
 }
 
+# A connection to a list of items.
+type FairConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [FairEdge]
+  pageCursors: PageCursors
+  totalCount: Int
+}
+
 type FairCounts {
   artists(
     # Returns a `String` when format is specified. e.g.`'0,0.0000''`
@@ -3372,6 +3393,15 @@ type FairCounts {
     format: String
     label: String
   ): FormattedNumber
+}
+
+# An edge in a connection.
+type FairEdge {
+  # The item at the end of the edge
+  node: Fair
+
+  # A cursor for use in pagination
+  cursor: String!
 }
 
 type FairExhibitor {
@@ -5869,6 +5899,9 @@ type OfferOrder implements Order {
 
   # Credit card on this order
   creditCard: CreditCard
+
+  # Whether or not the last attempt to charge the buyer failed
+  lastTransactionFailed: Boolean
   lastApprovedAt(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -6085,6 +6118,9 @@ interface Order {
 
   # Credit card on this order
   creditCard: CreditCard
+
+  # Whether or not the last attempt to charge the buyer failed
+  lastTransactionFailed: Boolean
   lastApprovedAt(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean

--- a/src/Apps/Order/__tests__/OrderApp.test.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.test.tsx
@@ -412,10 +412,11 @@ describe("OrderApp routing redirects", () => {
         createdAt: moment().toISOString(),
       },
       awaitingResponseFrom: "BUYER",
+      lastTransactionFailed: true,
     }
     it("stays on the /payment/new page if all conditions are met", async () => {
       const { redirect } = await render(
-        "/orders/1234/review/counter",
+        "/orders/1234/payment/new",
         mockResolver(counterOfferOrder)
       )
       expect(redirect).toBe(undefined)
@@ -423,7 +424,7 @@ describe("OrderApp routing redirects", () => {
     // goToStatusIfNotOfferOrder,
     it("redirects to /status if not an offer order", async () => {
       const { redirect } = await render(
-        "/orders/1234/review/counter",
+        "/orders/1234/payment/new",
         mockResolver({
           ...counterOfferOrder,
           mode: "BUY",
@@ -434,10 +435,21 @@ describe("OrderApp routing redirects", () => {
     // goToStatusIfOrderIsNotSubmitted,
     it("redirects to /status if order is not submitted", async () => {
       const { redirect } = await render(
-        "/orders/1234/review/counter",
+        "/orders/1234/payment/new",
         mockResolver({
           ...counterOfferOrder,
           state: "PENDING",
+        })
+      )
+      expect(redirect.url).toBe("/orders/1234/status")
+    })
+
+    it("redirects to /status if order does not have a failing last transaction", async () => {
+      const { redirect } = await render(
+        "/orders/1234/payment/new",
+        mockResolver({
+          ...counterOfferOrder,
+          lastTransactionFailed: false,
         })
       )
       expect(redirect.url).toBe("/orders/1234/status")

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -119,6 +119,11 @@ const goToStatusIfOrderIsNotSubmitted = goToStatusIf(
   "Order was not yet submitted"
 )
 
+const goToStatusIfNotLastTransactionFailed = goToStatusIf(
+  order => !order.lastTransactionFailed,
+  "Order's lastTransactionFailed must be true"
+)
+
 const goToReviewIfOrderIsPending: OrderPredicate = ({ order }) => {
   if (order.state === "PENDING") {
     return {
@@ -185,7 +190,11 @@ export const redirects: RedirectRecord<OrderQuery> = {
     },
     {
       path: "payment/new",
-      rules: [goToStatusIfNotOfferOrder, goToStatusIfOrderIsNotSubmitted],
+      rules: [
+        goToStatusIfNotOfferOrder,
+        goToStatusIfOrderIsNotSubmitted,
+        goToStatusIfNotLastTransactionFailed,
+      ],
     },
     {
       path: "review",
@@ -237,6 +246,7 @@ graphql`
     id
     mode
     state
+    lastTransactionFailed
     ... on OfferOrder {
       myLastOffer {
         id

--- a/src/__generated__/redirects_order.graphql.ts
+++ b/src/__generated__/redirects_order.graphql.ts
@@ -9,6 +9,7 @@ export type redirects_order = {
     readonly id: string | null;
     readonly mode: OrderModeEnum | null;
     readonly state: string | null;
+    readonly lastTransactionFailed: boolean | null;
     readonly requestedFulfillment: ({
         readonly __typename: string;
     }) | null;
@@ -93,6 +94,13 @@ return {
       "kind": "ScalarField",
       "alias": null,
       "name": "state",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "lastTransactionFailed",
       "args": null,
       "storageKey": null
     },
@@ -205,5 +213,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '6ebbf99189725ca37c7015f849d436a4';
+(node as any).hash = '69f41a6e9e04504f73cde98dea2ae25b';
 export default node;

--- a/src/__generated__/routes_OrderQuery.graphql.ts
+++ b/src/__generated__/routes_OrderQuery.graphql.ts
@@ -14,6 +14,7 @@ export type routes_OrderQueryResponse = {
         readonly id: string | null;
         readonly mode: OrderModeEnum | null;
         readonly state: string | null;
+        readonly lastTransactionFailed: boolean | null;
         readonly requestedFulfillment: ({
             readonly __typename: string;
         }) | null;
@@ -60,6 +61,7 @@ query routes_OrderQuery(
     id
     mode
     state
+    lastTransactionFailed
     ... on OfferOrder {
       myLastOffer {
         id
@@ -163,11 +165,18 @@ v6 = {
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "lastTransactionFailed",
   "args": null,
   "storageKey": null
 },
 v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "requestedFulfillment",
@@ -176,21 +185,21 @@ v8 = {
   "concreteType": null,
   "plural": false,
   "selections": [
-    v7
+    v8
   ]
 },
-v9 = [
+v10 = [
   v4,
   v1
 ],
-v10 = {
+v11 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "lineItems",
@@ -225,16 +234,16 @@ v11 = {
               "args": null,
               "concreteType": "Artwork",
               "plural": false,
-              "selections": v9
+              "selections": v10
             },
-            v10
+            v11
           ]
         }
       ]
     }
   ]
 },
-v12 = {
+v13 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "creditCard",
@@ -242,9 +251,9 @@ v12 = {
   "args": null,
   "concreteType": "CreditCard",
   "plural": false,
-  "selections": v9
+  "selections": v10
 },
-v13 = [
+v14 = [
   v4,
   {
     "kind": "ScalarField",
@@ -253,9 +262,9 @@ v13 = [
     "args": null,
     "storageKey": null
   },
-  v10
+  v11
 ],
-v14 = {
+v15 = {
   "kind": "InlineFragment",
   "type": "OfferOrder",
   "selections": [
@@ -267,7 +276,7 @@ v14 = {
       "args": null,
       "concreteType": "Offer",
       "plural": false,
-      "selections": v13
+      "selections": v14
     },
     {
       "kind": "LinkedField",
@@ -277,7 +286,7 @@ v14 = {
       "args": null,
       "concreteType": "Offer",
       "plural": false,
-      "selections": v13
+      "selections": v14
     },
     {
       "kind": "ScalarField",
@@ -293,7 +302,7 @@ return {
   "operationKind": "query",
   "name": "routes_OrderQuery",
   "id": null,
-  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    id\n    mode\n    state\n    ... on OfferOrder {\n      myLastOffer {\n        id\n        createdAt\n        __id: id\n      }\n      lastOffer {\n        id\n        createdAt\n        __id: id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
+  "text": "query routes_OrderQuery(\n  $orderID: String!\n) {\n  me {\n    name\n    __id\n  }\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    id\n    mode\n    state\n    lastTransactionFailed\n    ... on OfferOrder {\n      myLastOffer {\n        id\n        createdAt\n        __id: id\n      }\n      lastOffer {\n        id\n        createdAt\n        __id: id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            id\n            __id\n          }\n          __id: id\n        }\n      }\n    }\n    creditCard {\n      id\n      __id\n    }\n    __id: id\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -315,11 +324,12 @@ return {
           v4,
           v5,
           v6,
-          v8,
-          v11,
+          v7,
+          v9,
           v12,
-          v10,
-          v14
+          v13,
+          v11,
+          v15
         ]
       }
     ]
@@ -339,15 +349,16 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
-          v7,
+          v8,
           v4,
           v5,
           v6,
-          v8,
-          v11,
+          v7,
+          v9,
           v12,
-          v10,
-          v14
+          v13,
+          v11,
+          v15
         ]
       }
     ]


### PR DESCRIPTION
Blocked by: https://github.com/artsy/metaphysics/pull/1530

We only want people to be able to enter a new credit card if the last attempt to charge their card failed. In order to determine this, we query for `lastTransactionFailed` from exchange.

This PR updates our redirect logic for the `/payment/new` page to account for that.