### PR TITLE
DISCO-851: Always show related categories for artist

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -124,12 +124,7 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
               {showGenes && (
                 <>
                   <Spacer mb={1} />
-                  <Media at="xs">
-                    <Genes artist={artist} />
-                  </Media>
-                  <Media greaterThan="xs">
-                    <Genes artist={artist} />
-                  </Media>
+                  <Genes artist={artist} />
                   <Spacer mb={1} />
                 </>
               )}

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -126,18 +126,14 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                   <Spacer mb={1} />
                   <Media at="xs">
                     {bioLen < MAX_CHARS.xs ? (
-                      <>
-                        <Genes artist={artist} />
-                      </>
+                      <Genes artist={artist} />
                     ) : (
                       <Genes artist={artist} />
                     )}
                   </Media>
                   <Media greaterThan="xs">
                     {bioLen < MAX_CHARS.default ? (
-                      <>
-                        <Genes artist={artist} />
-                      </>
+                      <Genes artist={artist} />
                     ) : (
                       <Genes artist={artist} />
                     )}

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -10,12 +10,10 @@ import { hasSections as showMarketInsights } from "Components/Artist/MarketInsig
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
-import { Media } from "Utils/Responsive"
 import { CurrentEventFragmentContainer as CurrentEvent } from "./Components/CurrentEvent"
 
 import {
   ArtistBioFragmentContainer as ArtistBio,
-  MAX_CHARS,
   SelectedCareerAchievementsFragmentContainer as SelectedCareerAchievements,
 } from "Components/v2"
 
@@ -55,16 +53,6 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     // no-op
   }
 
-  maybeShowGenes() {
-    let showGenes = false
-    if (this.state.isReadMoreExpanded) {
-      showGenes = true
-    } else if (!this.props.artist.biography_blurb.text) {
-      showGenes = true
-    }
-    return showGenes
-  }
-
   @track<OverviewRouteProps>(props => {
     // TODO: remove after CollectionsRail a/b test
     const experiment = "artist_collections_rail"
@@ -95,7 +83,6 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     const showArtistBio = Boolean(artist.biography_blurb.text)
     const showCurrentEvent = Boolean(artist.currentEvent)
     const showConsignable = Boolean(artist.is_consignable)
-    const bioLen = artist.biography_blurb.text.length
     const hideMainOverviewSection =
       !showArtistInsights &&
       !showArtistBio &&
@@ -104,7 +91,6 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
 
     // TODO: Hide right column if missing current event. Waiting on feedback
     const colNum = 9 // artist.currentEvent ? 9 : 12
-    const showGenes = this.maybeShowGenes()
 
     return (
       <>
@@ -121,13 +107,9 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                   />
                 </>
               )}
-              {showGenes && (
-                <>
-                  <Spacer mb={1} />
-                  <Genes artist={artist} />
-                  <Spacer mb={1} />
-                </>
-              )}
+              <Spacer mb={1} />
+              <Genes artist={artist} />
+              <Spacer mb={1} />
               {showConsignable && (
                 <>
                   <Spacer mb={1} />

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -130,7 +130,7 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                         <Genes artist={artist} />
                       </>
                     ) : (
-                      showGenes && <Genes artist={artist} />
+                      <Genes artist={artist} />
                     )}
                   </Media>
                   <Media greaterThan="xs">
@@ -139,7 +139,7 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                         <Genes artist={artist} />
                       </>
                     ) : (
-                      showGenes && <Genes artist={artist} />
+                      <Genes artist={artist} />
                     )}
                   </Media>
                   <Spacer mb={1} />
@@ -155,7 +155,8 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                       onClick={this.handleConsignClick.bind(this)}
                     >
                       Learn more
-                    </a>.
+                    </a>
+                    .
                   </Sans>
                 </>
               )}

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -125,18 +125,10 @@ class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                 <>
                   <Spacer mb={1} />
                   <Media at="xs">
-                    {bioLen < MAX_CHARS.xs ? (
-                      <Genes artist={artist} />
-                    ) : (
-                      <Genes artist={artist} />
-                    )}
+                    <Genes artist={artist} />
                   </Media>
                   <Media greaterThan="xs">
-                    {bioLen < MAX_CHARS.default ? (
-                      <Genes artist={artist} />
-                    ) : (
-                      <Genes artist={artist} />
-                    )}
+                    <Genes artist={artist} />
                   </Media>
                   <Spacer mb={1} />
                 </>


### PR DESCRIPTION
There's been a lot of evolution on this artist page and the `showGenes` bit got a little wacky so I started by refactoring it down to it's simplest form. Then I took away the concept of showing and hiding genes at all - the goal here is to get an SEO lift from always showing these categories.

Here's how it looks:

<img width="1188" alt="Screen Shot 2019-03-14 at 2 48 29 PM" src="https://user-images.githubusercontent.com/79799/54387073-754c7980-4668-11e9-8c5f-71606c702168.png">
