### PR TITLE
Pass ArtistCard onClick to <Link> component.

### DIFF
--- a/src/Components/v2/ArtistCard.tsx
+++ b/src/Components/v2/ArtistCard.tsx
@@ -30,7 +30,11 @@ interface Props {
 export class ArtistCard extends React.Component<Props> {
   render() {
     return (
-      <Link href={this.props.artist.href} noUnderline>
+      <Link
+        onClick={this.props.onClick}
+        href={this.props.artist.href}
+        noUnderline
+      >
         <Media at="xs">
           <SmallArtistCard {...this.props} />
         </Media>


### PR DESCRIPTION
The `onClick` event handler passed to the `<ArtistCard>` component is not also passed into the rendered result, preventing our analytic tracking behavior from executing as intended.

This commit ensures that the `onClick` handler makes its way down to a rendered element via the `<Link>` styled component from Palette.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-783 :lock: 

Also depends on https://github.com/artsy/force/pull/3718 to fix analytic tracking on the Artwork page overall.