### PR TITLE
sync metaphystics schema and use new randomizationSeed argument

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1111,6 +1111,9 @@ type ArtworkContextFair {
   cached: Int
   banner_size: String
   counts: FairCounts
+
+  # A formatted description of the start to end dates
+  exhibition_period: String
   has_full_feature: Boolean
   has_homepage_section: Boolean
   has_large_banner: Boolean
@@ -3259,6 +3262,9 @@ type Fair {
   cached: Int
   banner_size: String
   counts: FairCounts
+
+  # A formatted description of the start to end dates
+  exhibition_period: String
   has_full_feature: Boolean
   has_homepage_section: Boolean
   has_large_banner: Boolean
@@ -4487,6 +4493,9 @@ type HomePageModuleContextFair {
   cached: Int
   banner_size: String
   counts: FairCounts
+
+  # A formatted description of the start to end dates
+  exhibition_period: String
   has_full_feature: Boolean
   has_homepage_section: Boolean
   has_large_banner: Boolean
@@ -7440,7 +7449,7 @@ type Query {
   # Find partners by ID
   _unused_gravity_partners(ids: [ID]!): [DoNotUseThisPartner]
   marketingCollections(
-    randomize: Boolean
+    randomizationSeed: String
     size: Int
     showOnEditorial: Boolean
     artistID: String

--- a/src/Components/CollectionsRail/index.tsx
+++ b/src/Components/CollectionsRail/index.tsx
@@ -6,10 +6,11 @@ import { ContextConsumer } from "Artsy"
 import { CollectionsRailFragmentContainer as CollectionsRail } from "./CollectionsRail"
 
 interface Props {
+  articleId?: string
   showOnEditorial?: boolean
 }
 
-export const CollectionsRailContent: React.SFC<Props> = () => {
+export const CollectionsRailContent: React.SFC<Props> = passedProps => {
   return (
     <ContextConsumer>
       {({ relayEnvironment }) => {
@@ -19,18 +20,18 @@ export const CollectionsRailContent: React.SFC<Props> = () => {
             variables={{
               showOnEditorial: true,
               size: 4,
-              randomize: true,
+              randomizationSeed: passedProps.articleId,
             }}
             query={graphql`
               query CollectionsRailQuery(
                 $showOnEditorial: Boolean
                 $size: Int
-                $randomize: Boolean
+                $randomizationSeed: String
               ) {
                 collections: marketingCollections(
                   showOnEditorial: $showOnEditorial
                   size: $size
-                  randomize: $randomize
+                  randomizationSeed: $randomizationSeed
                 ) {
                   ...CollectionsRail_collections
                 }

--- a/src/Components/Publishing/Layouts/Components/CanvasFooter.tsx
+++ b/src/Components/Publishing/Layouts/Components/CanvasFooter.tsx
@@ -33,7 +33,7 @@ export const CanvasFooter: React.SFC<CanvasFooterProps> = props => {
       {props.showCollectionsRail && (
         <div>
           <Separator mb={4} />
-          <CollectionsRailContent {...props} />
+          <CollectionsRailContent {...props} articleId={article.id} />
         </div>
       )}
 

--- a/src/Components/__stories__/CollectionsRail.story.tsx
+++ b/src/Components/__stories__/CollectionsRail.story.tsx
@@ -14,7 +14,7 @@ storiesOf("Components/CollectionsRail", module).add(
   () => (
     <Theme>
       <RailsContainer width="100%">
-        <CollectionsRailContent />
+        <CollectionsRailContent articleId="123" />
       </RailsContainer>
     </Theme>
   )

--- a/src/__generated__/CollectionsRailQuery.graphql.ts
+++ b/src/__generated__/CollectionsRailQuery.graphql.ts
@@ -5,7 +5,7 @@ import { CollectionsRail_collections$ref } from "./CollectionsRail_collections.g
 export type CollectionsRailQueryVariables = {
     readonly showOnEditorial?: boolean | null;
     readonly size?: number | null;
-    readonly randomize?: boolean | null;
+    readonly randomizationSeed?: string | null;
 };
 export type CollectionsRailQueryResponse = {
     readonly collections: ReadonlyArray<{
@@ -23,9 +23,9 @@ export type CollectionsRailQuery = {
 query CollectionsRailQuery(
   $showOnEditorial: Boolean
   $size: Int
-  $randomize: Boolean
+  $randomizationSeed: String
 ) {
-  collections: marketingCollections(showOnEditorial: $showOnEditorial, size: $size, randomize: $randomize) {
+  collections: marketingCollections(showOnEditorial: $showOnEditorial, size: $size, randomizationSeed: $randomizationSeed) {
     ...CollectionsRail_collections
     __id: id
   }
@@ -62,17 +62,17 @@ var v0 = [
   },
   {
     "kind": "LocalArgument",
-    "name": "randomize",
-    "type": "Boolean",
+    "name": "randomizationSeed",
+    "type": "String",
     "defaultValue": null
   }
 ],
 v1 = [
   {
     "kind": "Variable",
-    "name": "randomize",
-    "variableName": "randomize",
-    "type": "Boolean"
+    "name": "randomizationSeed",
+    "variableName": "randomizationSeed",
+    "type": "String"
   },
   {
     "kind": "Variable",
@@ -99,7 +99,7 @@ return {
   "operationKind": "query",
   "name": "CollectionsRailQuery",
   "id": null,
-  "text": "query CollectionsRailQuery(\n  $showOnEditorial: Boolean\n  $size: Int\n  $randomize: Boolean\n) {\n  collections: marketingCollections(showOnEditorial: $showOnEditorial, size: $size, randomize: $randomize) {\n    ...CollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment CollectionsRail_collections on MarketingCollection {\n  ...CollectionEntity_collection\n  __id: id\n}\n\nfragment CollectionEntity_collection on MarketingCollection {\n  slug\n  headerImage\n  title\n  price_guidance\n  show_on_editorial\n  __id: id\n}\n",
+  "text": "query CollectionsRailQuery(\n  $showOnEditorial: Boolean\n  $size: Int\n  $randomizationSeed: String\n) {\n  collections: marketingCollections(showOnEditorial: $showOnEditorial, size: $size, randomizationSeed: $randomizationSeed) {\n    ...CollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment CollectionsRail_collections on MarketingCollection {\n  ...CollectionEntity_collection\n  __id: id\n}\n\nfragment CollectionEntity_collection on MarketingCollection {\n  slug\n  headerImage\n  title\n  price_guidance\n  show_on_editorial\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -183,5 +183,5 @@ return {
   }
 };
 })();
-(node as any).hash = '566ba8777f4ede125598df15a4907d1f';
+(node as any).hash = 'e6e181f0317cc4947ddb0d4cf5613dca';
 export default node;


### PR DESCRIPTION
Related to https://github.com/artsy/kaws/pull/76

**Issue:**
When passing the same argument parameters, relay rerenders and replaces all instances of the collections rail components with the latest response. This causes all of the collections rails component to show the same rails. 

**Fix:**
We pass the article id as a unique randomization seed in order to make the query argument different.
![collections_rails](https://user-images.githubusercontent.com/5201004/53671466-72a35a80-3c4c-11e9-955a-2a7449236187.gif)

