### PR TITLE
switch tracking event property for marketing

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -55,7 +55,7 @@ export class ArtworkApp extends React.Component<Props> {
     if (is_acquireable || is_in_auction) {
       const trackingData = {
         action_type: Schema.ActionType.ViewedProduct,
-        id: _id,
+        product_id: _id,
       }
       if (tracking) tracking.trackEvent(trackingData)
     }


### PR DESCRIPTION
This is the only change required to switch Criteo retargeting back on, as we can integrate it via Segment now.