### PR TITLE
@pepopowitz => [Autosuggest] Ensure suggestions remain when suggestion is selected

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -260,6 +260,8 @@ export class SearchBar extends Component<Props, State> {
       node: { href },
     },
   }) {
+    this.userClickedOnDescendant = true
+
     window.location.assign(href)
   }
 
@@ -352,7 +354,9 @@ export class SearchBar extends Component<Props, State> {
     return (
       <AutosuggestManager ref={ref => (this.containerRef = ref)}>
         <Autosuggest
-          alwaysRenderSuggestions={searchState.state.hasEnteredPreviews}
+          alwaysRenderSuggestions={
+            searchState.state.hasEnteredPreviews || this.userClickedOnDescendant
+          }
           suggestions={suggestions}
           onSuggestionsClearRequested={this.onSuggestionsClearRequested}
           onSuggestionHighlighted={this.throttledOnSuggestionHighlighted}


### PR DESCRIPTION
We had a fix for making sure the suggestions stay when a preview is selected, this does a fix for the same issue when a suggestion is selected.

Fixes https://artsyproduct.atlassian.net/browse/DISCO-825
Fixes https://artsyproduct.atlassian.net/browse/DISCO-826

One fix, 2 JIRA tickets!