### PR TITLE
Artist insights 2.0 - Update biennial badge label

### DIFF
--- a/src/Apps/__tests__/Fixtures/SelectedCareerAchievements.ts
+++ b/src/Apps/__tests__/Fixtures/SelectedCareerAchievements.ts
@@ -30,7 +30,7 @@ export const artistResponse = {
     },
     {
       type: "BIENNIAL",
-      label: "Participated in a major biennial",
+      label: "Included in a major biennial",
       entities: ["frieze"],
     },
   ],

--- a/src/Components/v2/__tests__/SelectedCareerAchievements.test.tsx
+++ b/src/Components/v2/__tests__/SelectedCareerAchievements.test.tsx
@@ -38,6 +38,6 @@ describe("SelectedCareerAchievements", () => {
     expect(text).toContain("Solo show at a major institution")
     expect(text).toContain("Group show at a major institution")
     expect(text).toContain("Reviewed by a major art publication")
-    expect(text).toContain("Participated in a major biennial")
+    expect(text).toContain("Included in a major biennial")
   })
 })


### PR DESCRIPTION
Update “Participated in a major biennial” to "Included in a major biennial"

branches in metaphysics and force