### PR TITLE
Add images to ArtistCollectionRail

### DIFF
--- a/src/Apps/__tests__/Fixtures/Collections.ts
+++ b/src/Apps/__tests__/Fixtures/Collections.ts
@@ -42,12 +42,80 @@ export const CollectionsRailFixture = [
     headerImage: "http://files.artsy.net/images/jasperjohnsflag.png",
     title: "Jasper Johns: Flags",
     price_guidance: 1000,
+    artworks: {
+      hits: [
+        {
+          artist: {
+            name: "Jasper Johns",
+          },
+          title: "Flag",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+          },
+        },
+        {
+          artist: {
+            name: "Jasper Johns",
+          },
+          title: "Flag (Moratorium)",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+          },
+        },
+        {
+          artist: {
+            name: "Jasper Johns",
+          },
+          title: "Flag I",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+          },
+        },
+      ],
+    },
   },
   {
     slug: "street-art-now",
     headerImage: "http://files.artsy.net/images/banksygirlwithballoon.png",
     title: "Street Art Now",
     price_guidance: 200,
+    artworks: {
+      hits: [
+        {
+          artist: {
+            name: "Alec Monopoly",
+          },
+          title: "Community Chest: Go To Jail",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/DSa-4s-zRJEwW6mZRgDoxQ/small.jpg",
+          },
+        },
+        {
+          artist: {
+            name: "Alec Monopoly",
+          },
+          title: "DJ Monopoly",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/L0wx7i69h96MUFq9EgOpBQ/small.jpg",
+          },
+        },
+        {
+          artist: {
+            name: "Keith Haring",
+          },
+          title: "Keith Haring 1982 Dolphin lithograph",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/ZZodXz8Y7v7h0VWlQnZQCw/small.jpg",
+          },
+        },
+      ],
+    },
   },
   {
     slug: "contemporary-limited-editions",
@@ -55,12 +123,80 @@ export const CollectionsRailFixture = [
       "http://files.artsy.net/images/contemporarylimitededition2.png",
     title: "Contemporary Limited Editions",
     price_guidance: 1000,
+    artworks: {
+      hits: [
+        {
+          artist: {
+            name: "Kiki Smith",
+          },
+          title: "Untitled",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/VzteQ4joB2Iwjek9kPUrGg/small.jpg",
+          },
+        },
+        {
+          artist: {
+            name: "Gerhard Richter",
+          },
+          title: "P8",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/ZN_qyzZgvHz-DRMFW-Wrcw/small.jpg",
+          },
+        },
+        {
+          artist: {
+            name: "Robert Longo",
+          },
+          title: "Monsters",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/0vJm9FeXzxzZJpBC-A-4ig/small.jpg",
+          },
+        },
+      ],
+    },
   },
   {
     slug: "timeless-modern-prints",
     headerImage: "http://files.artsy.net/images/timelessmodernprints.png",
     title: "Timeless Modern Prints",
     price_guidance: 2500,
+    artworks: {
+      hits: [
+        {
+          artist: {
+            name: "Joan Miró",
+          },
+          title: "Migratory Bird I",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/_67k2lYpopsd-UK6LOD61g/small.jpg",
+          },
+        },
+        {
+          artist: {
+            name: "Pablo Picasso",
+          },
+          title: "Bacchanale",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/mepJj80_m4NiWUJviymyBw/small.jpg",
+          },
+        },
+        {
+          artist: {
+            name: "Josef Albers",
+          },
+          title: "Mitered Squares-Apricot ",
+          image: {
+            url:
+              "https://d32dm0rphc51dk.cloudfront.net/CbgUJdNK5lWvhKzziYgx7w/small.jpg",
+          },
+        },
+      ],
+    },
   },
 ]
 

--- a/src/Components/Artist/ArtistCollectionsRail/__tests__/ArtistCollectionEntity.test.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/__tests__/ArtistCollectionEntity.test.tsx
@@ -2,7 +2,11 @@ import { CollectionsRailFixture } from "Apps/__tests__/Fixtures/Collections"
 import { mockTracking } from "Artsy/Analytics"
 import { mount } from "enzyme"
 import React from "react"
