### PR TITLE
@dblandin => [SearchResults] Add send feedback component, for logged in users only

### DIFF
--- a/src/Apps/Search/Components/SendFeedback.tsx
+++ b/src/Apps/Search/Components/SendFeedback.tsx
@@ -1,8 +1,15 @@
-import { Box, Button, color, Flex, Serif, TextArea } from "@artsy/palette"
+import {
+  Box,
+  Button,
+  color,
+  Flex,
+  Input,
+  Serif,
+  TextArea,
+} from "@artsy/palette"
 import { SendFeedbackSearchResultsMutation } from "__generated__/SendFeedbackSearchResultsMutation.graphql"
 import { ContextProps } from "Artsy"
 import { withContext } from "Artsy/SystemContext"
-import Input from "Components/Input"
 import React from "react"
 import { commitMutation, graphql } from "react-relay"
 

--- a/src/Apps/Search/Components/SendFeedback.tsx
+++ b/src/Apps/Search/Components/SendFeedback.tsx
@@ -1,0 +1,99 @@
+import { Box, Button, color, Flex, Serif, TextArea } from "@artsy/palette"
+import { SendFeedbackSearchResultsMutation } from "__generated__/SendFeedbackSearchResultsMutation.graphql"
+import { ContextProps } from "Artsy"
+import { withContext } from "Artsy/SystemContext"
+import React from "react"
+import { commitMutation, graphql } from "react-relay"
+
+interface State {
+  submitted: boolean
+  message: string
+}
+
+class SendFeedbackForm extends React.Component<ContextProps, State> {
+  state = {
+    submitted: false,
+    message: null,
+  }
+
+  handleClick() {
+    const { user, relayEnvironment } = this.props
+    const { message } = this.state
+    if (!message) return
+    if (user && user.id) {
+      commitMutation<SendFeedbackSearchResultsMutation>(relayEnvironment, {
+        mutation: graphql`
+          mutation SendFeedbackSearchResultsMutation(
+            $input: SendFeedbackMutationInput!
+          ) {
+            sendFeedback(input: $input) {
+              feedbackOrError {
+                ... on SendFeedbackMutationSuccess {
+                  feedback {
+                    message
+                  }
+                }
+                ... on SendFeedbackMutationFailure {
+                  mutationError {
+                    type
+                    message
+                    detail
+                  }
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          input: { message },
+        },
+        optimisticUpdater: () => {
+          this.setState({
+            submitted: true,
+          })
+        },
+      })
+    }
+  }
+
+  render() {
+    return (
+      <Box bg={color("black5")} p={3} mt={3}>
+        <Flex
+          height="212px"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          width="100%"
+        >
+          <Box textAlign="center">
+            <Serif size="4">Your feedback is important to us.</Serif>
+          </Box>
+          <Box>
+            <Serif size="2">
+              Tell us how we can improve and help you find what you are looking
+              for.
+            </Serif>
+          </Box>
+          <Box mt={2} width="484px">
+            <TextArea
+              onChange={({ value: message }) => {
+                this.setState({ message })
+              }}
+              placeholder="Your comments here"
+            />
+          </Box>
+          <Button
+            onClick={() => {
+              this.handleClick()
+            }}
+          >
+            Submit
+          </Button>
+        </Flex>
+      </Box>
+    )
+  }
+}
+
+export const SendFeedback = withContext(SendFeedbackForm)

--- a/src/Apps/Search/Components/SendFeedback.tsx
+++ b/src/Apps/Search/Components/SendFeedback.tsx
@@ -11,6 +11,7 @@ import {
 import { SendFeedbackSearchResultsMutation } from "__generated__/SendFeedbackSearchResultsMutation.graphql"
 import { ContextProps } from "Artsy"
 import { withContext } from "Artsy/SystemContext"
+import { EMAIL_REGEX } from "Components/Publishing/Constants"
 import React from "react"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
@@ -33,9 +34,9 @@ const logger = createLogger("Apps/Search/Components/SendFeedback.tsx")
 class SendFeedbackForm extends React.Component<ContextProps, State> {
   state = {
     submitted: false,
-    message: null,
-    name: null,
-    email: null,
+    message: "",
+    name: "",
+    email: "",
     triggeredValidation: false,
   }
 
@@ -102,7 +103,8 @@ class SendFeedbackForm extends React.Component<ContextProps, State> {
   }
 
   renderPersonalInfoInputs() {
-    const { name, email, triggeredValidation } = this.state
+    const { name, triggeredValidation } = this.state
+    const errorForEmail = this.errorForEmail()
     return (
       <LoggedOutInputContainer mt={2} alignContent="space-between">
         <Box mr={1} width="50%">
@@ -124,13 +126,17 @@ class SendFeedbackForm extends React.Component<ContextProps, State> {
               this.setState({ email: value })
             }}
             required
-            error={
-              !email && triggeredValidation ? "Cannot leave field blank" : ""
-            }
+            error={errorForEmail && triggeredValidation ? errorForEmail : ""}
           />
         </Box>
       </LoggedOutInputContainer>
     )
+  }
+
+  errorForEmail() {
+    const { email } = this.state
+    if (!email) return "Cannot leave field blank"
+    if (!email.match(EMAIL_REGEX)) return "Invalid email."
   }
 
   renderFeedbackTextArea() {

--- a/src/Apps/Search/Components/SendFeedback.tsx
+++ b/src/Apps/Search/Components/SendFeedback.tsx
@@ -2,65 +2,108 @@ import { Box, Button, color, Flex, Serif, TextArea } from "@artsy/palette"
 import { SendFeedbackSearchResultsMutation } from "__generated__/SendFeedbackSearchResultsMutation.graphql"
 import { ContextProps } from "Artsy"
 import { withContext } from "Artsy/SystemContext"
+import Input from "Components/Input"
 import React from "react"
 import { commitMutation, graphql } from "react-relay"
 
 interface State {
   submitted: boolean
   message: string
+  name: string
+  email: string
 }
 
 class SendFeedbackForm extends React.Component<ContextProps, State> {
   state = {
     submitted: false,
     message: null,
+    name: null,
+    email: null,
   }
 
   handleClick() {
     const { user, relayEnvironment } = this.props
-    const { message } = this.state
+    const { message, name, email } = this.state
     if (!message) return
-    if (user && user.id) {
-      commitMutation<SendFeedbackSearchResultsMutation>(relayEnvironment, {
-        mutation: graphql`
-          mutation SendFeedbackSearchResultsMutation(
-            $input: SendFeedbackMutationInput!
-          ) {
-            sendFeedback(input: $input) {
-              feedbackOrError {
-                ... on SendFeedbackMutationSuccess {
-                  feedback {
-                    message
-                  }
+    if (!user && !name && !email) return
+
+    commitMutation<SendFeedbackSearchResultsMutation>(relayEnvironment, {
+      mutation: graphql`
+        mutation SendFeedbackSearchResultsMutation(
+          $input: SendFeedbackMutationInput!
+        ) {
+          sendFeedback(input: $input) {
+            feedbackOrError {
+              ... on SendFeedbackMutationSuccess {
+                feedback {
+                  message
                 }
-                ... on SendFeedbackMutationFailure {
-                  mutationError {
-                    type
-                    message
-                    detail
-                  }
+              }
+              ... on SendFeedbackMutationFailure {
+                mutationError {
+                  type
+                  message
+                  detail
                 }
               }
             }
           }
-        `,
-        variables: {
-          input: { message },
-        },
-        optimisticUpdater: () => {
-          this.setState({
-            submitted: true,
-          })
-        },
-      })
-    }
+        }
+      `,
+      variables: {
+        input: { message, email, name },
+      },
+      optimisticUpdater: () => {
+        this.setState({
+          submitted: true,
+        })
+      },
+    })
+  }
+
+  renderPersonalInfoInputs() {
+    return (
+      <Flex mt={2} width="484px">
+        <Box width="237px" mr={1}>
+          <Input
+            placeholder="Your name"
+            onChange={({ currentTarget: { value: name } }) => {
+              this.setState({ name })
+            }}
+          />
+        </Box>
+        <Box width="237px">
+          <Input
+            placeholder="Email address"
+            onChange={({ currentTarget: { value: email } }) => {
+              this.setState({ email })
+            }}
+          />
+        </Box>
+      </Flex>
+    )
+  }
+
+  renderFeedbackTextArea() {
+    return (
+      <Box mt={2} width="484px">
+        <TextArea
+          onChange={({ value: message }) => {
+            this.setState({ message })
+          }}
+          placeholder="Your comments here"
+        />
+      </Box>
+    )
   }
 
   render() {
+    const { user } = this.props
+
     return (
       <Box bg={color("black5")} p={3} mt={3}>
         <Flex
-          height="212px"
+          style={{ minHeight: "212px" }}
           flexDirection="column"
           alignItems="center"
           justifyContent="center"
@@ -75,14 +118,8 @@ class SendFeedbackForm extends React.Component<ContextProps, State> {
               for.
             </Serif>
           </Box>
-          <Box mt={2} width="484px">
-            <TextArea
-              onChange={({ value: message }) => {
-                this.setState({ message })
-              }}
-              placeholder="Your comments here"
-            />
-          </Box>
+          {!user ? this.renderPersonalInfoInputs() : null}
+          {this.renderFeedbackTextArea()}
           <Button
             onClick={() => {
               this.handleClick()

--- a/src/Apps/Search/Components/SendFeedback.tsx
+++ b/src/Apps/Search/Components/SendFeedback.tsx
@@ -12,6 +12,7 @@ import { ContextProps } from "Artsy"
 import { withContext } from "Artsy/SystemContext"
 import React from "react"
 import { commitMutation, graphql } from "react-relay"
+import styled from "styled-components"
 
 interface State {
   submitted: boolean
@@ -70,8 +71,8 @@ class SendFeedbackForm extends React.Component<ContextProps, State> {
 
   renderPersonalInfoInputs() {
     return (
-      <Flex mt={2} width="484px">
-        <Box width="237px" mr={1}>
+      <LoggedOutInputContainer mt={2} alignContent="space-between">
+        <Box mr={1} width="50%">
           <Input
             placeholder="Your name"
             onChange={({ currentTarget: { value: name } }) => {
@@ -79,7 +80,7 @@ class SendFeedbackForm extends React.Component<ContextProps, State> {
             }}
           />
         </Box>
-        <Box width="237px">
+        <Box width="50%">
           <Input
             placeholder="Email address"
             onChange={({ currentTarget: { value: email } }) => {
@@ -87,20 +88,20 @@ class SendFeedbackForm extends React.Component<ContextProps, State> {
             }}
           />
         </Box>
-      </Flex>
+      </LoggedOutInputContainer>
     )
   }
 
   renderFeedbackTextArea() {
     return (
-      <Box mt={2} width="484px">
+      <FeedbackTextAreaContainer mt={2}>
         <TextArea
           onChange={({ value: message }) => {
             this.setState({ message })
           }}
           placeholder="Your comments here"
         />
-      </Box>
+      </FeedbackTextAreaContainer>
     )
   }
 
@@ -109,8 +110,7 @@ class SendFeedbackForm extends React.Component<ContextProps, State> {
 
     return (
       <Box bg={color("black5")} p={3} mt={3}>
-        <Flex
-          style={{ minHeight: "212px" }}
+        <FeedbackContainer
           flexDirection="column"
           alignItems="center"
           justifyContent="center"
@@ -134,10 +134,22 @@ class SendFeedbackForm extends React.Component<ContextProps, State> {
           >
             Submit
           </Button>
-        </Flex>
+        </FeedbackContainer>
       </Box>
     )
   }
 }
+
+const FeedbackContainer = styled(Flex)`
+  min-height: 212px;
+`
+
+const FeedbackTextAreaContainer = styled(Box)`
+  width: 484px;
+`
+
+const LoggedOutInputContainer = styled(Flex)`
+  width: 484px;
+`
 
 export const SendFeedback = withContext(SendFeedbackForm)

--- a/src/Apps/Search/Components/ZeroState.tsx
+++ b/src/Apps/Search/Components/ZeroState.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, Serif } from "@artsy/palette"
+import { SendFeedback } from "Apps/Search/Components/SendFeedback"
 import React, { FC } from "react"
 
 interface Props {
@@ -11,22 +12,24 @@ export const ZeroState: FC<Props> = props => {
 
   return (
     <Flex
-      height="212px"
+      width="100%"
       flexDirection="column"
       alignItems="center"
       justifyContent="center"
-      width="100%"
     >
-      <Box textAlign="center">
+      <Box m={3} textAlign="center">
         <Serif size="6">
           {`We couldn't find any ${entity} for 
         "${term}"`}
         </Serif>
-      </Box>
-      <Box>
+
         <Serif size="3">
           Try checking your spelling or try another search term.
         </Serif>
+      </Box>
+
+      <Box width="100%">
+        <SendFeedback />
       </Box>
     </Flex>
   )

--- a/src/__generated__/SendFeedbackSearchResultsMutation.graphql.ts
+++ b/src/__generated__/SendFeedbackSearchResultsMutation.graphql.ts
@@ -1,0 +1,222 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type SendFeedbackMutationInput = {
+    readonly message: string;
+    readonly email?: string | null;
+    readonly name?: string | null;
+    readonly url?: string | null;
+    readonly clientMutationId?: string | null;
+};
+export type SendFeedbackSearchResultsMutationVariables = {
+    readonly input: SendFeedbackMutationInput;
+};
+export type SendFeedbackSearchResultsMutationResponse = {
+    readonly sendFeedback: ({
+        readonly feedbackOrError: ({
+            readonly feedback?: ({
+                readonly message: string;
+            }) | null;
+            readonly mutationError?: ({
+                readonly type: string | null;
+                readonly message: string | null;
+                readonly detail: string | null;
+            }) | null;
+        }) | null;
+    }) | null;
+};
+export type SendFeedbackSearchResultsMutation = {
+    readonly response: SendFeedbackSearchResultsMutationResponse;
+    readonly variables: SendFeedbackSearchResultsMutationVariables;
+};
+
+
+
+/*
+mutation SendFeedbackSearchResultsMutation(
+  $input: SendFeedbackMutationInput!
+) {
+  sendFeedback(input: $input) {
+    feedbackOrError {
+      __typename
+      ... on SendFeedbackMutationSuccess {
+        feedback {
+          message
+          __id
+        }
+      }
+      ... on SendFeedbackMutationFailure {
+        mutationError {
+          type
+          message
+          detail
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "SendFeedbackMutationInput!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input",
+    "type": "SendFeedbackMutationInput!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "message",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "type": "SendFeedbackMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "mutationError",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "type",
+          "args": null,
+          "storageKey": null
+        },
+        v2,
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "detail",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+},
+v4 = {
+  "kind": "InlineFragment",
+  "type": "SendFeedbackMutationSuccess",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "feedback",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Feedback",
+      "plural": false,
+      "selections": [
+        v2,
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "__id",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+};
+return {
+  "kind": "Request",
+  "operationKind": "mutation",
+  "name": "SendFeedbackSearchResultsMutation",
+  "id": null,
+  "text": "mutation SendFeedbackSearchResultsMutation(\n  $input: SendFeedbackMutationInput!\n) {\n  sendFeedback(input: $input) {\n    feedbackOrError {\n      __typename\n      ... on SendFeedbackMutationSuccess {\n        feedback {\n          message\n          __id\n        }\n      }\n      ... on SendFeedbackMutationFailure {\n        mutationError {\n          type\n          message\n          detail\n        }\n      }\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "SendFeedbackSearchResultsMutation",
+    "type": "Mutation",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "sendFeedback",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SendFeedbackMutationPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "feedbackOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v3,
+              v4
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "SendFeedbackSearchResultsMutation",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "sendFeedback",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "SendFeedbackMutationPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "feedbackOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "__typename",
+                "args": null,
+                "storageKey": null
+              },
+              v3,
+              v4
+            ]
+          }
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '37c6ef609611534460d2c76061671dac';
+export default node;


### PR DESCRIPTION
Looks like:

<img width="1150" alt="Screen Shot 2019-03-21 at 6 52 28 PM" src="https://user-images.githubusercontent.com/1457859/54789920-a0a40b00-4c0a-11e9-9cc6-0244b5e00bab.png">

and on the artworks tab:

<img width="1151" alt="Screen Shot 2019-03-21 at 6 52 11 PM" src="https://user-images.githubusercontent.com/1457859/54789932-a7cb1900-4c0a-11e9-91fc-4fc06a97bc15.png">

This works for logged in users!

Still to do:
  - ~~when user is logged out, there's additional fields for name/email~~
  - ~~proper success/error handling~~
  - specs