### PR TITLE
@dblandin => [SearchResults] Add 'more' tab

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -10,6 +10,13 @@ interface Props {
   term: string
 }
 
+const MORE_TABS = {
+  tag: "Tag",
+  city: "City",
+  fair: "Fair",
+  feature: "Feature",
+}
+
 export class NavigationTabs extends React.Component<Props> {
   renderTab(
     text: string,
@@ -83,6 +90,16 @@ export class NavigationTabs extends React.Component<Props> {
       0
     )
 
+    let restAggregationCount: number = 0
+    Object.keys(MORE_TABS).forEach(
+      key =>
+        (restAggregationCount += get(
+          this.aggregationFor(key),
+          agg => agg.count,
+          0
+        ))
+    )
+
     return (
       <>
         {this.renderTab(`Artworks ${artworkAggregationCount}`, route(""), {
@@ -110,6 +127,7 @@ export class NavigationTabs extends React.Component<Props> {
           `Auctions ${auctionsAggregationCount}`,
           route("/auctions")
         )}
+        {this.renderTab(`More ${restAggregationCount}`, route("/more"))}
       </>
     )
   }

--- a/src/Apps/Search/Routes/More/SearchResultsMore.tsx
+++ b/src/Apps/Search/Routes/More/SearchResultsMore.tsx
@@ -1,0 +1,169 @@
+import { Box, Separator, Spacer } from "@artsy/palette"
+import { SearchResultsAuctions_viewer } from "__generated__/SearchResultsAuctions_viewer.graphql"
+import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
+
+import { PaginationFragmentContainer as Pagination } from "Components/v2"
+import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
+import React from "react"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
+import { get } from "Utils/get"
+
+export interface Props {
+  viewer: SearchResultsAuctions_viewer
+  relay: RelayRefetchProp
+}
+
+const PAGE_SIZE = 10
+
+export class SearchResultMoreRoute extends React.Component<
+  Props,
+  LoadingAreaState
+> {
+  state = {
+    isLoading: false,
+  }
+
+  toggleLoading = isLoading => {
+    this.setState({
+      isLoading,
+    })
+  }
+
+  loadNext = () => {
+    const { viewer } = this.props
+    const { search: searchConnection } = viewer
+
+    const {
+      pageInfo: { hasNextPage, endCursor },
+    } = searchConnection
+
+    if (hasNextPage) {
+      this.loadAfter(endCursor)
+    }
+  }
+
+  loadAfter = cursor => {
+    this.toggleLoading(true)
+
+    this.props.relay.refetch(
+      {
+        first: PAGE_SIZE,
+        after: cursor,
+        before: null,
+        last: null,
+      },
+      null,
+      error => {
+        this.toggleLoading(false)
+
+        if (error) {
+          console.error(error)
+        }
+      }
+    )
+  }
+
+  render() {
+    const { viewer } = this.props
+    const { search: searchConnection } = viewer
+
+    const items = get(viewer, v => v.search.edges, []).map(e => e.node)
+    return (
+      <LoadingArea isLoading={this.state.isLoading}>
+        {items.map((searchableItem, index) => {
+          return (
+            <Box key={index}>
+              <GenericSearchResultItem
+                name={searchableItem.displayLabel}
+                index={index}
+                href={searchableItem.href}
+                imageUrl={searchableItem.imageUrl}
+                entityType={searchableItem.searchableType}
+              />
+              {index < items.length - 1 ? (
+                <>
+                  <Spacer mb={3} />
+                  <Separator />
+                  <Spacer mb={3} />
+                </>
+              ) : (
+                <Spacer mb={3} />
+              )}
+            </Box>
+          )
+        })}
+        <Pagination
+          pageCursors={searchConnection.pageCursors}
+          onClick={this.loadAfter}
+          onNext={this.loadNext}
+          scrollTo="#jumpto--searchResultTabs"
+          hasNextPage={searchConnection.pageInfo.hasNextPage}
+        />
+      </LoadingArea>
+    )
+  }
+}
+
+export const SearchResultsMoreRouteRouteFragmentContainer = createRefetchContainer(
+  SearchResultMoreRoute,
+  {
+    viewer: graphql`
+      fragment SearchResultsMore_viewer on Viewer
+        @argumentDefinitions(
+          term: { type: "String!", defaultValue: "" }
+          first: { type: "Int", defaultValue: 10 }
+          last: { type: "Int" }
+          after: { type: "String" }
+          before: { type: "String" }
+        ) {
+        search(
+          query: $term
+          first: $first
+          after: $after
+          before: $before
+          last: $last
+          entities: [TAG, CITY, FAIR, FEATURE]
+        ) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          pageCursors {
+            ...Pagination_pageCursors
+          }
+          edges {
+            node {
+              ... on SearchableItem {
+                id
+                displayLabel
+                href
+                imageUrl
+                searchableType
+              }
+            }
+          }
+        }
+      }
+    `,
+  },
+  graphql`
+    query SearchResultsMoreQuery(
+      $first: Int
+      $last: Int
+      $after: String
+      $before: String
+      $term: String!
+    ) {
+      viewer {
+        ...SearchResultsMore_viewer
+          @arguments(
+            first: $first
+            last: $last
+            after: $after
+            before: $before
+            term: $term
+          )
+      }
+    }
+  `
+)

--- a/src/Apps/Search/Routes/More/__tests__/SearchResultsMore.test.tsx
+++ b/src/Apps/Search/Routes/More/__tests__/SearchResultsMore.test.tsx
@@ -1,0 +1,53 @@
+import { ContextProvider } from "Artsy"
+import { PaginationFragmentContainer as Pagination } from "Components/v2/Pagination"
+import { MockBoot } from "DevTools"
+import { mount } from "enzyme"
+import React from "react"
+import { SearchResultMoreRoute as SearchResultsMore } from "../SearchResultsMore"
+
+describe("SearchResultsMore", () => {
+  const getWrapper = (searchProps: any) => {
+    return mount(
+      <MockBoot>
+        <ContextProvider>
+          <SearchResultsMore {...searchProps} />
+        </ContextProvider>
+      </MockBoot>
+    )
+  }
+
+  const props = {
+    term: "andy",
+    viewer: {
+      search: {
+        edges: [
+          {
+            node: {
+              id: "percy",
+              displayLabel: "Cat",
+              href: "/cat/percy",
+              searchableType: "Artistic Cats",
+            },
+          },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+        },
+        pageCursors: {
+          around: [],
+        },
+      },
+    },
+  }
+
+  it("renders artworks contents", () => {
+    const wrapper = getWrapper(props) as any
+    const html = wrapper.html()
+    expect(html).toContain("Artistic Cats")
+  })
+
+  it("renders the pagination control", () => {
+    const wrapper = getWrapper(props)
+    expect(wrapper.find(Pagination).exists).toBeTruthy()
+  })
+})

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -5,6 +5,7 @@ import { SearchResultsAuctionsRouteRouteFragmentContainer as SearchResultsAuctio
 import { SearchResultsCategoriesRouteRouteFragmentContainer as SearchResultsCategoriesRoute } from "Apps/Search/Routes/Categories/SearchResultsCategories"
 import { SearchResultsCollectionsRouteFragmentContainer as SearchResultsCollectionsRoute } from "Apps/Search/Routes/Collections/SearchResultsCollections"
 import { SearchResultsGalleriesRouteRouteFragmentContainer as SearchResultsGalleriesRoute } from "Apps/Search/Routes/Galleries/SearchResultsGalleries"
+import { SearchResultsMoreRouteRouteFragmentContainer as SearchResultsMoreRoute } from "Apps/Search/Routes/More/SearchResultsMore"
 import { SearchResultsShowsRouteRouteFragmentContainer as SearchResultsShowsRoute } from "Apps/Search/Routes/Shows/SearchResultsShows"
 import { RouteConfig } from "found"
 import qs from "qs"
@@ -192,6 +193,18 @@ export const routes: RouteConfig[] = [
           query routes_SearchResultsAuctionsQuery($term: String!) {
             viewer {
               ...SearchResultsAuctions_viewer @arguments(term: $term)
+            }
+          }
+        `,
+        prepareVariables,
+      },
+      {
+        path: "more",
+        Component: SearchResultsMoreRoute,
+        query: graphql`
+          query routes_SearchResultsMoreQuery($term: String!) {
+            viewer {
+              ...SearchResultsMore_viewer @arguments(term: $term)
             }
           }
         `,

--- a/src/__generated__/SearchResultsMoreQuery.graphql.ts
+++ b/src/__generated__/SearchResultsMoreQuery.graphql.ts
@@ -1,0 +1,447 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { SearchResultsMore_viewer$ref } from "./SearchResultsMore_viewer.graphql";
+export type SearchResultsMoreQueryVariables = {
+    readonly first?: number | null;
+    readonly last?: number | null;
+    readonly after?: string | null;
+    readonly before?: string | null;
+    readonly term: string;
+};
+export type SearchResultsMoreQueryResponse = {
+    readonly viewer: ({
+        readonly " $fragmentRefs": SearchResultsMore_viewer$ref;
+    }) | null;
+};
+export type SearchResultsMoreQuery = {
+    readonly response: SearchResultsMoreQueryResponse;
+    readonly variables: SearchResultsMoreQueryVariables;
+};
+
+
+
+/*
+query SearchResultsMoreQuery(
+  $first: Int
+  $last: Int
+  $after: String
+  $before: String
+  $term: String!
+) {
+  viewer {
+    ...SearchResultsMore_viewer_4c14dZ
+  }
+}
+
+fragment SearchResultsMore_viewer_4c14dZ on Viewer {
+  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [TAG, CITY, FAIR, FEATURE]) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    edges {
+      node {
+        __typename
+        ... on SearchableItem {
+          id
+          displayLabel
+          href
+          imageUrl
+          searchableType
+        }
+        ... on Node {
+          __id
+        }
+      }
+    }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "first",
+    "type": "Int",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "last",
+    "type": "Int",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "after",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "before",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "term",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "page",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  v1,
+  v2,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "isCurrent",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "SearchResultsMoreQuery",
+  "id": null,
+  "text": "query SearchResultsMoreQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsMore_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [TAG, CITY, FAIR, FEATURE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "SearchResultsMoreQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "viewer",
+        "name": "__viewer_viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "SearchResultsMore_viewer",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "after",
+                "variableName": "after",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "before",
+                "variableName": "before",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "first",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "last",
+                "variableName": "last",
+                "type": null
+              },
+              {
+                "kind": "Variable",
+                "name": "term",
+                "variableName": "term",
+                "type": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "SearchResultsMoreQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "search",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "after",
+                "variableName": "after",
+                "type": "String"
+              },
+              {
+                "kind": "Variable",
+                "name": "before",
+                "variableName": "before",
+                "type": "String"
+              },
+              {
+                "kind": "Literal",
+                "name": "entities",
+                "value": [
+                  "TAG",
+                  "CITY",
+                  "FAIR",
+                  "FEATURE"
+                ],
+                "type": "[SearchEntity]"
+              },
+              {
+                "kind": "Variable",
+                "name": "first",
+                "variableName": "first",
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "last",
+                "variableName": "last",
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "query",
+                "variableName": "term",
+                "type": "String!"
+              }
+            ],
+            "concreteType": "SearchableConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageCursors",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "around",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": true,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "first",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "last",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "previous",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": [
+                      v1,
+                      v2
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "SearchableEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": null,
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__id",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedHandle",
+        "alias": null,
+        "name": "viewer",
+        "args": null,
+        "handle": "viewer",
+        "key": "",
+        "filters": null
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '63aa32f28c607952f6852447581dd944';
+export default node;

--- a/src/__generated__/SearchResultsMore_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsMore_viewer.graphql.ts
@@ -1,0 +1,236 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+import { Pagination_pageCursors$ref } from "./Pagination_pageCursors.graphql";
+declare const _SearchResultsMore_viewer$ref: unique symbol;
+export type SearchResultsMore_viewer$ref = typeof _SearchResultsMore_viewer$ref;
+export type SearchResultsMore_viewer = {
+    readonly search: ({
+        readonly pageInfo: {
+            readonly hasNextPage: boolean;
+            readonly endCursor: string | null;
+        };
+        readonly pageCursors: ({
+            readonly " $fragmentRefs": Pagination_pageCursors$ref;
+        }) | null;
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly id?: string;
+                readonly displayLabel?: string | null;
+                readonly href?: string | null;
+                readonly imageUrl?: string | null;
+                readonly searchableType?: string | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+    readonly " $refType": SearchResultsMore_viewer$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "SearchResultsMore_viewer",
+  "type": "Viewer",
+  "metadata": null,
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "term",
+      "type": "String!",
+      "defaultValue": ""
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "first",
+      "type": "Int",
+      "defaultValue": 10
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "last",
+      "type": "Int",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "after",
+      "type": "String",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "before",
+      "type": "String",
+      "defaultValue": null
+    }
+  ],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "search",
+      "storageKey": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "after",
+          "variableName": "after",
+          "type": "String"
+        },
+        {
+          "kind": "Variable",
+          "name": "before",
+          "variableName": "before",
+          "type": "String"
+        },
+        {
+          "kind": "Literal",
+          "name": "entities",
+          "value": [
+            "TAG",
+            "CITY",
+            "FAIR",
+            "FEATURE"
+          ],
+          "type": "[SearchEntity]"
+        },
+        {
+          "kind": "Variable",
+          "name": "first",
+          "variableName": "first",
+          "type": "Int"
+        },
+        {
+          "kind": "Variable",
+          "name": "last",
+          "variableName": "last",
+          "type": "Int"
+        },
+        {
+          "kind": "Variable",
+          "name": "query",
+          "variableName": "term",
+          "type": "String!"
+        }
+      ],
+      "concreteType": "SearchableConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageInfo",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "hasNextPage",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "endCursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageCursors",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageCursors",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "FragmentSpread",
+              "name": "Pagination_pageCursors",
+              "args": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "SearchableEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": null,
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "type": "SearchableItem",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "displayLabel",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "href",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "imageUrl",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "searchableType",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '506ca72ee99012bc15c337b90e7830fb';
+export default node;

--- a/src/__generated__/routes_SearchResultsMoreQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsMoreQuery.graphql.ts
@@ -1,0 +1,373 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { SearchResultsMore_viewer$ref } from "./SearchResultsMore_viewer.graphql";
+export type routes_SearchResultsMoreQueryVariables = {
+    readonly term: string;
+};
+export type routes_SearchResultsMoreQueryResponse = {
+    readonly viewer: ({
+        readonly " $fragmentRefs": SearchResultsMore_viewer$ref;
+    }) | null;
+};
+export type routes_SearchResultsMoreQuery = {
+    readonly response: routes_SearchResultsMoreQueryResponse;
+    readonly variables: routes_SearchResultsMoreQueryVariables;
+};
+
+
+
+/*
+query routes_SearchResultsMoreQuery(
+  $term: String!
+) {
+  viewer {
+    ...SearchResultsMore_viewer_4hh6ED
+  }
+}
+
+fragment SearchResultsMore_viewer_4hh6ED on Viewer {
+  search(query: $term, first: 10, entities: [TAG, CITY, FAIR, FEATURE]) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    edges {
+      node {
+        __typename
+        ... on SearchableItem {
+          id
+          displayLabel
+          href
+          imageUrl
+          searchableType
+        }
+        ... on Node {
+          __id
+        }
+      }
+    }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "term",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "page",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  v1,
+  v2,
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "isCurrent",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_SearchResultsMoreQuery",
+  "id": null,
+  "text": "query routes_SearchResultsMoreQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsMore_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [TAG, CITY, FAIR, FEATURE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_SearchResultsMoreQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "viewer",
+        "name": "__viewer_viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "SearchResultsMore_viewer",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "term",
+                "variableName": "term",
+                "type": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_SearchResultsMoreQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewer",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "search",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "entities",
+                "value": [
+                  "TAG",
+                  "CITY",
+                  "FAIR",
+                  "FEATURE"
+                ],
+                "type": "[SearchEntity]"
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10,
+                "type": "Int"
+              },
+              {
+                "kind": "Variable",
+                "name": "query",
+                "variableName": "term",
+                "type": "String!"
+              }
+            ],
+            "concreteType": "SearchableConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageCursors",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "around",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": true,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "first",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "last",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": v3
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "previous",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "plural": false,
+                    "selections": [
+                      v1,
+                      v2
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "SearchableEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": null,
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__id",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "type": "SearchableItem",
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageUrl",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "searchableType",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "LinkedHandle",
+        "alias": null,
+        "name": "viewer",
+        "args": null,
+        "handle": "viewer",
+        "key": "",
+        "filters": null
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '07c2a8c280ceeb0bf9e121214ae5a357';
+export default node;


### PR DESCRIPTION

![search](https://user-images.githubusercontent.com/1457859/54570042-6e4ca080-49b3-11e9-85d8-1f077197c952.gif)


This adds in the 'More' tab in the same boilerplate-y way we have been, but here there's a list of entity types.

We need to handle searching for 'Institutions' in the same way we implemented the 'Gallery' custom thing, since that's the same deal- those aren't their own first-class 'entity', its actually a type of Profile.