-import { ArtistCollectionEntity, StyledLink } from "../ArtistCollectionEntity"
+import {
+  ArtistCollectionEntity,
+  ArtworkImage,
+  StyledLink,
+} from "../ArtistCollectionEntity"
 jest.unmock("react-tracking")
 
 describe("ArtistCollectionEntity", () => {
@@ -20,6 +24,44 @@ describe("ArtistCollectionEntity", () => {
     expect(component.text()).not.toMatch("Jasper Johns:")
     expect(component.text()).toMatch("Flags")
     expect(component.text()).toMatch("Works from $1,000")
+    expect(component.find(ArtworkImage).length).toBe(3)
+    const artworkImage = component
+      .find(ArtworkImage)
+      .at(0)
+      .getElement().props
+
+    expect(artworkImage.src).toBe(
+      "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg"
+    )
+    expect(artworkImage.alt).toBe("Jasper Johns, Flag")
+    expect(artworkImage.width).toBe(85)
+  })
+
+  it("Returns proper image size if 2 artworks returned", () => {
+    props.collection.artworks.hits.pop()
+    const component = mount(<ArtistCollectionEntity {...props} />)
+    const artworkImage = component
+      .find(ArtworkImage)
+      .at(0)
+      .getElement().props
+
+    expect(component.find(ArtworkImage).length).toBe(2)
+    expect(artworkImage.width).toBe(131)
+  })
+
+  it("Renders a backup image if no artworks returned", () => {
+    props.collection.artworks.hits = []
+    const component = mount(<ArtistCollectionEntity {...props} />)
+    const artworkImage = component
+      .find(ArtworkImage)
+      .at(0)
+      .getElement().props
+
+    expect(component.find(ArtworkImage).length).toBe(1)
+    expect(artworkImage.src).toBe(
+      "http://files.artsy.net/images/jasperjohnsflag.png"
+    )
+    expect(artworkImage.width).toBe(265)
   })
 
   it("Tracks link clicks", () => {

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -141,6 +141,20 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   padding-right: 10px;
 }
 
+.c5 {
+  font-family: artsy-icons;
+  color: #000;
+  font-size: 32px;
+  margin: 0 5px;
+  display: inline-block;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  position: relative;
+  color: #000;
+}
+
 .c20 {
   margin: 10px 20px 0 0;
 }
@@ -202,20 +216,6 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex-align: flex-end;
   align-items: flex-end;
   color: black;
-}
-
-.c5 {
-  font-family: artsy-icons;
-  color: #000;
-  font-size: 32px;
-  margin: 0 5px;
-  display: inline-block;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  position: relative;
-  color: #000;
 }
 
 .c3 {
@@ -6559,6 +6559,20 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   width: 100%;
 }
 
+.c5 {
+  font-family: artsy-icons;
+  color: black;
+  font-size: 32px;
+  margin: 0 5px;
+  display: inline-block;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  position: relative;
+  color: black;
+}
+
 .c21 {
   margin: 10px 20px 0 0;
 }
@@ -6644,20 +6658,6 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 
 .c38 > a:hover,
 .c38 a:hover {
-  color: black;
-}
-
-.c5 {
-  font-family: artsy-icons;
-  color: black;
-  font-size: 32px;
-  margin: 0 5px;
-  display: inline-block;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  position: relative;
   color: black;
 }
 

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -141,20 +141,6 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   padding-right: 10px;
 }
 
-.c5 {
-  font-family: artsy-icons;
-  color: #000;
-  font-size: 32px;
-  margin: 0 5px;
-  display: inline-block;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  position: relative;
-  color: #000;
-}
-
 .c20 {
   margin: 10px 20px 0 0;
 }
@@ -216,6 +202,20 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex-align: flex-end;
   align-items: flex-end;
   color: black;
+}
+
+.c5 {
+  font-family: artsy-icons;
+  color: #000;
+  font-size: 32px;
+  margin: 0 5px;
+  display: inline-block;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  position: relative;
+  color: #000;
 }
 
 .c3 {
@@ -6559,20 +6559,6 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   width: 100%;
 }
 
-.c5 {
-  font-family: artsy-icons;
-  color: black;
-  font-size: 32px;
-  margin: 0 5px;
-  display: inline-block;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  position: relative;
-  color: black;
-}
-
 .c21 {
   margin: 10px 20px 0 0;
 }
@@ -6658,6 +6644,20 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 
 .c38 > a:hover,
 .c38 a:hover {
+  color: black;
+}
+
+.c5 {
+  font-family: artsy-icons;
+  color: black;
+  font-size: 32px;
+  margin: 0 5px;
+  display: inline-block;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  position: relative;
   color: black;
 }
 

