### PR TITLE
@pepopowitz => [SearchResults] Add meta tags

### DIFF
--- a/src/Apps/Search/Components/SearchMeta.tsx
+++ b/src/Apps/Search/Components/SearchMeta.tsx
@@ -1,0 +1,24 @@
+import React, { Component } from "react"
+import { Link, Meta, Title } from "react-head"
+import { data as sd } from "sharify"
+
+interface Props {
+  term: string
+}
+
+export class SearchMeta extends Component<Props> {
+  render() {
+    const { term } = this.props
+
+    const title = `Search Results for '${term}' | Artsy`
+    const href = `/search2?term=${term}`
+    return (
+      <>
+        <Title>{title}</Title>
+        <Link rel="canonical" href={`${sd.APP_URL}${href}`} />
+        <Meta property="og:title" content={title} />
+        <Meta property="og:url" content={`${sd.APP_URL}${href}`} />
+      </>
+    )
+  }
+}

--- a/src/Apps/Search/Components/__tests__/SearchMeta.test.tsx
+++ b/src/Apps/Search/Components/__tests__/SearchMeta.test.tsx
@@ -1,0 +1,38 @@
+import { SearchMeta } from "Apps/Search/Components/SearchMeta"
+import { MockBoot } from "DevTools"
+import { mount } from "enzyme"
+import React from "react"
+import { Link, Title } from "react-head"
+
+jest.mock("sharify", () => ({
+  data: {
+    APP_URL: "test-url",
+  },
+}))
+describe("Meta tags", () => {
+  const getWrapper = () => {
+    return mount(
+      <MockBoot>
+        <SearchMeta term="cats" />
+      </MockBoot>
+    )
+  }
+
+  it("includes the proper title", () => {
+    const component = getWrapper()
+    const title = component.find(Title)
+    expect(title.at(0).text()).toContain("Search Results for 'cats' | Artsy")
+  })
+
+  it("includes the proper url", () => {
+    const component = getWrapper()
+    const link = component
+      .find(Link)
+      .at(0)
+      .html()
+
+    expect(link).toEqual(
+      '<link rel="canonical" href="test-url/search2?term=cats">'
+    )
+  })
+})

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -1,8 +1,9 @@
-import { Col, Row, Separator, Spacer } from "@artsy/palette"
+import { Col, Row, Separator, Serif, Spacer } from "@artsy/palette"
 import { SearchApp_viewer } from "__generated__/SearchApp_viewer.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Search/Components/NavigationTabs"
+import { SearchMeta } from "Apps/Search/Components/SearchMeta"
 import {
   Footer,
   RecentlyViewedQueryRenderer as RecentlyViewed,
@@ -28,15 +29,17 @@ export class SearchApp extends React.Component<ArtistAppProps> {
     return (
       <AppContainer>
         <HorizontalPadding>
-          <Row>
-            <Col>Search Header</Col>
-          </Row>
+          {/* NOTE: react-head automatically moves these tags to the <head> element */}
+          <SearchMeta term={term} />
 
           <Spacer mb={3} />
 
           <Row>
             <Col>
-              {viewer.search.totalCount} results for "{term}"<Spacer mb={3} />
+              <Serif size="5">
+                {viewer.search.totalCount.toLocaleString()} Results for "{term}"
+              </Serif>
+              <Spacer mb={3} />
               <span id="jumpto--searchResultTabs" />
               <NavigationTabs term={term} searchableConnection={search} />
               <Spacer mb={3} />

--- a/src/Apps/Search/__tests__/SearchApp.test.tsx
+++ b/src/Apps/Search/__tests__/SearchApp.test.tsx
@@ -48,16 +48,10 @@ describe("SearchApp", () => {
     },
   }
 
-  it("includes the header", () => {
-    const wrapper = getWrapper(props) as any
-    const html = wrapper.html()
-    expect(html).toContain("Search Header")
-  })
-
   it("includes the total count", () => {
     const wrapper = getWrapper(props) as any
     const html = wrapper.html()
-    expect(html).toContain('420 results for "andy"')
+    expect(html).toContain('420 Results for "andy"')
   })
 
   it("includes tabs w/ counts", () => {


### PR DESCRIPTION
The existing meta tags for the search results page is pretty simple: https://github.com/artsy/force/blob/eaeac419cc7512833946f76b1f851dc3e0c58b00/src/desktop/apps/search/templates/meta.jade

There didn't seem to be any structured data or other SEO/tags found for this. I'll bring up in #seo that we have an opportunity to make some worthy changes to the new search page. But for now, this just implements the existing tags.

Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-855 (for now...)