### PR TITLE
@dblandin => [SearchResults] Create shell for search2, with a tab navigation

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1209,6 +1209,7 @@ type ArtworkContextFair {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
+  sponsoredContent: FairSponsoredContent
 }
 
 type ArtworkContextPartnerShow implements Node {
@@ -2464,6 +2465,12 @@ type City {
     before: String
     last: Int
   ): FairConnection
+  sponsoredContent: CitySponsoredContent
+}
+
+type CitySponsoredContent {
+  introText: String
+  artGuideUrl: String
 }
 
 type Collection implements Node {
@@ -3360,6 +3367,7 @@ type Fair {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
+  sponsoredContent: FairSponsoredContent
 }
 
 enum FairArtistSorts {
@@ -3439,6 +3447,11 @@ enum FairSorts {
   NAME_DESC
   START_AT_ASC
   START_AT_DESC
+}
+
+type FairSponsoredContent {
+  activationText: String
+  pressReleaseUrl: String
 }
 
 type FeaturedLinkItem {
@@ -4591,6 +4604,7 @@ type HomePageModuleContextFair {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
+  sponsoredContent: FairSponsoredContent
 }
 
 type HomePageModuleContextFollowArtists {
@@ -5206,7 +5220,7 @@ type Me implements Node {
   # A list of the current user’s artist follows
   follow_artists(page: Int, size: Int): FollowArtists
 
-  # A list of the current user’s inquiry requests
+  # A Connection of followed artists by current user
   followed_artists_connection(
     after: String
     first: Int
@@ -6825,6 +6839,9 @@ type PartnerShowEventType {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of the start to end dates
+  exhibitionPeriod: String
 }
 
 enum PartnerShowSorts {
@@ -7342,6 +7359,7 @@ type Query {
 
     # Mode of search to execute. Default: SITE.
     mode: SearchMode
+    aggregations: [SearchAggregation]
     after: String
     first: Int
     before: String
@@ -7979,6 +7997,9 @@ type SearchableConnection {
   edges: [SearchableEdge]
   pageCursors: PageCursors
   totalCount: Int
+
+  # Returns aggregation counts for the given filter query.
+  aggregations: [SearchAggregationResults]
 }
 
 # An edge in a connection.
@@ -8002,6 +8023,16 @@ type SearchableItem implements Node & Searchable {
   imageUrl: String
   href: String
   searchableType: String
+}
+
+enum SearchAggregation {
+  TYPE
+}
+
+# The results for a requested aggregations
+type SearchAggregationResults {
+  counts: [AggregationCount]
+  slice: SearchAggregation
 }
 
 enum SearchEntity {
@@ -8399,6 +8430,14 @@ type Show implements Node {
 
   # Is it a fair booth or a show?
   type: String
+
+  # A Connection of followed artists by current user for this show
+  followedArtists(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowFollowArtistConnection
 }
 
 # A connection to a list of items.
@@ -8429,6 +8468,28 @@ type ShowCounts {
 type ShowEdge {
   # The item at the end of the edge
   node: Show
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
+type ShowFollowArtist {
+  artist: Artist
+}
+
+# A connection to a list of items.
+type ShowFollowArtistConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [ShowFollowArtistEdge]
+}
+
+# An edge in a connection.
+type ShowFollowArtistEdge {
+  # The item at the end of the edge
+  node: ShowFollowArtist
 
   # A cursor for use in pagination
   cursor: String!
@@ -9269,6 +9330,7 @@ type Viewer {
 
     # Mode of search to execute. Default: SITE.
     mode: SearchMode
+    aggregations: [SearchAggregation]
     after: String
     first: Int
     before: String

--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -1,0 +1,78 @@
+import { Flex } from "@artsy/palette"
+import { NavigationTabs_searchableConnection } from "__generated__/NavigationTabs_searchableConnection.graphql"
+import { RouteTab, RouteTabs } from "Components/v2"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface Props {
+  searchableConnection: NavigationTabs_searchableConnection
+  term: string
+}
+
+export class NavigationTabs extends React.Component<Props> {
+  renderTab(
+    text: string,
+    to: string,
+    options: {
+      exact?: boolean
+    } = {}
+  ) {
+    const { exact } = options
+
+    return (
+      <RouteTab to={to} exact={exact}>
+        {text}
+      </RouteTab>
+    )
+  }
+
+  renderTabs() {
+    const { searchableConnection, term } = this.props
+    const { aggregations } = searchableConnection
+
+    const typeAggregation = aggregations.find(agg => agg.slice === "TYPE")
+      .counts
+    const route = tab => `/search2${tab}?term=${term}`
+
+    const artistAggregation = typeAggregation.find(agg => agg.name === "artist")
+    const artworkAggregation = typeAggregation.find(
+      agg => agg.name === "artwork"
+    )
+    return (
+      <>
+        {this.renderTab(`Artworks ${artworkAggregation.count}`, route(""), {
+          exact: true,
+        })}
+        {this.renderTab(
+          `Artists ${artistAggregation.count}`,
+          route("/artists")
+        )}
+      </>
+    )
+  }
+
+  render() {
+    return (
+      <>
+        <Flex mx={[-2, 0]}>
+          <RouteTabs>{this.renderTabs()}</RouteTabs>
+        </Flex>
+      </>
+    )
+  }
+}
+
+export const NavigationTabsFragmentContainer = createFragmentContainer(
+  NavigationTabs,
+  graphql`
+    fragment NavigationTabs_searchableConnection on SearchableConnection {
+      aggregations {
+        slice
+        counts {
+          count
+          name
+        }
+      }
+    }
+  `
+)

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -1,0 +1,87 @@
+import { Col, Row, Separator, Spacer } from "@artsy/palette"
+import { SearchApp_viewer } from "__generated__/SearchApp_viewer.graphql"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Search/Components/NavigationTabs"
+import {
+  Footer,
+  RecentlyViewedQueryRenderer as RecentlyViewed,
+} from "Components/v2"
+import { Location } from "found"
+import React from "react"
+import { LazyLoadComponent } from "react-lazy-load-image-component"
+import { createFragmentContainer, graphql } from "react-relay"
+
+export interface ArtistAppProps {
+  viewer: SearchApp_viewer
+  location: Location
+}
+
+export class SearchApp extends React.Component<ArtistAppProps> {
+  render() {
+    const { viewer, location } = this.props
+    const { search } = viewer
+    const {
+      query: { term },
+    } = location
+
+    return (
+      <AppContainer>
+        <HorizontalPadding>
+          <Row>
+            <Col>Search Header</Col>
+          </Row>
+
+          <Spacer mb={3} />
+
+          <Row>
+            <Col>
+              {viewer.search.totalCount} results for "{term}"
+              <Spacer mb={3} />
+              <NavigationTabs term={term} searchableConnection={search} />
+              <Spacer mb={3} />
+              {this.props.children}
+            </Col>
+          </Row>
+
+          {typeof window !== "undefined" && (
+            <LazyLoadComponent threshold={1000}>
+              <Row>
+                <Col>
+                  <RecentlyViewed />
+                </Col>
+              </Row>
+            </LazyLoadComponent>
+          )}
+
+          <Separator mt={6} mb={3} />
+
+          <Row>
+            <Col>
+              <Footer />
+            </Col>
+          </Row>
+        </HorizontalPadding>
+      </AppContainer>
+    )
+  }
+}
+
+export const SearchAppFragmentContainer = createFragmentContainer(SearchApp, {
+  viewer: graphql`
+    fragment SearchApp_viewer on Viewer
+      @argumentDefinitions(term: { type: "String!", defaultValue: "" }) {
+      search(query: $term, first: 1, aggregations: [TYPE]) {
+        totalCount
+        ...NavigationTabs_searchableConnection
+        edges {
+          node {
+            ... on SearchableItem {
+              id
+            }
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/Apps/Search/__tests__/SearchApp.test.tsx
+++ b/src/Apps/Search/__tests__/SearchApp.test.tsx
@@ -1,0 +1,69 @@
+import { ContextProvider } from "Artsy"
+import { MockBoot } from "DevTools"
+import { mount } from "enzyme"
+import React from "react"
+import { SearchApp } from "../SearchApp"
+
+jest.mock("Artsy/Router/Components/PreloadLink", () => {
+  return {
+    PreloadLink: ({
+      to,
+      children: {
+        props: { children },
+      },
+    }) => {
+      return `<a href=${to}>${children}</a>`
+    },
+  }
+})
+
+describe("SearchApp", () => {
+  const getWrapper = (searchProps: any) => {
+    return mount(
+      <MockBoot>
+        <ContextProvider>
+          <SearchApp {...searchProps} />
+        </ContextProvider>
+      </MockBoot>
+    )
+  }
+
+  const props = {
+    location: {
+      query: { term: "andy" },
+    },
+    viewer: {
+      search: {
+        totalCount: 420,
+        aggregations: [
+          {
+            slice: "TYPE",
+            counts: [
+              { name: "artwork", count: 100 },
+              { name: "artist", count: 320 },
+            ],
+          },
+        ],
+      },
+    },
+  }
+
+  it("includes the header", () => {
+    const wrapper = getWrapper(props) as any
+    const html = wrapper.html()
+    expect(html).toContain("Search Header")
+  })
+
+  it("includes the total count", () => {
+    const wrapper = getWrapper(props) as any
+    const html = wrapper.html()
+    expect(html).toContain('420 results for "andy"')
+  })
+
+  it("includes tabs w/ counts", () => {
+    const wrapper = getWrapper(props) as any
+    const html = wrapper.html()
+    expect(html).toContain("Artworks 100")
+    expect(html).toContain("Artists 320")
+  })
+})

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -1,0 +1,46 @@
+import { RouteConfig } from "found"
+import React from "react"
+import { graphql } from "react-relay"
+import { SearchAppFragmentContainer as SearchApp } from "./SearchApp"
+
+// FIXME: The initial render includes `location` in props, but subsequent
+// renders (such as tabbing back to this route in your browser) will not.
+const prepareVariables = (params, props) => {
+  const paramsFromUrl = props.location ? props.location.query : {}
+  if (
+    Object.keys(paramsFromUrl).length === 0 &&
+    Object.keys(params).length === 0
+  ) {
+    return { term: "andy" }
+  }
+  return {
+    ...paramsFromUrl,
+    ...params,
+  }
+}
+
+export const routes: RouteConfig[] = [
+  {
+    path: "/search2",
+    Component: SearchApp,
+    query: graphql`
+      query routes_SearchBarTopLevelQuery($term: String!) {
+        viewer {
+          ...SearchApp_viewer @arguments(term: $term)
+        }
+      }
+    `,
+    prepareVariables,
+    children: [
+      {
+        path: "/",
+        Component: () => <div>Artwork search results</div>,
+      },
+      {
+        path: "artists",
+        Component: () => <div>Artist search results</div>,
+        prepareVariables,
+      },
+    ],
+  },
+]

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { routes as artistRoutes } from "../Artist/routes"
 import { routes as collectRoutes } from "../Collect/routes"
 import { routes as collectionsRoutes } from "../Collections/routes"
+import { routes as searchRoutes } from "../Search/routes"
 
 storiesOf("Apps", module)
   .add("Artist Page", () => {
@@ -52,5 +53,10 @@ storiesOf("Apps", module)
         initialRoute="/collections"
         context={{}}
       />
+    )
+  })
+  .add("Search Results page", () => {
+    return (
+      <MockRouter routes={searchRoutes} initialRoute="/search2?term=andy" />
     )
   })

--- a/src/__generated__/NavigationTabs_searchableConnection.graphql.ts
+++ b/src/__generated__/NavigationTabs_searchableConnection.graphql.ts
@@ -1,0 +1,80 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+export type SearchAggregation = "TYPE" | "%future added value";
+declare const _NavigationTabs_searchableConnection$ref: unique symbol;
+export type NavigationTabs_searchableConnection$ref = typeof _NavigationTabs_searchableConnection$ref;
+export type NavigationTabs_searchableConnection = {
+    readonly aggregations: ReadonlyArray<({
+        readonly slice: SearchAggregation | null;
+        readonly counts: ReadonlyArray<({
+            readonly count: number | null;
+            readonly name: string | null;
+        }) | null> | null;
+    }) | null> | null;
+    readonly " $refType": NavigationTabs_searchableConnection$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "NavigationTabs_searchableConnection",
+  "type": "SearchableConnection",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "aggregations",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "SearchAggregationResults",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "slice",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "counts",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "AggregationCount",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "count",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "name",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "__id",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '76f1af5fa568892ae22f4ba4840ff358';
+export default node;

--- a/src/__generated__/SearchApp_viewer.graphql.ts
+++ b/src/__generated__/SearchApp_viewer.graphql.ts
@@ -1,0 +1,125 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+import { NavigationTabs_searchableConnection$ref } from "./NavigationTabs_searchableConnection.graphql";
+declare const _SearchApp_viewer$ref: unique symbol;
+export type SearchApp_viewer$ref = typeof _SearchApp_viewer$ref;
+export type SearchApp_viewer = {
+    readonly search: ({
+        readonly totalCount: number | null;
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly id?: string;
+            }) | null;
+        }) | null> | null;
+        readonly " $fragmentRefs": NavigationTabs_searchableConnection$ref;
+    }) | null;
+    readonly " $refType": SearchApp_viewer$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "SearchApp_viewer",
+  "type": "Viewer",
+  "metadata": null,
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "term",
+      "type": "String!",
+      "defaultValue": ""
+    }
+  ],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "search",
+      "storageKey": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "aggregations",
+          "value": [
+            "TYPE"
+          ],
+          "type": "[SearchAggregation]"
+        },
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1,
+          "type": "Int"
+        },
+        {
+          "kind": "Variable",
+          "name": "query",
+          "variableName": "term",
+          "type": "String!"
+        }
+      ],
+      "concreteType": "SearchableConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "totalCount",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "FragmentSpread",
+          "name": "NavigationTabs_searchableConnection",
+          "args": null
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "SearchableEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": null,
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '813abcefae5db4f893b7ed4dd9a17de5';
+export default node;

--- a/src/__generated__/routes_SearchBarTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_SearchBarTopLevelQuery.graphql.ts
@@ -1,0 +1,270 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { SearchApp_viewer$ref } from "./SearchApp_viewer.graphql";
+export type routes_SearchBarTopLevelQueryVariables = {
+    readonly term: string;
+};
+export type routes_SearchBarTopLevelQueryResponse = {
+    readonly viewer: ({
+        readonly " $fragmentRefs": SearchApp_viewer$ref;
+    }) | null;
+};
+export type routes_SearchBarTopLevelQuery = {
+    readonly response: routes_SearchBarTopLevelQueryResponse;
+    readonly variables: routes_SearchBarTopLevelQueryVariables;
+};
+
+
+
+/*
+query routes_SearchBarTopLevelQuery(
+  $term: String!
+) {
+  viewer {
+    ...SearchApp_viewer_4hh6ED
+  }
+}
+
+fragment SearchApp_viewer_4hh6ED on Viewer {
+  search(query: $term, first: 1, aggregations: [TYPE]) {
+    totalCount
+    ...NavigationTabs_searchableConnection
+    edges {
+      node {
+        __typename
+        ... on SearchableItem {
+          id
+        }
+        ... on Node {
+          __id
+        }
+      }
+    }
+  }
+}
+
+fragment NavigationTabs_searchableConnection on SearchableConnection {
+  aggregations {
+    slice
+    counts {
+      count
+      name
+      __id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "term",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_SearchBarTopLevelQuery",
+  "id": null,
+  "text": "query routes_SearchBarTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 1, aggregations: [TYPE]) {\n    totalCount\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      __id\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_SearchBarTopLevelQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "viewer",
+        "name": "__viewer_viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "SearchApp_viewer",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "term",
+                "variableName": "term",
+                "type": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_SearchBarTopLevelQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "search",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "aggregations",
+                "value": [
+                  "TYPE"
+                ],
+                "type": "[SearchAggregation]"
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1,
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "query",
+                "variableName": "term",
+                "type": "String!"
+              }
+            ],
+            "concreteType": "SearchableConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "totalCount",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "SearchAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "name",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v1
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "SearchableEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": null,
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v1,
+                      {
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedHandle",
+        "alias": null,
+        "name": "viewer",
+        "args": null,
+        "handle": "viewer",
+        "key": "",
+        "filters": null
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '3b024d92fcba431a3667ed0d990cbbaa';
+export default node;


### PR DESCRIPTION
![search](https://user-images.githubusercontent.com/1457859/54157008-cfa5ca00-441d-11e9-9685-30d22251112b.gif)

This creates the shell for search results:
  - header and total count
  - tabs
  - placeholder for zero state/results
  - footer

I started this off as `/search2` so that it can be added to Force right away, without waiting for it to be AB tested (and admins/anyone can check out current progress by just visiting /search2 instead of /search).