### PR TITLE
Thread through description to search result items

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -8224,6 +8224,7 @@ type SearchableItem implements Node & Searchable {
 
   # A type-specific Gravity Mongo Document ID.
   _id: String!
+  description: String
   displayLabel: String
   imageUrl: String
   href: String

--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -1,13 +1,5 @@
-import {
-  Box,
-  Flex,
-  Image,
-  Link,
-  ReadMore,
-  Sans,
-  Serif,
-  Spacer,
-} from "@artsy/palette"
+import { Box, Flex, Image, Link, Sans, Serif, Spacer } from "@artsy/palette"
+import { Truncator } from "Components/Truncator"
 import React, { FC } from "react"
 
 interface GenericSearchResultItemProps {
@@ -55,7 +47,7 @@ export const GenericSearchResultItem: FC<
             <>
               <Spacer mb={0.5} />
               <Serif color="black60" size="3" maxWidth={536}>
-                <ReadMore maxChars={200} content={description} />
+                <Truncator maxLineCount={3}>{description}</Truncator>
               </Serif>
             </>
           )}

--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -1,4 +1,13 @@
-import { Box, Flex, Image, Link, Sans, Serif, Spacer } from "@artsy/palette"
+import {
+  Box,
+  Flex,
+  Image,
+  Link,
+  ReadMore,
+  Sans,
+  Serif,
+  Spacer,
+} from "@artsy/palette"
 import React, { FC } from "react"
 
 interface GenericSearchResultItemProps {
@@ -46,7 +55,7 @@ export const GenericSearchResultItem: FC<
             <>
               <Spacer mb={0.5} />
               <Serif color="black60" size="3" maxWidth={536}>
-                {description}
+                <ReadMore maxChars={200} content={description} />
               </Serif>
             </>
           )}

