### PR TITLE
DISCO-849: Fix the link to related artists

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
@@ -36,7 +36,7 @@ export class ArtworkRelatedArtists extends React.Component<
       return null
     }
 
-    const relatedUrl = sd.APP_URL + artist.href + "/related_artists"
+    const relatedUrl = sd.APP_URL + artist.href + "/related-artists"
 
     return (
       <ContextConsumer>


### PR DESCRIPTION
This link construction was incorrect and rather than resulting in a 404, the react router just sent us to the overview page. Fixed!