### PR TITLE
Clean `.cache` as part of `clean` task

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "styled-components": "^4"
   },
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rm -rf .cache && rm -rf dist",
     "compile": "babel src --out-dir dist -s --source-map --extensions '.js,.jsx,.ts,.tsx' --ignore src/**/__tests__,src/**/__stories__",
     "deploy-storybook-pr": "yarn relay && NODE_ENV=production build-storybook -s ./public -o storybook_build ",
     "emit-types": "tsc --declaration --emitDeclarationOnly --listEmittedFiles --jsx react --outDir dist",


### PR DESCRIPTION
As [discussed in Slack](https://artsy.slack.com/archives/C02BC3HEJ/p1552399118228900) - 

I am having trouble getting things running locally, and it was suspected that I need to clean my yarn cache. @damassi suggested I add it to the clean task, as well.