### PR TITLE
update viewed product analytics event

### DIFF
--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -92,8 +92,12 @@ export enum ActionType {
   SubmittedOrder = "submitted_order",
   SubmittedOffer = "submitted_offer",
   SubmittedCounterOffer = "submitted_counter_offer",
-  ViewedProduct = "Viewed Product",
   FocusedOnOfferInput = "Focused on offer input",
+
+  /**
+   * Paid Marketing - Retargeting
+   */
+  ViewedProduct = "Product Viewed",
 
   // MO speedbumps
   ViewedOfferTooLow = "Viewed offer too low",


### PR DESCRIPTION
Google Ads retargeting was broken during our artwork page redesign. This is an attempt to get it up and running again via Segment. 

* Renames the `Viewed Product` event to adopt the standard [Segment schema](https://segment.com/docs/spec/ecommerce/v2/#product-viewed) which should trigger Segment to notify Google Ads of the product ID.

After release I just need to update the AdRoll and Criteo integrations on the Segment side to use this event name.