### PR TITLE
DISCO-788: Add the placeholder on XS too

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -318,7 +318,7 @@ export class SearchBar extends Component<Props, State> {
     }
 
     const edges = get(viewer, v => v.search.edges, [])
-    const suggestions = xs ? edges : [firstSuggestionPlaceholder, ...edges]
+    const suggestions = [firstSuggestionPlaceholder, ...edges]
     return (
       <AutosuggestManager ref={ref => (this.containerRef = ref)}>
         <Autosuggest


### PR DESCRIPTION
All this does is use the behavior of adding a suggestion placeholder at all breakpoints.

<img width="1176" alt="screen shot 2019-03-04 at 3 06 43 pm" src="https://user-images.githubusercontent.com/79799/53762990-2e53cc80-3e8f-11e9-85a9-763cbc3bf3c1.png">
