### PR TITLE
Refactor spinner function

### DIFF
--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -17,32 +17,36 @@ const SpinnerContainer = styled.figure`
 
 export const LoadingClassName = "relay-loading"
 
+const handleError = error => {
+  // In tests we want errors to clearly bubble up.
+  if (typeof jest !== "undefined") {
+    throw error
+  }
+
+  if (error.message) {
+    console.error(error.message)
+  }
+
+  const networkError = error as any
+  if (networkError.response && networkError.response._bodyInit) {
+    let data = networkError.response._bodyInit
+    if (data) {
+      try {
+        data = JSON.parse(data)
+        console.error(`Metaphysics Error data:`, data)
+        // tslint:disable-next-line:no-empty
+      } catch (e) {}
+    }
+  }
+}
+
 export function renderWithLoadProgress<P>(
   Container: RelayContainer<P>,
   initialProps: object = {}
 ): (readyState: ReadyState<P>) => React.ReactElement<RelayContainer<P>> | null {
   return ({ error, props, retry }) => {
     if (error) {
-      // In tests we want errors to clearly bubble up.
-      if (typeof jest !== "undefined") {
-        throw error
-      }
-
-      const networkError = error as any
-      if (error.message) {
-        console.error(error.message)
-      }
-      if (networkError.response && networkError.response._bodyInit) {
-        let data = networkError.response._bodyInit
-        if (data) {
-          try {
-            data = JSON.parse(data)
-            console.error(`Metaphysics Error data:`, data)
-            // tslint:disable-next-line:no-empty
-          } catch (e) {}
-        }
-      }
-
+      handleError(error)
       return null
     } else if (props) {
       return <Container {...initialProps} {...props as any} />

--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -21,10 +21,6 @@ export function renderWithLoadProgress<P>(
   Container: RelayContainer<P>,
   initialProps: object = {}
 ): (readyState: ReadyState<P>) => React.ReactElement<RelayContainer<P>> | null {
-  // TODO: We need design for retry-ing, or the go-ahead to re-use the design of
-  //       the iOS app.
-  //
-  // let retrying = false
   return ({ error, props, retry }) => {
     if (error) {
       // In tests we want errors to clearly bubble up.
@@ -47,18 +43,6 @@ export function renderWithLoadProgress<P>(
         }
       }
 
-      // if (retrying) {
-      //   retrying = false
-      //   // TODO: Even though this code path is reached, the retry button keeps spinning. iirc it _should_ disappear when
-      //   //      `onRetry` on the instance is unset.
-      //   //
-      //   // This will re-use the native view first created in the renderFailure callback, which means it can
-      //   // continue its ‘retry’ animation.
-      //   return <LoadFailureView style={{ flex: 1 }} />
-      // } else {
-      //   retrying = true
-      //   return <LoadFailureView onRetry={retry} style={{ flex: 1 }} />
-      // }
       return null
     } else if (props) {
       return <Container {...initialProps} {...props as any} />

--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -2,6 +2,7 @@ import { Spinner } from "@artsy/palette"
 import React from "react"
 import { ReadyState, RelayContainer } from "react-relay"
 import styled from "styled-components"
+import createLogger from 'Utils/logger'
 
 /**
  * WARNING: Do _not_ change this element to something common like a div. If the
@@ -23,19 +24,21 @@ const handleError = error => {
     throw error
   }
 
+  const logger = createLogger('Artsy/Relay/renderWithLoadProgress')
+
   if (error.message) {
-    console.error(error.message)
+    logger.error(error.message)
   }
 
   const networkError = error as any
   if (networkError.response && networkError.response._bodyInit) {
-    let data = networkError.response._bodyInit
-    if (data) {
-      try {
-        data = JSON.parse(data)
-        console.error(`Metaphysics Error data:`, data)
-        // tslint:disable-next-line:no-empty
-      } catch (e) {}
+    const body = networkError.response._bodyInit
+    try {
+      const data = JSON.parse(body)
+      console.error(`Metaphysics Error data:`, data)
+      logger.error(data)
+    } catch (e) {
+      logger.error('Metaphysics Error could not be parsed.')
     }
   }
 }

--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -11,8 +11,10 @@ import createLogger from "Utils/logger"
  * from the SpinnerContainer and Spinner.
  */
 const SpinnerContainer = styled.figure`
