### PR TITLE
explicitly add redirectTo property for fb auth flow

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -230,7 +230,10 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         }
       })
     } else {
-      mediator.trigger("open:auth", { mode: "login" })
+      mediator.trigger("open:auth", {
+        mode: "login",
+        redirectTo: location.href,
+      })
     }
   }
 
@@ -310,7 +313,10 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         }
       })
     } else {
-      mediator.trigger("open:auth", { mode: "login" })
+      mediator.trigger("open:auth", {
+        mode: "login",
+        redirectTo: location.href,
+      })
     }
   }
 


### PR DESCRIPTION
Addresses: [GROW-1147](https://artsyproduct.atlassian.net/browse/GROW-1147)

When a user logs in with Facebook after clicking the make offer button on an artwork page, they get redirected to the homepage instead of back to the artwork page. I noticed that we weren't passing in a `redirectTo` property to the `open:auth` trigger and that it wasn't included as part of the [`authQueryData`](https://github.com/artsy/reaction/blob/fd1922d49906c2197834bdc69eebb25a62860007/src/Components/Authentication/FormSwitcher.tsx#L200-L203) that gets sent through to Facebook. I'm not able to verify this locally due to Facebook's [requirement of https for login](https://developers.facebook.com/blog/post/2018/06/08/enforce-https-facebook-login/). I think we can add the property and test it in staging.