### PR TITLE
Disco 786 xs placeholder

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -10,6 +10,7 @@ import { SearchPreviewWrapper as SearchPreview } from "Components/Search/Preview
 import {
   EmptySuggestion,
   PLACEHOLDER,
+  PLACEHOLDER_XS,
   SuggestionItem,
 } from "Components/Search/Suggestions/SuggestionItem"
 import { throttle } from "lodash"
@@ -298,7 +299,7 @@ export class SearchBar extends Component<Props, State> {
       onChange: this.searchTextChanged,
       onFocus: this.onFocus.bind(this),
       onBlur: this.onBlur,
-      placeholder: xs ? "" : PLACEHOLDER,
+      placeholder: xs ? PLACEHOLDER_XS : PLACEHOLDER,
       value: term,
       name: "term",
     }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -432,7 +432,7 @@ export const SearchBarQueryRenderer: React.SFC = () => {
                   <Input
                     name="term"
                     style={{ width: "100%" }}
-                    placeholder={PLACEHOLDER}
+                    placeholder={PLACEHOLDER_XS}
                   />
                 )
               }

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -47,6 +47,7 @@ const InnerWrapper = styled(Flex)`
 `
 
 export const PLACEHOLDER = "Search by artist, gallery, style, theme, tag, etc."
+export const PLACEHOLDER_XS = "Search Artsy"
 
 export const EmptySuggestion = () => (
   <SuggestionWrapper>{PLACEHOLDER}</SuggestionWrapper>

--- a/src/Components/Search/__tests__/SearchBar.test.tsx
+++ b/src/Components/Search/__tests__/SearchBar.test.tsx
@@ -73,7 +73,7 @@ describe("SearchBar", () => {
     expect(component.text()).toContain("Cat")
   })
 
-  it("displays placeholder text", async () => {
+  it("displays long placeholder text at sizes greater than xs", async () => {
     const component = await getWrapper(searchResults)
     await flushPromiseQueue()
     expect(component.find(Input).props().placeholder).toBe(
@@ -81,11 +81,11 @@ describe("SearchBar", () => {
     )
   })
 
-  it("doesn't display placeholder text in the xs breakpoint", async () => {
+  it("displays short placeholder text in the xs breakpoint", async () => {
     const component = await getWrapper(searchResults, "xs")
     await flushPromiseQueue()
 
-    expect(component.find(Input).props().placeholder).toBe("")
+    expect(component.find(Input).props().placeholder).toBe("Search Artsy")
   })
 
   it("navigates the user when clicking on an item", async () => {


### PR DESCRIPTION
Currently, we are rendering no placeholder for the search bar at xs sizes. We probably did this initially because the usual placeholder took up too much space. 

This PR uses "Search Artsy" as the placeholder at xs.