-  width: 100%;
-  height: 100px;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   position: relative;
 `
 

--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -2,7 +2,7 @@ import { Spinner } from "@artsy/palette"
 import React from "react"
 import { ReadyState, RelayContainer } from "react-relay"
 import styled from "styled-components"
-import createLogger from 'Utils/logger'
+import createLogger from "Utils/logger"
 
 /**
  * WARNING: Do _not_ change this element to something common like a div. If the
@@ -24,7 +24,7 @@ const handleError = error => {
     throw error
   }
 
-  const logger = createLogger('Artsy/Relay/renderWithLoadProgress')
+  const logger = createLogger("Artsy/Relay/renderWithLoadProgress")
 
   if (error.message) {
     logger.error(error.message)
@@ -38,7 +38,7 @@ const handleError = error => {
       console.error(`Metaphysics Error data:`, data)
       logger.error(data)
     } catch (e) {
-      logger.error('Metaphysics Error could not be parsed.')
+      logger.error("Metaphysics Error could not be parsed.", error)
     }
   }
 }

--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -42,7 +42,8 @@ const handleError = error => {
 
 export function renderWithLoadProgress<P>(
   Container: RelayContainer<P>,
-  initialProps: object = {}
+  initialProps: object = {},
+  Wrapper: any = SpinnerContainer,
 ): (readyState: ReadyState<P>) => React.ReactElement<RelayContainer<P>> | null {
   return ({ error, props, retry }) => {
     if (error) {
@@ -52,9 +53,9 @@ export function renderWithLoadProgress<P>(
       return <Container {...initialProps} {...props as any} />
     } else {
       return (
-        <SpinnerContainer className={LoadingClassName}>
+        <Wrapper className={LoadingClassName}>
           <Spinner />
-        </SpinnerContainer>
+        </Wrapper>
       )
     }
   }

--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -48,6 +48,8 @@ export function renderWithLoadProgress<P>(
   initialProps: object = {},
   wrapperProps: object = {}
 ): (readyState: ReadyState<P>) => React.ReactElement<RelayContainer<P>> | null {
+  // TODO: We need design for retrying or the approval to use the iOS design.
+  // See also: https://artsyproduct.atlassian.net/browse/PLATFORM-1272
   return ({ error, props, retry }) => {
     if (error) {
       handleError(error)

--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -43,7 +43,7 @@ const handleError = error => {
 export function renderWithLoadProgress<P>(
   Container: RelayContainer<P>,
   initialProps: object = {},
-  Wrapper: any = SpinnerContainer,
+  wrapperProps: object = {}
 ): (readyState: ReadyState<P>) => React.ReactElement<RelayContainer<P>> | null {
   return ({ error, props, retry }) => {
     if (error) {
@@ -53,9 +53,9 @@ export function renderWithLoadProgress<P>(
       return <Container {...initialProps} {...props as any} />
     } else {
       return (
-        <Wrapper className={LoadingClassName}>
+        <SpinnerContainer className={LoadingClassName} {...wrapperProps}>
           <Spinner />
-        </Wrapper>
+        </SpinnerContainer>
       )
     }
   }


### PR DESCRIPTION
While working with @pepopowitz on some styling improvement for the new search bar, we noticed that it's pretty hard to control how the spinner renders because you don't have access to the wrapper. This PR adds the ability to pass one in should you want that sort of control.

In order to feel good about the state of this file, I started by removing commented out code and some old todos. My philosophy is that todos like these are lies we tell ourselves with the best of intentions but are ultimately noise. Further, since this code exists in git, commenting it out is unnecessary. If or when we come back to the concept of retry, we can review the history of this file and get what we need from there. If returning to retry is important and something we don't want to forget to do, then I would argue that a ticket in Jira is far superior to the todos and comments. I would happily work with someone to get this ticket added!!

With that done, the next thing I noticed was that there was a lot of noise around handling errors, so I extracted a function for that part of this and that made it a lot easier to find the heart of this function.

Finally, I added a third argument to the function for the wrapper. It defaults to the existing `SpinnerContainer` so no calling code has to be changed. I played with typing it something other than `any`, but nothing I tried would work - open to ideas!! ❤️ 