### PR TITLE
[Router] Add queryParam support

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -30,7 +30,7 @@ export class NavigationTabs extends React.Component<Props> {
     const { exact } = options
 
     return (
-      <RouteTab to={to} exact={exact}>
+      <RouteTab to={to} exact={exact} preload={false}>
         {text}
       </RouteTab>
     )

--- a/src/Apps/Search/Routes/Artworks/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/Artworks/SearchResultsArtworks.tsx
@@ -3,19 +3,37 @@ import { SearchResultsArtworks_viewer } from "__generated__/SearchResultsArtwork
 import { SearchResultsFilterFragmentContainer as ArtworkGrid } from "Apps/Search/Routes/Artworks/Components/Filter/SearchResultsFilterContainer"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { Provider } from "unstated"
+import { FilterState } from "../../FilterState"
 
 export interface Props {
   viewer: SearchResultsArtworks_viewer
+  location: {
+    query: {
+      term: string
+    }
+  }
 }
 
 export class SearchResultsArtworksRoute extends React.Component<Props> {
   render() {
-    const { viewer } = this.props
+    const {
+      viewer,
+      location: { query },
+    } = this.props
 
     return (
-      <Box>
-        <ArtworkGrid viewer={viewer} />
-      </Box>
+      <Provider
+        inject={[
+          new FilterState({
+            keyword: query.term,
+          }),
+        ]}
+      >
+        <Box>
+          <ArtworkGrid viewer={viewer} />
+        </Box>
+      </Provider>
     )
   }
 }

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -1,3 +1,6 @@
+import { RouteConfig } from "found"
+import { graphql } from "react-relay"
+
 import { SearchResultsArticlesRouteRouteFragmentContainer as SearchResultsArticlesRoute } from "Apps/Search/Routes/Articles/SearchResultsArticles"
 import { SearchResultsArtistsRouteFragmentContainer as SearchResultsArtistsRoute } from "Apps/Search/Routes/Artists/SearchResultsArtists"
 import { SearchResultsArtworksRouteFragmentContainer as SearchResultsArtworksRoute } from "Apps/Search/Routes/Artworks/SearchResultsArtworks"
@@ -7,22 +10,11 @@ import { SearchResultsCollectionsRouteFragmentContainer as SearchResultsCollecti
 import { SearchResultsGalleriesRouteRouteFragmentContainer as SearchResultsGalleriesRoute } from "Apps/Search/Routes/Galleries/SearchResultsGalleries"
 import { SearchResultsMoreRouteRouteFragmentContainer as SearchResultsMoreRoute } from "Apps/Search/Routes/More/SearchResultsMore"
 import { SearchResultsShowsRouteRouteFragmentContainer as SearchResultsShowsRoute } from "Apps/Search/Routes/Shows/SearchResultsShows"
-import { RouteConfig } from "found"
-import React from "react"
-import { graphql } from "react-relay"
-import { Provider } from "unstated"
-import { FilterState } from "./FilterState"
+
 import { SearchAppFragmentContainer as SearchApp } from "./SearchApp"
 
-const prepareVariables = (params, props) => {
-  const paramsFromUrl = props.location ? props.location.query : {}
-  const allParams = {
-    ...paramsFromUrl,
-    ...params,
-  }
-
-  allParams.keyword = allParams.term
-  return allParams
+const prepareVariables = (_params, { location }) => {
+  return location.query
 }
 
 export const routes: RouteConfig[] = [
@@ -41,22 +33,10 @@ export const routes: RouteConfig[] = [
       {
         path: "/",
         Component: SearchResultsArtworksRoute,
-        render: ({ props, Component }) => {
-          if (!props) {
-            return null
-          }
-
-          const currentFilterState = props.location.query
-          currentFilterState.keyword = currentFilterState.term
-          return (
-            <Provider inject={[new FilterState(currentFilterState)]}>
-              <Component viewer={(props as any).viewer} />
-            </Provider>
-          )
-        },
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsArtworksQuery(
-            $keyword: String!
+            $term: String!
             $medium: String
             $major_periods: [String]
             $partner_id: ID
@@ -76,7 +56,7 @@ export const routes: RouteConfig[] = [
             viewer {
               ...SearchResultsArtworks_viewer
                 @arguments(
-                  keyword: $keyword
+                  keyword: $term
                   medium: $medium
                   major_periods: $major_periods
                   partner_id: $partner_id
@@ -96,11 +76,11 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
       {
         path: "artists",
         Component: SearchResultsArtistsRoute,
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsArtistsQuery($term: String!) {
             viewer {
@@ -108,11 +88,11 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
       {
         path: "collections",
         Component: SearchResultsCollectionsRoute,
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsCollectionsQuery($term: String!) {
             viewer {
@@ -120,11 +100,11 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
       {
         path: "shows",
         Component: SearchResultsShowsRoute,
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsShowsQuery($term: String!) {
             viewer {
@@ -132,11 +112,11 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
       {
         path: "galleries",
         Component: SearchResultsGalleriesRoute,
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsGalleriesQuery($term: String!) {
             viewer {
@@ -144,11 +124,11 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
       {
         path: "categories",
         Component: SearchResultsCategoriesRoute,
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsCategoriesQuery($term: String!) {
             viewer {
@@ -156,11 +136,11 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
       {
         path: "articles",
         Component: SearchResultsArticlesRoute,
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsArticlesQuery($term: String!) {
             viewer {
@@ -168,11 +148,11 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
       {
         path: "auctions",
         Component: SearchResultsAuctionsRoute,
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsAuctionsQuery($term: String!) {
             viewer {
@@ -180,11 +160,11 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
       {
         path: "more",
         Component: SearchResultsMoreRoute,
+        prepareVariables,
         query: graphql`
           query routes_SearchResultsMoreQuery($term: String!) {
             viewer {
@@ -192,7 +172,6 @@ export const routes: RouteConfig[] = [
             }
           }
         `,
-        prepareVariables,
       },
     ],
   },

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -8,30 +8,14 @@ import { SearchResultsGalleriesRouteRouteFragmentContainer as SearchResultsGalle
 import { SearchResultsMoreRouteRouteFragmentContainer as SearchResultsMoreRoute } from "Apps/Search/Routes/More/SearchResultsMore"
 import { SearchResultsShowsRouteRouteFragmentContainer as SearchResultsShowsRoute } from "Apps/Search/Routes/Shows/SearchResultsShows"
 import { RouteConfig } from "found"
-import qs from "qs"
 import React from "react"
 import { graphql } from "react-relay"
 import { Provider } from "unstated"
 import { FilterState } from "./FilterState"
 import { SearchAppFragmentContainer as SearchApp } from "./SearchApp"
 
-// FIXME: The initial render includes `location` in props, but subsequent
-// renders (such as tabbing back to this route in your browser) will not.
 const prepareVariables = (params, props) => {
-  let paramsFromUrl = props.location ? props.location.query : {}
-  if (
-    Object.keys(paramsFromUrl).length === 0 &&
-    Object.keys(params).length === 0
-  ) {
-    paramsFromUrl = qs.parse(location.search.replace(/^\?/, ""))
-
-    // FIXME: This snippet only is valid during storybook development.
-    // Optionally remove this when feature is launched.
-    if (!paramsFromUrl.term && process.env.NODE_ENV === "development") {
-      paramsFromUrl.term = "andy"
-    }
-  }
-
+  const paramsFromUrl = props.location ? props.location.query : {}
   const allParams = {
     ...paramsFromUrl,
     ...params,

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -56,5 +56,7 @@ storiesOf("Apps", module)
     )
   })
   .add("Search Results page", () => {
-    return <MockRouter routes={searchRoutes} initialRoute="/search2?term=art" />
+    return (
+      <MockRouter routes={searchRoutes} initialRoute="/search2?term=pablo" />
+    )
   })

--- a/src/Artsy/Router/Components/PreloadLink.tsx
+++ b/src/Artsy/Router/Components/PreloadLink.tsx
@@ -16,6 +16,17 @@ export interface PreloadLinkProps extends ContextProps, WithRouter, SizeProps {
   immediate?: boolean
   onClick?: () => void
   onToggleLoading?: (isLoading: boolean) => void
+  /**
+   * Toggles on / off preloading behavior.
+   *
+   * NOTE: If a route depends on `prepareVariables` in order to pass arguments
+   * to a graphql query this *must* be false. This is due to the inability to
+   * asyncronously resolve queries, and using `withRouter` will return the
+   * correct values on next tick.
+   *
+   * See: https://graphql.slack.com/archives/C0BEXJLKG/p1553118884211200
+   */
+  preload?: boolean
   replace?: string
   router: Router
   to?: string
@@ -80,6 +91,7 @@ const _PreloadLink: React.SFC<PreloadLinkProps> = preloadLinkProps => {
     static defaultProps = {
       activeClassName: "active",
       immediate: false,
+      preload: true,
       onToggleFetching: x => x,
     }
 
@@ -213,8 +225,13 @@ const _PreloadLink: React.SFC<PreloadLinkProps> = preloadLinkProps => {
         this.props
       )
 
+      const handlers: { onClick?: (event) => void } = {}
+      if (this.props.preload) {
+        handlers.onClick = this.handleClick
+      }
+
       return (
-        <Link {...whitelistedProps} onClick={this.handleClick}>
+        <Link {...whitelistedProps} {...handlers}>
           {this.props.children}
         </Link>
       )

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -1,18 +1,24 @@
-import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
-import { Boot } from "Artsy/Router/Components/Boot"
-import BrowserProtocol from "farce/lib/BrowserProtocol"
-import HashProtocol from "farce/lib/HashProtocol"
-import MemoryProtocol from "farce/lib/MemoryProtocol"
-import queryMiddleware from "farce/lib/queryMiddleware"
+import React, { ComponentType } from "react"
+
 import { Resolver } from "found-relay"
 import { ScrollManager } from "found-scroll"
 import createInitialFarceRouter from "found/lib/createInitialFarceRouter"
 import createRender from "found/lib/createRender"
-import React, { ComponentType } from "react"
+
+import BrowserProtocol from "farce/lib/BrowserProtocol"
+import createQueryMiddleware from "farce/lib/createQueryMiddleware"
+import HashProtocol from "farce/lib/HashProtocol"
+import MemoryProtocol from "farce/lib/MemoryProtocol"
+import qs from "qs"
+
 import { getUser } from "Utils/getUser"
 import createLogger from "Utils/logger"
-import { RouterConfig } from "./"
 import { createRouteConfig } from "./Utils/createRouteConfig"
+
+import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
+import { Boot } from "Artsy/Router/Components/Boot"
+
+import { RouterConfig } from "./"
 
 interface Resolve {
   ClientApp: ComponentType<any>
@@ -54,7 +60,12 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         }
       }
 
-      const historyMiddlewares = [queryMiddleware]
+      const historyMiddlewares = [
+        createQueryMiddleware({
+          parse: qs.parse,
+          stringify: qs.stringify,
+        }),
+      ]
       const resolver = new Resolver(relayEnvironment)
       const render = createRender({})
       const Router = await createInitialFarceRouter({

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -1,20 +1,26 @@
-import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
-import { Boot } from "Artsy/Router/Components/Boot"
-import queryMiddleware from "farce/lib/queryMiddleware"
-import { Resolver } from "found-relay"
-import createRender from "found/lib/createRender"
-import { getFarceResult } from "found/lib/server"
 import React from "react"
 import ReactDOMServer from "react-dom/server"
 import serialize from "serialize-javascript"
 import { ServerStyleSheet } from "styled-components"
+
+import { Resolver } from "found-relay"
+import createRender from "found/lib/createRender"
+import { getFarceResult } from "found/lib/server"
+import qs from "qs"
+
+import createQueryMiddleware from "farce/lib/createQueryMiddleware"
+
+import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
+import { Boot } from "Artsy/Router/Components/Boot"
+
 import { getUser } from "Utils/getUser"
 import createLogger from "Utils/logger"
 import { createMediaStyle } from "Utils/Responsive"
 import { trace } from "Utils/trace"
-import { RouterConfig } from "./"
 import { createRouteConfig } from "./Utils/createRouteConfig"
 import { matchingMediaQueriesForUserAgent } from "./Utils/matchingMediaQueriesForUserAgent"
+
+import { RouterConfig } from "./"
 
 interface Resolve {
   bodyHTML?: string
@@ -44,7 +50,12 @@ export function buildServerApp(config: ServerRouterConfig): Promise<Resolve> {
         const { context = {}, routes = [], url, userAgent } = config
         const user = getUser(context.user)
         const relayEnvironment = context.relayEnvironment || createRelaySSREnvironment({ user }) // prettier-ignore
-        const historyMiddlewares = [queryMiddleware]
+        const historyMiddlewares = [
+          createQueryMiddleware({
+            parse: qs.parse,
+            stringify: qs.stringify,
+          }),
+        ]
         const resolver = new Resolver(relayEnvironment)
         const render = createRender({})
 

--- a/src/Components/v2/RouteTabs.tsx
+++ b/src/Components/v2/RouteTabs.tsx
@@ -28,6 +28,12 @@ export const RouteTabs = styled(TabsContainer)`
 
 export const RouteTab: React.SFC<Partial<PreloadLinkProps>> = ({
   children,
+  /**
+   * If set to false it will fall back to <Link> (from found) under the hood, and
+   * skip all preload behavior. For routes that depend on prepareVariables this
+   * is required.
+   */
+  preload = true,
   ...props
 }) => {
   return (

--- a/src/Components/v2/RouteTabs.tsx
+++ b/src/Components/v2/RouteTabs.tsx
@@ -26,7 +26,7 @@ export const RouteTabs = styled(TabsContainer)`
   }
 `
 
-export const RouteTab: React.SFC<Partial<PreloadLinkProps>> = ({
+export const RouteTab: React.FC<Partial<PreloadLinkProps>> = ({
   children,
   /**
    * If set to false it will fall back to <Link> (from found) under the hood, and
@@ -37,7 +37,7 @@ export const RouteTab: React.SFC<Partial<PreloadLinkProps>> = ({
   ...props
 }) => {
   return (
-    <PreloadLink {...props}>
+    <PreloadLink {...props} preload={preload}>
       <Sans size="3t" weight="medium">
         {children}
       </Sans>

--- a/src/__generated__/routes_SearchResultsArtworksQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArtworksQuery.graphql.ts
@@ -3,7 +3,7 @@
 import { ConcreteRequest } from "relay-runtime";
 import { SearchResultsArtworks_viewer$ref } from "./SearchResultsArtworks_viewer.graphql";
 export type routes_SearchResultsArtworksQueryVariables = {
-    readonly keyword: string;
+    readonly term: string;
     readonly medium?: string | null;
     readonly major_periods?: ReadonlyArray<string | null> | null;
     readonly partner_id?: string | null;
@@ -34,7 +34,7 @@ export type routes_SearchResultsArtworksQuery = {
 
 /*
 query routes_SearchResultsArtworksQuery(
-  $keyword: String!
+  $term: String!
   $medium: String
   $major_periods: [String]
   $partner_id: ID
@@ -52,15 +52,15 @@ query routes_SearchResultsArtworksQuery(
   $color: String
 ) {
   viewer {
-    ...SearchResultsArtworks_viewer_17KNCl
+    ...SearchResultsArtworks_viewer_1iA755
   }
 }
 
-fragment SearchResultsArtworks_viewer_17KNCl on Viewer {
-  ...SearchResultsFilterContainer_viewer_17KNCl
+fragment SearchResultsArtworks_viewer_1iA755 on Viewer {
+  ...SearchResultsFilterContainer_viewer_1iA755
 }
 
-fragment SearchResultsFilterContainer_viewer_17KNCl on Viewer {
+fragment SearchResultsFilterContainer_viewer_1iA755 on Viewer {
   filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
     aggregations {
       slice
@@ -72,11 +72,11 @@ fragment SearchResultsFilterContainer_viewer_17KNCl on Viewer {
     }
     __id
   }
-  ...SearchResultsRefetch_viewer_17KNCl
+  ...SearchResultsRefetch_viewer_1iA755
 }
 
-fragment SearchResultsRefetch_viewer_17KNCl on Viewer {
-  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $keyword) {
+fragment SearchResultsRefetch_viewer_1iA755 on Viewer {
+  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $term) {
     ...SearchResultsArtworkGrid_filtered_artworks
     __id
   }
@@ -245,7 +245,7 @@ const node: ConcreteRequest = (function(){
 var v0 = [
   {
     "kind": "LocalArgument",
-    "name": "keyword",
+    "name": "term",
     "type": "String!",
     "defaultValue": null
   },
@@ -419,7 +419,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArtworksQuery",
   "id": null,
-  "text": "query routes_SearchResultsArtworksQuery(\n  $keyword: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $artist_id: String\n  $attribution_class: [String]\n  $color: String\n) {\n  viewer {\n    ...SearchResultsArtworks_viewer_17KNCl\n  }\n}\n\nfragment SearchResultsArtworks_viewer_17KNCl on Viewer {\n  ...SearchResultsFilterContainer_viewer_17KNCl\n}\n\nfragment SearchResultsFilterContainer_viewer_17KNCl on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...SearchResultsRefetch_viewer_17KNCl\n}\n\nfragment SearchResultsRefetch_viewer_17KNCl on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $keyword) {\n    ...SearchResultsArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment SearchResultsArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_SearchResultsArtworksQuery(\n  $term: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $artist_id: String\n  $attribution_class: [String]\n  $color: String\n) {\n  viewer {\n    ...SearchResultsArtworks_viewer_1iA755\n  }\n}\n\nfragment SearchResultsArtworks_viewer_1iA755 on Viewer {\n  ...SearchResultsFilterContainer_viewer_1iA755\n}\n\nfragment SearchResultsFilterContainer_viewer_1iA755 on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...SearchResultsRefetch_viewer_1iA755\n}\n\nfragment SearchResultsRefetch_viewer_1iA755 on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $term) {\n    ...SearchResultsArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment SearchResultsArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  is_biddable\n  sale {\n    is_preview\n    __id\n  }\n  is_acquireable\n  is_offerable\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -492,7 +492,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "keyword",
-                "variableName": "keyword",
+                "variableName": "term",
                 "type": null
               },
               {
@@ -677,7 +677,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "keyword",
-                "variableName": "keyword",
+                "variableName": "term",
                 "type": "String"
               },
               {
@@ -1146,5 +1146,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'cee1296e315eaab1244887edb577fca2';
+(node as any).hash = '7365514c04da75c3a6f5f64892daa43c';
 export default node;


### PR DESCRIPTION
Updates our `queryMiddleware` to support query in-router query params. See [documentation](https://github.com/4Catalyzer/farce#querymiddleware-and-createquerymiddleware) for more info. 

Also adds a `preload` boolean prop to `PreloadLink` which, if `false`, means that we bypass upfront loading in favor of an immediate route transition, then load, then display. It's not as nice UX but it's the only way we can get around the inability to access `prepareVariables` in an async fashion. See https://graphql.slack.com/archives/C0BEXJLKG/p1553118312208200. 

- [x] Ensure legacy query params still work on /collect and /artist/id
- [x] Ensure that things work SSR-wise, with JS disabled
- [x] Ensure route transitions work

![search](https://user-images.githubusercontent.com/236943/54647323-40249a80-4a5f-11e9-8cee-1ef3998f3391.gif)

![search](https://user-images.githubusercontent.com/236943/54727646-3457d780-4b36-11e9-87d9-47c443367861.gif)
