### PR TITLE
Set static preview height & use flex to vertically center 'no results'

### DIFF
--- a/src/Components/Search/Previews/Grids/ArtistSearch/NoResults.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/NoResults.tsx
@@ -30,7 +30,7 @@ export const NoResultsPreview: React.SFC = () => {
       justifyContent="center"
       alignItems="center"
       flexDirection="column"
-      my={140}
+      height="100%"
     >
       <ArtworkIcon />
       <Serif

--- a/src/Components/Search/Previews/index.tsx
+++ b/src/Components/Search/Previews/index.tsx
@@ -33,6 +33,7 @@ class SearchPreview extends React.Component<SearchPreviewProps> {
             this.props.searchState.enterPreviewWithoutSelection()
           }
           onMouseOut={() => this.props.searchState.leavePreviewIfNoSelection()}
+          height="100%"
         >
           <Preview {...rest} />
         </Box>

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -70,6 +70,12 @@ const SuggestionsWrapper = styled(Box)`
   border-right: 1px solid ${colors.grayRegular};
 `
 
+const PreviewWrapper = styled(Box)`
+  > div {
+    height: 100%;
+  }
+`
+
 const SuggestionContainer = ({ children, containerProps, preview }) => {
   return (
     <AutosuggestWrapper
@@ -98,9 +104,14 @@ const SuggestionContainer = ({ children, containerProps, preview }) => {
             {children}
           </Flex>
         </SuggestionsWrapper>
-        <Box width={["0px", "240px", "240px", "450px"]} px={[0, 2]} py={[0, 2]}>
+        <PreviewWrapper
+          width={["0px", "240px", "240px", "450px"]}
+          height="375px"
+          px={[0, 2]}
+          py={[0, 2]}
+        >
           {preview}
-        </Box>
+        </PreviewWrapper>
       </ResultsWrapper>
     </AutosuggestWrapper>
   )


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-758.

1. We noticed that the way we were getting the "no results" preview vertically centered was with a whole bunch of vertical margin. It's now centered via flexbox.

2. The height of the suggestions/preview box was dependent on the height of the content, so you'd get some dancing around that was distracting & looked not so "quality worthy of art." This PR adds a static height to the preview box, eliminating the dancing, and improving the QWOA factor.

What it looked like before (keep your eye on the bottom of the suggestion/preview box!):

![dancing-box-before](https://user-images.githubusercontent.com/1627089/53894714-324e2e80-3ff6-11e9-9306-47f7f100bd2e.gif)

What it looks like now:

![dancing-box-after](https://user-images.githubusercontent.com/1627089/53893998-e77fe700-3ff4-11e9-9e92-d1ffe3d6dd91.gif)

