### PR TITLE
Add h1/h2 to artwork pages

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
@@ -18,11 +18,11 @@ type Artist = ArtworkSidebarArtists_artwork["artists"][0]
 export class ArtworkSidebarArtists extends React.Component<ArtistsProps> {
   private renderArtistName(artist: Artist) {
     return artist.href ? (
-      <Serif size="5t" display="inline" weight="semibold">
+      <Serif size="5t" display="inline" weight="semibold" element="h1">
         <a href={artist.href}>{artist.name}</a>
       </Serif>
     ) : (
-      <Serif size="5t" display="inline" weight="semibold">
+      <Serif size="5t" display="inline" weight="semibold" element="h1">
         {artist.name}
       </Serif>
     )

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarTitleInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarTitleInfo.tsx
@@ -15,7 +15,7 @@ export class ArtworkSidebarTitleInfo extends React.Component<
     const { artwork } = this.props
     return (
       <Box color="black60">
-        <Serif size="2">
+        <Serif size="2" element="h2">
           <i>{artwork.title}</i>
           {artwork.date &&
             artwork.date.replace(/\s+/g, "").length > 0 &&


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-705.

This PR brings back `h1`/`h2` elements to the Artworks pages, for improved SEO. 

As seen below, the artist name is the `h1`; the artwork name & date are the `h2`.

![image](https://user-images.githubusercontent.com/1627089/54559530-41d25d80-498e-11e9-8619-4de96b335a0c.png)
