### PR TITLE
Use palette image for lazy loading

### DIFF
--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -1,4 +1,4 @@
-import { color, Flex, Image, Sans } from "@artsy/palette"
+import { color, Flex, Image as BaseImage, Sans } from "@artsy/palette"
 import { GridItem_artwork } from "__generated__/GridItem_artwork.graphql"
 import { Mediator } from "Artsy/SystemContext"
 import { isFunction } from "lodash"
@@ -16,7 +16,7 @@ const Placeholder = styled.div`
   overflow: hidden;
 `
 
-const AbsoluteImage = styled(Image)`
+const Image = styled(BaseImage)`
   width: 100%;
   position: absolute;
   top: 0;
@@ -167,7 +167,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
               }
             }}
           >
-            <AbsoluteImage
+            <Image
               title={artwork.title}
               alt={artwork.image_title}
               src={this.getImageUrl()}

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -1,57 +1,31 @@
-import { color, Flex, Sans } from "@artsy/palette"
+import { color, Flex, Image, Sans } from "@artsy/palette"
 import { GridItem_artwork } from "__generated__/GridItem_artwork.graphql"
 import { Mediator } from "Artsy/SystemContext"
 import { isFunction } from "lodash"
 import React from "react"
-import { LazyLoadImage } from "react-lazy-load-image-component"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
-import styled, { css, keyframes } from "styled-components"
+import styled from "styled-components"
 import Metadata from "./Metadata"
 import SaveButton from "./Save"
-
-/**
- * The animation that's used for the background of an image while it's loading
- * in.
- */
-const pulse = keyframes`
-  0% { background-color: ${color("black10")}; }
-  50% { background-color: ${color("black5")}; }
-  100% { background-color: ${color("black10")}; }
-`
-
-const pulseAnimation = props =>
-  css`
-    ${pulse} 2s ease-in-out infinite;
-  `
-
-const imageStyles = css`
-  width: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-`
-
-const LazyImage = styled(LazyLoadImage)`
-  transition: opacity 0.25s;
-  ${imageStyles};
-`
-
-const Image = styled.img`
-  ${imageStyles};
-`
 
 const Placeholder = styled.div`
   background-color: ${color("black10")};
   position: relative;
   width: 100%;
   overflow: hidden;
-  animation: ${pulseAnimation};
+`
+
+const AbsoluteImage = styled(Image)`
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 `
 
 interface Props extends React.HTMLProps<ArtworkGridItemContainer> {
   artwork: GridItem_artwork
-  preloadImage?: boolean
+  lazyLoad?: boolean
   mediator?: Mediator
   onClick?: () => void
   style?: any
@@ -60,7 +34,6 @@ interface Props extends React.HTMLProps<ArtworkGridItemContainer> {
 
 interface State {
   isMounted: boolean
-  isImageLoaded: boolean
 }
 
 const IMAGE_QUALITY = 80
@@ -85,7 +58,6 @@ const Badges = styled(Flex)`
 class ArtworkGridItemContainer extends React.Component<Props, State> {
   state = {
     isMounted: false,
-    isImageLoaded: false,
   }
 
   canHover: boolean
@@ -99,12 +71,6 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
     if (isFunction(window.matchMedia)) {
       this.canHover = !window.matchMedia("(hover: none)").matches
     }
-  }
-
-  imageLoaded = () => {
-    this.setState({
-      isImageLoaded: true,
-    })
   }
 
   getImageUrl() {
@@ -173,8 +139,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
   }
 
   render() {
-    const { style, className, artwork, user, preloadImage = false } = this.props
-    const { isImageLoaded } = this.state
+    const { style, className, artwork, user, lazyLoad = true } = this.props
 
     let userSpread = {}
     if (user) {
@@ -202,28 +167,12 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
               }
             }}
           >
-            {preloadImage ? (
-              <Image
-                title={artwork.title}
-                alt={artwork.image_title}
-                src={this.getImageUrl()}
-              />
-            ) : (
-              <LazyImage
-                title={artwork.title}
-                alt={artwork.image_title}
-                style={{ opacity: isImageLoaded ? "1" : "0" }}
-                src={this.getImageUrl()}
-                onLoad={this.imageLoaded}
-              />
-            )}
-            <noscript>
-              <Image
-                title={artwork.title}
-                alt={artwork.image_title}
-                src={this.getImageUrl()}
-              />
-            </noscript>
+            <AbsoluteImage
+              title={artwork.title}
+              alt={artwork.image_title}
+              src={this.getImageUrl()}
+              lazyLoad={lazyLoad}
+            />
           </a>
 
           {this.renderArtworkBadge(artwork)}

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -115,7 +115,7 @@ export class ArtworkGridContainer extends React.Component<
             key={"artwork-" + j + "-" + artwork.__id}
             user={this.props.user}
             mediator={this.props.mediator}
-            preloadImage={i + j < preloadImageCount}
+            lazyLoad={i + j >= preloadImageCount}
             onClick={() => {
               if (this.props.onBrickClick) {
                 this.props.onBrickClick()


### PR DESCRIPTION
Refactors the `GridItem` component in the artwork grid to use palette's `Image` component with its new `lazyLoad` prop to manage lazy loading. 

There was a minor change to the API of `GridItem` to use `lazyLoad` instead of `preloadImage` to be more consistent with how we enable lazy loading. 