### PR TITLE
@jonallured => [Autosuggest] Unselect keyboard when you bring the mouse in to previews

### DIFF
--- a/src/Components/Search/state.ts
+++ b/src/Components/Search/state.ts
@@ -33,7 +33,7 @@ export class SearchBarState extends Container<StateContainer> {
   }
 
   enterPreviewWithoutSelection() {
-    this.setState({ hasEnteredPreviews: true })
+    this.setState({ hasEnteredPreviews: true, selectedPreviewIndex: null })
   }
 
   enterPreview() {


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-778 (hopefully!)

Seems like a pretty straightforward update. Basically, when you use the mouse to hover into the preview pane, we want to unselect any currently selected preview item that's been accessed via keyboard.

This feels pretty good in my testing!