--- a/src/__generated__/ArtistCollectionEntity_collection.graphql.ts
+++ b/src/__generated__/ArtistCollectionEntity_collection.graphql.ts
@@ -4,15 +4,42 @@ import { ConcreteFragment } from "relay-runtime";
 declare const _ArtistCollectionEntity_collection$ref: unique symbol;
 export type ArtistCollectionEntity_collection$ref = typeof _ArtistCollectionEntity_collection$ref;
 export type ArtistCollectionEntity_collection = {
+    readonly headerImage: string | null;
     readonly slug: string;
     readonly title: string;
     readonly price_guidance: number | null;
+    readonly artworks: ({
+        readonly hits: ReadonlyArray<({
+            readonly artist: ({
+                readonly name: string | null;
+            }) | null;
+            readonly title: string | null;
+            readonly image: ({
+                readonly url: string | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
     readonly " $refType": ArtistCollectionEntity_collection$ref;
 };
 
 
 
-const node: ConcreteFragment = {
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
   "kind": "Fragment",
   "name": "ArtistCollectionEntity_collection",
   "type": "MarketingCollection",
@@ -22,23 +49,106 @@ const node: ConcreteFragment = {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "slug",
+      "name": "headerImage",
       "args": null,
       "storageKey": null
     },
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "title",
+      "name": "slug",
       "args": null,
       "storageKey": null
     },
+    v0,
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "price_guidance",
       "args": null,
       "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artworks",
+      "storageKey": "artworks(size:3,sort:\"merchandisability\")",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 3,
+          "type": "Int"
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "merchandisability",
+          "type": "String"
+        }
+      ],
+      "concreteType": "FilterArtworks",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "hits",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Artwork",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "artist",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artist",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "name",
+                  "args": null,
+                  "storageKey": null
+                },
+                v1
+              ]
+            },
+            v0,
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "image",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Image",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "url",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "version",
+                      "value": "small",
+                      "type": "[String]"
+                    }
+                  ],
+                  "storageKey": "url(version:\"small\")"
+                }
+              ]
+            },
+            v1
+          ]
+        },
+        v1
+      ]
     },
     {
       "kind": "ScalarField",
@@ -49,5 +159,6 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '15950008311f60b90cfb6cd743196ffb';
+})();
+(node as any).hash = '235c0ba8408305088395703809dbdb18';
 export default node;

--- a/src/__generated__/ArtistCollectionsRailQuery.graphql.ts
+++ b/src/__generated__/ArtistCollectionsRailQuery.graphql.ts
@@ -37,9 +37,24 @@ fragment ArtistCollectionsRail_collections on MarketingCollection {
 }
 
 fragment ArtistCollectionEntity_collection on MarketingCollection {
+  headerImage
   slug
   title
   price_guidance
+  artworks(size: 3, sort: "merchandisability") {
+    hits {
+      artist {
+        name
+        __id
+      }
+      title
+      image {
+        url(version: "small")
+      }
+      __id
+    }
+    __id
+  }
   __id: id
 }
 */
@@ -91,13 +106,27 @@ v2 = {
   "name": "id",
   "args": null,
   "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
 };
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "ArtistCollectionsRailQuery",
   "id": null,
-  "text": "query ArtistCollectionsRailQuery(\n  $isFeaturedArtistContent: Boolean\n  $size: Int\n  $artistID: String\n) {\n  collections: marketingCollections(isFeaturedArtistContent: $isFeaturedArtistContent, size: $size, artistID: $artistID) {\n    ...ArtistCollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n  __id: id\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  slug\n  title\n  price_guidance\n  __id: id\n}\n",
+  "text": "query ArtistCollectionsRailQuery(\n  $isFeaturedArtistContent: Boolean\n  $size: Int\n  $artistID: String\n) {\n  collections: marketingCollections(isFeaturedArtistContent: $isFeaturedArtistContent, size: $size, artistID: $artistID) {\n    ...ArtistCollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n  __id: id\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(size: 3, sort: \"merchandisability\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -142,23 +171,106 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "slug",
+            "name": "headerImage",
             "args": null,
             "storageKey": null
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "title",
+            "name": "slug",
             "args": null,
             "storageKey": null
           },
+          v3,
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "price_guidance",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artworks",
+            "storageKey": "artworks(size:3,sort:\"merchandisability\")",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 3,
+                "type": "Int"
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "merchandisability",
+                "type": "String"
+              }
+            ],
+            "concreteType": "FilterArtworks",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "hits",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artist",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "name",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v4
+                    ]
+                  },
+                  v3,
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "image",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "url",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "small",
+                            "type": "[String]"
+                          }
+                        ],
+                        "storageKey": "url(version:\"small\")"
+                      }
+                    ]
+                  },
+                  v4
+                ]
+              },
+              v4
+            ]
           },
           v2
         ]


### PR DESCRIPTION
- Fetches top 3 merchandisable artworks and includes images in artworks rail
- Displays 2 or 1 images if fewer than 3 are returned
- Displays headerImage as fallback if no artworks are returned

<img width="1239" alt="Screen Shot 2019-03-12 at 4 39 18 PM" src="https://user-images.githubusercontent.com/1497424/54234391-67bab680-44e5-11e9-98a6-97e5bffdadd7.png">
