### PR TITLE
Refactor search previews css

### DIFF
--- a/src/Components/Search/Previews/Grids/ArtistSearch/MarketingCollections.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/MarketingCollections.tsx
@@ -1,4 +1,4 @@
-import { Box, color, Flex, Link, Sans, Serif } from "@artsy/palette"
+import { Box, color, Flex, Link, Sans, Serif, space } from "@artsy/palette"
 import { MarketingCollectionsPreview_marketingCollections } from "__generated__/MarketingCollectionsPreview_marketingCollections.graphql"
 import { SearchBarState } from "Components/Search/state"
 import React from "react"
@@ -14,9 +14,14 @@ interface MarketingCollectionsPreviewProps {
   searchState?: SearchBarState
 }
 
-const CollectionBox = styled(Box)<{ imageUrl: string }>`
+const CollectionBox = styled(Box)<{ imageUrl: string; itemsPerRow: 1 | 2 }>`
   width: 185px;
   height: 80px;
+
+  &:nth-child(even) {
+    margin-left: ${p => (p.itemsPerRow === 2 ? space(2) : 0)}px;
+  }
+
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)),
     url(${p => p.imageUrl}) center;
 
@@ -58,6 +63,42 @@ export const CollectionTitles = ({ title }: { title: string }) => {
   )
 }
 
+const renderItems = (
+  {
+    marketingCollections,
+    searchState: { state },
+  }: MarketingCollectionsPreviewProps,
+  itemsPerRow: 1 | 2
+) => {
+  const displayedItems =
+    itemsPerRow === 1 ? marketingCollections.slice(0, 3) : marketingCollections
+
+  return displayedItems.map(({ headerImage, title, slug }, index) => {
+    const href = `${sd.APP_URL}/collection/${slug}`
+    const imageUrl = crop(headerImage, {
+      width: 185,
+      height: 80,
+    })
+
+    const highlighted =
+      state.hasEnteredPreviews && index === state.selectedPreviewIndex
+
+    return (
+      <CollectionBox
+        className={highlighted && "highlighted"}
+        imageUrl={imageUrl}
+        key={index}
+        mb={2}
+        itemsPerRow={itemsPerRow}
+      >
+        <Link href={href} noUnderline>
+          <CollectionTitles title={title} />
+        </Link>
+      </CollectionBox>
+    )
+  })
+}
+
 export class MarketingCollectionsPreview extends React.Component<
   MarketingCollectionsPreviewProps
 > {
@@ -68,37 +109,8 @@ export class MarketingCollectionsPreview extends React.Component<
 
     this.props.searchState.registerItems(items)
   }
