### PR TITLE
Add generic item component for search results page

### DIFF
--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -1,46 +1,60 @@
-import { Flex, Image, Link, Sans, Serif, Spacer } from "@artsy/palette"
-import React, { SFC } from "react"
+import { Box, Flex, Image, Link, Sans, Serif, Spacer } from "@artsy/palette"
+import React, { FC } from "react"
 
 interface GenericSearchResultItemProps {
-  item: any
+  imageUrl: string
+  name: string
+  description?: string
   index: number
+  href: string
+  entityType: string
 }
 
-export const GenericSearchResultItem: SFC<
+export const GenericSearchResultItem: FC<
   GenericSearchResultItemProps
 > = props => {
-  const { item, index } = props
+  const { imageUrl, href, name, description, index, entityType } = props
+
+  const translateEntityType = anEntityType => {
+    switch (anEntityType) {
+      case "PartnerShow":
+        return "Show"
+        break
+      default:
+        return anEntityType
+    }
+  }
 
   return (
     <>
       <Flex flexDirection="row">
-        <div>
-          <Link href={item.href}>
-            <Image
-              width={70}
-              height={70}
-              mr={20}
-              src={
-                item.imageUrl || `https://picsum.photos/70/70/?random=${index}`
-              }
-            />
-          </Link>
-        </div>
-        <div>
+        <Box>
+          <Image
+            width={70}
+            height={70}
+            mr={20}
+            src={imageUrl || `https://picsum.photos/70/70/?random=${index}`}
+          />
+        </Box>
+        <Box>
           <Sans color="black100" size="2" weight="medium">
-            {item.searchableType}
+            {translateEntityType(entityType)}
           </Sans>
           <Spacer mb={0.5} />
-          <Serif color="black100" size="3">
-            {item.displayLabel}
-          </Serif>
-          <Spacer mb={0.5} />
-          <Serif color="black60" size="3" maxWidth={536}>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam.
-          </Serif>
-        </div>
+          <Link href={href} underlineBehavior="hover">
+            <Serif color="black100" size="3">
+              {name}
+            </Serif>
+          </Link>
+          {description && (
+            <>
+              <Spacer mb={0.5} />
+              <Serif color="black60" size="3" maxWidth={536}>
+                {description}
+              </Serif>
+            </>
+          )}
+        </Box>
       </Flex>
     </>
   )

--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -1,0 +1,47 @@
+import { Flex, Image, Link, Sans, Serif, Spacer } from "@artsy/palette"
+import React, { SFC } from "react"
+
+interface GenericSearchResultItemProps {
+  item: any
+  index: number
+}
+
+export const GenericSearchResultItem: SFC<
+  GenericSearchResultItemProps
+> = props => {
+  const { item, index } = props
+
+  return (
+    <>
+      <Flex flexDirection="row">
+        <div>
+          <Link href={item.href}>
+            <Image
+              width={70}
+              height={70}
+              mr={20}
+              src={
+                item.imageUrl || `https://picsum.photos/70/70/?random=${index}`
+              }
+            />
+          </Link>
+        </div>
+        <div>
+          <Sans color="black100" size="2" weight="medium">
+            {item.searchableType}
+          </Sans>
+          <Spacer mb={0.5} />
+          <Serif color="black100" size="3">
+            {item.displayLabel}
+          </Serif>
+          <Spacer mb={0.5} />
+          <Serif color="black60" size="3" maxWidth={536}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam.
+          </Serif>
+        </div>
+      </Flex>
+    </>
+  )
+}

--- a/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
+++ b/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
@@ -1,5 +1,6 @@
-import { Box, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { SearchResultsArticles_viewer } from "__generated__/SearchResultsArticles_viewer.graphql"
+import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
 import React from "react"
@@ -71,7 +72,9 @@ export class SearchResultsArticlesRoute extends React.Component<
         {articles.map((article, index) => {
           return (
             <Box key={index}>
-              {article.displayLabel}
+              <GenericSearchResultItem item={article} index={index} />
+              <Spacer mb={3} />
+              <Separator />
               <Spacer mb={3} />
             </Box>
           )
@@ -117,7 +120,11 @@ export const SearchResultsArticlesRouteRouteFragmentContainer = createRefetchCon
           }
           edges {
             node {
-              displayLabel
+              ... on SearchableItem {
+                id
+                displayLabel
+                searchableType
+              }
             }
           }
         }

--- a/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
+++ b/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
@@ -72,10 +72,23 @@ export class SearchResultsArticlesRoute extends React.Component<
         {articles.map((article, index) => {
           return (
             <Box key={index}>
-              <GenericSearchResultItem item={article} index={index} />
-              <Spacer mb={3} />
-              <Separator />
-              <Spacer mb={3} />
+              <GenericSearchResultItem
+                name={article.displayLabel}
+                index={index}
+                href={article.href}
+                description=""
+                imageUrl={article.imageUrl}
+                entityType="Article"
+              />
+              {index < articles.length - 1 ? (
+                <>
+                  <Spacer mb={3} />
+                  <Separator />
+                  <Spacer mb={3} />
+                </>
+              ) : (
+                <Spacer mb={3} />
+              )}
             </Box>
           )
         })}
@@ -123,6 +136,8 @@ export const SearchResultsArticlesRouteRouteFragmentContainer = createRefetchCon
               ... on SearchableItem {
                 id
                 displayLabel
+                href
+                imageUrl
                 searchableType
               }
             }

--- a/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -18,10 +18,23 @@ export const SearchResultsArtistsRoute: SFC<Props> = props => {
       {artists.map((artist, index) => {
         return (
           <Box key={index}>
-            <GenericSearchResultItem item={artist} index={index} />
-            <Spacer mb={3} />
-            <Separator />
-            <Spacer mb={3} />
+            <GenericSearchResultItem
+              name={artist.name}
+              description={artist.bio}
+              imageUrl={artist.imageUrl}
+              index={index}
+              entityType="Artist"
+              href={artist.href}
+            />
+            {index < artists.length - 1 ? (
+              <>
+                <Spacer mb={3} />
+                <Separator />
+                <Spacer mb={3} />
+              </>
+            ) : (
+              <Spacer mb={3} />
+            )}
           </Box>
         )
       })}
@@ -37,10 +50,11 @@ export const SearchResultsArtistsRouteFragmentContainer = createFragmentContaine
       search(query: $term, first: 10, entities: [ARTIST]) {
         edges {
           node {
-            ... on SearchableItem {
-              id
-              displayLabel
-              searchableType
+            ... on Artist {
+              name
+              href
+              imageUrl
+              bio
             }
           }
         }

--- a/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -1,5 +1,6 @@
-import { Box, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { SearchResultsArtistsRoute_viewer } from "__generated__/SearchResultsArtistsRoute_viewer.graphql"
+import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
 import React, { SFC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
@@ -17,7 +18,9 @@ export const SearchResultsArtistsRoute: SFC<Props> = props => {
       {artists.map((artist, index) => {
         return (
           <Box key={index}>
-            {artist.name}
+            <GenericSearchResultItem item={artist} index={index} />
+            <Spacer mb={3} />
+            <Separator />
             <Spacer mb={3} />
           </Box>
         )
@@ -34,8 +37,10 @@ export const SearchResultsArtistsRouteFragmentContainer = createFragmentContaine
       search(query: $term, first: 10, entities: [ARTIST]) {
         edges {
           node {
-            ... on Artist {
-              name
+            ... on SearchableItem {
+              id
+              displayLabel
+              searchableType
             }
           }
         }

--- a/src/Apps/Search/Routes/Artists/__tests__/SearchResultsArtists.test.tsx
+++ b/src/Apps/Search/Routes/Artists/__tests__/SearchResultsArtists.test.tsx
@@ -22,7 +22,10 @@ describe("SearchResultsArtworks", () => {
         edges: [
           {
             node: {
-              displayLabel: "Catty Artist",
+              name: "Catty Artist",
+              imageUrl: "",
+              href: "/artist/catty-artist",
+              bio: null,
             },
           },
         ],

--- a/src/Apps/Search/Routes/Artists/__tests__/SearchResultsArtists.test.tsx
+++ b/src/Apps/Search/Routes/Artists/__tests__/SearchResultsArtists.test.tsx
@@ -22,7 +22,7 @@ describe("SearchResultsArtworks", () => {
         edges: [
           {
             node: {
-              name: "Catty Artist",
+              displayLabel: "Catty Artist",
             },
           },
         ],

--- a/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
+++ b/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
@@ -70,10 +70,16 @@ export class SearchResultAuctionsRoute extends React.Component<
     const sales = get(viewer, v => v.search.edges, []).map(e => e.node)
     return (
       <LoadingArea isLoading={this.state.isLoading}>
-        {sales.map((sale, index) => {
+        {sales.map((searchableItem, index) => {
           return (
             <Box key={index}>
-              <GenericSearchResultItem item={sale} index={index} />
+              <GenericSearchResultItem
+                name={searchableItem.displayLabel}
+                index={index}
+                href={searchableItem.href}
+                imageUrl={searchableItem.imageUrl}
+                entityType="Auction"
+              />
               <Spacer mb={3} />
               <Separator />
               <Spacer mb={3} />
@@ -124,6 +130,8 @@ export const SearchResultsAuctionsRouteRouteFragmentContainer = createRefetchCon
               ... on SearchableItem {
                 id
                 displayLabel
+                href
+                imageUrl
                 searchableType
               }
             }

--- a/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
+++ b/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
@@ -1,5 +1,7 @@
-import { Box, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { SearchResultsAuctions_viewer } from "__generated__/SearchResultsAuctions_viewer.graphql"
+import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
+
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
 import React from "react"
@@ -71,7 +73,9 @@ export class SearchResultAuctionsRoute extends React.Component<
         {sales.map((sale, index) => {
           return (
             <Box key={index}>
-              {sale.displayLabel}
+              <GenericSearchResultItem item={sale} index={index} />
+              <Spacer mb={3} />
+              <Separator />
               <Spacer mb={3} />
             </Box>
           )
@@ -117,7 +121,11 @@ export const SearchResultsAuctionsRouteRouteFragmentContainer = createRefetchCon
           }
           edges {
             node {
-              displayLabel
+              ... on SearchableItem {
+                id
+                displayLabel
+                searchableType
+              }
             }
           }
         }

--- a/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
+++ b/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
@@ -1,5 +1,6 @@
-import { Box, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { SearchResultsCategories_viewer } from "__generated__/SearchResultsCategories_viewer.graphql"
+import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
 import React from "react"
@@ -71,7 +72,9 @@ export class SearchResultCategoriesRoute extends React.Component<
         {genes.map((gene, index) => {
           return (
             <Box key={index}>
-              {gene.displayLabel}
+              <GenericSearchResultItem item={gene} index={index} />
+              <Spacer mb={3} />
+              <Separator />
               <Spacer mb={3} />
             </Box>
           )
@@ -117,7 +120,11 @@ export const SearchResultsCategoriesRouteRouteFragmentContainer = createRefetchC
           }
           edges {
             node {
-              displayLabel
+              ... on SearchableItem {
+                id
+                displayLabel
+                searchableType
+              }
             }
           }
         }

--- a/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
+++ b/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
@@ -72,10 +72,22 @@ export class SearchResultCategoriesRoute extends React.Component<
         {genes.map((gene, index) => {
           return (
             <Box key={index}>
-              <GenericSearchResultItem item={gene} index={index} />
-              <Spacer mb={3} />
-              <Separator />
-              <Spacer mb={3} />
+              <GenericSearchResultItem
+                name={gene.displayLabel}
+                index={index}
+                href={gene.href}
+                imageUrl={gene.imageUrl}
+                entityType="Category"
+              />
+              {index < genes.length - 1 ? (
+                <>
+                  <Spacer mb={3} />
+                  <Separator />
+                  <Spacer mb={3} />
+                </>
+              ) : (
+                <Spacer mb={3} />
+              )}
             </Box>
           )
         })}
@@ -123,6 +135,8 @@ export const SearchResultsCategoriesRouteRouteFragmentContainer = createRefetchC
               ... on SearchableItem {
                 id
                 displayLabel
+                href
+                imageUrl
                 searchableType
               }
             }

--- a/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
+++ b/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
@@ -72,10 +72,22 @@ export class SearchResultsCollectionsRoute extends React.Component<
         {collections.map((collection, index) => {
           return (
             <Box key={index}>
-              <GenericSearchResultItem item={collection} index={index} />
-              <Spacer mb={3} />
-              <Separator />
-              <Spacer mb={3} />
+              <GenericSearchResultItem
+                name={collection.displayLabel}
+                index={index}
+                href={collection.href}
+                imageUrl={collection.imageUrl}
+                entityType="Collection"
+              />
+              {index < collections.length - 1 ? (
+                <>
+                  <Spacer mb={3} />
+                  <Separator />
+                  <Spacer mb={3} />
+                </>
+              ) : (
+                <Spacer mb={3} />
+              )}
             </Box>
           )
         })}
@@ -123,6 +135,8 @@ export const SearchResultsCollectionsRouteFragmentContainer = createRefetchConta
               ... on SearchableItem {
                 id
                 displayLabel
+                href
+                imageUrl
                 searchableType
               }
             }

--- a/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
+++ b/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
@@ -1,5 +1,6 @@
-import { Box, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { SearchResultsCollections_viewer } from "__generated__/SearchResultsCollections_viewer.graphql"
+import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
 import React from "react"
@@ -71,7 +72,9 @@ export class SearchResultsCollectionsRoute extends React.Component<
         {collections.map((collection, index) => {
           return (
             <Box key={index}>
-              {collection.displayLabel}
+              <GenericSearchResultItem item={collection} index={index} />
+              <Spacer mb={3} />
+              <Separator />
               <Spacer mb={3} />
             </Box>
           )
@@ -117,7 +120,11 @@ export const SearchResultsCollectionsRouteFragmentContainer = createRefetchConta
           }
           edges {
             node {
-              displayLabel
+              ... on SearchableItem {
+                id
+                displayLabel
+                searchableType
+              }
             }
           }
         }

--- a/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
+++ b/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
@@ -1,5 +1,6 @@
-import { Box, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { SearchResultsGalleries_viewer } from "__generated__/SearchResultsGalleries_viewer.graphql"
+import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
 import React from "react"
@@ -71,7 +72,9 @@ export class SearchResultsGalleriesRoute extends React.Component<
         {galleries.map((gallery, index) => {
           return (
             <Box key={index}>
-              {gallery.displayLabel}
+              <GenericSearchResultItem item={gallery} index={index} />
+              <Spacer mb={3} />
+              <Separator />
               <Spacer mb={3} />
             </Box>
           )
@@ -117,7 +120,11 @@ export const SearchResultsGalleriesRouteRouteFragmentContainer = createRefetchCo
           }
           edges {
             node {
-              displayLabel
+              ... on SearchableItem {
+                id
+                displayLabel
+                searchableType
+              }
             }
           }
         }

--- a/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
+++ b/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
@@ -72,10 +72,23 @@ export class SearchResultsGalleriesRoute extends React.Component<
         {galleries.map((gallery, index) => {
           return (
             <Box key={index}>
-              <GenericSearchResultItem item={gallery} index={index} />
-              <Spacer mb={3} />
-              <Separator />
-              <Spacer mb={3} />
+              <GenericSearchResultItem
+                name={gallery.displayLabel}
+                index={index}
+                href={gallery.href}
+                description=""
+                imageUrl={gallery.imageUrl}
+                entityType="Gallery"
+              />
+              {index < galleries.length - 1 ? (
+                <>
+                  <Spacer mb={3} />
+                  <Separator />
+                  <Spacer mb={3} />
+                </>
+              ) : (
+                <Spacer mb={3} />
+              )}
             </Box>
           )
         })}
@@ -123,6 +136,8 @@ export const SearchResultsGalleriesRouteRouteFragmentContainer = createRefetchCo
               ... on SearchableItem {
                 id
                 displayLabel
+                href
+                imageUrl
                 searchableType
               }
             }

--- a/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
+++ b/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
@@ -1,5 +1,6 @@
-import { Box, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer } from "@artsy/palette"
 import { SearchResultsShows_viewer } from "__generated__/SearchResultsShows_viewer.graphql"
+import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
 import React from "react"
@@ -71,7 +72,9 @@ export class SearchResultsShowsRoute extends React.Component<
         {shows.map((show, index) => {
           return (
             <Box key={index}>
-              {show.displayLabel}
+              <GenericSearchResultItem item={show} index={index} />
+              <Spacer mb={3} />
+              <Separator />
               <Spacer mb={3} />
             </Box>
           )
@@ -117,7 +120,11 @@ export const SearchResultsShowsRouteRouteFragmentContainer = createRefetchContai
           }
           edges {
             node {
-              displayLabel
+              ... on SearchableItem {
+                id
+                displayLabel
+                searchableType
+              }
             }
           }
         }

--- a/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
+++ b/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
@@ -72,10 +72,23 @@ export class SearchResultsShowsRoute extends React.Component<
         {shows.map((show, index) => {
           return (
             <Box key={index}>
-              <GenericSearchResultItem item={show} index={index} />
-              <Spacer mb={3} />
-              <Separator />
-              <Spacer mb={3} />
+              <GenericSearchResultItem
+                name={show.displayLabel}
+                index={index}
+                href={show.href}
+                description=""
+                imageUrl={show.imageUrl}
+                entityType="Show"
+              />
+              {index < shows.length - 1 ? (
+                <>
+                  <Spacer mb={3} />
+                  <Separator />
+                  <Spacer mb={3} />
+                </>
+              ) : (
+                <Spacer mb={3} />
+              )}
             </Box>
           )
         })}
@@ -123,6 +136,8 @@ export const SearchResultsShowsRouteRouteFragmentContainer = createRefetchContai
               ... on SearchableItem {
                 id
                 displayLabel
+                href
+                imageUrl
                 searchableType
               }
             }

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -78,6 +78,8 @@ export const SearchAppFragmentContainer = createFragmentContainer(SearchApp, {
           node {
             ... on SearchableItem {
               id
+              displayLabel
+              searchableType
             }
           }
         }

--- a/src/__generated__/SearchApp_viewer.graphql.ts
+++ b/src/__generated__/SearchApp_viewer.graphql.ts
@@ -10,6 +10,8 @@ export type SearchApp_viewer = {
         readonly edges: ReadonlyArray<({
             readonly node: ({
                 readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
         readonly " $fragmentRefs": NavigationTabs_searchableConnection$ref;
@@ -110,6 +112,20 @@ const node: ConcreteFragment = {
                       "name": "id",
                       "args": null,
                       "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
                     }
                   ]
                 }
@@ -121,5 +137,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '813abcefae5db4f893b7ed4dd9a17de5';
+(node as any).hash = 'c7337eb9cc0b3d6722f1d77660ed2fb9';
 export default node;

--- a/src/__generated__/SearchResultsArticlesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsArticlesQuery.graphql.ts
@@ -46,7 +46,11 @@ fragment SearchResultsArticles_viewer_4c14dZ on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -141,7 +145,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsArticlesQuery",
   "id": null,
-  "text": "query SearchResultsArticlesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArticles_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsArticlesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArticles_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -368,16 +372,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/SearchResultsArticlesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsArticlesQuery.graphql.ts
@@ -49,6 +49,8 @@ fragment SearchResultsArticles_viewer_4c14dZ on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -145,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsArticlesQuery",
   "id": null,
-  "text": "query SearchResultsArticlesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArticles_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsArticlesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArticles_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -391,6 +393,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsArticles_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArticles_viewer.graphql.ts
@@ -17,6 +17,8 @@ export type SearchResultsArticles_viewer = {
             readonly node: ({
                 readonly id?: string;
                 readonly displayLabel?: string | null;
+                readonly href?: string | null;
+                readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
@@ -199,6 +201,20 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "href",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "imageUrl",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "searchableType",
                       "args": null,
                       "storageKey": null
@@ -213,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '0479a386ea001dd141b2ca3f64af8666';
+(node as any).hash = '05e1afe2699e33d3f4d70aa01a9db155';
 export default node;

--- a/src/__generated__/SearchResultsArticles_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArticles_viewer.graphql.ts
@@ -15,7 +15,9 @@ export type SearchResultsArticles_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly displayLabel: string | null;
+                readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -172,16 +174,36 @@ const node: ConcreteFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "displayLabel",
+                  "name": "__id",
                   "args": null,
                   "storageKey": null
                 },
                 {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "__id",
-                  "args": null,
-                  "storageKey": null
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
                 }
               ]
             }
@@ -191,5 +213,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'a0e6214abaabdc976b077fdb7648b228';
+(node as any).hash = '0479a386ea001dd141b2ca3f64af8666';
 export default node;

--- a/src/__generated__/SearchResultsArtistsRoute_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArtistsRoute_viewer.graphql.ts
@@ -7,9 +7,10 @@ export type SearchResultsArtistsRoute_viewer = {
     readonly search: ({
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly id?: string;
-                readonly displayLabel?: string | null;
-                readonly searchableType?: string | null;
+                readonly name?: string | null;
+                readonly href?: string | null;
+                readonly imageUrl?: string | null;
+                readonly bio?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -89,26 +90,33 @@ const node: ConcreteFragment = {
                 },
                 {
                   "kind": "InlineFragment",
-                  "type": "SearchableItem",
+                  "type": "Artist",
                   "selections": [
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "id",
+                      "name": "name",
                       "args": null,
                       "storageKey": null
                     },
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "displayLabel",
+                      "name": "href",
                       "args": null,
                       "storageKey": null
                     },
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "imageUrl",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "bio",
                       "args": null,
                       "storageKey": null
                     }
@@ -122,5 +130,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '20cb3345f552df13ed6861c1242da86d';
+(node as any).hash = '3de93f67523eeaf2d5161e147e28c288';
 export default node;

--- a/src/__generated__/SearchResultsArtistsRoute_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArtistsRoute_viewer.graphql.ts
@@ -7,7 +7,9 @@ export type SearchResultsArtistsRoute_viewer = {
     readonly search: ({
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly name?: string | null;
+                readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -87,12 +89,26 @@ const node: ConcreteFragment = {
                 },
                 {
                   "kind": "InlineFragment",
-                  "type": "Artist",
+                  "type": "SearchableItem",
                   "selections": [
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "name",
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
                       "args": null,
                       "storageKey": null
                     }
@@ -106,5 +122,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '3d3faae97e6950ba05e320b5cdd93944';
+(node as any).hash = '20cb3345f552df13ed6861c1242da86d';
 export default node;

--- a/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
@@ -46,7 +46,11 @@ fragment SearchResultsAuctions_viewer_4c14dZ on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -141,7 +145,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -368,16 +372,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
@@ -49,6 +49,8 @@ fragment SearchResultsAuctions_viewer_4c14dZ on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -145,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -391,6 +393,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
@@ -17,6 +17,8 @@ export type SearchResultsAuctions_viewer = {
             readonly node: ({
                 readonly id?: string;
                 readonly displayLabel?: string | null;
+                readonly href?: string | null;
+                readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
@@ -199,6 +201,20 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "href",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "imageUrl",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "searchableType",
                       "args": null,
                       "storageKey": null
@@ -213,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'bedc0d1209a1beb274de3998aa56c887';
+(node as any).hash = 'e46be1907b708dd5616aefea8ad66b4a';
 export default node;

--- a/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
@@ -15,7 +15,9 @@ export type SearchResultsAuctions_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly displayLabel: string | null;
+                readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -172,16 +174,36 @@ const node: ConcreteFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "displayLabel",
+                  "name": "__id",
                   "args": null,
                   "storageKey": null
                 },
                 {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "__id",
-                  "args": null,
-                  "storageKey": null
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
                 }
               ]
             }
@@ -191,5 +213,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '47c71193a83ee0c919e02e968eba30ad';
+(node as any).hash = 'bedc0d1209a1beb274de3998aa56c887';
 export default node;

--- a/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
@@ -49,6 +49,8 @@ fragment SearchResultsCategories_viewer_4c14dZ on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -145,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -391,6 +393,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
@@ -46,7 +46,11 @@ fragment SearchResultsCategories_viewer_4c14dZ on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -141,7 +145,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -368,16 +372,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/SearchResultsCategories_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCategories_viewer.graphql.ts
@@ -15,7 +15,9 @@ export type SearchResultsCategories_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly displayLabel: string | null;
+                readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -172,16 +174,36 @@ const node: ConcreteFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "displayLabel",
+                  "name": "__id",
                   "args": null,
                   "storageKey": null
                 },
                 {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "__id",
-                  "args": null,
-                  "storageKey": null
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
                 }
               ]
             }
@@ -191,5 +213,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'cd14d1794b9ce9dee792d57762f04d81';
+(node as any).hash = '5cfd980ace5877314a28a594b42c5777';
 export default node;

--- a/src/__generated__/SearchResultsCategories_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCategories_viewer.graphql.ts
@@ -17,6 +17,8 @@ export type SearchResultsCategories_viewer = {
             readonly node: ({
                 readonly id?: string;
                 readonly displayLabel?: string | null;
+                readonly href?: string | null;
+                readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
@@ -199,6 +201,20 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "href",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "imageUrl",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "searchableType",
                       "args": null,
                       "storageKey": null
@@ -213,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '5cfd980ace5877314a28a594b42c5777';
+(node as any).hash = 'a867077f4138e4de4ab6fda83caaecc2';
 export default node;

--- a/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
@@ -49,6 +49,8 @@ fragment SearchResultsCollections_viewer_4c14dZ on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -145,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -391,6 +393,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
@@ -46,7 +46,11 @@ fragment SearchResultsCollections_viewer_4c14dZ on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -141,7 +145,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -368,16 +372,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/SearchResultsCollections_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCollections_viewer.graphql.ts
@@ -15,7 +15,9 @@ export type SearchResultsCollections_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly displayLabel: string | null;
+                readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -172,16 +174,36 @@ const node: ConcreteFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "displayLabel",
+                  "name": "__id",
                   "args": null,
                   "storageKey": null
                 },
                 {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "__id",
-                  "args": null,
-                  "storageKey": null
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
                 }
               ]
             }
@@ -191,5 +213,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '067f0fe12df1f0e94af9092dd10f5aeb';
+(node as any).hash = 'df8a1f93ff46a2329b984f0d765065f2';
 export default node;

--- a/src/__generated__/SearchResultsCollections_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCollections_viewer.graphql.ts
@@ -17,6 +17,8 @@ export type SearchResultsCollections_viewer = {
             readonly node: ({
                 readonly id?: string;
                 readonly displayLabel?: string | null;
+                readonly href?: string | null;
+                readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
@@ -199,6 +201,20 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "href",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "imageUrl",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "searchableType",
                       "args": null,
                       "storageKey": null
@@ -213,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'df8a1f93ff46a2329b984f0d765065f2';
+(node as any).hash = '73dd6a9b9923accde130791d4bb9f966';
 export default node;

--- a/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
@@ -49,6 +49,8 @@ fragment SearchResultsGalleries_viewer_4c14dZ on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -145,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -391,6 +393,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
@@ -46,7 +46,11 @@ fragment SearchResultsGalleries_viewer_4c14dZ on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -141,7 +145,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -368,16 +372,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
@@ -17,6 +17,8 @@ export type SearchResultsGalleries_viewer = {
             readonly node: ({
                 readonly id?: string;
                 readonly displayLabel?: string | null;
+                readonly href?: string | null;
+                readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
@@ -199,6 +201,20 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "href",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "imageUrl",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "searchableType",
                       "args": null,
                       "storageKey": null
@@ -213,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '4c8fe847d7d43ffa8db65ab1a7fbaa7f';
+(node as any).hash = 'e3220c9c2fd17487db8f5e3e920b5fba';
 export default node;

--- a/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
@@ -15,7 +15,9 @@ export type SearchResultsGalleries_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly displayLabel: string | null;
+                readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -172,16 +174,36 @@ const node: ConcreteFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "displayLabel",
+                  "name": "__id",
                   "args": null,
                   "storageKey": null
                 },
                 {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "__id",
-                  "args": null,
-                  "storageKey": null
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
                 }
               ]
             }
@@ -191,5 +213,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '3e6c737427ac3505e8947c280e7a7322';
+(node as any).hash = '4c8fe847d7d43ffa8db65ab1a7fbaa7f';
 export default node;

--- a/src/__generated__/SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsShowsQuery.graphql.ts
@@ -46,7 +46,11 @@ fragment SearchResultsShows_viewer_4c14dZ on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -141,7 +145,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsShowsQuery",
   "id": null,
-  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -368,16 +372,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsShowsQuery.graphql.ts
@@ -49,6 +49,8 @@ fragment SearchResultsShows_viewer_4c14dZ on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -145,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsShowsQuery",
   "id": null,
-  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -391,6 +393,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsShows_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsShows_viewer.graphql.ts
@@ -15,7 +15,9 @@ export type SearchResultsShows_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly displayLabel: string | null;
+                readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -172,16 +174,36 @@ const node: ConcreteFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "displayLabel",
+                  "name": "__id",
                   "args": null,
                   "storageKey": null
                 },
                 {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "__id",
-                  "args": null,
-                  "storageKey": null
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
                 }
               ]
             }
@@ -191,5 +213,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'aa109c7681ba0ea658ad360754bf51f1';
+(node as any).hash = 'd9489a2f02434fe1e7cdcf621c905003';
 export default node;

--- a/src/__generated__/SearchResultsShows_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsShows_viewer.graphql.ts
@@ -17,6 +17,8 @@ export type SearchResultsShows_viewer = {
             readonly node: ({
                 readonly id?: string;
                 readonly displayLabel?: string | null;
+                readonly href?: string | null;
+                readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
         }) | null> | null;
@@ -199,6 +201,20 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "href",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "imageUrl",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "searchableType",
                       "args": null,
                       "storageKey": null
@@ -213,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'd9489a2f02434fe1e7cdcf621c905003';
+(node as any).hash = '033de097b3f66ddbf6f984002a164e62';
 export default node;

--- a/src/__generated__/routes_SearchBarTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_SearchBarTopLevelQuery.graphql.ts
@@ -35,6 +35,8 @@ fragment SearchApp_viewer_4hh6ED on Viewer {
         __typename
         ... on SearchableItem {
           id
+          displayLabel
+          searchableType
         }
         ... on Node {
           __id
@@ -77,7 +79,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchBarTopLevelQuery",
   "id": null,
-  "text": "query routes_SearchBarTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 1, aggregations: [TYPE]) {\n    totalCount\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      __id\n    }\n  }\n}\n",
+  "text": "query routes_SearchBarTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 1, aggregations: [TYPE]) {\n    totalCount\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      __id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -240,6 +242,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsArticlesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArticlesQuery.graphql.ts
@@ -38,7 +38,11 @@ fragment SearchResultsArticles_viewer_4hh6ED on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -109,7 +113,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArticlesQuery",
   "id": null,
-  "text": "query routes_SearchResultsArticlesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArticles_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsArticlesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArticles_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -294,16 +298,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/routes_SearchResultsArticlesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArticlesQuery.graphql.ts
@@ -41,6 +41,8 @@ fragment SearchResultsArticles_viewer_4hh6ED on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -113,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArticlesQuery",
   "id": null,
-  "text": "query routes_SearchResultsArticlesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArticles_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsArticlesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArticles_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -317,6 +319,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
@@ -31,10 +31,11 @@ fragment SearchResultsArtistsRoute_viewer_4hh6ED on Viewer {
     edges {
       node {
         __typename
-        ... on SearchableItem {
-          id
-          displayLabel
-          searchableType
+        ... on Artist {
+          name
+          href
+          imageUrl
+          bio
         }
         ... on Node {
           __id
@@ -59,7 +60,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArtistsQuery",
   "id": null,
-  "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArtistsRoute_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArtistsRoute_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTIST]) {\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArtistsRoute_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArtistsRoute_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTIST]) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -171,26 +172,33 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "type": "SearchableItem",
+                        "type": "Artist",
                         "selections": [
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "name",
                             "args": null,
                             "storageKey": null
                           },
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "displayLabel",
+                            "name": "href",
                             "args": null,
                             "storageKey": null
                           },
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "imageUrl",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "bio",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
@@ -31,8 +31,10 @@ fragment SearchResultsArtistsRoute_viewer_4hh6ED on Viewer {
     edges {
       node {
         __typename
-        ... on Artist {
-          name
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
         }
         ... on Node {
           __id
@@ -57,7 +59,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArtistsQuery",
   "id": null,
-  "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArtistsRoute_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArtistsRoute_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTIST]) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArtistsRoute_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArtistsRoute_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTIST]) {\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -169,12 +171,26 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "type": "Artist",
+                        "type": "SearchableItem",
                         "selections": [
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "name",
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
@@ -38,7 +38,11 @@ fragment SearchResultsAuctions_viewer_4hh6ED on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -109,7 +113,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -294,16 +298,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
@@ -41,6 +41,8 @@ fragment SearchResultsAuctions_viewer_4hh6ED on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -113,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -317,6 +319,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
@@ -38,7 +38,11 @@ fragment SearchResultsCategories_viewer_4hh6ED on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -109,7 +113,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -294,16 +298,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
@@ -41,6 +41,8 @@ fragment SearchResultsCategories_viewer_4hh6ED on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -113,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -317,6 +319,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
@@ -38,7 +38,11 @@ fragment SearchResultsCollections_viewer_4hh6ED on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -109,7 +113,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -294,16 +298,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
@@ -41,6 +41,8 @@ fragment SearchResultsCollections_viewer_4hh6ED on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -113,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -317,6 +319,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
@@ -38,7 +38,11 @@ fragment SearchResultsGalleries_viewer_4hh6ED on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -109,7 +113,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -294,16 +298,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
@@ -41,6 +41,8 @@ fragment SearchResultsGalleries_viewer_4hh6ED on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -113,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -317,6 +319,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
@@ -38,7 +38,11 @@ fragment SearchResultsShows_viewer_4hh6ED on Viewer {
     edges {
       node {
         __typename
-        displayLabel
+        ... on SearchableItem {
+          id
+          displayLabel
+          searchableType
+        }
         ... on Node {
           __id
         }
@@ -109,7 +113,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsShowsQuery",
   "id": null,
-  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -294,16 +298,36 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "displayLabel",
+                        "name": "__id",
                         "args": null,
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "__id",
-                        "args": null,
-                        "storageKey": null
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
@@ -41,6 +41,8 @@ fragment SearchResultsShows_viewer_4hh6ED on Viewer {
         ... on SearchableItem {
           id
           displayLabel
+          href
+          imageUrl
           searchableType
         }
         ... on Node {
@@ -113,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsShowsQuery",
   "id": null,
-  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -317,6 +319,20 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
                             "args": null,
                             "storageKey": null
                           },


### PR DESCRIPTION
This commit introduces a generic component for search result items when a richer component is not needed.

**Next steps**

- Add a new fallback image provided by design
- Add `description` attribute to `SearchableItem` type from Metaphysics and use in component

**Questions**

- ~Should we translate entity types here or should that happen upstream?
  For example `PartnerShow` -> `Show`~ Putting this in the reaction component
- ~Should we add any information we might need to the SearchableItem
  type, or will we need some attributes from entity-specific endpoints?~ Using entity-specific types when available. Will need to add more support in Metaphysics.

**Screenshots**

![2019-03-15-154722_954x328_scrot](https://user-images.githubusercontent.com/123595/54458241-c11b2380-4739-11e9-9625-81625416b5e2.png)
![2019-03-15-154758_1027x396_scrot](https://user-images.githubusercontent.com/123595/54458240-c11b2380-4739-11e9-9959-681173fa3f8e.png)
