### PR TITLE
SearchBar - Don't show suggestions container at xs when there is no query.

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -252,6 +252,9 @@ export class SearchBar extends Component<Props, State> {
     if (!focused) {
       return null
     }
+    if (xs && !query) {
+      return null
+    }
 
     const showEmptySuggestion = !xs && !query && focused
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-785.

There is a little gray bar that shows up at xs when you set focus to the new search box. It looks like this:

<img width="448" alt="tiny gray bar" src="https://user-images.githubusercontent.com/1627089/53823134-c1940d00-3f36-11e9-9f58-9c917b6d73c6.png">

This PR removes it, by suppressing render of the `< SuggestionContainer>` when you are focused on the box, at xs, and haven't typed anything yet. 