### PR TITLE
Render a gray box for search result items without an image

### DIFF
--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -5,7 +5,6 @@ interface GenericSearchResultItemProps {
   imageUrl: string
   name: string
   description?: string
-  index: number
   href: string
   entityType: string
 }
@@ -13,7 +12,7 @@ interface GenericSearchResultItemProps {
 export const GenericSearchResultItem: FC<
   GenericSearchResultItemProps
 > = props => {
-  const { imageUrl, href, name, description, index, entityType } = props
+  const { imageUrl, href, name, description, entityType } = props
 
   const translateEntityType = anEntityType => {
     switch (anEntityType) {
@@ -28,14 +27,11 @@ export const GenericSearchResultItem: FC<
   return (
     <>
       <Flex flexDirection="row">
-        <Box>
-          <Image
-            width={70}
-            height={70}
-            mr={20}
-            src={imageUrl || `https://picsum.photos/70/70/?random=${index}`}
-          />
-        </Box>
+        <Link href={href}>
+          <Box height={70} width={70} mr={2} bg="black5">
+            {imageUrl && <Image width={70} height={70} src={imageUrl} />}
+          </Box>
+        </Link>
         <Box>
           <Sans color="black100" size="2" weight="medium">
             {translateEntityType(entityType)}

--- a/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
+++ b/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
@@ -74,7 +74,6 @@ export class SearchResultsArticlesRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={article.displayLabel}
-                index={index}
                 href={article.href}
                 description=""
                 imageUrl={article.imageUrl}

--- a/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -76,7 +76,6 @@ export class SearchResultsArtistsRoute extends React.Component<
                 name={artist.name}
                 description={artist.bio}
                 imageUrl={artist.imageUrl}
-                index={index}
                 entityType="Artist"
                 href={artist.href}
               />

--- a/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
+++ b/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
@@ -75,7 +75,6 @@ export class SearchResultAuctionsRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={searchableItem.displayLabel}
-                index={index}
                 href={searchableItem.href}
                 imageUrl={searchableItem.imageUrl}
                 entityType="Auction"

--- a/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
+++ b/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
@@ -74,7 +74,6 @@ export class SearchResultCategoriesRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={gene.displayLabel}
-                index={index}
                 href={gene.href}
                 imageUrl={gene.imageUrl}
                 entityType="Category"

--- a/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
+++ b/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
@@ -74,7 +74,6 @@ export class SearchResultsCollectionsRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={collection.displayLabel}
-                index={index}
                 href={collection.href}
                 imageUrl={collection.imageUrl}
                 entityType="Collection"

--- a/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
+++ b/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
@@ -74,7 +74,6 @@ export class SearchResultsGalleriesRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={gallery.displayLabel}
-                index={index}
                 href={gallery.href}
                 description=""
                 imageUrl={gallery.imageUrl}

--- a/src/Apps/Search/Routes/More/SearchResultsMore.tsx
+++ b/src/Apps/Search/Routes/More/SearchResultsMore.tsx
@@ -75,7 +75,6 @@ export class SearchResultMoreRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={searchableItem.displayLabel}
-                index={index}
                 href={searchableItem.href}
                 imageUrl={searchableItem.imageUrl}
                 entityType={searchableItem.searchableType}

--- a/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
+++ b/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
@@ -74,7 +74,6 @@ export class SearchResultsShowsRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={show.displayLabel}
-                index={index}
                 href={show.href}
                 description=""
                 imageUrl={show.imageUrl}


### PR DESCRIPTION
This gray box will serve as a fallback for search result items that might have an image, but don't currently. We're also discussing new fallback images or icons for entity types that don't currently support an image at all, like City.

![2019-03-20-144508_1370x426_scrot](https://user-images.githubusercontent.com/123595/54710773-ce138a80-4b1e-11e9-9de9-63af486e96cb.png)
