### PR TITLE
Enable lazy loading on related artist component

### DIFF
--- a/src/Apps/Artist/Routes/RelatedArtists/RelatedArtistsList.tsx
+++ b/src/Apps/Artist/Routes/RelatedArtists/RelatedArtistsList.tsx
@@ -103,6 +103,7 @@ class RelatedArtistsList extends Component<ShowProps, LoadingAreaState> {
                               key={index}
                             >
                               <ArtistCard
+                                lazyLoad
                                 artist={node}
                                 mediator={mediator}
                                 user={user}

--- a/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
@@ -49,6 +49,7 @@ export class ArtworkRelatedArtists extends React.Component<
                   return (
                     <Box pr={2} mb={[1, 4]} width={["100%", "25%"]} key={index}>
                       <ArtistCard
+                        lazyLoad
                         artist={node}
                         mediator={mediator}
                         user={user}

--- a/src/Components/v2/ArtistCard.tsx
+++ b/src/Components/v2/ArtistCard.tsx
@@ -24,10 +24,16 @@ interface Props {
   artist: ArtistCard_artist
   user: User
   mediator?: Mediator
+  /** Lazy load the avatar image */
+  lazyLoad?: boolean
   onClick?: () => void
 }
 
 export class ArtistCard extends React.Component<Props> {
+  static defaultProps = {
+    lazyLoad: false,
+  }
+
   render() {
     return (
       <Link
@@ -51,7 +57,10 @@ export const LargeArtistCard: SFC<Props> = props => (
     <Flex flexDirection="column" flexGrow="0" alignItems="center" pt={1} mb={1}>
       {props.artist.image && (
         <Box mb={1}>
-          <Avatar src={get(props.artist.image, i => i.cropped.url)} />
+          <Avatar
+            lazyLoad={props.lazyLoad}
+            src={get(props.artist.image, i => i.cropped.url)}
+          />
         </Box>
       )}
 
@@ -83,7 +92,11 @@ export const SmallArtistCard: SFC<Props> = props => (
   <BorderBox hover width="100%">
     {props.artist.image && (
       <Box mr={2}>
-        <Avatar size="xs" src={get(props.artist.image, i => i.cropped.url)} />
+        <Avatar
+          lazyLoad={props.lazyLoad}
+          size="xs"
+          src={get(props.artist.image, i => i.cropped.url)}
+        />
       </Box>
     )}
     <Flex flexDirection="column">


### PR DESCRIPTION
This updates the Related Artist sections to lazy load their images (as those components appear well below the fold).

Most of the work was done in palette. See https://github.com/artsy/palette/pull/334.