### PR TITLE
Fix bid icon colors

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
@@ -89,7 +89,11 @@ export class ArtworkSidebarCurrentBidInfo extends React.Component<
           >
             {myBidPresent && (
               <Box pt={0.5}>
-                {myBidWinning ? <WinningBidIcon /> : <LosingBidIcon />}
+                {myBidWinning ? (
+                  <WinningBidIcon fill="green100" />
+                ) : (
+                  <LosingBidIcon fill="red100" />
+                )}
               </Box>
             )}
             <Serif size="5t" weight="semibold" pl={0.5}>


### PR DESCRIPTION
These colors were previously assumed but are now required. Here's what it looks like now:

<img width="802" alt="Screen Shot 2019-03-14 at 4 16 39 PM" src="https://user-images.githubusercontent.com/79799/54392114-c6fb0100-4674-11e9-9b74-bd4aa4d94d38.png">
