### PR TITLE
add tabIndex={0} to preview links to get Safari to specify e.relatedTarget on blur

### DIFF
--- a/src/Components/Search/Previews/Grids/ArtistSearch/MarketingCollections.tsx
+++ b/src/Components/Search/Previews/Grids/ArtistSearch/MarketingCollections.tsx
@@ -92,7 +92,7 @@ const renderItems = (
         mb={2}
         itemsPerRow={itemsPerRow}
       >
-        <Link href={href} color="black100" noUnderline>
+        <Link href={href} color="black100" noUnderline tabIndex={0}>
           <CollectionTitles title={title} />
         </Link>
       </CollectionBox>

--- a/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
+++ b/src/Components/Search/Previews/Grids/PreviewGridItem.tsx
@@ -51,7 +51,7 @@ export class PreviewGridItem extends React.Component<PreviewGridItemProps> {
 
     return (
       <Wrapper isHighlight={highlight} p={1}>
-        <Link {...linkProps} noUnderline>
+        <Link {...linkProps} noUnderline tabIndex={0}>
           <Box width="40px" height="40px" mr={2}>
             {imageUrl && (
               <Image
@@ -62,7 +62,7 @@ export class PreviewGridItem extends React.Component<PreviewGridItemProps> {
             )}
           </Box>
         </Link>
-        <Link href={artwork.href} color="black100" noUnderline>
+        <Link href={artwork.href} color="black100" noUnderline tabIndex={0}>
           <Box>
             <OverflowEllipsis size="2" italic>
               {artwork.title}, {artwork.date}


### PR DESCRIPTION
Inspired by this stackoverflow answer: https://stackoverflow.com/a/42764495