### PR TITLE
Ensure SEO parsing doesn't fail if no dimensions

### DIFF
--- a/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
+++ b/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
@@ -24,7 +24,7 @@ export const SeoDataForArtwork: React.FC<SeoDataForArtworkProps> = ({
 }) => {
   const artistsName = artwork.artist_names
 
-  const dimensions = parseDimensions(get(artwork, a => a.dimensions.in))
+  const dimensions = parseDimensions(get(artwork, a => a.dimensions.in, ""))
 
   const artworkMetaData = {
     name: artwork.meta.title,
@@ -163,8 +163,8 @@ const buildPriceSpecification = (
   }
 }
 
-const parseDimensions = dimensionsAsString => {
-  const segments = dimensionsAsString.replace(" in", "").split("×")
+const parseDimensions = (dimensions: string) => {
+  const segments = dimensions.replace(" in", "").split("×")
 
   if (segments.length === 2) {
     return {

--- a/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
+++ b/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
@@ -164,6 +164,8 @@ const buildPriceSpecification = (
 }
 
 const parseDimensions = (dimensions: string) => {
+  if (!dimensions) return {}
+
   const segments = dimensions.replace(" in", "").split("×")
 
   if (segments.length === 2) {

--- a/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
+++ b/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
@@ -253,6 +253,13 @@ describe("SeoDataForArtwork", () => {
         expect(getProductData(wrapper).height).toEqual("4 in")
         expect(getProductData(wrapper).depth).toBeUndefined()
       })
+
+      it("successfully handles case when no dimensions a present", async () => {
+        const wrapper = await getWrapper({
+          ...SeoDataForArtworkFixture,
+          dimensions: undefined,
+        })
+      })
     })
   })
 })

--- a/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
+++ b/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
@@ -255,10 +255,12 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("successfully handles case when no dimensions a present", async () => {
-        const wrapper = await getWrapper({
-          ...SeoDataForArtworkFixture,
-          dimensions: undefined,
-        })
+        expect(
+          getWrapper({
+            ...SeoDataForArtworkFixture,
+            dimensions: undefined,
+          })
+        ).not.toThrow()
       })
     })
   })

--- a/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
+++ b/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
@@ -255,11 +255,8 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("successfully handles case when no dimensions a present", async () => {
-        expect(
-          getWrapper({
-            ...SeoDataForArtworkFixture,
-            dimensions: undefined,
-          })
+        expect(() =>
+          getWrapper({ ...SeoDataForArtworkFixture, dimensions: undefined })
         ).not.toThrow()
       })
     })


### PR DESCRIPTION
On artworks without dimensions this code was failing. I provided a default value for `get` so it wouldn't return undefined. 

Something to look into later: Why didn't the types catch this? 