### PR TITLE
Show artwork "additional info" component if any of the fields exist

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
@@ -38,9 +38,20 @@ export class ArtworkDetailsAdditionalInfo extends React.Component<
       conditionDescription,
       certificateOfAuthenticity,
     } = this.props.artwork
-    if (!series && !publisher && !manufacturer && !image_rights) {
+
+    if (
+      !series &&
+      !publisher &&
+      !manufacturer &&
+      !image_rights &&
+      !framed &&
+      !signatureInfo &&
+      !conditionDescription &&
+      !certificateOfAuthenticity
+    ) {
       return null
     }
+
     return (
       <StackableBorderBox p={2}>
         <Box>

--- a/src/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetails.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetails.test.tsx
@@ -24,6 +24,21 @@ describe("ArtworkDetails", () => {
   }
   let wrapper
 
+  describe("ArtworkDetails for a gallery artwork that is missing some fields", () => {
+    it("renders additional info with just what is present", async () => {
+      const data = cloneDeep(ArtworkDetailsFixture)
+      data.series = null
+      data.publisher = null
+      data.manufacturer = null
+      data.image_rights = null
+      data.framed = null
+      wrapper = await getWrapper(data)
+      expect(wrapper.html()).toContain("Signed")
+      expect(wrapper.html()).toContain("Condition details")
+      expect(wrapper.html()).toContain("Certificate of authenticity")
+    })
+  })
+
   describe("ArtworkDetails for gallery artwork with complete details", () => {
     beforeAll(async () => {
       wrapper = await getWrapper()


### PR DESCRIPTION
#minor This fixes an issue where we weren't showing _any_ artwork details if `series`, `publisher`, `manufacturer`, or `image_rights` didn't exist. This needed to be updated since the component now also shows a bunch more fields.

Added a test that would have caught this also.

![image](https://user-images.githubusercontent.com/2081340/53901496-14d88f00-400d-11e9-9262-de727f601377.png)
