### PR TITLE
Remove restriction on layout for EditorialFeatures

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -59,23 +59,27 @@ export interface ArticleProps {
 )
 export class Article extends React.Component<ArticleProps> {
   getArticleLayout = () => {
-    const { article } = this.props
+    const { article, customEditorial } = this.props
 
-    switch (article.layout) {
-      case "classic": {
-        return <ClassicLayout {...this.props} />
-      }
-      case "series": {
-        return <SeriesLayout {...this.props} />
-      }
-      case "video": {
-        return <VideoLayout {...this.props} />
-      }
-      case "news": {
-        return <NewsLayout {...this.props} />
-      }
-      default: {
-        return <ArticleWithFullScreen {...this.props} />
+    if (customEditorial) {
+      return <ArticleWithFullScreen {...this.props} />
+    } else {
+      switch (article.layout) {
+        case "classic": {
+          return <ClassicLayout {...this.props} />
+        }
+        case "series": {
+          return <SeriesLayout {...this.props} />
+        }
+        case "video": {
+          return <VideoLayout {...this.props} />
+        }
+        case "news": {
+          return <NewsLayout {...this.props} />
+        }
+        default: {
+          return <ArticleWithFullScreen {...this.props} />
+        }
       }
     }
   }

--- a/src/Components/Publishing/Layouts/ArticleWithFullScreen.tsx
+++ b/src/Components/Publishing/Layouts/ArticleWithFullScreen.tsx
@@ -77,12 +77,10 @@ export class ArticleWithFullScreen extends React.Component<
         shouldFetchData={this.props.showTooltips}
         onOpenAuthModal={onOpenAuthModal}
       >
-        {article.layout === "feature" ? (
-          customEditorial ? (
-            <EditorialFeature {...articleProps} />
-          ) : (
-            <FeatureLayout {...articleProps} />
-          )
+        {customEditorial ? (
+          <EditorialFeature {...articleProps} />
+        ) : article.layout === "feature" ? (
+          <FeatureLayout {...articleProps} />
         ) : (
           <StandardLayout {...articleProps} />
         )}

--- a/src/Components/Publishing/__tests__/Article.test.tsx
+++ b/src/Components/Publishing/__tests__/Article.test.tsx
@@ -42,6 +42,13 @@ it("renders feature articles in fullscreen layout", () => {
   expect(article.find(ArticleWithFullScreen).length).toBe(1)
 })
 
+it("renders custom articles in fullscreen layout", () => {
+  const article = mount(
+    <Article article={FeatureArticle} customEditorial="MY_CUSTOM_ARTICLE" />
+  )
+  expect(article.find(ArticleWithFullScreen).length).toBe(1)
+})
+
 it("renders series articles in series layout", () => {
   const article = mount(<Article article={SeriesArticle} />)
   expect(article.find(SeriesLayout).length).toBe(1)
@@ -56,6 +63,7 @@ it("renders news articles in news layout", () => {
   const article = mount(<Article article={NewsArticle} />)
   expect(article.find(NewsLayout).length).toBe(1)
 })
+
 it("does not renders mobile BannerWrapper for standard article layouts for desktop", () => {
   const article = shallow(
     <Article article={StandardArticle} isMobile={false} isLoggedIn={false} />


### PR DESCRIPTION
We are limiting articles allowed to have custom layouts to those saved as layout "feature", but this is an unnecessary distinction that reflected the layouts of articles used in our first implementation.

Removes limitation so any layout can be custom, this anticipates conversations around customizing series articles for future projects.