### PR TITLE
[Icons Upgrade] Fix incompatabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Art.sy Inc <it@artsymail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@artsy/palette": "^3.0.0",
+    "@artsy/palette": "^4.0.1",
     "@sentry/browser": "^4.2.3",
     "dd-trace": "^0.6.0",
     "react": "^16.5.0",
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "0.1.0",
-    "@artsy/palette": "3.2.6",
+    "@artsy/palette": "^4.0.1",
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -15,7 +15,6 @@ import {
   Box,
   Button,
   Checkbox,
-  color,
   Flex,
   Message,
   Radio,
@@ -280,7 +279,7 @@ class Filter extends Component<Props> {
             onClick={() => filterState.showActionSheet(true)}
           >
             <Flex justifyContent="space-between" alignItems="center">
-              <FilterIcon fill={color("white100")} />
+              <FilterIcon fill={"white100"} />
               <Spacer mr={0.5} />
               Filter
             </Flex>

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -14,12 +14,14 @@ import { Media } from "Utils/Responsive"
 import { ArtworkSharePanelFragmentContainer as ArtworkSharePanel } from "./ArtworkSharePanel"
 
 import {
+  BellFillIcon,
   BellIcon,
   color,
   DownloadIcon,
   EditIcon,
   Flex,
   GenomeIcon,
+  HeartFillIcon,
   HeartIcon,
   Join,
   Link,
@@ -313,6 +315,7 @@ interface UtilButtonProps {
   onClick?: () => void
   selected?: boolean
   label?: string
+  Icon?: React.ReactNode
 }
 
 export class UtilButton extends React.Component<
@@ -324,7 +327,7 @@ export class UtilButton extends React.Component<
   }
 
   render() {
-    const { href, label, name, onClick, ...props } = this.props
+    const { href, label, name, onClick, Icon, ...props } = this.props
 
     const getIcon = () => {
       switch (name) {
@@ -347,9 +350,16 @@ export class UtilButton extends React.Component<
       }
     }
 
-    const Icon = getIcon()
-    const defaultFill = name === "more" ? null : color("black100")
-    const fill = this.state.hovered ? color("purple100") : defaultFill
+    // If we're passing in an `Icon`, override
+    let ActionIcon
+    if (Icon) {
+      ActionIcon = Icon
+    } else {
+      ActionIcon = getIcon()
+    }
+
+    const defaultFill = name === "more" ? null : "black100"
+    const fill = this.state.hovered ? "purple100" : defaultFill
 
     return (
       <UtilButtonContainer
@@ -365,7 +375,7 @@ export class UtilButton extends React.Component<
       >
         {href ? (
           <UtilButtonLink className="noUnderline" href={href} target="_blank">
-            <Icon {...props} fill={fill} />
+            <ActionIcon {...props} fill={"black100"} />
             {label && (
               <Sans size="2" pl={0.5} pt="1px">
                 {label}
@@ -374,7 +384,7 @@ export class UtilButton extends React.Component<
           </UtilButtonLink>
         ) : (
           <>
-            <Icon {...props} fill={fill} />
+            <ActionIcon {...props} fill={fill} />
             {label && (
               <Sans size="2" pl={0.5} pt="1px">
                 {label}
@@ -433,9 +443,23 @@ const Save = (actionProps: ArtworkActionsProps) => (
 
   // If an Auction, use Bell (for notifications); if a standard artwork use Heart
   if (isOpenSale) {
-    return <UtilButton name="bell" selected={isSaved} label="Watch lot" />
+    const FilledIcon = () => <BellFillIcon fill="purple100" />
+    return (
+      <UtilButton
+        name="bell"
+        Icon={isSaved ? FilledIcon : BellIcon}
+        label="Watch lot"
+      />
+    )
   } else {
-    return <UtilButton name="heart" selected={isSaved} label="Save" />
+    const FilledIcon = () => <HeartFillIcon fill="purple100" />
+    return (
+      <UtilButton
+        name="heart"
+        Icon={isSaved ? FilledIcon : HeartIcon}
+        label="Save"
+      />
+    )
   }
 }
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -172,7 +172,7 @@ const ArrowButton = ({ direction, onClick }) => {
       alignItems={direction === "left" ? "flex-start" : "flex-end"}
       onClick={onClick}
     >
-      <ChevronIcon direction={direction} size={50} />
+      <ChevronIcon direction={direction} width={30} height={30} />
     </ArrowButtonContainer>
   )
 }

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.test.tsx
@@ -7,6 +7,17 @@ import { cloneDeep } from "lodash"
 import React from "react"
 import { ArtworkActionsFragmentContainer } from "../ArtworkActions"
 
+import {
+  BellFillIcon,
+  DownloadIcon,
+  EditIcon,
+  GenomeIcon,
+  HeartFillIcon,
+  MoreIcon,
+  OpenEyeIcon,
+  ShareIcon,
+} from "@artsy/palette"
+
 describe("ArtworkActions", () => {
   const getWrapper = (
     breakpoint: Breakpoint = "lg",
@@ -23,26 +34,22 @@ describe("ArtworkActions", () => {
 
   it("renders proper components for an admin", () => {
     const wrapper = getWrapper()
-    expect(wrapper.find("Heart").length).toBe(1)
-    expect(wrapper.find("Share").length).toBe(1)
-    expect(wrapper.find("OpenEye").length).toBe(1)
-    expect(wrapper.find("Download").length).toBe(1)
-    expect(wrapper.find("Edit").length).toBe(1)
-    expect(wrapper.find("Genome").length).toBe(1)
-    expect(wrapper.find("More").length).toBe(0)
+    expect(wrapper.find(EditIcon).length).toBe(1)
+    expect(wrapper.find(GenomeIcon).length).toBe(1)
+    expect(wrapper.find(MoreIcon).length).toBe(0)
   })
 
   it("renders proper components for a non-admin", () => {
     const data = cloneDeep(ArtworkActionsFixture)
     data.user.type = "User"
     const wrapper = getWrapper("lg", data)
-    expect(wrapper.find("Heart").length).toBe(1)
-    expect(wrapper.find("Share").length).toBe(1)
-    expect(wrapper.find("OpenEye").length).toBe(1)
-    expect(wrapper.find("Download").length).toBe(1)
-    expect(wrapper.find("Edit").length).toBe(0)
-    expect(wrapper.find("Genome").length).toBe(0)
-    expect(wrapper.find("More").length).toBe(0)
+    expect(wrapper.find(HeartFillIcon).length).toBe(1)
+    expect(wrapper.find(ShareIcon).length).toBe(1)
+    expect(wrapper.find(OpenEyeIcon).length).toBe(1)
+    expect(wrapper.find(DownloadIcon).length).toBe(1)
+    expect(wrapper.find(EditIcon).length).toBe(0)
+    expect(wrapper.find(GenomeIcon).length).toBe(0)
+    expect(wrapper.find(MoreIcon).length).toBe(0)
   })
 
   describe("concerning SaveButton states icon states", () => {
@@ -50,16 +57,16 @@ describe("ArtworkActions", () => {
       const data = cloneDeep(ArtworkActionsFixture)
       data.artwork.sale = null
       const wrapper = getWrapper("lg", data)
-      expect(wrapper.find("Heart").length).toBe(1)
-      expect(wrapper.find("Bell").length).toBe(0)
+      expect(wrapper.find(HeartFillIcon).length).toBe(1)
+      expect(wrapper.find(BellFillIcon).length).toBe(0)
     })
 
     it("renders heart icon when sale is closed", () => {
       const data = cloneDeep(ArtworkActionsFixture)
       data.artwork.sale.is_closed = true
       const wrapper = getWrapper("lg", data)
-      expect(wrapper.find("Heart").length).toBe(1)
-      expect(wrapper.find("Bell").length).toBe(0)
+      expect(wrapper.find(HeartFillIcon).length).toBe(1)
+      expect(wrapper.find(BellFillIcon).length).toBe(0)
     })
 
     it("renders bell icon when sale is open", async () => {
@@ -67,8 +74,8 @@ describe("ArtworkActions", () => {
       data.artwork.sale.is_auction = true
       data.artwork.sale.is_closed = false
       const wrapper = getWrapper("lg", data)
-      expect(wrapper.find("Heart").length).toBe(0)
-      expect(wrapper.find("Bell").length).toBe(1)
+      expect(wrapper.find(HeartFillIcon).length).toBe(0)
+      expect(wrapper.find(BellFillIcon).length).toBe(1)
     })
   })
 
@@ -78,7 +85,7 @@ describe("ArtworkActions", () => {
       data.user.type = "Admin"
       data.artwork.is_hangable = true
       const wrapper = getWrapper("lg", data)
-      expect(wrapper.find("OpenEye").length).toBe(1)
+      expect(wrapper.find(OpenEyeIcon).length).toBe(1)
     })
 
     it("is not available for non hangable artworks", () => {
@@ -86,7 +93,7 @@ describe("ArtworkActions", () => {
       data.user.type = "Admin"
       data.artwork.is_hangable = false
       const wrapper = getWrapper("lg", data)
-      expect(wrapper.find("OpenEye").length).toBe(0)
+      expect(wrapper.find(OpenEyeIcon).length).toBe(0)
     })
   })
 
@@ -97,7 +104,7 @@ describe("ArtworkActions", () => {
         data.user.type = "User"
         data.artwork.is_downloadable = true
         const wrapper = getWrapper("lg", data)
-        expect(wrapper.find("Download").length).toBe(1)
+        expect(wrapper.find(DownloadIcon).length).toBe(1)
       })
 
       it("renders link if admin", () => {
@@ -105,7 +112,7 @@ describe("ArtworkActions", () => {
         data.user.type = "Admin"
         data.artwork.is_downloadable = false
         const wrapper = getWrapper("lg", data)
-        expect(wrapper.find("Download").length).toBe(1)
+        expect(wrapper.find(DownloadIcon).length).toBe(1)
       })
 
       it("hides link if is_downloadable=false and the user is not an admin", () => {
@@ -113,7 +120,7 @@ describe("ArtworkActions", () => {
         data.user.type = "User"
         data.artwork.is_downloadable = false
         const wrapper = getWrapper("lg", data)
-        expect(wrapper.find("Download").length).toBe(0)
+        expect(wrapper.find(DownloadIcon).length).toBe(0)
       })
     })
   })
@@ -121,21 +128,21 @@ describe("ArtworkActions", () => {
   describe("in the xs breakpoint", () => {
     it("shows the More icon", () => {
       const wrapper = getWrapper("xs")
-      expect(wrapper.find("Heart").length).toBe(1)
-      expect(wrapper.find("Share").length).toBe(1)
-      expect(wrapper.find("OpenEye").length).toBe(1)
-      expect(wrapper.find("More").length).toBe(1)
-      expect(wrapper.find("Download").length).toBe(0)
-      expect(wrapper.find("Edit").length).toBe(0)
-      expect(wrapper.find("Genome").length).toBe(0)
+      expect(wrapper.find(HeartFillIcon).length).toBe(1)
+      expect(wrapper.find(ShareIcon).length).toBe(1)
+      expect(wrapper.find(OpenEyeIcon).length).toBe(1)
+      expect(wrapper.find(MoreIcon).length).toBe(1)
+      expect(wrapper.find(DownloadIcon).length).toBe(0)
+      expect(wrapper.find(EditIcon).length).toBe(0)
+      expect(wrapper.find(GenomeIcon).length).toBe(0)
     })
 
     it("clicking the More icon shows the download link if non-admin", () => {
       const wrapper = getWrapper("xs")
-      wrapper.find("More").simulate("click")
-      expect(wrapper.find("Download").length).toBe(1)
-      expect(wrapper.find("Edit").length).toBe(1)
-      expect(wrapper.find("Genome").length).toBe(1)
+      wrapper.find(MoreIcon).simulate("click")
+      expect(wrapper.find(DownloadIcon).length).toBe(1)
+      expect(wrapper.find(EditIcon).length).toBe(1)
+      expect(wrapper.find(GenomeIcon).length).toBe(1)
     })
 
     it("shows no More icon if there are <= 3 actions", () => {
@@ -143,13 +150,13 @@ describe("ArtworkActions", () => {
       data.user.type = "User"
       data.artwork.is_downloadable = false
       const wrapper = getWrapper("xs", data)
-      expect(wrapper.find("Heart").length).toBe(1)
-      expect(wrapper.find("Share").length).toBe(1)
-      expect(wrapper.find("OpenEye").length).toBe(1)
-      expect(wrapper.find("Download").length).toBe(0)
-      expect(wrapper.find("Edit").length).toBe(0)
-      expect(wrapper.find("Genome").length).toBe(0)
-      expect(wrapper.find("More").length).toBe(0)
+      expect(wrapper.find(HeartFillIcon).length).toBe(1)
+      expect(wrapper.find(ShareIcon).length).toBe(1)
+      expect(wrapper.find(OpenEyeIcon).length).toBe(1)
+      expect(wrapper.find(DownloadIcon).length).toBe(0)
+      expect(wrapper.find(EditIcon).length).toBe(0)
+      expect(wrapper.find(GenomeIcon).length).toBe(0)
+      expect(wrapper.find(MoreIcon).length).toBe(0)
     })
   })
 })

--- a/src/Apps/Collect/Components/Filters/SortFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/SortFilter.tsx
@@ -3,14 +3,7 @@ import React, { useContext } from "react"
 import { Media } from "Utils/Responsive"
 import { FilterState } from "../../FilterState"
 
-import {
-  Button,
-  color,
-  FilterIcon,
-  Flex,
-  SmallSelect,
-  Spacer,
-} from "@artsy/palette"
+import { Button, FilterIcon, Flex, SmallSelect, Spacer } from "@artsy/palette"
 
 export const SortFilter: React.FC<{
   filters: FilterState
@@ -52,7 +45,7 @@ export const SortFilter: React.FC<{
       <Media at="xs">
         <Button size="small" mt={-1} onClick={onShow}>
           <Flex justifyContent="space-between" alignItems="center">
-            <FilterIcon fill={color("white100")} />
+            <FilterIcon fill="white100" />
             <Spacer mr={0.5} />
             Filter
           </Flex>

--- a/src/Apps/Order/Routes/__tests__/Accept.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Accept.test.tsx
@@ -90,7 +90,9 @@ describe("Accept seller offer", () => {
     })
 
     it("Shows the stepper", async () => {
-      expect(page.orderStepper.text()).toMatchInlineSnapshot(`"Respond Review"`)
+      expect(page.orderStepper.text()).toMatchInlineSnapshot(
+        `"checkRespond navigate rightReview"`
+      )
       expect(page.orderStepperCurrentStep).toBe(`Review`)
     })
 
@@ -111,13 +113,13 @@ describe("Accept seller offer", () => {
 
     it("shows the shipping details", async () => {
       expect(page.shippingSummary.text()).toMatch(
-        "Ship toJoelle Van Dyne401 Broadway"
+        "Ship toLockedJoelle Van Dyne401 Broadway"
       )
     })
 
     it("shows the payment details", async () => {
       expect(page.paymentSummary.text()).toMatchInlineSnapshot(
-        `"•••• 4444  Exp 3/21"`
+        `"Lockedvisa•••• 4444  Exp 3/21"`
       )
     })
 

--- a/src/Apps/Order/Routes/__tests__/Counter.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.test.tsx
@@ -90,7 +90,9 @@ describe("Submit Pending Counter Offer", () => {
     })
 
     it("Shows the stepper", () => {
-      expect(page.orderStepper.text()).toMatchInlineSnapshot(`"Respond Review"`)
+      expect(page.orderStepper.text()).toMatchInlineSnapshot(
+        `"checkRespond navigate rightReview"`
+      )
       expect(page.orderStepperCurrentStep).toBe("Review")
     })
 
@@ -110,13 +112,13 @@ describe("Submit Pending Counter Offer", () => {
 
     it("shows the shipping details", () => {
       expect(page.shippingSummary.text()).toMatch(
-        "Ship toJoelle Van Dyne401 Broadway"
+        "Ship toLockedJoelle Van Dyne401 Broadway"
       )
     })
 
     it("shows the payment details", () => {
       expect(page.paymentSummary.text()).toMatchInlineSnapshot(
-        `"•••• 4444  Exp 3/21"`
+        `"Lockedvisa•••• 4444  Exp 3/21"`
       )
     })
 

--- a/src/Apps/Order/Routes/__tests__/Payment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.test.tsx
@@ -501,7 +501,7 @@ describe("Payment", () => {
         },
       })
       expect(page.orderStepper.text()).toMatchInlineSnapshot(
-        `"Offer Shipping PaymentReview"`
+        `"checkOffer navigate rightcheckShipping navigate rightPaymentnavigate rightReview"`
       )
       expect(page.orderStepperCurrentStep).toBe("Payment")
     })

--- a/src/Apps/Order/Routes/__tests__/Reject.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Reject.test.tsx
@@ -73,7 +73,9 @@ describe("Buyer rejects seller offer", () => {
     })
 
     it("Shows the stepper", () => {
-      expect(page.orderStepper.text()).toMatchInlineSnapshot(`"Respond Review"`)
+      expect(page.orderStepper.text()).toMatchInlineSnapshot(
+        `"checkRespond navigate rightReview"`
+      )
       expect(page.orderStepperCurrentStep).toBe("Review")
     })
 

--- a/src/Apps/Order/Routes/__tests__/Respond.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Respond.test.tsx
@@ -140,7 +140,9 @@ describe("The respond page", () => {
     })
 
     it("shows the stepper", () => {
-      expect(page.orderStepper.text()).toMatchInlineSnapshot(`"RespondReview"`)
+      expect(page.orderStepper.text()).toMatchInlineSnapshot(
+        `"Respondnavigate rightReview"`
+      )
       expect(page.orderStepperCurrentStep).toBe("Respond")
     })
 
@@ -187,13 +189,13 @@ describe("The respond page", () => {
 
     it("shows the shipping details", () => {
       expect(page.shippingSummary.text()).toMatch(
-        "Ship toJoelle Van Dyne401 Broadway"
+        "Ship toLockedJoelle Van Dyne401 Broadway"
       )
     })
 
     it("shows the payment details", () => {
       expect(page.paymentSummary.text()).toMatchInlineSnapshot(
-        `"•••• 4444  Exp 3/21"`
+        `"Lockedvisa•••• 4444  Exp 3/21"`
       )
     })
 

--- a/src/Apps/Order/Routes/__tests__/Review.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.test.tsx
@@ -139,7 +139,7 @@ describe("Review", () => {
 
     it("shows an active offer stepper if the order is an Offer Order", () => {
       expect(page.orderStepper.text()).toMatchInlineSnapshot(
-        `"Offer Shipping Payment Review"`
+        `"checkOffer navigate rightcheckShipping navigate rightcheckPayment navigate rightReview"`
       )
       expect(page.orderStepperCurrentStep).toBe("Review")
     })

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -345,7 +345,7 @@ Object {
         },
       })
       expect(page.orderStepper.text()).toMatchInlineSnapshot(
-        `"Offer ShippingPaymentReview"`
+        `"checkOffer navigate rightShippingnavigate rightPaymentnavigate rightReview"`
       )
       expect(page.orderStepperCurrentStep).toBe("Shipping")
     })

--- a/src/Components/Artist/MarketInsights/__tests__/__snapshots__/MarketInsights.test.tsx.snap
+++ b/src/Components/Artist/MarketInsights/__tests__/__snapshots__/MarketInsights.test.tsx.snap
@@ -147,29 +147,19 @@ exports[`MarketInsights snapshots renders correctly 1`] = `
               }
             >
               <svg
-                className="icon__help c4"
-                height="17px"
-                viewBox="0 0 17 17"
-                width="17px"
-                xmlns="http://www.w3.org/2000/svg"
+                className="c4"
+                fill="black100"
+                height="18px"
+                viewBox="0 0 18 18"
+                width="18px"
               >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  transform="translate(1 1)"
-                >
-                  <circle
-                    cx="7.5"
-                    cy="7.5"
-                    fill="#FFF"
-                    r="7.5"
-                    stroke="#666"
-                  />
-                  <path
-                    d="M7.92 11.13V9.94H6.73v1.19h1.19zM7.8 9.04v-.18c0-1.74 2.2-2.03 2.2-3.8C10 3.68 8.8 3 7.61 3 6.33 3 5.01 3.82 5 5.47h1.05c0-1.18.76-1.65 1.5-1.65.7 0 1.33.4 1.33 1.25 0 .45-.25.9-.71 1.29-1.13.98-1.32 1.34-1.35 2.48v.2h.98z"
-                    fill="#666"
-                  />
-                </g>
+                <title>
+                  Help
+                </title>
+                <path
+                  d="M9 1.889A7.111 7.111 0 1 1 9 16.11 7.111 7.111 0 0 1 9 1.89zM9 1a8 8 0 1 0 0 16A8 8 0 0 0 9 1zm-.658 9.92v-.142c0-1.111.214-1.458 1.307-2.418.405-.294.66-.753.693-1.253a1.182 1.182 0 0 0-1.298-1.254 1.422 1.422 0 0 0-1.448 1.6H6.573a2.391 2.391 0 0 1 2.534-2.4 2.089 2.089 0 0 1 2.32 2c0 1.716-2.143 2.01-2.143 3.69v.177h-.942zm-.089 2.027V11.8H9.41v1.147H8.253z"
+                  fillRule="nonzero"
+                />
               </svg>
             </span>
           </div>

--- a/src/Components/__stories__/Icons.story.tsx
+++ b/src/Components/__stories__/Icons.story.tsx
@@ -1,5 +1,5 @@
-import { storiesOf } from "@storybook/react"
 import React from "react"
+import { storiesOf } from "storybook/storiesOf"
 
 import { Box, Col, Flex, Grid, Row } from "@artsy/palette"
 import * as svgs from "@artsy/palette"
@@ -20,13 +20,13 @@ storiesOf("Components/Icons", module).add("All Icons", () => {
         <Row>
           <Flex flexDirection="row" flexWrap="wrap">
             <Col p={1} width="auto">
-              <svgs.BellIcon />
+              <svgs.BellIcon width="25" />
             </Col>
             <Col p={1} width="auto">
               <svgs.CheckIcon />
             </Col>
             <Col p={1} width="auto">
-              <svgs.ChevronIcon size={40} />
+              <svgs.ChevronIcon width={40} height={40} />
             </Col>
             <Col p={1} width="auto">
               <svgs.CircleBlackCheckIcon width="25" height="25" />
@@ -38,7 +38,7 @@ storiesOf("Components/Icons", module).add("All Icons", () => {
               <svgs.ClosedEyeIcon />
             </Col>
             <Col p={1} width="auto">
-              <svgs.FilterIcon fill="#000" />
+              <svgs.FilterIcon fill="black10" />
             </Col>
             <Col p={1} width="auto">
               <svgs.HeartIcon />

--- a/src/Components/__tests__/__snapshots__/PasswordInput.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/PasswordInput.test.tsx.snap
@@ -147,17 +147,16 @@ exports[`PasswordInput renders masked as a snapshot 1`] = `
     >
       <svg
         className="c5"
-        height="18"
+        fill="black100"
+        height="18px"
         onClick={[Function]}
         viewBox="0 0 18 18"
-        width="18"
-        xmlns="http://www.w3.org/2000/svg"
+        width="18px"
       >
         <title>
-          Action/View/Md
+          view
         </title>
         <g
-          fill="#000"
           fillRule="nonzero"
         >
           <path
@@ -176,7 +175,6 @@ exports[`PasswordInput renders masked as a snapshot 1`] = `
 exports[`PasswordInput renders unmasked as a snapshot 1`] = `
 .c5 {
   position: relative;
-  vertical-align: middle;
 }
 
 .c0 {
@@ -321,24 +319,28 @@ exports[`PasswordInput renders unmasked as a snapshot 1`] = `
     >
       <svg
         className="c5"
-        height={20}
+        fill="black100"
+        height="18px"
         onClick={[Function]}
-        viewBox="0 0 12 12"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 18 18"
+        width="18px"
       >
-        <path
-          d="M4.5,6s0,0,0,.08L6.07,4.51H6A1.5,1.5,0,0,0,4.5,6Z"
-          fill="#c2c2c2"
-        />
-        <path
-          d="M3.68,6.91A2.54,2.54,0,0,1,3.5,6,2.5,2.5,0,0,1,6,3.5a2.54,2.54,0,0,1,.91.18L8.19,2.4A6.14,6.14,0,0,0,6,2,6.75,6.75,0,0,0,0,6,7.9,7.9,0,0,0,2,8.56Z"
-          fill="#c2c2c2"
-        />
-        <path
-          d="M9.57,3.14l.78-.79-.7-.7-8,8,.7.7,1-1A6.08,6.08,0,0,0,6,10a6.75,6.75,0,0,0,6-4A7.67,7.67,0,0,0,9.57,3.14ZM6,8.5a2.46,2.46,0,0,1-1.37-.42l.73-.73a1.49,1.49,0,0,0,2-2l.73-.73A2.46,2.46,0,0,1,8.5,6,2.5,2.5,0,0,1,6,8.5Z"
-          fill="#c2c2c2"
-        />
+        <title>
+          hide
+        </title>
+        <g
+          fillRule="nonzero"
+        >
+          <path
+            d="M2.249 8.605a.56.56 0 0 0 .016.6C4.172 12.044 6.406 13.43 9 13.43c2.594 0 4.828-1.387 6.736-4.225a.56.56 0 0 0 .017-.6c-1.714-2.901-3.944-4.318-6.742-4.318S3.975 5.703 2.25 8.605zM1.238 8.03C3.163 4.795 5.77 3.143 9.01 3.143c3.241 0 5.843 1.653 7.755 4.89.331.561.31 1.257-.053 1.798-2.109 3.139-4.69 4.74-7.713 4.74-3.021 0-5.602-1.6-7.711-4.738a1.681 1.681 0 0 1-.05-1.802z"
+          />
+          <path
+            d="M9 11.714A2.857 2.857 0 1 1 9 6a2.857 2.857 0 0 1 0 5.714zm0-1.143a1.714 1.714 0 1 0 0-3.428 1.714 1.714 0 0 0 0 3.428z"
+          />
+          <path
+            d="M15.054 2.053l.805.81-12.893 12.79-.805-.81z"
+          />
+        </g>
       </svg>
     </span>
   </div>

--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -59,7 +59,7 @@ export const LargeCarousel = (props: Props) => {
           props.onArrowClick && props.onArrowClick()
         }}
       >
-        <ChevronIcon direction="left" fill="black100" size={50} />
+        <ChevronIcon direction="left" fill="black100" width={30} height={30} />
       </ArrowButton>
 
       <CarouselContainer height={props.height}>
@@ -77,7 +77,7 @@ export const LargeCarousel = (props: Props) => {
           props.onArrowClick && props.onArrowClick()
         }}
       >
-        <ChevronIcon direction="right" fill="black100" size={50} />
+        <ChevronIcon direction="right" fill="black100" width={30} height={30} />
       </ArrowButton>
     </Flex>
   )

--- a/src/Components/v2/__tests__/CountdownTimer.test.tsx
+++ b/src/Components/v2/__tests__/CountdownTimer.test.tsx
@@ -61,7 +61,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"01d 00s leftRespond by Dec 04, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Dec 04, 8:50 AM ESTExpired offers end the negotiation process permanently."`
       )
     })
 
@@ -71,7 +71,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"01d 00s leftRespond by Dec 04, 1:50 PM GMTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Dec 04, 1:50 PM GMTExpired offers end the negotiation process permanently."`
       )
     })
   })
@@ -85,7 +85,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"01d 00s leftRespond by Aug 04, 9:50 AM EDTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Aug 04, 9:50 AM EDTExpired offers end the negotiation process permanently."`
       )
     })
 
@@ -95,7 +95,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"01d 00s leftRespond by Aug 04, 2:50 PM BSTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Aug 04, 2:50 PM BSTExpired offers end the negotiation process permanently."`
       )
     })
   })
@@ -114,7 +114,7 @@ describe("CountdownTimer", () => {
 
     const text = timer.text()
     expect(text).toMatchInlineSnapshot(
-      `"01d 30m 00s leftRespond by Dec 04, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01d 30m 00s leftRespond by Dec 04, 8:50 AM ESTExpired offers end the negotiation process permanently."`
     )
   })
 
@@ -132,7 +132,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"01d 15h 10m 05s leftRespond by Dec 05, 12:00 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01d 15h 10m 05s leftRespond by Dec 05, 12:00 AM ESTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -147,7 +147,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"15h 10m 05s leftRespond by Dec 04, 12:00 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining15h 10m 05s leftRespond by Dec 04, 12:00 AM ESTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -159,7 +159,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"15m 10s leftRespond by Dec 03, 9:05 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining15m 10s leftRespond by Dec 03, 9:05 AM ESTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -169,7 +169,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"01s leftRespond by Dec 03, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01s leftRespond by Dec 03, 8:50 AM ESTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -179,7 +179,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"0 days leftRespond by Dec 03, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining0 days leftRespond by Dec 03, 8:50 AM ESTExpired offers end the negotiation process permanently."`
     )
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.0.1.tgz#3d83384bf3323fbd4679a2d73155ab85dc73e850"
   integrity sha512-jqrC40t1P6w9zIvsJJhWe8pxLWdEC/kJQmDc4/b3vAnGy1EsJpcIJGUys37kwut7tDYPiypUF06SImtZVLGQnQ==
 
-"@artsy/palette@3.2.6":
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-3.2.6.tgz#195a125874e1e37a29e6e159cff808f3b4d27656"
-  integrity sha512-rbsT1kbUbBcmfV3SST9CEw58KXo2qj1IGVt5gjOztNZPcDhj1XMVdnCT6rkF7ALmwBGwzhSC46P+FYwU/N0K9Q==
+"@artsy/palette@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.0.1.tgz#6bb293867e7839bd8a74f6358402a075a2d997d2"
+  integrity sha512-tk9Y8VnJyTVhnOolScXyNneh7dRXI5l+rW9E4ZVL6ZuOaxcYkx1995+n2pQ7djjrMV21EFj2J9bK8YmFgFTP4Q==
   dependencies:
     babel-plugin-styled-components "^1.10.0"
     moment "^2.23.0"


### PR DESCRIPTION
Follow-up to https://github.com/artsy/palette/pull/308 which fixes some stuff around 
- No more state full icons; e.g., HeartIcon -> HeartIcon + HeartFillIcon
- No more unnecessary displayNames; since all icons are now SFC's we get displayNames for free
- No more inconsistent colors; interfaces guard against passing anything not defined in theme, and no need for `color` helper
- No more inconsistent heights / widths / size props; these props all inherit from Icon base component
- Icons now have titles, so users and screen-readers and so on can get context.