+
   render() {
-    const { marketingCollections, searchState } = this.props
-
-    const { state } = searchState
-    const items = marketingCollections.map(
-      ({ headerImage, title, slug }, index) => {
-        const href = `${sd.APP_URL}/collection/${slug}`
-        const imageUrl = crop(headerImage, {
-          width: 185,
-          height: 80,
-        })
-
-        const highlighted =
-          state.hasEnteredPreviews && index === state.selectedPreviewIndex
-
-        return (
-          <CollectionBox
-            className={highlighted && "highlighted"}
-            imageUrl={imageUrl}
-            key={index}
-            mr={2}
-            mb={2}
-          >
-            <Link href={href} noUnderline>
-              <CollectionTitles title={title} />
-            </Link>
-          </CollectionBox>
-        )
-      }
-    )
-
     return (
       <>
         <Sans size="3" weight="medium" color="black100" mb={2}>
@@ -107,13 +119,13 @@ export class MarketingCollectionsPreview extends React.Component<
 
         <Media lessThan="lg">
           <Flex alignItems="flex-start" flexWrap="wrap">
-            {items.slice(0, 3)}
+            {renderItems(this.props, 1)}
           </Flex>
         </Media>
 
         <Media greaterThan="md">
           <Flex alignItems="flex-start" flexWrap="wrap">
-            {items}
+            {renderItems(this.props, 2)}
           </Flex>
         </Media>
       </>

--- a/src/Components/Search/Previews/Grids/ArtistSearch/NoResults.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/NoResults.tsx
@@ -31,7 +31,6 @@ export const NoResultsPreview: React.SFC = () => {
       alignItems="center"
       flexDirection="column"
       my={140}
-      pr={3}
     >
       <ArtworkIcon />
       <Serif

--- a/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
@@ -26,12 +26,10 @@ export class RelatedArtworksPreview extends React.Component<
   RelatedArtworksPreviewProps
 > {
   componentDidMount() {
-    const items = this.getArtworks()
-
-    this.props.searchState.registerItems(items)
+    this.props.searchState.registerItems(this.artworks)
   }
 
-  getArtworks(): any {
+  get artworks(): any {
     return get(
       this.props.viewer,
       x => x.filter_artworks.artworks_connection.edges,
@@ -40,11 +38,13 @@ export class RelatedArtworksPreview extends React.Component<
   }
 
   renderItems(itemsPerRow: 1 | 2) {
-    const artworks = this.getArtworks()
     const displayedArtworks =
-      itemsPerRow === 1 ? artworks.slice(0, 5) : artworks
+      itemsPerRow === 1 ? this.artworks.slice(0, 5) : this.artworks
 
-    const { state } = this.props.searchState
+    const {
+      searchState: { state },
+    } = this.props
+
     return displayedArtworks.map((artwork, i) => (
       <ItemContainer width={["0%", "180px"]} key={i} itemsPerRow={itemsPerRow}>
         <PreviewGridItem
@@ -59,7 +59,7 @@ export class RelatedArtworksPreview extends React.Component<
   }
 
   render() {
-    if (this.getArtworks().length === 0) {
+    if (this.artworks.length === 0) {
       return <NoResultsPreview />
     }
 

--- a/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Sans } from "@artsy/palette"
+import { Box, Flex, Sans, space } from "@artsy/palette"
 import { SearchBarState } from "Components/Search/state"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -7,6 +7,7 @@ import { get } from "Utils/get"
 import { Media } from "Utils/Responsive"
 
 import { RelatedArtworksPreview_viewer } from "__generated__/RelatedArtworksPreview_viewer.graphql"
+import styled from "styled-components"
 import { PreviewGridItemFragmentContainer as PreviewGridItem } from "../PreviewGridItem"
 import { NoResultsPreview } from "./NoResults"
 
@@ -14,47 +15,54 @@ interface RelatedArtworksPreviewProps {
   viewer: RelatedArtworksPreview_viewer
   searchState?: SearchBarState
 }
+
+const ItemContainer = styled(Box)<{ itemsPerRow: 1 | 2 }>`
+  &:nth-child(even) {
+    margin-left: ${p => (p.itemsPerRow === 2 ? space(2) : 0)}px;
+  }
+`
+
 export class RelatedArtworksPreview extends React.Component<
   RelatedArtworksPreviewProps
 > {
   componentDidMount() {
-    const items = get(
-      this.props.viewer,
-      x => x.filter_artworks.artworks_connection.edges,
-      []
-    ).map(x => x.node)
+    const items = this.getArtworks()
 
     this.props.searchState.registerItems(items)
   }
 
-  render() {
-    const { viewer, searchState } = this.props
-
-    const artworks = get(
-      viewer,
+  getArtworks(): any {
+    return get(
+      this.props.viewer,
       x => x.filter_artworks.artworks_connection.edges,
       []
     ).map(x => x.node)
+  }
 
-    const { state } = searchState
+  renderItems(itemsPerRow: 1 | 2) {
+    const artworks = this.getArtworks()
+    const displayedArtworks =
+      itemsPerRow === 1 ? artworks.slice(0, 5) : artworks
 
-    if (artworks.length === 0) {
+    const { state } = this.props.searchState
+    return displayedArtworks.map((artwork, i) => (
+      <ItemContainer width={["0%", "180px"]} key={i} itemsPerRow={itemsPerRow}>
+        <PreviewGridItem
+          artwork={artwork}
+          highlight={
+            state.hasEnteredPreviews && i === state.selectedPreviewIndex
+          }
+          emphasizeArtist
+        />
+      </ItemContainer>
+    ))
+  }
+
+  render() {
+    if (this.getArtworks().length === 0) {
       return <NoResultsPreview />
     }
 
-    const relatedArtworks = artworks.map((artwork, i) => {
-      return (
-        <Box width={["0%", "100%", "100%", "50%"]} key={i}>
-          <PreviewGridItem
-            artwork={artwork}
-            highlight={
-              state.hasEnteredPreviews && i === state.selectedPreviewIndex
-            }
-            emphasizeArtist
-          />
-        </Box>
-      )
-    })
     return (
       <Box>
         <Sans size="3" weight="medium" color="black100" mb={2}>
@@ -63,13 +71,13 @@ export class RelatedArtworksPreview extends React.Component<
 
         <Media lessThan="lg">
           <Flex alignItems="flex-start" flexWrap="wrap">
-            {relatedArtworks.slice(0, 5)}
+            {this.renderItems(1)}
           </Flex>
         </Media>
 
         <Media greaterThan="md">
           <Flex alignItems="flex-start" flexWrap="wrap">
-            {relatedArtworks}
+            {this.renderItems(2)}
           </Flex>
         </Media>
       </Box>

--- a/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
@@ -1,12 +1,13 @@
 import React from "react"
 
-import { Box, Flex, Sans } from "@artsy/palette"
+import { Box, Flex, Sans, space } from "@artsy/palette"
 import { MerchandisableArtworks_viewer } from "__generated__/MerchandisableArtworks_viewer.graphql"
 import { MerchandisableArtworksPreviewQuery } from "__generated__/MerchandisableArtworksPreviewQuery.graphql"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { ContextConsumer, ContextProps } from "Artsy/SystemContext"
 import { SearchBarState } from "Components/Search/state"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import styled from "styled-components"
 import { Subscribe } from "unstated"
 import { get } from "Utils/get"
 import { Media } from "Utils/Responsive"
@@ -17,39 +18,51 @@ interface MerchandisableArtworksPreviewProps {
   searchState?: SearchBarState
 }
 
+const ItemContainer = styled(Box)<{ itemsPerRow: 1 | 2 }>`
+  &:nth-child(even) {
+    margin-left: ${p => (p.itemsPerRow === 2 ? space(2) : 0)}px;
+  }
+`
+
 class MerchandisableArtworksPreview extends React.Component<
   MerchandisableArtworksPreviewProps
 > {
   componentDidMount() {
-    const items = get(
-      this.props.viewer,
-      x => x.filter_artworks.artworks_connection.edges,
-      []
-    ).map(x => x.node)
+    const items = this.getArtworks()
 
     this.props.searchState.registerItems(items)
   }
 
-  render() {
-    const { viewer, searchState } = this.props
-    const artworks = get(
-      viewer,
+  getArtworks(): any {
+    return get(
+      this.props.viewer,
       x => x.filter_artworks.artworks_connection.edges,
       []
     ).map(x => x.node)
+  }
 
-    const { state } = searchState
-    const merchandisableItems = artworks.map((artwork, i) => (
-      <Box width={["0%", "100%", "100%", "50%"]} key={i}>
+  renderItems(itemsPerRow: 1 | 2) {
+    const {
+      searchState: { state },
+    } = this.props
+
+    const artworks = this.getArtworks()
+    const displayedArtworks =
+      itemsPerRow === 1 ? artworks.slice(0, 5) : artworks
+
+    return displayedArtworks.map((artwork, i) => (
+      <ItemContainer width={["0%", "180px"]} key={i} itemsPerRow={itemsPerRow}>
         <PreviewGridItem
           highlight={
             state.hasEnteredPreviews && i === state.selectedPreviewIndex
           }
           artwork={artwork}
         />
-      </Box>
+      </ItemContainer>
     ))
+  }
 
+  render() {
     return (
       <Box>
         <Sans size="3" weight="medium" color="black100" mb={2}>
@@ -58,13 +71,13 @@ class MerchandisableArtworksPreview extends React.Component<
 
         <Media lessThan="lg">
           <Flex alignItems="flex-start" flexWrap="wrap">
-            {merchandisableItems.slice(0, 5)}
+            {this.renderItems(1)}
           </Flex>
         </Media>
 
         <Media greaterThan="md">
           <Flex alignItems="flex-start" flexWrap="wrap">
-            {merchandisableItems}
+            {this.renderItems(2)}
           </Flex>
         </Media>
       </Box>

--- a/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
@@ -28,12 +28,10 @@ class MerchandisableArtworksPreview extends React.Component<
   MerchandisableArtworksPreviewProps
 > {
   componentDidMount() {
-    const items = this.getArtworks()
-
-    this.props.searchState.registerItems(items)
+    this.props.searchState.registerItems(this.artworks)
   }
 
-  getArtworks(): any {
+  get artworks(): any {
     return get(
       this.props.viewer,
       x => x.filter_artworks.artworks_connection.edges,
@@ -42,13 +40,12 @@ class MerchandisableArtworksPreview extends React.Component<
   }
 
   renderItems(itemsPerRow: 1 | 2) {
+    const displayedArtworks =
+      itemsPerRow === 1 ? this.artworks.slice(0, 5) : this.artworks
+
     const {
       searchState: { state },
     } = this.props
-
-    const artworks = this.getArtworks()
-    const displayedArtworks =
-      itemsPerRow === 1 ? artworks.slice(0, 5) : artworks
 
     return displayedArtworks.map((artwork, i) => (
       <ItemContainer width={["0%", "180px"]} key={i} itemsPerRow={itemsPerRow}>

--- a/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
+++ b/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
@@ -33,7 +33,6 @@ export class PreviewGridItem extends React.Component<PreviewGridItemProps> {
         style={{
           backgroundColor: highlight ? color("black5") : color("white100"),
         }}
-        mr={2}
         mb={2}
       >
         <Link href={artwork.href} noUnderline>

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -94,7 +94,7 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
             {children}
           </Flex>
         </SuggestionsWrapper>
-        <Box width={["0px", "240px", "240px", "450px"]} pl={[0, 3]} py={[0, 2]}>
+        <Box width={["0px", "240px", "240px", "450px"]} px={[0, 3]} py={[0, 2]}>
           {preview}
         </Box>
       </ResultsWrapper>


### PR DESCRIPTION
Currently, the horizontal padding for our preview pane is dispersed throughout our components. The left padding is taken care of by the container, but the right padding is taken care of by margins on the previews themselves. 

This PR removes that asymmetry, and moves the management of horizontal padding/margin where it belongs. The container handles the left/right padding, and the previews handle any margin in between individual items. 

It's probably not the worst thing in the world to leave the padding/margin asymmetrical, but it caused me headaches when trying to center the "empty" preview, and I anticipate that it would cause more headaches in the future. 

From the end-user's perspective, there should be no changes. This change is purely for maintainability.

One nice side-effect of these changes is that I was able to move some related bits closer together, as well as reduce some duplication. I'll point it all out in the code!