### PR TITLE
DISCO-738: Conditionally open mobile sign up when saving artwork

### DIFF
--- a/src/Components/Artwork/Save.tsx
+++ b/src/Components/Artwork/Save.tsx
@@ -16,6 +16,9 @@ import styled from "styled-components"
 import colors from "../../Assets/Colors"
 import Icon from "../Icon"
 
+import { stringify } from "qs"
+import { data as sd } from "sharify"
+
 const SIZE = 40
 
 export interface SaveTrackingProps {
@@ -126,22 +129,44 @@ export class SaveButton extends React.Component<SaveProps, SaveState> {
       })
       this.trackSave()
     } else {
-      if (this.props.mediator) {
-        this.props.mediator.trigger("open:auth", {
-          mode: "signup",
-          copy: `Sign up to save artworks`,
-          intent: "save artwork",
-          signupIntent: "save artwork",
-          trigger: "click",
-          afterSignUpAction: {
-            action: "save",
-            objectId: this.props.artwork.id,
-          },
-        })
+      if (sd.IS_MOBILE) {
+        this.openMobileAuth(this.props.artwork)
+      } else if (this.props.mediator) {
+        this.openDesktopAuth(this.props.mediator, this.props.artwork.id)
       } else {
         window.location.href = "/login"
       }
     }
+  }
+
+  openMobileAuth(artwork) {
+    const params = stringify({
+      action: "save",
+      contextModule: "Artwork page",
+      intent: "save artwork",
+      kind: "artwork",
+      objectId: artwork.id,
+      signUpIntent: "save artwork",
+      trigger: "click",
+      entityName: artwork.title,
+    })
+    const href = `/sign_up?redirect-to=${window.location}&${params}`
+
+    window.location.href = href
+  }
+
+  openDesktopAuth(mediator, artworkId) {
+    mediator.trigger("open:auth", {
+      mode: "signup",
+      copy: `Sign up to save artworks`,
+      intent: "save artwork",
+      signupIntent: "save artwork",
+      trigger: "click",
+      afterSignUpAction: {
+        action: "save",
+        objectId: artworkId,
+      },
+    })
   }
 
   mixinButtonActions() {


### PR DESCRIPTION
I paired with @xtina-starr on this and after some poking around, we figured out that this `SaveButton` component's `handleSave` function could be improved to include a check for `IS_MOBILE` and use that experience when true.

We started by extracting a function called `openDesktopAuth` so that we could keep our logic in `handleSave` nice and neat. From there we investigated how to get access to `sd.IS_MOBILE` and found that it was an import away, so added sharify to the file. That set us up to add a check for that flag and open the mobile sign up by adding a `openMobileAuth` function.

The mobile signup flow encodes details in the URL, including a redirect url, so that's where we'll land after signing up/in.