### PR TITLE
[Router] Add queryParam support

### DIFF
--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -7,30 +7,14 @@ import { SearchResultsCollectionsRouteFragmentContainer as SearchResultsCollecti
 import { SearchResultsGalleriesRouteRouteFragmentContainer as SearchResultsGalleriesRoute } from "Apps/Search/Routes/Galleries/SearchResultsGalleries"
 import { SearchResultsShowsRouteRouteFragmentContainer as SearchResultsShowsRoute } from "Apps/Search/Routes/Shows/SearchResultsShows"
 import { RouteConfig } from "found"
-import qs from "qs"
 import React from "react"
 import { graphql } from "react-relay"
 import { Provider } from "unstated"
 import { FilterState } from "./FilterState"
 import { SearchAppFragmentContainer as SearchApp } from "./SearchApp"
 
-// FIXME: The initial render includes `location` in props, but subsequent
-// renders (such as tabbing back to this route in your browser) will not.
 const prepareVariables = (params, props) => {
-  let paramsFromUrl = props.location ? props.location.query : {}
-  if (
-    Object.keys(paramsFromUrl).length === 0 &&
-    Object.keys(params).length === 0
-  ) {
-    paramsFromUrl = qs.parse(location.search.replace(/^\?/, ""))
-
-    // FIXME: This snippet only is valid during storybook development.
-    // Optionally remove this when feature is launched.
-    if (!paramsFromUrl.term && process.env.NODE_ENV === "development") {
-      paramsFromUrl.term = "andy"
-    }
-  }
-
+  const paramsFromUrl = props.location ? props.location.query : {}
   const allParams = {
     ...paramsFromUrl,
     ...params,

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -57,6 +57,6 @@ storiesOf("Apps", module)
   })
   .add("Search Results page", () => {
     return (
-      <MockRouter routes={searchRoutes} initialRoute="/search2?term=andy" />
+      <MockRouter routes={searchRoutes} initialRoute="/search2?term=pablo" />
     )
   })

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -1,18 +1,24 @@
-import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
-import { Boot } from "Artsy/Router/Components/Boot"
-import BrowserProtocol from "farce/lib/BrowserProtocol"
-import HashProtocol from "farce/lib/HashProtocol"
-import MemoryProtocol from "farce/lib/MemoryProtocol"
-import queryMiddleware from "farce/lib/queryMiddleware"
+import React, { ComponentType } from "react"
+
 import { Resolver } from "found-relay"
 import { ScrollManager } from "found-scroll"
 import createInitialFarceRouter from "found/lib/createInitialFarceRouter"
 import createRender from "found/lib/createRender"
-import React, { ComponentType } from "react"
+
+import BrowserProtocol from "farce/lib/BrowserProtocol"
+import createQueryMiddleware from "farce/lib/createQueryMiddleware"
+import HashProtocol from "farce/lib/HashProtocol"
+import MemoryProtocol from "farce/lib/MemoryProtocol"
+import qs from "qs"
+
 import { getUser } from "Utils/getUser"
 import createLogger from "Utils/logger"
-import { RouterConfig } from "./"
 import { createRouteConfig } from "./Utils/createRouteConfig"
+
+import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
+import { Boot } from "Artsy/Router/Components/Boot"
+
+import { RouterConfig } from "./"
 
 interface Resolve {
   ClientApp: ComponentType<any>
@@ -54,7 +60,12 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         }
       }
 
-      const historyMiddlewares = [queryMiddleware]
+      const historyMiddlewares = [
+        createQueryMiddleware({
+          parse: qs.parse,
+          stringify: qs.stringify,
+        }),
+      ]
       const resolver = new Resolver(relayEnvironment)
       const render = createRender({})
       const Router = await createInitialFarceRouter({

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -1,20 +1,26 @@
-import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
-import { Boot } from "Artsy/Router/Components/Boot"
-import queryMiddleware from "farce/lib/queryMiddleware"
-import { Resolver } from "found-relay"
-import createRender from "found/lib/createRender"
-import { getFarceResult } from "found/lib/server"
 import React from "react"
 import ReactDOMServer from "react-dom/server"
 import serialize from "serialize-javascript"
 import { ServerStyleSheet } from "styled-components"
+
+import { Resolver } from "found-relay"
+import createRender from "found/lib/createRender"
+import { getFarceResult } from "found/lib/server"
+import qs from "qs"
+
+import createQueryMiddleware from "farce/lib/createQueryMiddleware"
+
+import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
+import { Boot } from "Artsy/Router/Components/Boot"
+
 import { getUser } from "Utils/getUser"
 import createLogger from "Utils/logger"
 import { createMediaStyle } from "Utils/Responsive"
 import { trace } from "Utils/trace"
-import { RouterConfig } from "./"
 import { createRouteConfig } from "./Utils/createRouteConfig"
 import { matchingMediaQueriesForUserAgent } from "./Utils/matchingMediaQueriesForUserAgent"
+
+import { RouterConfig } from "./"
 
 interface Resolve {
   bodyHTML?: string
@@ -44,7 +50,12 @@ export function buildServerApp(config: ServerRouterConfig): Promise<Resolve> {
         const { context = {}, routes = [], url, userAgent } = config
         const user = getUser(context.user)
         const relayEnvironment = context.relayEnvironment || createRelaySSREnvironment({ user }) // prettier-ignore
-        const historyMiddlewares = [queryMiddleware]
+        const historyMiddlewares = [
+          createQueryMiddleware({
+            parse: qs.parse,
+            stringify: qs.stringify,
+          }),
+        ]
         const resolver = new Resolver(relayEnvironment)
         const render = createRender({})
 


### PR DESCRIPTION
Updates our `queryMiddleware` to support query in-router query params. See [documentation](https://github.com/4Catalyzer/farce#querymiddleware-and-createquerymiddleware) for more info. 

- [x] Ensure legacy query params still work on /collect and /artist/id
- [x] Ensure that things work SSR-wise, with JS disabled

![search](https://user-images.githubusercontent.com/236943/54647323-40249a80-4a5f-11e9-8cee-1ef3998f3391.gif)

