### PR TITLE
updating artsy for galleries link

### DIFF
--- a/src/Components/v2/Footer.tsx
+++ b/src/Components/v2/Footer.tsx
@@ -100,9 +100,7 @@ const FooterContainer: React.SFC<FlexDirectionProps & Props> = props => {
             Partners
           </Sans>
           <Serif size="2">
-            <Link href="https://www.artsy.net/gallery-partnerships">
-              Artsy for Galleries
-            </Link>
+            <Link href="https://partners.artsy.net">Artsy for Galleries</Link>
             <Link href="https://www.artsy.net/institution-partnerships">
               Artsy for Museums
             </Link>


### PR DESCRIPTION
The follow up on this one: https://github.com/artsy/force/pull/3716
to address reaction rendered footer.

Will also follow up with one more link update on force. Missed that this link also appears on Fair partner pages.