### PR TITLE
DISCO-846: Fix other artwork page follows

### DIFF
--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -19,6 +19,8 @@ import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { data as sd } from "sharify"
 import { get } from "Utils/get"
 
+import { stringify } from "qs"
+
 import {
   ArtistBioFragmentContainer as ArtistBio,
   MarketInsightsFragmentContainer as MarketInsights,
@@ -69,6 +71,45 @@ export class ArtistInfo extends Component<ArtistInfoProps, ArtistInfoState> {
     })
   }
 
+  handleOpenAuth = (mediator, artist) => {
+    if (sd.IS_MOBILE) {
+      this.openMobileAuth(artist)
+    } else if (mediator) {
+      this.openDesktopAuth(mediator, artist)
+    } else {
+      window.location.href = "/login"
+    }
+  }
+
+  openMobileAuth = artist => {
+    const params = stringify({
+      action: "follow",
+      contextModule: "Artwork page",
+      intent: "follow artist",
+      kind: "artist",
+      objectId: artist.id,
+      signUpIntent: "follow artist",
+      trigger: "click",
+      entityName: artist.name,
+    })
+    const href = `/sign_up?redirect-to=${window.location}&${params}`
+
+    window.location.href = href
+  }
+
+  openDesktopAuth = (mediator, artist) => {
+    mediator.trigger("open:auth", {
+      mode: "signup",
+      copy: `Sign up to follow ${artist.name}`,
+      signupIntent: "follow artist",
+      afterSignUpAction: {
+        kind: "artist",
+        action: "follow",
+        objectId: artist.id,
+      },
+    })
+  }
+
   render() {
     const { artist } = this.props
     const { biography_blurb, image, id, _id } = this.props.artist
@@ -105,18 +146,9 @@ export class ArtistInfo extends Component<ArtistInfoProps, ArtistInfoState> {
                       entity_id: _id,
                       entity_slug: id,
                     }}
-                    onOpenAuthModal={() => {
-                      mediator.trigger("open:auth", {
-                        mode: "signup",
-                        copy: `Sign up to follow ${this.props.artist.name}`,
-                        signupIntent: "follow artist",
-                        afterSignUpAction: {
-                          kind: "artist",
-                          action: "follow",
-                          objectId: this.props.artist.id,
-                        },
-                      })
-                    }}
+                    onOpenAuthModal={() =>
+                      this.handleOpenAuth(mediator, this.props.artist)
+                    }
                     render={({ is_followed }) => {
                       return (
                         <Sans

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -81,14 +81,13 @@ export class FollowArtistButton extends React.Component<Props, State> {
 
     if (user && user.id) {
       this.followArtistForUser(user)
-    } else {
-      if (onOpenAuthModal) {
-        onOpenAuthModal("register", {
-          contextModule: "intext tooltip",
-          intent: "follow artist",
-          copy: "Sign up to follow artists",
-        })
+    } else if (onOpenAuthModal) {
+      const config = {
+        contextModule: "intext tooltip",
+        intent: "follow artist",
+        copy: "Sign up to follow artists",
       }
+      onOpenAuthModal("register", config)
     }
   }
 

--- a/src/Components/v2/ArtistCard.tsx
+++ b/src/Components/v2/ArtistCard.tsx
@@ -7,6 +7,9 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
 import { Media } from "Utils/Responsive"
 
+import { stringify } from "qs"
+import { data as sd } from "sharify"
+
 import {
   Avatar,
   BorderBox,
@@ -75,7 +78,7 @@ export const LargeArtistCard: SFC<Props> = props => (
       <FollowArtistButton
         artist={props.artist}
         user={props.user}
-        onOpenAuthModal={() => maybeAuthenticated(props)}
+        onOpenAuthModal={() => handleOpenAuth(props)}
         render={({ is_followed }) => {
           return (
             <Button variant="secondaryOutline" size="small" width={space(9)}>
@@ -111,7 +114,7 @@ export const SmallArtistCard: SFC<Props> = props => (
       <FollowArtistButton
         artist={props.artist}
         user={props.user}
-        onOpenAuthModal={() => maybeAuthenticated(props)}
+        onOpenAuthModal={() => handleOpenAuth(props)}
         render={({ is_followed }) => {
           return (
             <Button variant="secondaryOutline" size="small" width="70px">
@@ -124,15 +127,41 @@ export const SmallArtistCard: SFC<Props> = props => (
   </BorderBox>
 )
 
-function maybeAuthenticated(props: Props) {
-  return props.mediator.trigger("open:auth", {
+const handleOpenAuth = props => {
+  if (sd.IS_MOBILE) {
+    openMobileAuth(props.artist)
+  } else if (props.mediator) {
+    openDesktopAuth(props.mediator, props.artist)
+  } else {
+    window.location.href = "/login"
+  }
+}
+
+const openMobileAuth = artist => {
+  const params = stringify({
+    action: "follow",
+    contextModule: "Artwork page",
+    intent: "follow artist",
+    kind: "artist",
+    objectId: artist.id,
+    signUpIntent: "follow artist",
+    trigger: "click",
+    entityName: artist.name,
+  })
+  const href = `/sign_up?redirect-to=${window.location}&${params}`
+
+  window.location.href = href
+}
+
+const openDesktopAuth = (mediator, artist) => {
+  mediator.trigger("open:auth", {
     mode: "signup",
-    copy: `Sign up to follow ${props.artist.name}`,
+    copy: `Sign up to follow ${artist.name}`,
     signupIntent: "follow artist",
     afterSignUpAction: {
       kind: "artist",
       action: "follow",
-      objectId: props.artist.id,
+      objectId: artist.id,
     },
   })
 }


### PR DESCRIPTION
This PR is a sibling of https://github.com/artsy/reaction/pull/2151 and aims to fix the other places where the mobile sign in should be triggered. There were four places I zeroed in on per the Jira ticket:

https://artsyproduct.atlassian.net/browse/DISCO-846

* following artists from the sidebar
* following partners from the partner section
* following artists from their bio section
* following artists from the related artists grid

In each case I have verified by linking my local force to my local reaction that when viewed from a mobile device, the correct flow is rendered:

### before
<img width="429" alt="Screen Shot 2019-03-22 at 12 21 41 PM" src="https://user-images.githubusercontent.com/79799/54841407-3ee0b100-4c9d-11e9-91e6-c29ac5609e95.png">

### after
<img width="428" alt="Screen Shot 2019-03-22 at 12 21 52 PM" src="https://user-images.githubusercontent.com/79799/54841408-3ee0b100-4c9d-11e9-8b2b-464b1c05bbcf.png">

To do this, I worked backwards from the `ArtworkApp` drilling down to find where we could make a choice about which type of auth experience to trigger. What I found was that in each case there was an `onOpenAuthModal` function that was triggering the desktop experience. What I did was to point this at a new function called `handleOpenAuth` which would give us a seam to make our choice. That func checks `IS_MOBILE` and `mediator` and uses the pair of `openMobileAuth` and `openDesktopAuth` functions to cover all bases with a fallback to just redirecting to `/login`.

Final thought: there's a bit of duplication here and I don't think it's much worse than what was here before, but this diff does present an opportunity to factor something out. I spent a few minutes trying to do this, but I couldn't quite figure out the refactor - if someone has a suggestion I'd be happy to work on it!! ❤️ 