### PR TITLE
/accept charge failure handling

### DIFF
--- a/src/Apps/Order/Dialogs.tsx
+++ b/src/Apps/Order/Dialogs.tsx
@@ -56,25 +56,25 @@ export class DialogContainer extends Container<DialogState> {
     })
   }
 
-  showAcceptDialog = ({
+  showConfirmDialog = ({
     title,
     message,
-    continueButtonText = "Continue",
+    confirmButtonText = "Continue",
     cancelButtonText = "Cancel",
   }: {
     title: React.ReactNode
     message: React.ReactNode
-    continueButtonText?: string
+    confirmButtonText?: string
     cancelButtonText?: string
-  }): Promise<{ accepted: boolean }> => {
-    return new Promise<{ accepted: boolean }>(resolve => {
+  }): Promise<{ confirmed: boolean }> => {
+    return new Promise<{ confirmed: boolean }>(resolve => {
       const accept = () => {
         this.hide()
-        resolve({ accepted: true })
+        resolve({ confirmed: true })
       }
       const reject = () => {
         this.hide()
-        resolve({ accepted: false })
+        resolve({ confirmed: false })
       }
 
       this.show({
@@ -83,7 +83,7 @@ export class DialogContainer extends Container<DialogState> {
           heading: title,
           detail: message,
           primaryCta: {
-            text: continueButtonText,
+            text: confirmButtonText,
             action: accept,
           },
           secondaryCta: {
@@ -149,12 +149,12 @@ const extractDialogHelpers = ({
   show,
   hide,
   showErrorDialog,
-  showAcceptDialog,
+  showConfirmDialog,
 }: DialogContainer) => ({
   show,
   hide,
   showErrorDialog,
-  showAcceptDialog,
+  showConfirmDialog,
 })
 
 export type Dialog = ReturnType<typeof extractDialogHelpers>

--- a/src/Apps/Order/Dialogs.tsx
+++ b/src/Apps/Order/Dialogs.tsx
@@ -56,6 +56,47 @@ export class DialogContainer extends Container<DialogState> {
     })
   }
 
+  showAcceptDialog = ({
+    title,
+    message,
+    continueButtonText = "Continue",
+    cancelButtonText = "Cancel",
+  }: {
+    title: React.ReactNode
+    message: React.ReactNode
+    continueButtonText?: string
+    cancelButtonText?: string
+  }): Promise<{ accepted: boolean }> => {
+    return new Promise<{ accepted: boolean }>(resolve => {
+      const accept = () => {
+        this.hide()
+        resolve({ accepted: true })
+      }
+      const reject = () => {
+        this.hide()
+        resolve({ accepted: false })
+      }
+
+      this.show({
+        props: {
+          show: true,
+          heading: title,
+          detail: message,
+          primaryCta: {
+            text: continueButtonText,
+            action: accept,
+          },
+          secondaryCta: {
+            text: cancelButtonText,
+            action: reject,
+          },
+          onClose: reject,
+        },
+        onForceClose: reject,
+      })
+    })
+  }
+
   /**
    * returns a promise that resolves to `true` if the user clicked the
    * continue button, and `false` if the modal was dismissed through other means.
@@ -108,10 +149,12 @@ const extractDialogHelpers = ({
   show,
   hide,
   showErrorDialog,
+  showAcceptDialog,
 }: DialogContainer) => ({
   show,
   hide,
   showErrorDialog,
+  showAcceptDialog,
 })
 
 export type Dialog = ReturnType<typeof extractDialogHelpers>

--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -3,7 +3,7 @@ import { Accept_order } from "__generated__/Accept_order.graphql"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { TwoColumnLayout } from "Apps/Order/Components/TwoColumnLayout"
 import { track } from "Artsy/Analytics"
-import { Router } from "found"
+import { RouteConfig, Router } from "found"
 import React, { Component } from "react"
 import { Media } from "Utils/Responsive"
 import {
@@ -26,6 +26,7 @@ import { Dialog, injectDialog } from "Apps/Order/Dialogs"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
 import { CountdownTimer } from "Components/v2/CountdownTimer"
 import { ErrorWithMetadata } from "Utils/errors"
+import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "../../Components/ArtworkSummaryItem"
 import { CreditCardSummaryItemFragmentContainer as CreditCardSummaryItem } from "../../Components/CreditCardSummaryItem"
@@ -34,6 +35,7 @@ interface AcceptProps {
   order: Accept_order
   relay?: RelayProp
   router: Router
+  route: RouteConfig
   dialog: Dialog
 }
 
@@ -102,8 +104,23 @@ export class Accept extends Component<AcceptProps, AcceptState> {
         case "capture_failed": {
           this.onMutationError(
             new ErrorWithMetadata(error.code, error),
-            "An error occurred",
-            "There was an error processing your payment. Please try again or contact orders@artsy.net."
+            "Charge failed",
+            "Payment authorization has been declined. Please contact your card provider and try again.",
+            () =>
+              this.props.router.push(
+                `/orders/${this.props.order.id}/payment/new`
+              )
+          )
+          break
+        }
+        case "insufficient_inventory": {
+          this.onMutationError(
+            new ErrorWithMetadata(error.code, error),
+            "Not available",
+            "Sorry, the work is no longer available.",
+            () => {
+              this.routeToArtistPage()
+            }
           )
           break
         }
@@ -121,9 +138,17 @@ export class Accept extends Component<AcceptProps, AcceptState> {
     this.props.router.push(`/orders/${this.props.order.id}/status`)
   }
 
-  onMutationError(error, title?, message?) {
+  onMutationError(
+    error: Error,
+    title?: string,
+    message?: string,
+    onDismiss?: () => void
+  ) {
     logger.error(error)
-    this.props.dialog.showErrorDialog({ title, message })
+    const result = this.props.dialog.showErrorDialog({ title, message })
+    if (onDismiss) {
+      result.then(onDismiss)
+    }
     this.setState({
       isCommittingMutation: false,
     })
@@ -132,6 +157,21 @@ export class Accept extends Component<AcceptProps, AcceptState> {
   onChangeResponse = () => {
     const { order } = this.props
     this.props.router.push(`/orders/${order.id}/respond`)
+  }
+
+  artistId() {
+    return get(
+      this.props.order,
+      o => o.lineItems.edges[0].node.artwork.artists[0].id
+    )
+  }
+
+  routeToArtistPage() {
+    const artistId = this.artistId()
+
+    // Don't confirm whether or not you want to leave the page
+    this.props.route.onTransition = () => null
+    window.location.assign(`/artist/${artistId}`)
   }
 
   render() {
@@ -241,6 +281,9 @@ export const AcceptFragmentContainer = createFragmentContainer(
           node {
             artwork {
               id
+              artists {
+                id
+              }
             }
           }
         }

--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -99,12 +99,12 @@ export class Accept extends Component<AcceptProps, AcceptState> {
 
   async showCardFailureDialog(props: { title: string; message: string }) {
     this.setState({ isCommittingMutation: false })
-    const { accepted } = await this.props.dialog.showAcceptDialog({
+    const { confirmed } = await this.props.dialog.showConfirmDialog({
       ...props,
       cancelButtonText: "OK",
-      continueButtonText: "Use new card",
+      confirmButtonText: "Use new card",
     })
-    if (accepted) {
+    if (confirmed) {
       this.props.router.push(`/orders/${this.props.order.id}/payment/new`)
     }
   }

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/acceptOffer.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/acceptOffer.ts
@@ -26,7 +26,19 @@ export const acceptOfferPaymentFailed = {
       error: {
         type: "processing",
         code: "capture_failed",
-        data: { some_details: "more details" },
+        data: null,
+      },
+    },
+  },
+}
+
+export const acceptOfferPaymentFailedInsufficientFunds = {
+  ecommerceBuyerAcceptOffer: {
+    orderOrError: {
+      error: {
+        type: "processing",
+        code: "capture_failed",
+        data: `{"failure_code": "insufficient_funds"}`,
       },
     },
   },

--- a/src/Apps/Order/Routes/__tests__/Accept.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Accept.test.tsx
@@ -12,6 +12,7 @@ import {
   acceptOfferFailed,
   acceptOfferInsufficientInventoryFailure,
   acceptOfferPaymentFailed,
+  acceptOfferPaymentFailedInsufficientFunds,
   acceptOfferSuccess,
 } from "../__fixtures__/MutationResults"
 import { AcceptFragmentContainer } from "../Accept"
@@ -159,7 +160,19 @@ describe("Accept seller offer", () => {
       await page.clickSubmit()
       await page.expectAndDismissErrorDialogMatching(
         "Charge failed",
-        "Payment authorization has been declined. Please contact your card provider and try again."
+        "Payment authorization has been declined. Please contact your card provider, then press “Submit” again. Alternatively, use a new card."
+      )
+      expect(routes.mockPushRoute).toHaveBeenCalledWith(
+        `/orders/${testOrder.id}/payment/new`
+      )
+    })
+
+    it("shows an error modal if there is a capture_failed error with insuffient_funds", async () => {
+      mutations.useResultsOnce(acceptOfferPaymentFailedInsufficientFunds)
+      await page.clickSubmit()
+      await page.expectAndDismissErrorDialogMatching(
+        "Insufficient funds",
+        "There aren’t enough funds available on the card you provided. Please use a new card. Alternatively, contact your card provider, then press “Submit” again."
       )
       expect(routes.mockPushRoute).toHaveBeenCalledWith(
         `/orders/${testOrder.id}/payment/new`

--- a/src/Components/Modal/ModalDialog.tsx
+++ b/src/Components/Modal/ModalDialog.tsx
@@ -1,7 +1,7 @@
 import { color, Flex, Sans } from "@artsy/palette"
 import { ModalWidth, ModalWrapper } from "Components/Modal/ModalWrapper"
 import React from "react"
-import styled, { css } from "styled-components"
+import styled from "styled-components"
 
 export interface CtaProps {
   action(): void
@@ -64,26 +64,10 @@ const StyledSans = styled(Sans)`
   transition: color 0.14s ease;
   cursor: pointer;
   color: ${color("purple100")};
-  ${({ secondary }: { secondary: boolean }) =>
-    secondary &&
-    css`
-      color: ${color("black30")};
-      &:hover {
-        color: ${color("black60")};
-      }
-    `};
 `
 
 // TODO: Generalize this button and move it to @artsy/palette
 export const ModalButton: React.SFC<{
   secondary?: boolean
   onClick: () => void
-}> = props => (
-  <StyledSans
-    p={2}
-    size="3"
-    secondary={props.secondary}
-    weight="medium"
-    {...props}
-  />
-)
+}> = props => <StyledSans p={2} size="3" weight="medium" {...props} />

--- a/src/__generated__/AcceptTestQuery.graphql.ts
+++ b/src/__generated__/AcceptTestQuery.graphql.ts
@@ -32,6 +32,10 @@ fragment Accept_order on Order {
       node {
         artwork {
           id
+          artists {
+            id
+            __id
+          }
           __id
         }
         __id: id
@@ -300,7 +304,7 @@ return {
   "operationKind": "query",
   "name": "AcceptTestQuery",
   "id": null,
-  "text": "query AcceptTestQuery {\n  order(id: \"\") {\n    __typename\n    ...Accept_order\n    __id: id\n  }\n}\n\nfragment Accept_order on Order {\n  id\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      id\n      createdAt\n      __id: id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query AcceptTestQuery {\n  order(id: \"\") {\n    __typename\n    ...Accept_order\n    __id: id\n  }\n}\n\nfragment Accept_order on Order {\n  id\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          artists {\n            id\n            __id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      id\n      createdAt\n      __id: id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -381,6 +385,19 @@ return {
                         "plural": false,
                         "selections": [
                           v3,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "artists",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "plural": true,
+                            "selections": [
+                              v3,
+                              v4
+                            ]
+                          },
                           v4,
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/Accept_order.graphql.ts
+++ b/src/__generated__/Accept_order.graphql.ts
@@ -15,6 +15,9 @@ export type Accept_order = {
             readonly node: ({
                 readonly artwork: ({
                     readonly id: string;
+                    readonly artists: ReadonlyArray<({
+                        readonly id: string;
+                    }) | null> | null;
                 }) | null;
             }) | null;
         }) | null> | null;
@@ -38,6 +41,13 @@ var v0 = {
   "storageKey": null
 },
 v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
@@ -97,15 +107,22 @@ return {
                   "selections": [
                     v0,
                     {
-                      "kind": "ScalarField",
+                      "kind": "LinkedField",
                       "alias": null,
-                      "name": "__id",
+                      "name": "artists",
+                      "storageKey": null,
                       "args": null,
-                      "storageKey": null
-                    }
+                      "concreteType": "Artist",
+                      "plural": true,
+                      "selections": [
+                        v0,
+                        v1
+                      ]
+                    },
+                    v1
                   ]
                 },
-                v1
+                v2
               ]
             }
           ]
@@ -132,7 +149,7 @@ return {
       "name": "CreditCardSummaryItem_order",
       "args": null
     },
-    v1,
+    v2,
     {
       "kind": "InlineFragment",
       "type": "OfferOrder",
@@ -154,7 +171,7 @@ return {
               "args": null,
               "storageKey": null
             },
-            v1
+            v2
           ]
         }
       ]
@@ -162,5 +179,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '1594b97f14c43f23bc0141ee9ce8bf2b';
+(node as any).hash = '24e55f9d54ff55efe08283ee3f1d8c04';
 export default node;

--- a/src/__generated__/routes_AcceptQuery.graphql.ts
+++ b/src/__generated__/routes_AcceptQuery.graphql.ts
@@ -36,6 +36,10 @@ fragment Accept_order on Order {
       node {
         artwork {
           id
+          artists {
+            id
+            __id
+          }
           __id
         }
         __id: id
@@ -312,7 +316,7 @@ return {
   "operationKind": "query",
   "name": "routes_AcceptQuery",
   "id": null,
-  "text": "query routes_AcceptQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Accept_order\n    __id: id\n  }\n}\n\nfragment Accept_order on Order {\n  id\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      id\n      createdAt\n      __id: id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query routes_AcceptQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Accept_order\n    __id: id\n  }\n}\n\nfragment Accept_order on Order {\n  id\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          artists {\n            id\n            __id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      id\n      createdAt\n      __id: id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -393,6 +397,19 @@ return {
                         "plural": false,
                         "selections": [
                           v4,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "artists",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "plural": true,
+                            "selections": [
+                              v4,
+                              v5
+                            ]
+                          },
                           v5,
                           {
                             "kind": "ScalarField",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-883

This ticket is about redirecting the user to the `/payment/new` page if charging their credit card fails on the `/accept` page.

It handles the 'insuffucient_funds' failure code with unique copy. I don't think it is possible to manually test this one case in staging using the stripe test credit cards, because of the way we use the stripe API. We'd have to re-write the way gravity and exchange handle stripe payments so... 😬 Yeah... Not gonna do that.

![charde_failed](https://user-images.githubusercontent.com/1242537/53735787-cfd32200-3e7f-11e9-8e08-bd081d3b4fa8.gif)
