### PR TITLE
Remove h1 css reset from Boot now that Palette covers it

### DIFF
--- a/src/Artsy/Router/Components/Boot.tsx
+++ b/src/Artsy/Router/Components/Boot.tsx
@@ -32,15 +32,7 @@ export interface BootProps {
 // issue will be fixed
 const { GlobalStyles } = injectGlobalStyles<{
   suppressMultiMountWarning: boolean
-}>(`
-  h1 {
-    font-style: inherit;
-    font-family: inherit;
-    font-weight: inherit;
-    font-size: inherit;
-    margin: 0;
-  }
-`)
+}>()
 
 @track(null, {
   dispatch: data => Events.postEvent(data),


### PR DESCRIPTION
This PR removes an h1 reset, because with https://github.com/artsy/palette/pull/333, we have css resets built into palette for h1-h6.