### PR TITLE
Refactor commitMutation usage

### DIFF
--- a/src/Apps/Order/Dialogs.tsx
+++ b/src/Apps/Order/Dialogs.tsx
@@ -116,7 +116,7 @@ export class DialogContainer extends Container<DialogState> {
     message?: React.ReactNode
     supportEmail?: string
     continueButtonText?: string
-  }): Promise<boolean> => {
+  } = {}): Promise<boolean> => {
     return new Promise<boolean>(resolve => {
       const onContinue = () => {
         this.hide()

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -11,7 +11,6 @@ import { Elements, StripeProvider } from "react-stripe-elements"
 import styled from "styled-components"
 import { get } from "Utils/get"
 import { ConnectedModalDialog } from "./Dialogs"
-import { ProvideMutationContext } from "./Utils/commitMutation"
 
 declare global {
   interface Window {
@@ -116,13 +115,11 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
               />
             )}
             <SafeAreaContainer>
-              <ProvideMutationContext>
-                <StripeProvider stripe={this.state.stripe}>
-                  <Elements>
-                    <>{children}</>
-                  </Elements>
-                </StripeProvider>
-              </ProvideMutationContext>
+              <StripeProvider stripe={this.state.stripe}>
+                <Elements>
+                  <>{children}</>
+                </Elements>
+              </StripeProvider>
             </SafeAreaContainer>
             <StickyFooter orderType={order.mode} artworkId={artworkId} />
             <ConnectedModalDialog />

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -11,6 +11,7 @@ import { Elements, StripeProvider } from "react-stripe-elements"
 import styled from "styled-components"
 import { get } from "Utils/get"
 import { ConnectedModalDialog } from "./Dialogs"
+import { ProvideMutationContext } from "./Utils/commitMutation"
 
 declare global {
   interface Window {
@@ -115,11 +116,13 @@ export class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
               />
             )}
             <SafeAreaContainer>
-              <StripeProvider stripe={this.state.stripe}>
-                <Elements>
-                  <>{children}</>
-                </Elements>
-              </StripeProvider>
+              <ProvideMutationContext>
+                <StripeProvider stripe={this.state.stripe}>
+                  <Elements>
+                    <>{children}</>
+                  </Elements>
+                </StripeProvider>
+              </ProvideMutationContext>
             </SafeAreaContainer>
             <StickyFooter orderType={order.mode} artworkId={artworkId} />
             <ConnectedModalDialog />

--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -117,7 +117,7 @@ export class Accept extends Component<AcceptProps> {
       case "insufficient_inventory": {
         await this.props.dialog.showErrorDialog({
           title: "Not available",
-          message: "Sorry, the work is no longer available",
+          message: "Sorry, the work is no longer available.",
         })
         this.routeToArtistPage()
         break

--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -11,21 +11,19 @@ import {
   OrderStepper,
 } from "../../Components/OrderStepper"
 
-import {
-  commitMutation,
-  createFragmentContainer,
-  graphql,
-  RelayProp,
-} from "react-relay"
+import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 
 import { AcceptOfferMutation } from "__generated__/AcceptOfferMutation.graphql"
 import { ConditionsOfSaleDisclaimer } from "Apps/Order/Components/ConditionsOfSaleDisclaimer"
 import { ShippingSummaryItemFragmentContainer as ShippingSummaryItem } from "Apps/Order/Components/ShippingSummaryItem"
 import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "Apps/Order/Components/TransactionDetailsSummaryItem"
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
+import {
+  CommitMutation,
+  injectCommitMutation,
+} from "Apps/Order/Utils/commitMutation"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
 import { CountdownTimer } from "Components/v2/CountdownTimer"
-import { ErrorWithMetadata } from "Utils/errors"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "../../Components/ArtworkSummaryItem"
@@ -37,90 +35,68 @@ interface AcceptProps {
   router: Router
   route: RouteConfig
   dialog: Dialog
-}
-
-interface AcceptState {
+  commitMutation: CommitMutation
   isCommittingMutation: boolean
 }
 
 const logger = createLogger("Order/Routes/Offer/index.tsx")
 
 @track()
-export class Accept extends Component<AcceptProps, AcceptState> {
-  state: AcceptState = {
-    isCommittingMutation: false,
-  }
-
-  onSubmit: () => void = () => {
-    this.setState({ isCommittingMutation: true }, () => {
-      if (this.props.relay && this.props.relay.environment) {
-        commitMutation<AcceptOfferMutation>(this.props.relay.environment, {
-          mutation: graphql`
-            mutation AcceptOfferMutation($input: buyerAcceptOfferInput!) {
-              ecommerceBuyerAcceptOffer(input: $input) {
-                orderOrError {
-                  ... on OrderWithMutationSuccess {
-                    __typename
-                    order {
-                      id
-                      ... on OfferOrder {
-                        awaitingResponseFrom
-                      }
-                    }
-                  }
-                  ... on OrderWithMutationFailure {
-                    error {
-                      type
-                      code
-                      data
-                    }
+export class Accept extends Component<AcceptProps> {
+  acceptOffer(variables: AcceptOfferMutation["variables"]) {
+    return this.props.commitMutation<AcceptOfferMutation>({
+      mutation: graphql`
+        mutation AcceptOfferMutation($input: buyerAcceptOfferInput!) {
+          ecommerceBuyerAcceptOffer(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                __typename
+                order {
+                  id
+                  ... on OfferOrder {
+                    awaitingResponseFrom
                   }
                 }
               }
+              ... on OrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
+                }
+              }
             }
-          `,
-          variables: {
-            input: {
-              offerId: this.props.order.lastOffer.id,
-            },
-          },
-          onCompleted: data => {
-            this.setState({ isCommittingMutation: false })
-            const {
-              ecommerceBuyerAcceptOffer: { orderOrError },
-            } = data
-            this.onSubmitCompleted(orderOrError)
-          },
-          onError: this.onMutationError.bind(this),
-        })
+          }
+        }
+      `,
+      variables,
+    })
+  }
+
+  onSubmit = async () => {
+    try {
+      const {
+        ecommerceBuyerAcceptOffer: { orderOrError },
+      } = await this.acceptOffer({
+        input: { offerId: this.props.order.lastOffer.id },
+      })
+
+      if (!orderOrError.error) {
+        this.props.router.push(`/orders/${this.props.order.id}/status`)
+        return
       }
-    })
-  }
 
-  async showCardFailureDialog(props: { title: string; message: string }) {
-    this.setState({ isCommittingMutation: false })
-    const { confirmed } = await this.props.dialog.showConfirmDialog({
-      ...props,
-      cancelButtonText: "OK",
-      confirmButtonText: "Use new card",
-    })
-    if (confirmed) {
-      this.props.router.push(`/orders/${this.props.order.id}/payment/new`)
-    }
-  }
+      const { code, data } = orderOrError.error
 
-  async onSubmitCompleted(orderOrError) {
-    const error = orderOrError.error
-    if (error) {
-      switch (error.code) {
+      switch (code) {
         case "capture_failed": {
-          let data = {} as any
-          if (error.data) {
-            data = JSON.parse(error.data)
+          let parsedData = {} as any
+          if (data) {
+            parsedData = JSON.parse(data)
           }
 
           // https://stripe.com/docs/declines/codes
-          if (data.failure_code === "insufficient_funds") {
+          if (parsedData.failure_code === "insufficient_funds") {
             this.showCardFailureDialog({
               title: "Insufficient funds",
               message:
@@ -136,44 +112,31 @@ export class Accept extends Component<AcceptProps, AcceptState> {
           break
         }
         case "insufficient_inventory": {
-          this.onMutationError(
-            new ErrorWithMetadata(error.code, error),
-            "Not available",
-            "Sorry, the work is no longer available.",
-            () => {
-              this.routeToArtistPage()
-            }
-          )
+          await this.props.dialog.showErrorDialog({
+            title: "Not available",
+            message: "Sorry, the work is no longer available",
+          })
+          this.routeToArtistPage()
           break
         }
-        default: {
-          this.onMutationError(new ErrorWithMetadata(error.code, error))
-          break
-        }
+        default:
+          this.props.dialog.showErrorDialog()
       }
-    } else {
-      this.onSuccessfulSubmit()
+    } catch (error) {
+      logger.error(error)
+      this.props.dialog.showErrorDialog()
     }
   }
 
-  onSuccessfulSubmit() {
-    this.props.router.push(`/orders/${this.props.order.id}/status`)
-  }
-
-  onMutationError(
-    error: Error,
-    title?: string,
-    message?: string,
-    onDismiss?: () => void
-  ) {
-    logger.error(error)
-    const result = this.props.dialog.showErrorDialog({ title, message })
-    if (onDismiss) {
-      result.then(onDismiss)
-    }
-    this.setState({
-      isCommittingMutation: false,
+  async showCardFailureDialog(props: { title: string; message: string }) {
+    const { confirmed } = await this.props.dialog.showConfirmDialog({
+      ...props,
+      cancelButtonText: "OK",
+      confirmButtonText: "Use new card",
     })
+    if (confirmed) {
+      this.props.router.push(`/orders/${this.props.order.id}/payment/new`)
+    }
   }
 
   onChangeResponse = () => {
@@ -197,8 +160,7 @@ export class Accept extends Component<AcceptProps, AcceptState> {
   }
 
   render() {
-    const { order } = this.props
-    const { isCommittingMutation } = this.state
+    const { order, isCommittingMutation } = this.props
 
     return (
       <>
@@ -293,7 +255,7 @@ export class Accept extends Component<AcceptProps, AcceptState> {
 }
 
 export const AcceptFragmentContainer = createFragmentContainer(
-  injectDialog(trackPageViewWrapper(Accept)),
+  injectCommitMutation(injectDialog(trackPageViewWrapper(Accept))),
   graphql`
     fragment Accept_order on Order {
       id

--- a/src/Apps/Order/Routes/Counter/index.tsx
+++ b/src/Apps/Order/Routes/Counter/index.tsx
@@ -84,21 +84,26 @@ export class CounterRoute extends Component<CounterProps> {
         },
       })
 
-      if (!orderOrError.error) {
-        this.onSuccessfulSubmit()
+      if (orderOrError.error) {
+        this.handleSubmitError(orderOrError.error)
         return
       }
 
-      if (orderOrError.error.code === "insufficient_inventory") {
-        this.props.dialog.showErrorDialog({
-          title: "This work has already been sold.",
-          message: "Please contact orders@artsy.net with any questions.",
-        })
-      } else {
-        this.props.dialog.showErrorDialog()
-      }
+      this.onSuccessfulSubmit()
     } catch (error) {
       logger.error(error)
+      this.props.dialog.showErrorDialog()
+    }
+  }
+
+  handleSubmitError(error: { code: string }) {
+    logger.error(error)
+    if (error.code === "insufficient_inventory") {
+      this.props.dialog.showErrorDialog({
+        title: "This work has already been sold.",
+        message: "Please contact orders@artsy.net with any questions.",
+      })
+    } else {
       this.props.dialog.showErrorDialog()
     }
   }

--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -137,11 +137,9 @@ export class NewPaymentRoute extends Component<
         return
       }
 
-      const {
-        createCreditCard: { creditCardOrError },
-      } = await this.createCreditCard({
+      const creditCardOrError = (await this.createCreditCard({
         input: { token: stripeResult.token.id, oneTimeUse: true },
-      })
+      })).createCreditCard.creditCardOrError
 
       if (creditCardOrError.mutationError) {
         this.props.dialog.showErrorDialog({
@@ -150,14 +148,12 @@ export class NewPaymentRoute extends Component<
         return
       }
 
-      const {
-        ecommerceFixFailedPayment: { orderOrError },
-      } = await this.fixFailedPayment({
+      const orderOrError = (await this.fixFailedPayment({
         input: {
           creditCardId: creditCardOrError.creditCard.id,
           offerId: this.props.order.lastOffer.id,
         },
-      })
+      })).ecommerceFixFailedPayment.orderOrError
 
       if (orderOrError.error) {
         this.handleFixFailedPaymentError(orderOrError.error.code)

--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -22,14 +22,8 @@ import { track } from "Artsy/Analytics"
 import { CountdownTimer } from "Components/v2/CountdownTimer"
 import { RouteConfig, Router } from "found"
 import React, { Component } from "react"
-import {
-  commitMutation,
-  createFragmentContainer,
-  graphql,
-  RelayRefetchProp,
-} from "react-relay"
+import { createFragmentContainer, graphql, RelayRefetchProp } from "react-relay"
 import { injectStripe, ReactStripeElements } from "react-stripe-elements"
-import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 
@@ -45,6 +39,10 @@ import {
   Spacer,
 } from "@artsy/palette"
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
+import {
+  CommitMutation,
+  injectCommitMutation,
+} from "Apps/Order/Utils/commitMutation"
 import { get } from "Utils/get"
 
 export const ContinueButton = props => (
@@ -60,6 +58,8 @@ export interface NewPaymentProps
   router: Router
   route: RouteConfig
   dialog: Dialog
+  commitMutation: CommitMutation
+  isCommittingMutation: boolean
 }
 
 interface NewPaymentState {
@@ -68,7 +68,7 @@ interface NewPaymentState {
   addressErrors: AddressErrors
   addressTouched: AddressTouched
   stripeError: stripe.Error
-  isCommittingMutation: boolean
+  isCreatingStripeToken: boolean
 }
 
 const logger = createLogger("Order/Routes/NewPayment/index.tsx")
@@ -81,10 +81,10 @@ export class NewPaymentRoute extends Component<
   state = {
     hideBillingAddress: true,
     stripeError: null,
-    isCommittingMutation: false,
     address: this.startingAddress(),
     addressErrors: {},
     addressTouched: {},
+    isCreatingStripeToken: false,
   }
 
   startingAddress(): Address {
@@ -107,37 +107,68 @@ export class NewPaymentRoute extends Component<
     }
   }
 
-  onContinue: () => void = () => {
-    this.setState({ isCommittingMutation: true }, () => {
-      if (this.needsAddress()) {
-        const { errors, hasErrors } = validateAddress(this.state.address)
-        if (hasErrors) {
-          this.setState({
-            isCommittingMutation: false,
-            addressErrors: errors,
-            addressTouched: this.touchedAddress,
-          })
-          return
-        }
+  createStripeToken = async () => {
+    try {
+      this.setState({ isCreatingStripeToken: true })
+      const stripeBillingAddress = this.getStripeBillingAddress()
+      return await this.props.stripe.createToken(stripeBillingAddress)
+    } finally {
+      this.setState({ isCreatingStripeToken: false })
+    }
+  }
+
+  onContinue = async () => {
+    if (this.needsAddress()) {
+      const { errors, hasErrors } = validateAddress(this.state.address)
+      if (hasErrors) {
+        this.setState({
+          addressErrors: errors,
+          addressTouched: this.touchedAddress,
+        })
+        return
+      }
+    }
+
+    try {
+      const stripeResult = await this.createStripeToken()
+
+      if (stripeResult.error) {
+        this.setState({ stripeError: stripeResult.error })
+        return
       }
 
-      const stripeBillingAddress = this.getStripeBillingAddress()
-      this.props.stripe
-        .createToken(stripeBillingAddress)
-        .then(({ error, token }) => {
-          if (error) {
-            this.setState({
-              isCommittingMutation: false,
-              stripeError: error,
-            })
-          } else {
-            this.createCreditCard({ token: token.id, oneTimeUse: true })
-          }
+      const {
+        createCreditCard: { creditCardOrError },
+      } = await this.createCreditCard({
+        input: { token: stripeResult.token.id, oneTimeUse: true },
+      })
+
+      if (creditCardOrError.mutationError) {
+        this.props.dialog.showErrorDialog({
+          message: creditCardOrError.mutationError.detail,
         })
-        .catch(e => {
-          this.onMutationError(new ErrorWithMetadata(e))
-        })
-    })
+        return
+      }
+
+      const {
+        ecommerceFixFailedPayment: { orderOrError },
+      } = await this.fixFailedPayment({
+        input: {
+          creditCardId: creditCardOrError.creditCard.id,
+          offerId: this.props.order.lastOffer.id,
+        },
+      })
+
+      if (orderOrError.error) {
+        this.handleFixFailedPaymentError(orderOrError.error.code)
+        return
+      }
+
+      this.props.router.push(`/orders/${this.props.order.id}/status`)
+    } catch (error) {
+      logger.error(error)
+      this.props.dialog.showErrorDialog()
+    }
   }
 
   handleChangeHideBillingAddress(hideBillingAddress: boolean) {
@@ -169,14 +200,16 @@ export class NewPaymentRoute extends Component<
   }
 
   render() {
-    const { order } = this.props
+    const { order, isCommittingMutation } = this.props
     const {
       stripeError,
-      isCommittingMutation,
       address,
       addressErrors,
       addressTouched,
+      isCreatingStripeToken,
     } = this.state
+
+    const isLoading = isCommittingMutation || isCreatingStripeToken
 
     return (
       <>
@@ -192,7 +225,7 @@ export class NewPaymentRoute extends Component<
             Content={
               <Flex
                 flexDirection="column"
-                style={isCommittingMutation ? { pointerEvents: "none" } : {}}
+                style={isLoading ? { pointerEvents: "none" } : {}}
               >
                 {order.mode === "OFFER" && (
                   <>
@@ -241,7 +274,7 @@ export class NewPaymentRoute extends Component<
                   <Media greaterThan="xs">
                     <ContinueButton
                       onClick={this.onContinue}
-                      loading={isCommittingMutation}
+                      loading={isLoading}
                     />
                   </Media>
                 </Join>
@@ -259,7 +292,7 @@ export class NewPaymentRoute extends Component<
                     <Spacer mb={3} />
                     <ContinueButton
                       onClick={this.onContinue}
-                      loading={isCommittingMutation}
+                      loading={isLoading}
                     />
                   </>
                 </Media>
@@ -295,168 +328,102 @@ export class NewPaymentRoute extends Component<
     }
   }
 
-  private createCreditCard({ token, oneTimeUse }) {
-    commitMutation<NewPaymentRouteCreateCreditCardMutation>(
-      this.props.relay.environment,
-      {
-        onCompleted: (data, errors) => {
-          const {
-            createCreditCard: { creditCardOrError },
-          } = data
-
-          if (creditCardOrError.creditCard) {
-            this.fixFailedPayment({
-              creditCardId: creditCardOrError.creditCard.id,
-            })
-          } else {
-            if (errors) {
-              errors.forEach(this.onMutationError.bind(this))
-            } else {
-              const mutationError = creditCardOrError.mutationError
-              this.onMutationError(
-                new ErrorWithMetadata(mutationError.message, mutationError),
-                "An error occurred",
-                mutationError.detail
-              )
+  createCreditCard(
+    variables: NewPaymentRouteCreateCreditCardMutation["variables"]
+  ) {
+    return this.props.commitMutation<NewPaymentRouteCreateCreditCardMutation>({
+      variables,
+      mutation: graphql`
+        mutation NewPaymentRouteCreateCreditCardMutation(
+          $input: CreditCardInput!
+        ) {
+          createCreditCard(input: $input) {
+            creditCardOrError {
+              ... on CreditCardMutationSuccess {
+                creditCard {
+                  id
+                }
+              }
+              ... on CreditCardMutationFailure {
+                mutationError {
+                  type
+                  message
+                  detail
+                }
+              }
             }
           }
-        },
-        onError: this.onMutationError.bind(this),
-        mutation: graphql`
-          mutation NewPaymentRouteCreateCreditCardMutation(
-            $input: CreditCardInput!
-          ) {
-            createCreditCard(input: $input) {
-              creditCardOrError {
-                ... on CreditCardMutationSuccess {
+        }
+      `,
+    })
+  }
+
+  fixFailedPayment(
+    variables: NewPaymentRouteSetOrderPaymentMutation["variables"]
+  ) {
+    return this.props.commitMutation<NewPaymentRouteSetOrderPaymentMutation>({
+      variables,
+      mutation: graphql`
+        mutation NewPaymentRouteSetOrderPaymentMutation(
+          $input: FixFailedPaymentInput!
+        ) {
+          ecommerceFixFailedPayment(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                order {
+                  state
                   creditCard {
                     id
-                  }
-                }
-                ... on CreditCardMutationFailure {
-                  mutationError {
-                    type
-                    message
-                    detail
-                  }
-                }
-              }
-            }
-          }
-        `,
-        variables: {
-          input: { token, oneTimeUse },
-        },
-      }
-    )
-  }
-
-  private fixFailedPayment({ creditCardId }) {
-    commitMutation<NewPaymentRouteSetOrderPaymentMutation>(
-      this.props.relay.environment,
-      {
-        onCompleted: (data, errors) => {
-          this.setState({ isCommittingMutation: false })
-
-          const {
-            ecommerceFixFailedPayment: { orderOrError },
-          } = data
-
-          if (orderOrError.order) {
-            this.props.router.push(`/orders/${this.props.order.id}/status`)
-          } else {
-            if (errors) {
-              errors.forEach(this.onMutationError.bind(this))
-            } else {
-              const orderError = orderOrError.error
-              switch (orderError.code) {
-                case "capture_failed": {
-                  this.onMutationError(
-                    new ErrorWithMetadata(orderError.code, orderError),
-                    "Charge failed",
-                    "Payment authorization has been declined. Please contact your card provider and try again."
-                  )
-                  break
-                }
-                case "insufficient_inventory": {
-                  this.onMutationError(
-                    new ErrorWithMetadata(orderError.code, orderError),
-                    "Not available",
-                    "Sorry, the work is no longer available.",
-                    () => {
-                      this.routeToArtistPage()
-                    }
-                  )
-                  break
-                }
-                default: {
-                  this.onMutationError(
-                    new ErrorWithMetadata(orderError.code, orderError)
-                  )
-                  break
-                }
-              }
-            }
-          }
-        },
-        onError: this.onMutationError.bind(this),
-        mutation: graphql`
-          mutation NewPaymentRouteSetOrderPaymentMutation(
-            $input: FixFailedPaymentInput!
-          ) {
-            ecommerceFixFailedPayment(input: $input) {
-              orderOrError {
-                ... on OrderWithMutationSuccess {
-                  order {
+                    name
+                    street1
+                    street2
+                    city
                     state
-                    creditCard {
-                      id
-                      name
-                      street1
-                      street2
-                      city
-                      state
-                      country
-                      postal_code
-                    }
-                    ... on OfferOrder {
-                      awaitingResponseFrom
-                    }
+                    country
+                    postal_code
+                  }
+                  ... on OfferOrder {
+                    awaitingResponseFrom
                   }
                 }
-                ... on OrderWithMutationFailure {
-                  error {
-                    type
-                    code
-                    data
-                  }
+              }
+              ... on OrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
                 }
               }
             }
           }
-        `,
-        variables: {
-          input: {
-            offerId: this.props.order.lastOffer.id,
-            creditCardId,
-          },
-        },
-      }
-    )
+        }
+      `,
+    })
   }
 
-  private onMutationError(
-    error: ErrorWithMetadata,
-    title?: string,
-    message?: string,
-    onDismiss?: () => void
-  ) {
-    logger.error(error)
-    const result = this.props.dialog.showErrorDialog({ title, message })
-    if (onDismiss) {
-      result.then(onDismiss)
+  async handleFixFailedPaymentError(code: string) {
+    switch (code) {
+      case "capture_failed": {
+        this.props.dialog.showErrorDialog({
+          title: "Charge failed",
+          message:
+            "Payment authorization has been declined. Please contact your card provider and try again.",
+        })
+        break
+      }
+      case "insufficient_inventory": {
+        await this.props.dialog.showErrorDialog({
+          title: "Not available",
+          message: "Sorry, the work is no longer available.",
+        })
+        this.routeToArtistPage()
+        break
+      }
+      default: {
+        this.props.dialog.showErrorDialog()
+        break
+      }
     }
-    this.setState({ isCommittingMutation: false })
   }
 
   private isPickup = () => {
@@ -484,7 +451,9 @@ export class NewPaymentRoute extends Component<
 }
 
 export const NewPaymentFragmentContainer = createFragmentContainer(
-  injectStripe(trackPageViewWrapper(injectDialog(NewPaymentRoute))),
+  injectCommitMutation(
+    injectStripe(trackPageViewWrapper(injectDialog(NewPaymentRoute)))
+  ),
   graphql`
     fragment NewPayment_order on Order {
       id

--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -18,7 +18,10 @@ import { RevealButton } from "Apps/Order/Components/RevealButton"
 import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "Apps/Order/Components/TransactionDetailsSummaryItem"
 import { TwoColumnLayout } from "Apps/Order/Components/TwoColumnLayout"
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
-import { CommitMutation } from "Apps/Order/Utils/commitMutation"
+import {
+  CommitMutation,
+  injectCommitMutation,
+} from "Apps/Order/Utils/commitMutation"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics"
@@ -309,7 +312,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
 }
 
 export const OfferFragmentContainer = createFragmentContainer(
-  injectDialog(trackPageViewWrapper(OfferRoute)),
+  injectCommitMutation(injectDialog(trackPageViewWrapper(OfferRoute))),
   graphql`
     fragment Offer_order on Order {
       id

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -136,14 +136,12 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
         return
       }
 
-      const {
-        createCreditCard: { creditCardOrError },
-      } = await this.createCreditCard({
+      const creditCardOrError = (await this.createCreditCard({
         input: {
           token: stripeResult.token.id,
           oneTimeUse: true,
         },
-      })
+      })).createCreditCard.creditCardOrError
 
       if (creditCardOrError.mutationError) {
         this.props.dialog.showErrorDialog({
@@ -152,18 +150,15 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
         return
       }
 
-      const {
-        ecommerceSetOrderPayment: { orderOrError },
-      } = await this.setOrderPayment({
+      const orderOrError = (await this.setOrderPayment({
         input: {
           creditCardId: creditCardOrError.creditCard.id,
           orderId: this.props.order.id,
         },
-      })
+      })).ecommerceSetOrderPayment.orderOrError
 
       if (orderOrError.error) {
-        this.props.dialog.showErrorDialog()
-        return
+        throw orderOrError.error
       }
 
       this.props.router.push(`/orders/${this.props.order.id}/review`)

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -49,6 +49,10 @@ import {
   Spacer,
 } from "@artsy/palette"
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
+import {
+  CommitMutation,
+  injectCommitMutation,
+} from "Apps/Order/Utils/commitMutation"
 
 export const ContinueButton = props => (
   <Button size="large" width="100%" {...props}>
@@ -61,6 +65,8 @@ export interface PaymentProps extends ReactStripeElements.InjectedStripeProps {
   relay?: RelayRefetchProp
   router: Router
   dialog: Dialog
+  commitMutation: CommitMutation
+  isCommittingMutation: boolean
 }
 
 interface PaymentState {
@@ -69,7 +75,7 @@ interface PaymentState {
   addressErrors: AddressErrors
   addressTouched: AddressTouched
   stripeError: stripe.Error
-  isCommittingMutation: boolean
+  isCreatingStripeToken: boolean
 }
 
 const logger = createLogger("Order/Routes/Payment/index.tsx")
@@ -79,7 +85,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
   state = {
     hideBillingAddress: true,
     stripeError: null,
-    isCommittingMutation: false,
+    isCreatingStripeToken: false,
     address: this.startingAddress(),
     addressErrors: {},
     addressTouched: {},
@@ -105,38 +111,72 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     }
   }
 
-  onContinue: () => void = () => {
-    this.setState({ isCommittingMutation: true }, () => {
-      if (this.needsAddress()) {
-        const { errors, hasErrors } = validateAddress(this.state.address)
-        if (hasErrors) {
-          this.setState({
-            isCommittingMutation: false,
-            addressErrors: errors,
-            addressTouched: this.touchedAddress,
-          })
-          return
-        }
+  createStripeToken = async () => {
+    try {
+      this.setState({ isCreatingStripeToken: true })
+      const stripeBillingAddress = this.getStripeBillingAddress()
+      return await this.props.stripe.createToken(stripeBillingAddress)
+    } finally {
+      this.setState({ isCreatingStripeToken: false })
+    }
+  }
+
+  onContinue = async () => {
+    if (this.needsAddress()) {
+      const { errors, hasErrors } = validateAddress(this.state.address)
+      if (hasErrors) {
+        this.setState({
+          addressErrors: errors,
+          addressTouched: this.touchedAddress,
+        })
+        return
+      }
+    }
+
+    try {
+      const stripeResult = await this.createStripeToken()
+      if (stripeResult.error) {
+        this.setState({
+          stripeError: stripeResult.error,
+        })
+        return
       }
 
-      const { address } = this.state
-      const stripeBillingAddress = this.getStripeBillingAddress(address)
-      this.props.stripe
-        .createToken(stripeBillingAddress)
-        .then(({ error, token }) => {
-          if (error) {
-            this.setState({
-              isCommittingMutation: false,
-              stripeError: error,
-            })
-          } else {
-            this.createCreditCard({ token: token.id, oneTimeUse: true })
-          }
+      const {
+        createCreditCard: { creditCardOrError },
+      } = await this.createCreditCard({
+        input: {
+          token: stripeResult.token.id,
+          oneTimeUse: true,
+        },
+      })
+
+      if (creditCardOrError.mutationError) {
+        this.props.dialog.showErrorDialog({
+          message: creditCardOrError.mutationError.detail,
         })
-        .catch(e => {
-          this.onMutationError(new ErrorWithMetadata(e))
-        })
-    })
+        return
+      }
+
+      const {
+        ecommerceSetOrderPayment: { orderOrError },
+      } = await this.setOrderPayment({
+        input: {
+          creditCardId: creditCardOrError.creditCard.id,
+          orderId: this.props.order.id,
+        },
+      })
+
+      if (orderOrError.error) {
+        this.props.dialog.showErrorDialog()
+        return
+      }
+
+      this.props.router.push(`/orders/${this.props.order.id}/review`)
+    } catch (error) {
+      logger.error(error)
+      this.props.dialog.showErrorDialog()
+    }
   }
 
   @track((props, state, args) => {
@@ -179,14 +219,16 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
   }
 
   render() {
-    const { order } = this.props
+    const { order, isCommittingMutation } = this.props
     const {
       stripeError,
-      isCommittingMutation,
       address,
       addressErrors,
       addressTouched,
+      isCreatingStripeToken,
     } = this.state
+
+    const isLoading = isCreatingStripeToken || isCommittingMutation
 
     return (
       <>
@@ -208,7 +250,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
             Content={
               <Flex
                 flexDirection="column"
-                style={isCommittingMutation ? { pointerEvents: "none" } : {}}
+                style={isLoading ? { pointerEvents: "none" } : {}}
               >
                 <Join separator={<Spacer mb={3} />}>
                   <Flex flexDirection="column">
@@ -244,7 +286,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
                   <Media greaterThan="xs">
                     <ContinueButton
                       onClick={this.onContinue}
-                      loading={isCommittingMutation}
+                      loading={isLoading}
                     />
                   </Media>
                 </Join>
@@ -262,7 +304,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
                     <Spacer mb={3} />
                     <ContinueButton
                       onClick={this.onContinue}
-                      loading={isCommittingMutation}
+                      loading={isLoading}
                     />
                   </>
                 </Media>
@@ -274,7 +316,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     )
   }
 
-  private getStripeBillingAddress(formAddress: Address): stripe.TokenOptions {
+  private getStripeBillingAddress(): stripe.TokenOptions {
     const selectedBillingAddress = (this.needsAddress()
       ? this.state.address
       : this.props.order.requestedFulfillment) as Address
@@ -298,131 +340,71 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     }
   }
 
-  private createCreditCard({ token, oneTimeUse }) {
-    commitMutation<PaymentRouteCreateCreditCardMutation>(
-      this.props.relay.environment,
-      {
-        onCompleted: (data, errors) => {
-          const {
-            createCreditCard: { creditCardOrError },
-          } = data
-
-          if (creditCardOrError.creditCard) {
-            this.setOrderPayment({
-              creditCardId: creditCardOrError.creditCard.id,
-            })
-          } else {
-            if (errors) {
-              errors.forEach(this.onMutationError.bind(this))
-            } else {
-              const mutationError = creditCardOrError.mutationError
-              this.onMutationError(
-                new ErrorWithMetadata(mutationError.message, mutationError),
-                mutationError.detail
-              )
+  createCreditCard(
+    variables: PaymentRouteCreateCreditCardMutation["variables"]
+  ) {
+    return this.props.commitMutation<PaymentRouteCreateCreditCardMutation>({
+      variables,
+      mutation: graphql`
+        mutation PaymentRouteCreateCreditCardMutation(
+          $input: CreditCardInput!
+        ) {
+          createCreditCard(input: $input) {
+            creditCardOrError {
+              ... on CreditCardMutationSuccess {
+                creditCard {
+                  id
+                }
+              }
+              ... on CreditCardMutationFailure {
+                mutationError {
+                  type
+                  message
+                  detail
+                }
+              }
             }
           }
-        },
-        onError: this.onMutationError.bind(this),
-        mutation: graphql`
-          mutation PaymentRouteCreateCreditCardMutation(
-            $input: CreditCardInput!
-          ) {
-            createCreditCard(input: $input) {
-              creditCardOrError {
-                ... on CreditCardMutationSuccess {
+        }
+      `,
+    })
+  }
+
+  setOrderPayment(variables: PaymentRouteSetOrderPaymentMutation["variables"]) {
+    return this.props.commitMutation<PaymentRouteSetOrderPaymentMutation>({
+      variables,
+      mutation: graphql`
+        mutation PaymentRouteSetOrderPaymentMutation(
+          $input: SetOrderPaymentInput!
+        ) {
+          ecommerceSetOrderPayment(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                order {
                   creditCard {
                     id
+                    name
+                    street1
+                    street2
+                    city
+                    state
+                    country
+                    postal_code
                   }
                 }
-                ... on CreditCardMutationFailure {
-                  mutationError {
-                    type
-                    message
-                    detail
-                  }
+              }
+              ... on OrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
                 }
               }
             }
           }
-        `,
-        variables: {
-          input: { token, oneTimeUse },
-        },
-      }
-    )
-  }
-
-  private setOrderPayment({ creditCardId }) {
-    commitMutation<PaymentRouteSetOrderPaymentMutation>(
-      this.props.relay.environment,
-      {
-        onCompleted: (data, errors) => {
-          this.setState({ isCommittingMutation: false })
-
-          const {
-            ecommerceSetOrderPayment: { orderOrError },
-          } = data
-
-          if (orderOrError.order) {
-            this.props.router.push(`/orders/${this.props.order.id}/review`)
-          } else {
-            if (errors) {
-              errors.forEach(this.onMutationError.bind(this))
-            } else {
-              const orderError = orderOrError.error
-              this.onMutationError(
-                new ErrorWithMetadata(orderError.code, orderError)
-              )
-            }
-          }
-        },
-        onError: this.onMutationError.bind(this),
-        mutation: graphql`
-          mutation PaymentRouteSetOrderPaymentMutation(
-            $input: SetOrderPaymentInput!
-          ) {
-            ecommerceSetOrderPayment(input: $input) {
-              orderOrError {
-                ... on OrderWithMutationSuccess {
-                  order {
-                    creditCard {
-                      id
-                      name
-                      street1
-                      street2
-                      city
-                      state
-                      country
-                      postal_code
-                    }
-                  }
-                }
-                ... on OrderWithMutationFailure {
-                  error {
-                    type
-                    code
-                    data
-                  }
-                }
-              }
-            }
-          }
-        `,
-        variables: {
-          input: {
-            orderId: this.props.order.id,
-            creditCardId,
-          },
-        },
-      }
-    )
-  }
-
-  private onMutationError(error, message?) {
-    logger.error(error)
-    this.props.dialog.showErrorDialog({ message })
-    this.setState({ isCommittingMutation: false })
+        }
+      `,
+    })
   }
 
   private isPickup = () => {
@@ -435,7 +417,9 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
 }
 
 export const PaymentFragmentContainer = createFragmentContainer(
-  injectStripe(trackPageViewWrapper(injectDialog(PaymentRoute))),
+  injectCommitMutation(
+    injectStripe(trackPageViewWrapper(injectDialog(PaymentRoute)))
+  ),
   graphql`
     fragment Payment_order on Order {
       id

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -26,14 +26,8 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { Router } from "found"
 import React, { Component } from "react"
-import {
-  commitMutation,
-  createFragmentContainer,
-  graphql,
-  RelayRefetchProp,
-} from "react-relay"
+import { createFragmentContainer, graphql, RelayRefetchProp } from "react-relay"
 import { injectStripe, ReactStripeElements } from "react-stripe-elements"
-import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 

--- a/src/Apps/Order/Routes/Reject/index.tsx
+++ b/src/Apps/Order/Routes/Reject/index.tsx
@@ -68,17 +68,14 @@ export class Reject extends Component<RejectProps> {
 
   onSubmit = async () => {
     try {
-      const {
-        ecommerceBuyerRejectOffer: { orderOrError },
-      } = await this.rejectOffer({
+      const orderOrError = (await this.rejectOffer({
         input: {
           offerId: this.props.order.lastOffer.id,
         },
-      })
+      })).ecommerceBuyerRejectOffer.orderOrError
 
       if (orderOrError.error) {
-        this.props.dialog.showErrorDialog()
-        return
+        throw orderOrError.error
       }
 
       this.props.router.push(`/orders/${this.props.order.id}/status`)

--- a/src/Apps/Order/Routes/Reject/index.tsx
+++ b/src/Apps/Order/Routes/Reject/index.tsx
@@ -11,7 +11,6 @@ import React, { Component } from "react"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { StepSummaryItem } from "Components/v2"
 import { CountdownTimer } from "Components/v2/CountdownTimer"
-import { ErrorWithMetadata } from "Utils/errors"
 import { Media } from "Utils/Responsive"
 import { logger } from "../Respond"
 
@@ -22,90 +21,71 @@ import {
 
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
 import {
-  commitMutation,
-  createFragmentContainer,
-  graphql,
-  RelayProp,
-} from "react-relay"
+  CommitMutation,
+  injectCommitMutation,
+} from "Apps/Order/Utils/commitMutation"
+import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 
 interface RejectProps {
   order: Reject_order
   relay?: RelayProp
   router: Router
   dialog: Dialog
-}
-
-interface RejectState {
+  commitMutation: CommitMutation
   isCommittingMutation: boolean
 }
 
-export class Reject extends Component<RejectProps, RejectState> {
-  state: RejectState = {
-    isCommittingMutation: false,
-  }
-
-  onSubmit: () => void = () => {
-    this.setState({ isCommittingMutation: true }, () => {
-      if (this.props.relay && this.props.relay.environment) {
-        commitMutation<RejectOfferMutation>(this.props.relay.environment, {
-          mutation: graphql`
-            mutation RejectOfferMutation($input: buyerRejectOfferInput!) {
-              ecommerceBuyerRejectOffer(input: $input) {
-                orderOrError {
-                  ... on OrderWithMutationSuccess {
-                    __typename
-                    order {
-                      id
-                      ... on OfferOrder {
-                        awaitingResponseFrom
-                      }
-                    }
-                  }
-                  ... on OrderWithMutationFailure {
-                    error {
-                      type
-                      code
-                      data
-                    }
+export class Reject extends Component<RejectProps> {
+  rejectOffer(variables: RejectOfferMutation["variables"]) {
+    return this.props.commitMutation<RejectOfferMutation>({
+      variables,
+      mutation: graphql`
+        mutation RejectOfferMutation($input: buyerRejectOfferInput!) {
+          ecommerceBuyerRejectOffer(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                __typename
+                order {
+                  id
+                  ... on OfferOrder {
+                    awaitingResponseFrom
                   }
                 }
               }
+              ... on OrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
+                }
+              }
             }
-          `,
-          variables: {
-            input: {
-              offerId: this.props.order.lastOffer.id,
-            },
-          },
-          onCompleted: data => {
-            this.setState({ isCommittingMutation: false })
-            const {
-              ecommerceBuyerRejectOffer: { orderOrError },
-            } = data
-
-            if (orderOrError.error) {
-              this.onMutationError(
-                new ErrorWithMetadata(
-                  orderOrError.error.code,
-                  orderOrError.error
-                )
-              )
-            } else {
-              this.props.router.push(`/orders/${this.props.order.id}/status`)
-            }
-          },
-          onError: this.onMutationError.bind(this),
-        })
-      }
+          }
+        }
+      `,
     })
   }
 
-  onMutationError(error, title?, message?) {
-    logger.error(error)
-    this.props.dialog.showErrorDialog({ title, message })
-    this.setState({
-      isCommittingMutation: false,
-    })
+  onSubmit = async () => {
+    try {
+      const {
+        ecommerceBuyerRejectOffer: { orderOrError },
+      } = await this.rejectOffer({
+        input: {
+          offerId: this.props.order.lastOffer.id,
+        },
+      })
+
+      if (orderOrError.error) {
+        this.props.dialog.showErrorDialog()
+        return
+      }
+
+      this.props.router.push(`/orders/${this.props.order.id}/status`)
+    } catch (error) {
+      logger.error(error)
+      this.props.dialog.showErrorDialog()
+    }
   }
 
   onChangeResponse = () => {
@@ -114,8 +94,7 @@ export class Reject extends Component<RejectProps, RejectState> {
   }
 
   render() {
-    const { order } = this.props
-    const { isCommittingMutation } = this.state
+    const { order, isCommittingMutation } = this.props
 
     return (
       <>
@@ -207,7 +186,7 @@ export class Reject extends Component<RejectProps, RejectState> {
 }
 
 export const RejectFragmentContainer = createFragmentContainer(
-  trackPageViewWrapper(injectDialog(Reject)),
+  trackPageViewWrapper(injectCommitMutation(injectDialog(Reject))),
   graphql`
     fragment Reject_order on Order {
       id

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -19,19 +19,17 @@ import { RevealButton } from "Apps/Order/Components/RevealButton"
 import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "Apps/Order/Components/TransactionDetailsSummaryItem"
 import { TwoColumnLayout } from "Apps/Order/Components/TwoColumnLayout"
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
+import {
+  CommitMutation,
+  injectCommitMutation,
+} from "Apps/Order/Utils/commitMutation"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
 import { track } from "Artsy"
 import * as Schema from "Artsy/Analytics/Schema"
 import { CountdownTimer } from "Components/v2/CountdownTimer"
 import { Router } from "found"
 import React, { Component } from "react"
-import {
-  commitMutation,
-  createFragmentContainer,
-  graphql,
-  RelayProp,
-} from "react-relay"
-import { ErrorWithMetadata } from "Utils/errors"
+import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "../../Components/ArtworkSummaryItem"
@@ -48,6 +46,8 @@ export interface RespondProps {
   relay?: RelayProp
   router: Router
   dialog: Dialog
+  commitMutation: CommitMutation
+  isCommittingMutation: boolean
 }
 
 export interface RespondState {
@@ -55,7 +55,6 @@ export interface RespondState {
   offerNoteValue: TextAreaChange
   formIsDirty: boolean
   responseOption: "ACCEPT" | "COUNTER" | "DECLINE"
-  isCommittingMutation: boolean
   lowSpeedBumpEncountered: boolean
   highSpeedBumpEncountered: boolean
 }
@@ -68,7 +67,6 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
     offerValue: 0,
     offerNoteValue: { value: "", exceedsCharacterLimit: false },
     responseOption: null,
-    isCommittingMutation: false,
     formIsDirty: false,
     lowSpeedBumpEncountered: false,
     highSpeedBumpEncountered: false,
@@ -121,119 +119,92 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
       highSpeedBumpEncountered,
     } = this.state
 
-    if (responseOption === "COUNTER") {
-      if (offerValue <= 0 || offerNoteValue.exceedsCharacterLimit) {
-        this.setState({ formIsDirty: true })
-        return
-      }
-      const currentOfferPrice = this.props.order.itemsTotalCents
-
-      if (
-        !lowSpeedBumpEncountered &&
-        offerValue * 100 < currentOfferPrice * 0.75
-      ) {
-        this.showLowSpeedbump()
-        return
-      }
-
-      if (
-        !highSpeedBumpEncountered &&
-        this.state.offerValue * 100 > currentOfferPrice
-      ) {
-        this.showHighSpeedbump()
-        return
-      }
+    if (responseOption === "ACCEPT") {
+      this.props.router.push(`/orders/${this.props.order.id}/review/accept`)
+      return
     }
 
-    this.setState({ isCommittingMutation: true }, () => {
-      switch (responseOption) {
-        case "COUNTER":
-          this.createCounterOffer(this.state.offerValue)
-            .then(() => {
-              this.props.router.push(
-                `/orders/${this.props.order.id}/review/counter`
-              )
-            })
-            .catch(this.onMutationError)
-          break
-        case "ACCEPT":
-          this.props.router.push(`/orders/${this.props.order.id}/review/accept`)
-          break
-        case "DECLINE":
-          this.props.router.push(
-            `/orders/${this.props.order.id}/review/decline`
-          )
-          break
+    if (responseOption === "DECLINE") {
+      this.props.router.push(`/orders/${this.props.order.id}/review/decline`)
+      return
+    }
+
+    // responseOption === "COUNTER"
+
+    if (offerValue <= 0 || offerNoteValue.exceedsCharacterLimit) {
+      this.setState({ formIsDirty: true })
+      return
+    }
+    const currentOfferPrice = this.props.order.itemsTotalCents
+
+    if (
+      !lowSpeedBumpEncountered &&
+      offerValue * 100 < currentOfferPrice * 0.75
+    ) {
+      this.showLowSpeedbump()
+      return
+    }
+
+    if (
+      !highSpeedBumpEncountered &&
+      this.state.offerValue * 100 > currentOfferPrice
+    ) {
+      this.showHighSpeedbump()
+      return
+    }
+
+    try {
+      const {
+        ecommerceBuyerCounterOffer: { orderOrError },
+      } = await this.createCounterOffer({
+        input: {
+          offerId: this.props.order.lastOffer.id,
+          offerPrice: {
+            amount: this.state.offerValue,
+            currencyCode: "USD",
+          },
+          note: this.state.offerNoteValue && this.state.offerNoteValue.value,
+        },
+      })
+      if (orderOrError.error) {
+        this.props.dialog.showErrorDialog()
+        return
       }
-    })
+      this.props.router.push(`/orders/${this.props.order.id}/review/counter`)
+    } catch (error) {
+      logger.error(error)
+      this.props.dialog.showErrorDialog()
+    }
   }
 
-  createCounterOffer(price: number) {
-    return new Promise((resolve, reject) =>
-      commitMutation<RespondCounterOfferMutation>(
-        this.props.relay.environment,
-        {
-          mutation: graphql`
-            mutation RespondCounterOfferMutation(
-              $input: buyerCounterOfferInput!
-            ) {
-              ecommerceBuyerCounterOffer(input: $input) {
-                orderOrError {
-                  ... on OrderWithMutationSuccess {
-                    order {
-                      ...Respond_order
-                    }
-                  }
-                  ... on OrderWithMutationFailure {
-                    error {
-                      type
-                      code
-                      data
-                    }
-                  }
+  createCounterOffer(variables: RespondCounterOfferMutation["variables"]) {
+    return this.props.commitMutation<RespondCounterOfferMutation>({
+      variables,
+      mutation: graphql`
+        mutation RespondCounterOfferMutation($input: buyerCounterOfferInput!) {
+          ecommerceBuyerCounterOffer(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                order {
+                  ...Respond_order
+                }
+              }
+              ... on OrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
                 }
               }
             }
-          `,
-          variables: {
-            input: {
-              offerId: this.props.order.lastOffer.id,
-              offerPrice: {
-                amount: price,
-                currencyCode: "USD",
-              },
-              note:
-                this.state.offerNoteValue && this.state.offerNoteValue.value,
-            },
-          },
-          onCompleted: result => {
-            const orderOrError = result.ecommerceBuyerCounterOffer.orderOrError
-            if (orderOrError.error) {
-              reject(
-                new ErrorWithMetadata(
-                  orderOrError.error.code,
-                  orderOrError.error
-                )
-              )
-            } else {
-              resolve(orderOrError.order)
-            }
-          },
-          onError: reject,
+          }
         }
-      )
-    )
-  }
-
-  onMutationError = (errors, title?, message?) => {
-    logger.error(errors)
-    this.props.dialog.showErrorDialog({ title, message })
-    this.setState({ isCommittingMutation: false })
+      `,
+    })
   }
 
   render() {
-    const { order } = this.props
-    const { isCommittingMutation } = this.state
+    const { order, isCommittingMutation } = this.props
 
     const artworkId = order.lineItems.edges[0].node.artwork.id
 
@@ -369,7 +340,7 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
 }
 
 export const RespondFragmentContainer = createFragmentContainer(
-  injectDialog(trackPageViewWrapper(RespondRoute)),
+  injectCommitMutation(injectDialog(trackPageViewWrapper(RespondRoute))),
   graphql`
     fragment Respond_order on Order {
       id

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -154,9 +154,7 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
     }
 
     try {
-      const {
-        ecommerceBuyerCounterOffer: { orderOrError },
-      } = await this.createCounterOffer({
+      const orderOrError = (await this.createCounterOffer({
         input: {
           offerId: this.props.order.lastOffer.id,
           offerPrice: {
@@ -165,11 +163,12 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
           },
           note: this.state.offerNoteValue && this.state.offerNoteValue.value,
         },
-      })
+      })).ecommerceBuyerCounterOffer.orderOrError
+
       if (orderOrError.error) {
-        this.props.dialog.showErrorDialog()
-        return
+        throw orderOrError.error
       }
+
       this.props.router.push(`/orders/${this.props.order.id}/review/counter`)
     } catch (error) {
       logger.error(error)

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -129,6 +129,7 @@ export class ReviewRoute extends Component<ReviewProps> {
   }
 
   async handleSubmitError(error: { code: string; data: string }) {
+    logger.error(error)
     switch (error.code) {
       case "missing_required_info": {
         this.props.dialog.showErrorDialog({

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -53,17 +53,23 @@ export class ReviewRoute extends Component<ReviewProps> {
     order_id: props.order.id,
   }))
   async onSubmit() {
-    const orderOrError =
-      this.props.order.mode === "BUY"
-        ? (await this.submitBuyOrder()).ecommerceSubmitOrder.orderOrError
-        : (await this.submitOffer()).ecommerceSubmitOrderWithOffer.orderOrError
+    try {
+      const orderOrError =
+        this.props.order.mode === "BUY"
+          ? (await this.submitBuyOrder()).ecommerceSubmitOrder.orderOrError
+          : (await this.submitOffer()).ecommerceSubmitOrderWithOffer
+              .orderOrError
 
-    if (orderOrError.error) {
-      this.handleSubmitError(orderOrError.error)
-      return
+      if (orderOrError.error) {
+        this.handleSubmitError(orderOrError.error)
+        return
+      }
+
+      this.props.router.push(`/orders/${this.props.order.id}/status`)
+    } catch (error) {
+      logger.error(error)
+      this.props.dialog.showErrorDialog()
     }
-
-    this.props.router.push(`/orders/${this.props.order.id}/status`)
   }
 
   submitBuyOrder() {

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -14,18 +14,16 @@ import {
 import { ShippingSummaryItemFragmentContainer as ShippingSummaryItem } from "Apps/Order/Components/ShippingSummaryItem"
 import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "Apps/Order/Components/TransactionDetailsSummaryItem"
 import { Dialog, injectDialog } from "Apps/Order/Dialogs"
+import {
+  CommitMutation,
+  injectCommitMutation,
+} from "Apps/Order/Utils/commitMutation"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { RouteConfig, Router } from "found"
 import React, { Component } from "react"
-import {
-  commitMutation,
-  createFragmentContainer,
-  graphql,
-  RelayProp,
-} from "react-relay"
-import { ErrorWithMetadata } from "Utils/errors"
+import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
@@ -39,25 +37,14 @@ export interface ReviewProps {
   router: Router
   route: RouteConfig
   dialog: Dialog
-}
-
-interface ReviewState {
-  isSubmitting: boolean
+  commitMutation: CommitMutation
+  isCommittingMutation: boolean
 }
 
 const logger = createLogger("Order/Routes/Review/index.tsx")
 
 @track()
-export class ReviewRoute extends Component<ReviewProps, ReviewState> {
-  state: ReviewState = {
-    isSubmitting: false,
-  }
-
-  constructor(props) {
-    super(props)
-    this.onSuccessfulSubmit = this.onSuccessfulSubmit.bind(this)
-  }
-
+export class ReviewRoute extends Component<ReviewProps> {
   @track<ReviewProps>(props => ({
     action_type:
       props.order.mode === "BUY"
@@ -65,153 +52,125 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
         : Schema.ActionType.SubmittedOffer,
     order_id: props.order.id,
   }))
-  onSuccessfulSubmit() {
+  async onSubmit() {
+    const orderOrError =
+      this.props.order.mode === "BUY"
+        ? (await this.submitBuyOrder()).ecommerceSubmitOrder.orderOrError
+        : (await this.submitOffer()).ecommerceSubmitOrderWithOffer.orderOrError
+
+    if (orderOrError.error) {
+      this.handleSubmitError(orderOrError.error)
+      return
+    }
+
     this.props.router.push(`/orders/${this.props.order.id}/status`)
   }
 
-  onSubmit() {
-    this.props.order.mode === "BUY"
-      ? this.onOrderSubmitted()
-      : this.onOfferOrderSubmitted()
-  }
-
-  onOrderSubmitted() {
-    if (this.props.relay && this.props.relay.environment) {
-      this.setState({ isSubmitting: true }, () =>
-        commitMutation<ReviewSubmitOrderMutation>(
-          this.props.relay.environment,
-          {
-            mutation: graphql`
-              mutation ReviewSubmitOrderMutation($input: SubmitOrderInput!) {
-                ecommerceSubmitOrder(input: $input) {
-                  orderOrError {
-                    ... on OrderWithMutationSuccess {
-                      order {
-                        state
-                      }
-                    }
-                    ... on OrderWithMutationFailure {
-                      error {
-                        type
-                        code
-                        data
-                      }
-                    }
-                  }
+  submitBuyOrder() {
+    return this.props.commitMutation<ReviewSubmitOrderMutation>({
+      variables: {
+        input: {
+          orderId: this.props.order.id,
+        },
+      },
+      mutation: graphql`
+        mutation ReviewSubmitOrderMutation($input: SubmitOrderInput!) {
+          ecommerceSubmitOrder(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                order {
+                  state
                 }
               }
-            `,
-            variables: {
-              input: {
-                orderId: this.props.order.id,
-              },
-            },
-            onCompleted: result => {
-              const {
-                ecommerceSubmitOrder: { orderOrError },
-              } = result
-              this.onSubmitCompleted(orderOrError)
-            },
-            onError: this.onMutationError.bind(this),
-          }
-        )
-      )
-    }
-  }
-
-  onOfferOrderSubmitted() {
-    if (this.props.relay && this.props.relay.environment) {
-      this.setState({ isSubmitting: true }, () =>
-        commitMutation<ReviewSubmitOfferOrderMutation>(
-          this.props.relay.environment,
-          {
-            mutation: graphql`
-              mutation ReviewSubmitOfferOrderMutation(
-                $input: SubmitOrderWithOfferInput!
-              ) {
-                ecommerceSubmitOrderWithOffer(input: $input) {
-                  orderOrError {
-                    ... on OrderWithMutationSuccess {
-                      order {
-                        state
-                      }
-                    }
-                    ... on OrderWithMutationFailure {
-                      error {
-                        type
-                        code
-                        data
-                      }
-                    }
-                  }
+              ... on OrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
                 }
               }
-            `,
-            variables: {
-              input: {
-                offerId: this.props.order.myLastOffer.id,
-              },
-            },
-            onCompleted: result => {
-              const {
-                ecommerceSubmitOrderWithOffer: { orderOrError },
-              } = result
-              this.onSubmitCompleted(orderOrError)
-            },
-            onError: this.onMutationError.bind(this),
+            }
           }
-        )
-      )
-    }
+        }
+      `,
+    })
   }
 
-  onSubmitCompleted = orderOrError => {
-    const error = orderOrError.error
-    if (error) {
-      switch (error.code) {
-        case "missing_required_info": {
-          this.onMutationError(
-            new ErrorWithMetadata(error.code, error),
-            "Missing information",
-            "Please review and update your shipping and/or payment details and try again."
-          )
-          break
+  submitOffer() {
+    return this.props.commitMutation<ReviewSubmitOfferOrderMutation>({
+      variables: {
+        input: {
+          offerId: this.props.order.myLastOffer.id,
+        },
+      },
+      mutation: graphql`
+        mutation ReviewSubmitOfferOrderMutation(
+          $input: SubmitOrderWithOfferInput!
+        ) {
+          ecommerceSubmitOrderWithOffer(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                order {
+                  state
+                }
+              }
+              ... on OrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
+                }
+              }
+            }
+          }
         }
-        case "insufficient_inventory": {
-          const artistId = this.artistId()
-          this.onMutationError(
-            new ErrorWithMetadata(error.code, error),
-            "Not available",
-            "Sorry, the work is no longer available.",
-            artistId ? this.routeToArtistPage.bind(this) : null
-          )
-          break
-        }
-        case "failed_charge_authorize": {
-          const parsedData = JSON.parse(error.data)
-          this.onMutationError(
-            new ErrorWithMetadata(error.code, error),
-            "An error occurred",
-            parsedData.failure_message
-          )
-          break
-        }
-        case "artwork_version_mismatch": {
-          this.onMutationError(
-            new ErrorWithMetadata(error.code, error),
-            "Work has been updated",
-            "Something about the work changed since you started checkout. Please review the work before submitting your order.",
-            this.routeToArtworkPage.bind(this)
-          )
-          break
-        }
-        default: {
-          this.onMutationError(new ErrorWithMetadata(error.code, error))
-          break
-        }
+      `,
+    })
+  }
+
+  async handleSubmitError(error: { code: string; data: string }) {
+    switch (error.code) {
+      case "missing_required_info": {
+        this.props.dialog.showErrorDialog({
+          title: "Missing information",
+          message:
+            "Please review and update your shipping and/or payment details and try again.",
+        })
+        break
       }
-    } else {
-      this.onSuccessfulSubmit()
+      case "insufficient_inventory": {
+        await this.props.dialog.showErrorDialog({
+          title: "Not available",
+          message: "Sorry, the work is no longer available.",
+        })
+        const artistId = this.artistId()
+        if (artistId) {
+          this.routeToArtistPage()
+        }
+        break
+      }
+      case "failed_charge_authorize": {
+        const parsedData = JSON.parse(error.data)
+        this.props.dialog.showErrorDialog({
+          title: "An error occurred",
+          message: parsedData.failure_message,
+        })
+        break
+      }
+      case "artwork_version_mismatch": {
+        await this.props.dialog.showErrorDialog({
+          title: "Work has been updated",
+          message:
+            "Something about the work changed since you started checkout. Please review the work before submitting your order.",
+        })
+        this.routeToArtworkPage()
+        break
+      }
+      default: {
+        logger.error(error)
+        this.props.dialog.showErrorDialog()
+        break
+      }
     }
   }
 
@@ -240,17 +199,6 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
     window.location.assign(`/artist/${artistId}`)
   }
 
-  onMutationError(error, title?, message?, onContinue?) {
-    logger.error(error)
-    this.props.dialog
-      .showErrorDialog({ message, title })
-      // tslint:disable-next-line:no-empty
-      .then(onContinue || (() => {}))
-    this.setState({
-      isSubmitting: false,
-    })
-  }
-
   onChangeOffer = () => {
     this.props.router.push(`/orders/${this.props.order.id}/offer`)
   }
@@ -264,8 +212,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
   }
 
   render() {
-    const { order } = this.props
-    const { isSubmitting } = this.state
+    const { order, isCommittingMutation } = this.props
 
     return (
       <>
@@ -312,7 +259,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                     <Button
                       size="large"
                       width="100%"
-                      loading={isSubmitting}
+                      loading={isCommittingMutation}
                       onClick={() => this.onSubmit()}
                     >
                       Submit
@@ -334,7 +281,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
                   <Button
                     size="large"
                     width="100%"
-                    loading={isSubmitting}
+                    loading={isCommittingMutation}
                     onClick={() => this.onSubmit()}
                   >
                     Submit
@@ -352,7 +299,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
 }
 
 export const ReviewFragmentContainer = createFragmentContainer(
-  trackPageViewWrapper(injectDialog(ReviewRoute)),
+  trackPageViewWrapper(injectCommitMutation(injectDialog(ReviewRoute))),
   graphql`
     fragment Review_order on Order {
       id

--- a/src/Apps/Order/Utils/__tests__/commitMutation.test.tsx
+++ b/src/Apps/Order/Utils/__tests__/commitMutation.test.tsx
@@ -1,0 +1,113 @@
+import { commitMutationTest1Mutation } from "__generated__/commitMutationTest1Mutation.graphql"
+import { settingOrderPaymentFailed } from "Apps/Order/Routes/__fixtures__/MutationResults"
+import { ContextProvider } from "Artsy"
+import { createMockNetworkLayer2 } from "DevTools"
+import { mount } from "enzyme"
+import React from "react"
+import { graphql } from "react-relay"
+import { Environment, RecordSource, Store } from "relay-runtime"
+import { flushPromiseQueue } from "Utils/flushPromiseQueue"
+import { CommitMutation, injectCommitMutation } from "../commitMutation"
+
+describe(injectCommitMutation, () => {
+  const network = createMockNetworkLayer2({
+    mockMutationResults: {
+      ...settingOrderPaymentFailed,
+    },
+  })
+  const source = new RecordSource()
+  const store = new Store(source)
+  const relayEnvironment = new Environment({
+    network,
+    store,
+  })
+
+  const Provider: React.FC = props => (
+    <ContextProvider relayEnvironment={relayEnvironment}>
+      {props.children}
+    </ContextProvider>
+  )
+
+  it("injects two props", () => {
+    const Injected = injectCommitMutation(props => {
+      expect(props.isCommittingMutation).toBe(false)
+      expect(typeof props.commitMutation).toBe("function")
+      return <div />
+    })
+
+    mount(
+      <Provider>
+        <Injected />
+      </Provider>
+    )
+
+    expect.assertions(2)
+  })
+
+  it("lets you commit a mutation", async () => {
+    const resultFn = jest.fn()
+    const Injected = injectCommitMutation(
+      (props: {
+        isCommittingMutation: boolean
+        commitMutation: CommitMutation
+        word: string
+      }) => {
+        return (
+          <div
+            className={
+              props.isCommittingMutation ? "isCommittingMutation" : "nothing"
+            }
+            onClick={() => {
+              props
+                .commitMutation<commitMutationTest1Mutation>({
+                  variables: {
+                    input: {
+                      creditCardId: "card",
+                      orderId: "order",
+                    },
+                  },
+                  mutation: graphql`
+                    mutation commitMutationTest1Mutation(
+                      $input: SetOrderPaymentInput!
+                    ) {
+                      ecommerceSetOrderPayment(input: $input) {
+                        orderOrError {
+                          ... on OrderWithMutationFailure {
+                            error {
+                              code
+                            }
+                          }
+                        }
+                      }
+                    }
+                  `,
+                })
+                .then(resultFn)
+            }}
+          >
+            {props.word}
+          </div>
+        )
+      }
+    )
+
+    const wrapper = mount(
+      <Provider>
+        <Injected word="hello" />
+      </Provider>
+    )
+    expect(wrapper.text()).toBe("hello")
+    expect(wrapper.find("div").props().className).toBe("nothing")
+    wrapper.find("div").simulate("click")
+    expect(wrapper.find("div").props().className).toBe("isCommittingMutation")
+    expect(resultFn).not.toHaveBeenCalled()
+    await flushPromiseQueue()
+    wrapper.update()
+    expect(wrapper.find("div").props().className).toBe("nothing")
+    expect(resultFn).toHaveBeenCalledWith({
+      ecommerceSetOrderPayment: {
+        orderOrError: { error: { code: "invalid_state" } },
+      },
+    })
+  })
+})

--- a/src/Apps/Order/Utils/commitMutation.tsx
+++ b/src/Apps/Order/Utils/commitMutation.tsx
@@ -1,11 +1,11 @@
-import { SystemContext } from "Artsy"
+import { ContextConsumer } from "Artsy"
 import { GraphQLError } from "graphql"
-import React, { useCallback, useContext, useRef, useState } from "react"
+import React from "react"
 import {
   commitMutation as relayCommitMutation,
   GraphQLTaggedNode,
 } from "react-relay"
-import { OperationBase } from "relay-runtime"
+import { Environment, OperationBase } from "relay-runtime"
 
 export type CommitMutation = <MutationType extends OperationBase>(
   args: {
@@ -26,49 +26,57 @@ const MutationContext = React.createContext<CommitMutationProps>({
   },
 })
 
-export const ProvideMutationContext: React.FC = ({ children }) => {
-  const [isCommittingMutation, setIsComittingMutation] = useState(false)
-  const { relayEnvironment } = useContext(SystemContext)
-  const lastMutationPromise = useRef(Promise.resolve())
-
-  const commitMutation: CommitMutation = useCallback(
-    ({ variables, mutation }) =>
-      new Promise((resolve, reject) => {
-        // wait for last mutation to finish
-        const mutationPromise = lastMutationPromise.current
-          .catch(() => {
-            return
-          })
-          .then(() => {
-            lastMutationPromise.current = mutationPromise
-            setIsComittingMutation(true)
-            relayCommitMutation(relayEnvironment, {
-              // tslint:disable-next-line:relay-operation-generics
-              mutation,
-              variables,
-              onCompleted: (data, errors) => {
-                setIsComittingMutation(false)
-                if (errors) {
-                  reject(new GraphQLError(errors.join("\n")))
-                  return
-                }
-                resolve(data)
-              },
-              onError: e => {
-                setIsComittingMutation(false)
-                reject(e)
-              },
+class ProvideMutationContext extends React.Component<
+  { relayEnvironment: Environment },
+  { isCommittingMutation: boolean }
+> {
+  execQueue: Array<() => Promise<any>> = []
+  state = { isCommittingMutation: false }
+  commitMutation: CommitMutation = ({ variables, mutation }) => {
+    if (this.state.isCommittingMutation) {
+      throw new Error(
+        "Mutliple simulataneous mutations is not currently supported"
+      )
+    }
+    this.setState({ isCommittingMutation: true })
+    return new Promise((resolve, reject) => {
+      try {
+        relayCommitMutation(this.props.relayEnvironment, {
+          mutation,
+          variables,
+          onCompleted: (data, errors) => {
+            this.setState({ isCommittingMutation: false }, () => {
+              if (errors) {
+                reject(new GraphQLError(errors.join("\n")))
+                return
+              }
+              resolve(data)
             })
-          })
-      }),
-    [lastMutationPromise, setIsComittingMutation]
-  )
+          },
+          onError: e => {
+            this.setState({ isCommittingMutation: false }, () => {
+              reject(e)
+            })
+          },
+        })
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
 
-  return (
-    <MutationContext.Provider value={{ commitMutation, isCommittingMutation }}>
-      {children}
-    </MutationContext.Provider>
-  )
+  render() {
+    return (
+      <MutationContext.Provider
+        value={{
+          commitMutation: this.commitMutation,
+          isCommittingMutation: this.state.isCommittingMutation,
+        }}
+      >
+        {this.props.children}
+      </MutationContext.Provider>
+    )
+  }
 }
 
 export function injectCommitMutation<Props extends CommitMutationProps>(
@@ -76,12 +84,23 @@ export function injectCommitMutation<Props extends CommitMutationProps>(
 ): React.ComponentType<
   Pick<Props, Exclude<keyof Props, keyof CommitMutationProps>>
 > {
-  const { isCommittingMutation, commitMutation } = useContext(MutationContext)
-  return props => (
-    <Component
-      isCommittingMutation={isCommittingMutation}
-      commitMutation={commitMutation}
-      {...props}
-    />
-  )
+  return props => {
+    return (
+      <ContextConsumer>
+        {({ relayEnvironment }) => (
+          <ProvideMutationContext relayEnvironment={relayEnvironment}>
+            <MutationContext.Consumer>
+              {({ isCommittingMutation, commitMutation }) => (
+                <Component
+                  isCommittingMutation={isCommittingMutation}
+                  commitMutation={commitMutation}
+                  {...props}
+                />
+              )}
+            </MutationContext.Consumer>
+          </ProvideMutationContext>
+        )}
+      </ContextConsumer>
+    )
+  }
 }

--- a/src/Apps/Order/Utils/commitMutation.tsx
+++ b/src/Apps/Order/Utils/commitMutation.tsx
@@ -1,0 +1,87 @@
+import { SystemContext } from "Artsy"
+import { GraphQLError } from "graphql"
+import React, { useCallback, useContext, useRef, useState } from "react"
+import {
+  commitMutation as relayCommitMutation,
+  GraphQLTaggedNode,
+} from "react-relay"
+import { OperationBase } from "relay-runtime"
+
+export type CommitMutation = <MutationType extends OperationBase>(
+  args: {
+    mutation: GraphQLTaggedNode
+    variables: MutationType["variables"]
+  }
+) => Promise<MutationType["response"]>
+
+interface CommitMutationProps {
+  commitMutation: CommitMutation
+  isCommittingMutation: boolean
+}
+
+const MutationContext = React.createContext<CommitMutationProps>({
+  isCommittingMutation: false,
+  commitMutation() {
+    throw new Error("no mutation context in react tree")
+  },
+})
+
+export const ProvideMutationContext: React.FC = ({ children }) => {
+  const [isCommittingMutation, setIsComittingMutation] = useState(false)
+  const { relayEnvironment } = useContext(SystemContext)
+  const lastMutationPromise = useRef(Promise.resolve())
+
+  const commitMutation: CommitMutation = useCallback(
+    ({ variables, mutation }) =>
+      new Promise((resolve, reject) => {
+        // wait for last mutation to finish
+        const mutationPromise = lastMutationPromise.current
+          .catch(() => {
+            return
+          })
+          .then(() => {
+            lastMutationPromise.current = mutationPromise
+            setIsComittingMutation(true)
+            relayCommitMutation(relayEnvironment, {
+              // tslint:disable-next-line:relay-operation-generics
+              mutation,
+              variables,
+              onCompleted: (data, errors) => {
+                setIsComittingMutation(false)
+                if (errors) {
+                  reject(new GraphQLError(errors.join("\n")))
+                  return
+                }
+                resolve(data)
+              },
+              onError: e => {
+                setIsComittingMutation(false)
+                reject(e)
+              },
+            })
+          })
+      }),
+    [lastMutationPromise, setIsComittingMutation]
+  )
+
+  return (
+    <MutationContext.Provider value={{ commitMutation, isCommittingMutation }}>
+      {children}
+    </MutationContext.Provider>
+  )
+}
+
+export function injectCommitMutation<Props extends CommitMutationProps>(
+  Component: React.ComponentType<Props>
+): React.ComponentType<
+  Pick<Props, Exclude<keyof Props, keyof CommitMutationProps>>
+> {
+  const { isCommittingMutation, commitMutation } = useContext(MutationContext)
+  return props => (
+    <Component
+      isCommittingMutation={isCommittingMutation}
+      commitMutation={commitMutation}
+      {...props}
+    />
+  )
+}

--- a/src/Apps/Order/Utils/commitMutation.tsx
+++ b/src/Apps/Order/Utils/commitMutation.tsx
@@ -1,6 +1,6 @@
-import { ContextConsumer } from "Artsy"
+import { SystemContext } from "Artsy"
 import { GraphQLError } from "graphql"
-import React from "react"
+import React, { useContext } from "react"
 import {
   commitMutation as relayCommitMutation,
   GraphQLTaggedNode,
@@ -86,22 +86,19 @@ export function injectCommitMutation<Props extends CommitMutationProps>(
   Pick<Props, Exclude<keyof Props, keyof CommitMutationProps>>
 > {
   return props => {
+    const { relayEnvironment } = useContext(SystemContext)
     return (
-      <ContextConsumer>
-        {({ relayEnvironment }) => (
-          <ProvideMutationContext relayEnvironment={relayEnvironment}>
-            <MutationContext.Consumer>
-              {({ isCommittingMutation, commitMutation }) => (
-                <Component
-                  isCommittingMutation={isCommittingMutation}
-                  commitMutation={commitMutation}
-                  {...props}
-                />
-              )}
-            </MutationContext.Consumer>
-          </ProvideMutationContext>
-        )}
-      </ContextConsumer>
+      <ProvideMutationContext relayEnvironment={relayEnvironment}>
+        <MutationContext.Consumer>
+          {({ isCommittingMutation, commitMutation }) => (
+            <Component
+              isCommittingMutation={isCommittingMutation}
+              commitMutation={commitMutation}
+              {...props}
+            />
+          )}
+        </MutationContext.Consumer>
+      </ProvideMutationContext>
     )
   }
 }

--- a/src/Apps/Order/Utils/commitMutation.tsx
+++ b/src/Apps/Order/Utils/commitMutation.tsx
@@ -6,6 +6,7 @@ import {
   GraphQLTaggedNode,
 } from "react-relay"
 import { Environment, OperationBase } from "relay-runtime"
+jest.unmock("react-relay")
 
 export type CommitMutation = <MutationType extends OperationBase>(
   args: {

--- a/src/DevTools/createTestEnv.tsx
+++ b/src/DevTools/createTestEnv.tsx
@@ -1,4 +1,5 @@
 import { ConnectedModalDialog } from "Apps/Order/Dialogs"
+import { SystemContext } from "Artsy"
 import { createMockFetchQuery, MockBoot, renderRelayTree } from "DevTools"
 import React, { ReactElement } from "react"
 import { GraphQLTaggedNode } from "react-relay"
@@ -154,17 +155,24 @@ class TestEnv<MutationNames extends string, TestPage extends RootTestPage> {
     // @ts-ignore
     page.root = await renderRelayTree({
       Component: (props: any) => (
-        <MockBoot
-          breakpoint={breakpoint || defaultBreakpoint}
-          headTags={this.headTags}
-        >
-          <Component
-            {...props}
-            router={{ push: this.routes.mockPushRoute }}
-            route={{ onTransition: this.routes.mockOnTransition }}
-          />
-          <ConnectedModalDialog />
-        </MockBoot>
+        <SystemContext.Consumer>
+          {context => (
+            // bypass MockBoot's SystemContext provider
+            <MockBoot
+              breakpoint={breakpoint || defaultBreakpoint}
+              headTags={this.headTags}
+            >
+              <SystemContext.Provider value={context}>
+                <Component
+                  {...props}
+                  router={{ push: this.routes.mockPushRoute }}
+                  route={{ onTransition: this.routes.mockOnTransition }}
+                />
+                <ConnectedModalDialog />
+              </SystemContext.Provider>
+            </MockBoot>
+          )}
+        </SystemContext.Consumer>
       ),
       query,
       mockNetwork,
@@ -180,7 +188,7 @@ class TestEnv<MutationNames extends string, TestPage extends RootTestPage> {
  * Creates a testing environment for a relay-powered component. The environment
  * has useful tooling for dealing with relay data. Especially for mocking mutation
  * results and for abstracting away boilerplate.
- * 
+ *
 
  * @param opts.Component the component to render. Will be passed props
   `relay: RelayProp`, a mock for `route: { onTransition(cb): void {} }` and a

--- a/src/__generated__/commitMutationTest1Mutation.graphql.ts
+++ b/src/__generated__/commitMutationTest1Mutation.graphql.ts
@@ -1,0 +1,165 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type SetOrderPaymentInput = {
+    readonly orderId: string;
+    readonly creditCardId: string;
+    readonly clientMutationId?: string | null;
+};
+export type commitMutationTest1MutationVariables = {
+    readonly input: SetOrderPaymentInput;
+};
+export type commitMutationTest1MutationResponse = {
+    readonly ecommerceSetOrderPayment: ({
+        readonly orderOrError: ({
+            readonly error?: ({
+                readonly code: string;
+            }) | null;
+        }) | null;
+    }) | null;
+};
+export type commitMutationTest1Mutation = {
+    readonly response: commitMutationTest1MutationResponse;
+    readonly variables: commitMutationTest1MutationVariables;
+};
+
+
+
+/*
+mutation commitMutationTest1Mutation(
+  $input: SetOrderPaymentInput!
+) {
+  ecommerceSetOrderPayment(input: $input) {
+    orderOrError {
+      __typename
+      ... on OrderWithMutationFailure {
+        error {
+          code
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "SetOrderPaymentInput!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input",
+    "type": "SetOrderPaymentInput!"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "type": "OrderWithMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "error",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "EcommerceError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "code",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+};
+return {
+  "kind": "Request",
+  "operationKind": "mutation",
+  "name": "commitMutationTest1Mutation",
+  "id": null,
+  "text": "mutation commitMutationTest1Mutation(\n  $input: SetOrderPaymentInput!\n) {\n  ecommerceSetOrderPayment(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationFailure {\n        error {\n          code\n        }\n      }\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "commitMutationTest1Mutation",
+    "type": "Mutation",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "ecommerceSetOrderPayment",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SetOrderPaymentPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "orderOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v2
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "commitMutationTest1Mutation",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "ecommerceSetOrderPayment",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SetOrderPaymentPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "orderOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "__typename",
+                "args": null,
+                "storageKey": null
+              },
+              v2
+            ]
+          }
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '185f6aacd76ffb48524e52100e0988d0';
+export default node;


### PR DESCRIPTION
Problems and solutions:

- We had some gnarly spaghetti logic because we were using the raw version of `commitMutation` which is built on callbacks, and things evolved organically over several months. I created a promise-based wrapper for `commitMutation` and did as much as I could to linearize the logic around invoking mutations and handling their results.
- Every page in the order app (except the status page) independently managed the state of whether or not a mutation is being committed. This state is used to show loading spinners and so forth. Here I abstracted that state management out into context land and made the `isCommittingMutation` state an injected prop.

This order app code was all quite well-tested and made it easy to work on this! Huge shout out to @sweir27 for keeping up that level of testing :pray:

I also manually tested all of the user flows in force and everything was looking :+1: 👌 🙆‍♂️ 🏄‍♀️ 