### PR TITLE
Match comp for active preview items

### DIFF
--- a/src/Components/Search/Previews/Grids/ArtistSearch/MarketingCollections.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/MarketingCollections.tsx
@@ -91,7 +91,7 @@ const renderItems = (
         mb={2}
         itemsPerRow={itemsPerRow}
       >
-        <Link href={href} noUnderline>
+        <Link href={href} color="black100" noUnderline>
           <CollectionTitles title={title} />
         </Link>
       </CollectionBox>

--- a/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/RelatedArtworks.tsx
@@ -18,7 +18,7 @@ interface RelatedArtworksPreviewProps {
 
 const ItemContainer = styled(Box)<{ itemsPerRow: 1 | 2 }>`
   &:nth-child(even) {
-    margin-left: ${p => (p.itemsPerRow === 2 ? space(2) : 0)}px;
+    margin-left: ${p => (p.itemsPerRow === 2 ? space(1) : 0)}px;
   }
 `
 
@@ -46,7 +46,7 @@ export class RelatedArtworksPreview extends React.Component<
     } = this.props
 
     return displayedArtworks.map((artwork, i) => (
-      <ItemContainer width={["0%", "180px"]} key={i} itemsPerRow={itemsPerRow}>
+      <ItemContainer width={["0%", "200px"]} key={i} itemsPerRow={itemsPerRow}>
         <PreviewGridItem
           artwork={artwork}
           highlight={
@@ -65,7 +65,7 @@ export class RelatedArtworksPreview extends React.Component<
 
     return (
       <Box>
-        <Sans size="3" weight="medium" color="black100" mb={2}>
+        <Sans size="3" weight="medium" color="black100" mb={1} ml={1}>
           Related Artworks
         </Sans>
 

--- a/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
@@ -20,7 +20,7 @@ interface MerchandisableArtworksPreviewProps {
 
 const ItemContainer = styled(Box)<{ itemsPerRow: 1 | 2 }>`
   &:nth-child(even) {
-    margin-left: ${p => (p.itemsPerRow === 2 ? space(2) : 0)}px;
+    margin-left: ${p => (p.itemsPerRow === 2 ? space(1) : 0)}px;
   }
 `
 
@@ -48,7 +48,7 @@ class MerchandisableArtworksPreview extends React.Component<
     } = this.props
 
     return displayedArtworks.map((artwork, i) => (
-      <ItemContainer width={["0%", "180px"]} key={i} itemsPerRow={itemsPerRow}>
+      <ItemContainer width={["0%", "200px"]} key={i} itemsPerRow={itemsPerRow}>
         <PreviewGridItem
           highlight={
             state.hasEnteredPreviews && i === state.selectedPreviewIndex
@@ -62,7 +62,7 @@ class MerchandisableArtworksPreview extends React.Component<
   render() {
     return (
       <Box>
-        <Sans size="3" weight="medium" color="black100" mb={2}>
+        <Sans size="3" weight="medium" color="black100" mb={1} ml={1}>
           Now Available for Buy Now/ Make Offer
         </Sans>
 

--- a/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
+++ b/src/Components/Search/Previews/Grids/MerchandisableArtworks.tsx
@@ -63,7 +63,7 @@ class MerchandisableArtworksPreview extends React.Component<
     return (
       <Box>
         <Sans size="3" weight="medium" color="black100" mb={1} ml={1}>
-          Now Available for Buy Now/ Make Offer
+          Now available on Artsy
         </Sans>
 
         <Media lessThan="lg">

--- a/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
+++ b/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
@@ -23,17 +23,23 @@ const OverflowEllipsis = styled(Serif)`
   max-width: ${space(12)}px;
 `
 
+const Wrapper = styled(Flex)<{isHighlight: boolean}>`
+  background-color: ${props => props.isHighlight ? color("black5") : color("white100")};
+
+  :hover {
+    background-color: ${color("black5")}
+  }
+`
+
 export class PreviewGridItem extends React.Component<PreviewGridItemProps> {
   render() {
     const { artwork, emphasizeArtist, highlight } = this.props
     const imageUrl = get(artwork, x => x.image.cropped.url, "")
 
     return (
-      <Flex
-        style={{
-          backgroundColor: highlight ? color("black5") : color("white100"),
-        }}
-        mb={2}
+      <Wrapper
+        isHighlight={highlight}
+        p={1}
       >
         <Link href={artwork.href} noUnderline>
           <Box width="40px" height="40px" mr={2}>
@@ -46,7 +52,7 @@ export class PreviewGridItem extends React.Component<PreviewGridItemProps> {
             )}
           </Box>
         </Link>
-        <Link href={artwork.href} noUnderline>
+        <Link href={artwork.href} color="black100" noUnderline>
           <Box>
             <OverflowEllipsis size="2" italic>
               {artwork.title}, {artwork.date}
@@ -59,7 +65,7 @@ export class PreviewGridItem extends React.Component<PreviewGridItemProps> {
             </OverflowEllipsis>
           </Box>
         </Link>
-      </Flex>
+      </Wrapper>
     )
   }
 }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -94,7 +94,7 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
             {children}
           </Flex>
         </SuggestionsWrapper>
-        <Box width={["0px", "240px", "240px", "450px"]} px={[0, 3]} py={[0, 2]}>
+        <Box width={["0px", "240px", "240px", "450px"]} px={[0, 2]} py={[0, 2]}>
           {preview}
         </Box>
       </ResultsWrapper>

--- a/src/Components/Search/__tests__/SearchBar.test.tsx
+++ b/src/Components/Search/__tests__/SearchBar.test.tsx
@@ -118,6 +118,6 @@ describe("SearchBar", () => {
     simulateTyping(component, "blah") // Any text of non-zero length.
     await flushPromiseQueue()
 
-    expect(component.text()).toContain("Now Available for Buy Now/ Make Offer")
+    expect(component.text()).toContain("Now available on Artsy")
   })
 })


### PR DESCRIPTION
This PR addresses the following Jira tickets:
https://artsyproduct.atlassian.net/browse/DISCO-781
https://artsyproduct.atlassian.net/browse/DISCO-769
https://artsyproduct.atlassian.net/browse/DISCO-762
https://artsyproduct.atlassian.net/browse/DISCO-767

Here is some visual proof:

<img width="1199" alt="screen shot 2019-02-28 at 4 48 43 pm" src="https://user-images.githubusercontent.com/79799/53604009-dd836180-3b78-11e9-9c7f-8bdcb879da13.png">

<img width="1478" alt="screen shot 2019-02-28 at 4 50 17 pm" src="https://user-images.githubusercontent.com/79799/53604264-9b0e5480-3b79-11e9-9ba4-7bca0297351c.png">
<img width="1478" alt="screen shot 2019-02-28 at 4 50 24 pm" src="https://user-images.githubusercontent.com/79799/53604270-9d70ae80-3b79-11e9-9e65-f58a55c0edd5.png">
<img width="1217" alt="screen shot 2019-02-28 at 4 55 23 pm" src="https://user-images.githubusercontent.com/79799/53604349-d1e46a80-3b79-11e9-851d-5374bff23f2e.png">
<img width="1478" alt="screen shot 2019-02-28 at 4 50 38 pm" src="https://user-images.githubusercontent.com/79799/53604370-df015980-3b79-11e9-95ca-3b0f658b8e77.png">

That last shot shows the known bug where we are able to combine the keyboard and mouse to have two "active" previews because the keyboard has one code path (unstated) and the mouse has another (css hover selector).