--- a/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
+++ b/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
@@ -70,13 +70,14 @@ export class SearchResultAuctionsRoute extends React.Component<
     const sales = get(viewer, v => v.search.edges, []).map(e => e.node)
     return (
       <LoadingArea isLoading={this.state.isLoading}>
-        {sales.map((searchableItem, index) => {
+        {sales.map((auction, index) => {
           return (
             <Box key={index}>
               <GenericSearchResultItem
-                name={searchableItem.displayLabel}
-                href={searchableItem.href}
-                imageUrl={searchableItem.imageUrl}
+                name={auction.displayLabel}
+                description={auction.description}
+                href={auction.href}
+                imageUrl={auction.imageUrl}
                 entityType="Auction"
               />
               <Spacer mb={3} />
@@ -127,7 +128,7 @@ export const SearchResultsAuctionsRouteRouteFragmentContainer = createRefetchCon
           edges {
             node {
               ... on SearchableItem {
-                id
+                description
                 displayLabel
                 href
                 imageUrl

--- a/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
+++ b/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
@@ -74,6 +74,7 @@ export class SearchResultCategoriesRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={gene.displayLabel}
+                description={gene.description}
                 href={gene.href}
                 imageUrl={gene.imageUrl}
                 entityType="Category"
@@ -132,7 +133,7 @@ export const SearchResultsCategoriesRouteRouteFragmentContainer = createRefetchC
           edges {
             node {
               ... on SearchableItem {
-                id
+                description
                 displayLabel
                 href
                 imageUrl

--- a/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
+++ b/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
@@ -74,6 +74,7 @@ export class SearchResultsCollectionsRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={collection.displayLabel}
+                description={collection.description}
                 href={collection.href}
                 imageUrl={collection.imageUrl}
                 entityType="Collection"
@@ -132,7 +133,7 @@ export const SearchResultsCollectionsRouteFragmentContainer = createRefetchConta
           edges {
             node {
               ... on SearchableItem {
-                id
+                description
                 displayLabel
                 href
                 imageUrl

--- a/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
+++ b/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
@@ -74,8 +74,8 @@ export class SearchResultsGalleriesRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={gallery.displayLabel}
+                description={gallery.description}
                 href={gallery.href}
-                description=""
                 imageUrl={gallery.imageUrl}
                 entityType="Gallery"
               />
@@ -133,7 +133,7 @@ export const SearchResultsGalleriesRouteRouteFragmentContainer = createRefetchCo
           edges {
             node {
               ... on SearchableItem {
-                id
+                description
                 displayLabel
                 href
                 imageUrl

--- a/src/Apps/Search/Routes/More/SearchResultsMore.tsx
+++ b/src/Apps/Search/Routes/More/SearchResultsMore.tsx
@@ -75,6 +75,7 @@ export class SearchResultMoreRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={searchableItem.displayLabel}
+                description={searchableItem.description}
                 href={searchableItem.href}
                 imageUrl={searchableItem.imageUrl}
                 entityType={searchableItem.searchableType}
@@ -133,7 +134,7 @@ export const SearchResultsMoreRouteRouteFragmentContainer = createRefetchContain
           edges {
             node {
               ... on SearchableItem {
-                id
+                description
                 displayLabel
                 href
                 imageUrl

--- a/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
+++ b/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
@@ -74,8 +74,8 @@ export class SearchResultsShowsRoute extends React.Component<
             <Box key={index}>
               <GenericSearchResultItem
                 name={show.displayLabel}
+                description={show.description}
                 href={show.href}
-                description=""
                 imageUrl={show.imageUrl}
                 entityType="Show"
               />
@@ -133,7 +133,7 @@ export const SearchResultsShowsRouteRouteFragmentContainer = createRefetchContai
           edges {
             node {
               ... on SearchableItem {
-                id
+                description
                 displayLabel
                 href
                 imageUrl

--- a/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
@@ -47,7 +47,7 @@ fragment SearchResultsAuctions_viewer_4c14dZ on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -147,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -385,7 +385,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
@@ -15,7 +15,7 @@ export type SearchResultsAuctions_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly id?: string;
+                readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
@@ -187,7 +187,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "id",
+                      "name": "description",
                       "args": null,
                       "storageKey": null
                     },
@@ -229,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'e46be1907b708dd5616aefea8ad66b4a';
+(node as any).hash = '0ff35562fda42f98c9076a2740d05306';
 export default node;

--- a/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
@@ -47,7 +47,7 @@ fragment SearchResultsCategories_viewer_4c14dZ on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -147,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -385,7 +385,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsCategories_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCategories_viewer.graphql.ts
@@ -15,7 +15,7 @@ export type SearchResultsCategories_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly id?: string;
+                readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
@@ -187,7 +187,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "id",
+                      "name": "description",
                       "args": null,
                       "storageKey": null
                     },
@@ -229,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'a867077f4138e4de4ab6fda83caaecc2';
+(node as any).hash = '08d3e3aa8e22cc82ad28fb73bb3b25f7';
 export default node;

--- a/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
@@ -47,7 +47,7 @@ fragment SearchResultsCollections_viewer_4c14dZ on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -147,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -385,7 +385,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsCollections_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCollections_viewer.graphql.ts
@@ -15,7 +15,7 @@ export type SearchResultsCollections_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly id?: string;
+                readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
@@ -187,7 +187,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "id",
+                      "name": "description",
                       "args": null,
                       "storageKey": null
                     },
@@ -229,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '73dd6a9b9923accde130791d4bb9f966';
+(node as any).hash = 'ad1ed82c761d47e4f62d5adecfc0a8bb';
 export default node;

--- a/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
@@ -47,7 +47,7 @@ fragment SearchResultsGalleries_viewer_4c14dZ on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -147,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -385,7 +385,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
@@ -15,7 +15,7 @@ export type SearchResultsGalleries_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly id?: string;
+                readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
@@ -187,7 +187,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "id",
+                      "name": "description",
                       "args": null,
                       "storageKey": null
                     },
@@ -229,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'e3220c9c2fd17487db8f5e3e920b5fba';
+(node as any).hash = '98ee017a72c0726e0ca3fffb708b8ac2';
 export default node;

--- a/src/__generated__/SearchResultsMoreQuery.graphql.ts
+++ b/src/__generated__/SearchResultsMoreQuery.graphql.ts
@@ -47,7 +47,7 @@ fragment SearchResultsMore_viewer_4c14dZ on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -147,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsMoreQuery",
   "id": null,
-  "text": "query SearchResultsMoreQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsMore_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsMoreQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsMore_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -389,7 +389,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsMore_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsMore_viewer.graphql.ts
@@ -15,7 +15,7 @@ export type SearchResultsMore_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly id?: string;
+                readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
@@ -191,7 +191,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "id",
+                      "name": "description",
                       "args": null,
                       "storageKey": null
                     },
@@ -233,5 +233,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '98e0e027ac2a4f89228ba85fad8dba6b';
+(node as any).hash = '8d03f2b4be9e4ae455da699f9a22f794';
 export default node;

--- a/src/__generated__/SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsShowsQuery.graphql.ts
@@ -47,7 +47,7 @@ fragment SearchResultsShows_viewer_4c14dZ on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -147,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsShowsQuery",
   "id": null,
-  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -385,7 +385,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsShows_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsShows_viewer.graphql.ts
@@ -15,7 +15,7 @@ export type SearchResultsShows_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly id?: string;
+                readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
@@ -187,7 +187,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "id",
+                      "name": "description",
                       "args": null,
                       "storageKey": null
                     },
@@ -229,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '033de097b3f66ddbf6f984002a164e62';
+(node as any).hash = '2001fd869ba4b5fdbc8ec2be7270ea2d';
 export default node;

--- a/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
@@ -39,7 +39,7 @@ fragment SearchResultsAuctions_viewer_4hh6ED on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -115,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -311,7 +311,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
@@ -39,7 +39,7 @@ fragment SearchResultsCategories_viewer_4hh6ED on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -115,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -311,7 +311,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
@@ -39,7 +39,7 @@ fragment SearchResultsCollections_viewer_4hh6ED on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -115,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -311,7 +311,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
@@ -39,7 +39,7 @@ fragment SearchResultsGalleries_viewer_4hh6ED on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -115,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -311,7 +311,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsMoreQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsMoreQuery.graphql.ts
@@ -39,7 +39,7 @@ fragment SearchResultsMore_viewer_4hh6ED on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -115,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsMoreQuery",
   "id": null,
-  "text": "query routes_SearchResultsMoreQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsMore_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsMoreQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsMore_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -315,7 +315,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
@@ -39,7 +39,7 @@ fragment SearchResultsShows_viewer_4hh6ED on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          description
           displayLabel
           href
           imageUrl
@@ -115,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsShowsQuery",
   "id": null,
-  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -311,7 +311,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           },


### PR DESCRIPTION
Show the `descriptions` from `SearchableItem` results returned from Metaphysics. Metaphysics should handle the formatting of the description. Reaction may truncate the attribute as needed.

![2019-03-20-183708_1222x369_scrot](https://user-images.githubusercontent.com/123595/54723843-4d18bb00-4b3f-11e9-886d-eac56771a2aa.png)

![2019-03-20-183725_1265x544_scrot](https://user-images.githubusercontent.com/123595/54723849-4f7b1500-4b3f-11e9-8939-a28ea4b84ad1.png)
![2019-03-20-183741_1668x539_scrot](https://user-images.githubusercontent.com/123595/54723858-5570f600-4b3f-11e9-8b58-8f2f0d4b2a6b.png)

