### PR TITLE
@damassi => [SearchResults] Implement analytics

### DIFF
--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -1,6 +1,8 @@
 import { Box, Flex, Image, Link, Sans, Serif, Spacer } from "@artsy/palette"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { Truncator } from "Components/Truncator"
-import React, { FC } from "react"
+import React from "react"
 
 interface GenericSearchResultItemProps {
   imageUrl: string
@@ -8,51 +10,78 @@ interface GenericSearchResultItemProps {
   description?: string
   href: string
   entityType: string
+  term: string
+  index: number
+  id: string
 }
 
-export const GenericSearchResultItem: FC<
+@track()
+export class GenericSearchResultItem extends React.Component<
   GenericSearchResultItemProps
-> = props => {
-  const { imageUrl, href, name, description, entityType } = props
-
-  const translateEntityType = anEntityType => {
-    switch (anEntityType) {
-      case "PartnerShow":
-        return "Show"
-        break
-      default:
-        return anEntityType
-    }
+> {
+  @track((props: GenericSearchResultItemProps) => ({
+    action_type: Schema.ActionType.Click,
+    query: props.term,
+    item_number: props.index,
+    item_type: props.entityType,
+    item_id: props.id,
+    destination_path: props.href,
+  }))
+  handleClick() {
+    // no-op
   }
 
-  return (
-    <>
-      <Flex flexDirection="row">
-        <Link href={href}>
-          <Box height={70} width={70} mr={2} bg="black5">
-            {imageUrl && <Image width={70} height={70} src={imageUrl} />}
-          </Box>
-        </Link>
-        <Box>
-          <Sans color="black100" size="2" weight="medium">
-            {translateEntityType(entityType)}
-          </Sans>
-          <Spacer mb={0.5} />
-          <Link href={href} underlineBehavior="hover">
-            <Serif color="black100" size="3">
-              {name}
-            </Serif>
+  render() {
+    const { imageUrl, href, name, description, entityType } = this.props
+    const translateEntityType = anEntityType => {
+      switch (anEntityType) {
+        case "PartnerShow":
+          return "Show"
+        default:
+          return anEntityType
+      }
+    }
+
+    return (
+      <>
+        <Flex flexDirection="row">
+          <Link
+            href={href}
+            onClick={() => {
+              this.handleClick()
+            }}
+          >
+            <Box height={70} width={70} mr={2} bg="black5">
+              {imageUrl && <Image width={70} height={70} src={imageUrl} />}
+            </Box>
           </Link>
-          {description && (
-            <>
-              <Spacer mb={0.5} />
-              <Serif color="black60" size="3" maxWidth={536}>
-                <Truncator maxLineCount={3}>{description}</Truncator>
+          <Box>
+            <Sans color="black100" size="2" weight="medium">
+              {translateEntityType(entityType)}
+            </Sans>
+            <Spacer mb={0.5} />
+            <Link
+              href={href}
+              underlineBehavior="hover"
+              onClick={() => {
+                this.handleClick()
+              }}
+            >
+              <Serif color="black100" size="3">
+                {name}
               </Serif>
-            </>
-          )}
-        </Box>
-      </Flex>
-    </>
-  )
+            </Link>
+            {description && (
+              <>
+                <Spacer mb={0.5} />
+                <Serif color="black60" size="3" maxWidth={536}>
+                  <Truncator maxLineCount={3}>{description}</Truncator>
+                </Serif>
+              </>
+            )}
+          </Box>
+        </Flex>
+      </>
+    )
+  }
 }

--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -1,5 +1,7 @@
 import { Flex } from "@artsy/palette"
 import { NavigationTabs_searchableConnection } from "__generated__/NavigationTabs_searchableConnection.graphql"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { RouteTab, RouteTabs } from "Components/v2"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -19,7 +21,19 @@ const MORE_TABS = [
   "PartnerInstitutionalSeller",
 ]
 
+@track({
+  context_module: Schema.ContextModule.NavigationTabs,
+})
 export class NavigationTabs extends React.Component<Props> {
+  @track((_props, _state, [tab, destination_path]: string[]) => ({
+    action_type: Schema.ActionType.Click,
+    subject: tab,
+    destination_path,
+  }))
+  handleClick(tab: string, destination_path: string) {
+    // no-op
+  }
+
   renderTab(
     text: string,
     to: string,
@@ -30,7 +44,14 @@ export class NavigationTabs extends React.Component<Props> {
     const { exact } = options
 
     return (
-      <RouteTab to={to} exact={exact} preload={false}>
+      <RouteTab
+        to={to}
+        exact={exact}
+        preload={false}
+        onClick={() => {
+          this.handleClick(text, to)
+        }}
+      >
         {text}
       </RouteTab>
     )

--- a/src/Apps/Search/FilterState.tsx
+++ b/src/Apps/Search/FilterState.tsx
@@ -22,7 +22,7 @@ export interface State {
 }
 
 export const initialState = {
-  medium: "*",
+  medium: null,
   for_sale: null,
   page: 1,
   major_periods: [],

--- a/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
+++ b/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
@@ -66,7 +66,8 @@ export class SearchResultsArticlesRoute extends React.Component<
   }
 
   renderArticles() {
-    const { viewer } = this.props
+    const { viewer, location } = this.props
+    const { term } = get(location, l => l.query)
     const { search: searchConnection } = viewer
 
     const articles = get(viewer, v => v.search.edges, []).map(e => e.node)
@@ -82,6 +83,9 @@ export class SearchResultsArticlesRoute extends React.Component<
                 description=""
                 imageUrl={article.imageUrl}
                 entityType="Article"
+                index={index}
+                term={term}
+                id={article._id}
               />
               {index < articles.length - 1 ? (
                 <>
@@ -152,7 +156,7 @@ export const SearchResultsArticlesRouteRouteFragmentContainer = createRefetchCon
           edges {
             node {
               ... on SearchableItem {
-                id
+                _id
                 displayLabel
                 href
                 imageUrl

--- a/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -66,7 +66,8 @@ export class SearchResultsArtistsRoute extends React.Component<
   }
 
   renderArtists() {
-    const { viewer } = this.props
+    const { viewer, location } = this.props
+    const { term } = get(location, l => l.query)
     const { search: searchConnection } = viewer
 
     const artists = get(viewer, v => v.search.edges, []).map(e => e.node)
@@ -82,6 +83,9 @@ export class SearchResultsArtistsRoute extends React.Component<
                 imageUrl={artist.imageUrl}
                 entityType="Artist"
                 href={artist.href}
+                index={index}
+                term={term}
+                id={artist._id}
               />
               {index < artists.length - 1 ? (
                 <>
@@ -154,6 +158,7 @@ export const SearchResultsArtistsRouteFragmentContainer = createRefetchContainer
             node {
               ... on Artist {
                 name
+                _id
                 href
                 imageUrl
                 bio

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/ColorFilter.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/ColorFilter.tsx
@@ -1,6 +1,7 @@
 import { CheckIcon } from "@artsy/palette"
 import { FilterState } from "Apps/Search/FilterState"
-import { ContextConsumer } from "Artsy/SystemContext"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import React from "react"
 
 interface Props {
@@ -59,173 +60,142 @@ const CheckmarkPositions = {
   },
 }
 
+@track()
 export class ColorFilter extends React.Component<Props> {
-  toggleColor(color, filters, mediator) {
+  @track((props: Props, _state, [color]) => {
+    return {
+      action_type: Schema.ActionType.ClickedCommercialFilter,
+      changed: { color },
+      current: { ...props.filters.state },
+    }
+  })
+  toggleColor(color) {
+    const { filters } = this.props
     if (filters.state.color === color) {
-      filters.unsetFilter("color", mediator)
+      filters.unsetFilter("color")
     } else {
-      filters.setFilter("color", color, mediator)
+      filters.setFilter("color", color)
     }
   }
 
   render() {
     const { filters } = this.props
 
+    const CheckmarkStyle = {
+      position: "relative",
+      cursor: "pointer",
+      ...CheckmarkPositions[filters.state.color],
+    }
     return (
-      <ContextConsumer>
-        {({ mediator }) => {
-          const CheckmarkStyle = {
-            position: "relative",
-            cursor: "pointer",
-            ...CheckmarkPositions[filters.state.color],
-          }
-          return (
-            <>
-              <svg
-                version="1.1"
-                id="Layer_1"
-                height="175"
-                width="175"
-                x="0px"
-                y="0px"
-                viewBox="0 0 175 175"
-                enableBackground="new 0 0 175 175"
-                xmlSpace="preserve"
-              >
-                <g>
-                  <path
-                    fill="#F7923A"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("orange", filters, mediator)
-                    }
-                    d="M64.9,172.1c14.4,3.9,29.9,4.1,45.3,0l-9.7-36.2c-8.8,2.4-17.7,2.2-25.9,0L64.9,172.1z"
-                  />
-                  <path
-                    fill="#435EA9"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("darkblue", filters, mediator)
-                    }
-                    d="M110.2,3C95.8-0.9,80.3-1.1,64.9,3l9.7,36.2c8.8-2.4,17.7-2.2,25.9,0L110.2,3z"
-                  />
-                  <polygon
-                    fill="none"
-                    points="87.5,87.5 87.5,87.5 87.5,87.5  "
-                  />
-                  <path
-                    fill="#FFC749"
-                    style={{ cursor: "pointer" }}
-                    onClick={() => this.toggleColor("gold", filters, mediator)}
-                    d="M52.2,122.9l-26.5,26.5c10.9,10.8,24.4,18.7,39.2,22.7l9.7-36.2C66.1,133.5,58.4,129.1,52.2,122.9z"
-                  />
-                  <polygon
-                    fill="#FFF200"
-                    points="87.5,87.5 87.5,87.5 87.5,87.5  "
-                  />
-                  <path
-                    fill="#388540"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("darkgreen", filters, mediator)
-                    }
-                    d="M52.2,52.2L25.6,25.6C14.8,36.5,7,50.1,3,64.9l36.2,9.7C41.5,66.1,46,58.4,52.2,52.2z"
-                  />
-                  <path
-                    fill="#438C97"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("lightblue", filters, mediator)
-                    }
-                    d="M74.6,39.2L64.9,3C49.5,7.1,36.2,15.1,25.6,25.6l26.5,26.5C58.2,46.2,65.8,41.6,74.6,39.2z"
-                  />
-                  <polygon
-                    fill="#FFF200"
-                    points="87.5,87.5 87.5,87.5 87.5,87.5  "
-                  />
-                  <path
-                    fill="#BCCC46"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("lightgreen", filters, mediator)
-                    }
-                    d="M3,64.9c-3.9,14.4-4.1,29.9,0,45.3l36.2-9.7c-2.4-8.8-2.2-17.7,0-25.9L3,64.9z"
-                  />
-                  <path
-                    fill="#FBE854"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("yellow", filters, mediator)
-                    }
-                    d="M39.2,100.5L3,110.2c4.1,15.4,12.1,28.7,22.6,39.2l26.5-26.5C46.2,116.9,41.6,109.3,39.2,100.5z"
-                  />
-                  <polygon
-                    fill="#FFF200"
-                    points="87.5,87.5 87.5,87.5 87.5,87.5  "
-                  />
-                  <path
-                    fill="#F1572C"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("darkorange", filters, mediator)
-                    }
-                    d="M100.5,135.8l9.7,36.2c15.4-4.1,28.7-12.1,39.2-22.6l-26.5-26.5C116.9,128.9,109.3,133.5,100.5,135.8z"
-                  />
-                  <path
-                    fill="#D73127"
-                    style={{ cursor: "pointer" }}
-                    onClick={() => this.toggleColor("red", filters, mediator)}
-                    d="M135.8,100.5c-2.3,8.5-6.7,16.2-12.9,22.4l26.5,26.5c10.8-10.9,18.7-24.4,22.7-39.2L135.8,100.5z"
-                  />
-                  <path
-                    fill="#B82C83"
-                    style={{ cursor: "pointer" }}
-                    onClick={() => this.toggleColor("pink", filters, mediator)}
-                    d="M135.8,74.6c2.4,8.8,2.2,17.7,0,25.9l36.2,9.7c3.9-14.4,4.1-29.9,0-45.3L135.8,74.6z"
-                  />
-                  <path
-                    fill="#642B7F"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("darkviolet", filters, mediator)
-                    }
-                    d="M149.4,25.6l-26.5,26.5c6,6,10.6,13.6,12.9,22.4l36.2-9.7C167.9,49.5,159.9,36.2,149.4,25.6z"
-                  />
-                  <path
-                    fill="#6C479C"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("violet", filters, mediator)
-                    }
-                    d="M122.9,52.2l26.5-26.5C138.5,14.8,125,7,110.2,3l-9.7,36.2C108.9,41.5,116.7,46,122.9,52.2z"
-                  />
-                  <path
-                    fill="#DFDFDF"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("black-and-white", filters, mediator)
-                    }
-                    d="M101.7,73.4c7.8,7.8,7.8,20.5,0,28.3L73.4,73.4C81.2,65.6,93.9,65.6,101.7,73.4z"
-                  />
-                  <path
-                    fill="#595A5B"
-                    style={{ cursor: "pointer" }}
-                    onClick={() =>
-                      this.toggleColor("black-and-white", filters, mediator)
-                    }
-                    d="M73.4,73.4l28.3,28.3c-7.8,7.8-20.5,7.8-28.3,0C65.6,93.9,65.6,81.2,73.4,73.4z"
-                  />
-                </g>
-              </svg>
-              <CheckIcon
-                onClick={e => filters.unsetFilter("color")}
-                style={CheckmarkStyle}
-                fill="white100"
-              />
-            </>
-          )
-        }}
-      </ContextConsumer>
+      <>
+        <svg
+          version="1.1"
+          id="Layer_1"
+          height="175"
+          width="175"
+          x="0px"
+          y="0px"
+          viewBox="0 0 175 175"
+          enableBackground="new 0 0 175 175"
+          xmlSpace="preserve"
+        >
+          <g>
+            <path
+              fill="#F7923A"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("orange")}
+              d="M64.9,172.1c14.4,3.9,29.9,4.1,45.3,0l-9.7-36.2c-8.8,2.4-17.7,2.2-25.9,0L64.9,172.1z"
+            />
+            <path
+              fill="#435EA9"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("darkblue")}
+              d="M110.2,3C95.8-0.9,80.3-1.1,64.9,3l9.7,36.2c8.8-2.4,17.7-2.2,25.9,0L110.2,3z"
+            />
+            <polygon fill="none" points="87.5,87.5 87.5,87.5 87.5,87.5  " />
+            <path
+              fill="#FFC749"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("gold")}
+              d="M52.2,122.9l-26.5,26.5c10.9,10.8,24.4,18.7,39.2,22.7l9.7-36.2C66.1,133.5,58.4,129.1,52.2,122.9z"
+            />
+            <polygon fill="#FFF200" points="87.5,87.5 87.5,87.5 87.5,87.5  " />
+            <path
+              fill="#388540"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("darkgreen")}
+              d="M52.2,52.2L25.6,25.6C14.8,36.5,7,50.1,3,64.9l36.2,9.7C41.5,66.1,46,58.4,52.2,52.2z"
+            />
+            <path
+              fill="#438C97"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("lightblue")}
+              d="M74.6,39.2L64.9,3C49.5,7.1,36.2,15.1,25.6,25.6l26.5,26.5C58.2,46.2,65.8,41.6,74.6,39.2z"
+            />
+            <polygon fill="#FFF200" points="87.5,87.5 87.5,87.5 87.5,87.5  " />
+            <path
+              fill="#BCCC46"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("lightgreen")}
+              d="M3,64.9c-3.9,14.4-4.1,29.9,0,45.3l36.2-9.7c-2.4-8.8-2.2-17.7,0-25.9L3,64.9z"
+            />
+            <path
+              fill="#FBE854"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("yellow")}
+              d="M39.2,100.5L3,110.2c4.1,15.4,12.1,28.7,22.6,39.2l26.5-26.5C46.2,116.9,41.6,109.3,39.2,100.5z"
+            />
+            <polygon fill="#FFF200" points="87.5,87.5 87.5,87.5 87.5,87.5  " />
+            <path
+              fill="#F1572C"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("darkorange")}
+              d="M100.5,135.8l9.7,36.2c15.4-4.1,28.7-12.1,39.2-22.6l-26.5-26.5C116.9,128.9,109.3,133.5,100.5,135.8z"
+            />
+            <path
+              fill="#D73127"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("red")}
+              d="M135.8,100.5c-2.3,8.5-6.7,16.2-12.9,22.4l26.5,26.5c10.8-10.9,18.7-24.4,22.7-39.2L135.8,100.5z"
+            />
+            <path
+              fill="#B82C83"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("pink")}
+              d="M135.8,74.6c2.4,8.8,2.2,17.7,0,25.9l36.2,9.7c3.9-14.4,4.1-29.9,0-45.3L135.8,74.6z"
+            />
+            <path
+              fill="#642B7F"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("darkviolet")}
+              d="M149.4,25.6l-26.5,26.5c6,6,10.6,13.6,12.9,22.4l36.2-9.7C167.9,49.5,159.9,36.2,149.4,25.6z"
+            />
+            <path
+              fill="#6C479C"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("violet")}
+              d="M122.9,52.2l26.5-26.5C138.5,14.8,125,7,110.2,3l-9.7,36.2C108.9,41.5,116.7,46,122.9,52.2z"
+            />
+            <path
+              fill="#DFDFDF"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("black-and-white")}
+              d="M101.7,73.4c7.8,7.8,7.8,20.5,0,28.3L73.4,73.4C81.2,65.6,93.9,65.6,101.7,73.4z"
+            />
+            <path
+              fill="#595A5B"
+              style={{ cursor: "pointer" }}
+              onClick={() => this.toggleColor("black-and-white")}
+              d="M73.4,73.4l28.3,28.3c-7.8,7.8-20.5,7.8-28.3,0C65.6,93.9,65.6,81.2,73.4,73.4z"
+            />
+          </g>
+        </svg>
+        <CheckIcon
+          onClick={e => filters.unsetFilter("color")}
+          style={CheckmarkStyle}
+          fill="white100"
+        />
+      </>
     )
   }
 }

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/MediumFilter.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/MediumFilter.tsx
@@ -1,39 +1,51 @@
-import { Radio } from "@artsy/palette"
+import { Radio, RadioGroup } from "@artsy/palette"
 import { FilterState } from "Apps/Search/FilterState"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import React from "react"
 
-export const MediumFilter: React.SFC<{
+interface Props {
   filters: FilterState
   mediums: Array<{
     id: string
     name: string
   }>
-}> = ({ filters, mediums }) => {
-  const allowedMediums = mediums && mediums.length ? mediums : hardcodedMediums
-  return (
-    <>
-      {allowedMediums.map((medium, index) => {
-        const isSelected = filters.state.medium === medium.id
+}
 
-        return (
-          <Radio
-            my={0.3}
-            selected={isSelected}
-            value={medium.id}
-            onSelect={({ selected }) => {
-              if (selected) {
-                return filters.setFilter("medium", medium.id)
-              } else {
-                return filters.unsetFilter("medium")
-              }
-            }}
-            key={index}
-            label={medium.name}
-          />
-        )
-      })}
-    </>
-  )
+@track()
+export class MediumFilter extends React.Component<Props> {
+  @track((props: Props, _state, [medium]) => {
+    return {
+      action_type: Schema.ActionType.ClickedCommercialFilter,
+      changed: { medium },
+      current: { ...props.filters.state },
+    }
+  })
+  onClick(value) {
+    const { filters } = this.props
+    filters.setFilter("medium", value)
+  }
+
+  render() {
+    const { mediums } = this.props
+    const allowedMediums =
+      mediums && mediums.length ? mediums : hardcodedMediums
+
+    const radioButtons = allowedMediums.map((medium, index) => {
+      return (
+        <Radio key={index} my={0.3} value={medium.id} label={medium.name} />
+      )
+    })
+    return (
+      <RadioGroup
+        onSelect={selectedOption => {
+          this.onClick(selectedOption)
+        }}
+      >
+        {radioButtons}
+      </RadioGroup>
+    )
+  }
 }
 
 const hardcodedMediums = [

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/PriceRangeFilter.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/PriceRangeFilter.tsx
@@ -1,25 +1,45 @@
 import { PriceRange } from "@artsy/palette"
 import { FilterState } from "Apps/Search/FilterState"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import React from "react"
 
-export const PriceRangeFilter: React.FC<{
+interface Props {
   filters: FilterState
-}> = ({ filters }) => {
-  const [initialMin, initialMax] = filters.rangeToTuple("price_range")
-  return (
-    <PriceRange
-      allowCross={false}
-      min={FilterState.MIN_PRICE}
-      max={FilterState.MAX_PRICE}
-      step={50}
-      defaultValue={[initialMin, initialMax]}
-      disabled={filters.state.at_auction}
-      onAfterChange={([min, max]) => {
-        const minStr = min === FilterState.MIN_PRICE ? "*" : min
-        const maxStr = max === FilterState.MAX_PRICE ? "*" : max
+}
 
-        filters.setFilter("price_range", `${minStr}-${maxStr}`)
-      }}
-    />
-  )
+@track()
+export class PriceRangeFilter extends React.Component<Props> {
+  @track((props: Props, _state, [price_range]) => {
+    return {
+      action_type: Schema.ActionType.ClickedCommercialFilter,
+      changed: { price_range },
+      current: { ...props.filters.state },
+    }
+  })
+  setRange(range) {
+    const { filters } = this.props
+    filters.setFilter("price_range", range)
+  }
+
+  render() {
+    const { filters } = this.props
+    const [initialMin, initialMax] = filters.rangeToTuple("price_range")
+    return (
+      <PriceRange
+        allowCross={false}
+        min={FilterState.MIN_PRICE}
+        max={FilterState.MAX_PRICE}
+        step={50}
+        defaultValue={[initialMin, initialMax]}
+        disabled={filters.state.at_auction}
+        onAfterChange={([min, max]) => {
+          const minStr = min === FilterState.MIN_PRICE ? "*" : min
+          const maxStr = max === FilterState.MAX_PRICE ? "*" : max
+
+          this.setRange(`${minStr}-${maxStr}`)
+        }}
+      />
+    )
+  }
 }

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/SizeRangeFilters.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/SizeRangeFilters.tsx
@@ -1,42 +1,61 @@
 import { LabeledRange } from "@artsy/palette"
 import { FilterState } from "Apps/Search/FilterState"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import React from "react"
 
-export const SizeRangeFilters: React.FC<{
+interface Props {
   filters: FilterState
-}> = ({ filters }) => {
-  const [initialMinHeight, initialMaxHeight] = filters.rangeToTuple("height")
-  const [initialMinWidth, initialMaxWidth] = filters.rangeToTuple("width")
-  return (
-    <>
-      <LabeledRange
-        label="Height"
-        allowCross={false}
-        min={FilterState.MIN_HEIGHT}
-        max={FilterState.MAX_HEIGHT}
-        unit="in"
-        step={1}
-        defaultValue={[initialMinHeight, initialMaxHeight]}
-        onAfterChange={([min, max]) => {
-          const minStr = min === FilterState.MIN_HEIGHT ? "*" : min
-          const maxStr = max === FilterState.MAX_HEIGHT ? "*" : max
-          filters.setFilter("height", `${minStr}-${maxStr}`)
-        }}
-      />
-      <LabeledRange
-        label="Width"
-        allowCross={false}
-        min={FilterState.MIN_WIDTH}
-        max={FilterState.MAX_WIDTH}
-        unit="in"
-        step={1}
-        defaultValue={[initialMinWidth, initialMaxWidth]}
-        onAfterChange={([min, max]) => {
-          const minStr = min === FilterState.MIN_WIDTH ? "*" : min
-          const maxStr = max === FilterState.MAX_WIDTH ? "*" : max
-          filters.setFilter("width", `${minStr}-${maxStr}`)
-        }}
-      />
-    </>
-  )
+}
+
+@track()
+export class SizeRangeFilters extends React.Component<Props> {
+  @track((props: Props, _state, [type, value]) => {
+    return {
+      action_type: Schema.ActionType.ClickedCommercialFilter,
+      changed: { [type]: value },
+      current: { ...props.filters.state },
+    }
+  })
+  setRange(type, value) {
+    const { filters } = this.props
+    filters.setFilter(type, value)
+  }
+  render() {
+    const { filters } = this.props
+    const [initialMinHeight, initialMaxHeight] = filters.rangeToTuple("height")
+    const [initialMinWidth, initialMaxWidth] = filters.rangeToTuple("width")
+    return (
+      <>
+        <LabeledRange
+          label="Height"
+          allowCross={false}
+          min={FilterState.MIN_HEIGHT}
+          max={FilterState.MAX_HEIGHT}
+          unit="in"
+          step={1}
+          defaultValue={[initialMinHeight, initialMaxHeight]}
+          onAfterChange={([min, max]) => {
+            const minStr = min === FilterState.MIN_HEIGHT ? "*" : min
+            const maxStr = max === FilterState.MAX_HEIGHT ? "*" : max
+            this.setRange("height", `${minStr}-${maxStr}`)
+          }}
+        />
+        <LabeledRange
+          label="Width"
+          allowCross={false}
+          min={FilterState.MIN_WIDTH}
+          max={FilterState.MAX_WIDTH}
+          unit="in"
+          step={1}
+          defaultValue={[initialMinWidth, initialMaxWidth]}
+          onAfterChange={([min, max]) => {
+            const minStr = min === FilterState.MIN_WIDTH ? "*" : min
+            const maxStr = max === FilterState.MAX_WIDTH ? "*" : max
+            this.setRange("width", `${minStr}-${maxStr}`)
+          }}
+        />
+      </>
+    )
+  }
 }

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/TimePeriodFilter.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/TimePeriodFilter.tsx
@@ -1,38 +1,50 @@
+import { Radio, RadioGroup } from "@artsy/palette"
 import { FilterState } from "Apps/Search/FilterState"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import React from "react"
 
-import { Radio } from "@artsy/palette"
-
-export const TimePeriodFilter: React.SFC<{
+interface Props {
   filters: FilterState
   timePeriods?: string[]
-}> = ({ filters, timePeriods }) => {
-  return (
-    <>
-      {(timePeriods || allowedPeriods)
-        .filter(timePeriod => allowedPeriods.includes(timePeriod))
-        .map((timePeriod, index) => {
-          const isSelected = filters.state.major_periods[0] === timePeriod
+}
 
-          return (
-            <Radio
-              my={0.3}
-              selected={isSelected}
-              value={timePeriod}
-              onSelect={({ selected }) => {
-                if (selected) {
-                  return filters.setFilter("major_periods", timePeriod)
-                } else {
-                  return filters.unsetFilter("major_periods")
-                }
-              }}
-              key={index}
-              label={timePeriod}
-            />
-          )
-        })}
-    </>
-  )
+@track()
+export class TimePeriodFilter extends React.Component<Props> {
+  @track((props: Props, _state, [major_periods]) => {
+    return {
+      action_type: Schema.ActionType.ClickedCommercialFilter,
+      changed: { major_periods },
+      current: { ...props.filters.state },
+    }
+  })
+  onClick(value) {
+    const { filters } = this.props
+    filters.setFilter("major_periods", value)
+  }
+
+  render() {
+    const { timePeriods } = this.props
+
+    const periods = (timePeriods || allowedPeriods).filter(timePeriod =>
+      allowedPeriods.includes(timePeriod)
+    )
+
+    const radioButtons = periods.map((timePeriod, index) => {
+      return (
+        <Radio my={0.3} value={timePeriod} key={index} label={timePeriod} />
+      )
+    })
+    return (
+      <RadioGroup
+        onSelect={selectedOption => {
+          this.onClick(selectedOption)
+        }}
+      >
+        {radioButtons}
+      </RadioGroup>
+    )
+  }
 }
 
 const allowedPeriods = [

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/WaysToBuyFilter.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/WaysToBuyFilter.tsx
@@ -1,5 +1,7 @@
 import { Checkbox, Sans } from "@artsy/palette"
 import { FilterState, State } from "Apps/Search/FilterState"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import React from "react"
 
 interface WayToBuy {
@@ -8,50 +10,68 @@ interface WayToBuy {
   state: keyof State
 }
 
-export const WaysToBuyFilter: React.FC<{
+interface Props {
   filters: FilterState
-}> = ({ filters }) => {
-  const ways: WayToBuy[] = [
-    {
-      disabled: false,
-      name: "Buy now",
-      state: "acquireable",
-    },
-    {
-      disabled: false,
-      name: "Make offer",
-      state: "offerable",
-    },
-    {
-      disabled: filters.isRangeSelected("price_range"),
-      name: "Bid",
-      state: "at_auction",
-    },
-    {
-      disabled: false,
-      name: "Inquire",
-      state: "inquireable_only",
-    },
-  ]
+}
 
-  const constructCheckboxes = () =>
-    ways.map((way, index) => {
-      const props = {
-        disabled: way.disabled,
-        key: index,
-        onSelect: value => filters.setFilter(way.state, value),
-        selected: filters.state[way.state],
-      }
+@track()
+export class WaysToBuyFilter extends React.Component<Props> {
+  @track((props: Props, _state, [type, value]) => {
+    return {
+      action_type: Schema.ActionType.ClickedCommercialFilter,
+      changed: { [type]: value },
+      current: { ...props.filters.state },
+    }
+  })
+  onSelect(type, value) {
+    const { filters } = this.props
+    filters.setFilter(type, value)
+  }
 
-      return <Checkbox {...props}>{way.name}</Checkbox>
-    })
+  render() {
+    const { filters } = this.props
+    const ways: WayToBuy[] = [
+      {
+        disabled: false,
+        name: "Buy now",
+        state: "acquireable",
+      },
+      {
+        disabled: false,
+        name: "Make offer",
+        state: "offerable",
+      },
+      {
+        disabled: filters.isRangeSelected("price_range"),
+        name: "Bid",
+        state: "at_auction",
+      },
+      {
+        disabled: false,
+        name: "Inquire",
+        state: "inquireable_only",
+      },
+    ]
 
-  return (
-    <React.Fragment>
-      <Sans size="2" weight="medium" color="black100" my={1}>
-        Ways to buy
-      </Sans>
-      {constructCheckboxes()}
-    </React.Fragment>
-  )
+    const constructCheckboxes = () =>
+      ways.map((way, index) => {
+        const props = {
+          disabled: way.disabled,
+          key: index,
+          onSelect: value => this.onSelect(way.state, value),
+          selected: filters.state[way.state],
+        }
+
+        return <Checkbox {...props}>{way.name}</Checkbox>
+      })
+
+    return (
+      <React.Fragment>
+        <Sans size="2" weight="medium" color="black100" my={1}>
+          Ways to buy
+        </Sans>
+        {constructCheckboxes()}
+      </React.Fragment>
+    )
+  }
 }

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsFilterContainer.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsFilterContainer.tsx
@@ -49,7 +49,7 @@ export const SearchResultsFilterFragmentContainer = createFragmentContainer(
   graphql`
     fragment SearchResultsFilterContainer_viewer on Viewer
       @argumentDefinitions(
-        medium: { type: "String", defaultValue: "*" }
+        medium: { type: "String" }
         major_periods: { type: "[String]" }
         partner_id: { type: "ID" }
         for_sale: { type: "Boolean" }

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx
@@ -75,7 +75,7 @@ export const SearchResultsRefetchContainer = createRefetchContainer(
     viewer: graphql`
       fragment SearchResultsRefetch_viewer on Viewer
         @argumentDefinitions(
-          medium: { type: "String", defaultValue: "*" }
+          medium: { type: "String" }
           major_periods: { type: "[String]" }
           partner_id: { type: "ID" }
           for_sale: { type: "Boolean" }

--- a/src/Apps/Search/Routes/Artworks/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/Artworks/SearchResultsArtworks.tsx
@@ -1,11 +1,11 @@
 import { Box } from "@artsy/palette"
 import { SearchResultsArtworks_viewer } from "__generated__/SearchResultsArtworks_viewer.graphql"
+import { FilterState } from "Apps/Search/FilterState"
 import { SearchResultsFilterFragmentContainer as ArtworkGrid } from "Apps/Search/Routes/Artworks/Components/Filter/SearchResultsFilterContainer"
 import { Location } from "found"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Provider } from "unstated"
-import { FilterState } from "../../FilterState"
 
 export interface Props {
   viewer: SearchResultsArtworks_viewer
@@ -24,7 +24,7 @@ export class SearchResultsArtworksRoute extends React.Component<Props> {
       <Provider
         inject={[
           new FilterState({
-            keyword: query.term,
+            keyword: term,
           }),
         ]}
       >
@@ -42,7 +42,7 @@ export const SearchResultsArtworksRouteFragmentContainer = createFragmentContain
     fragment SearchResultsArtworks_viewer on Viewer
       @argumentDefinitions(
         keyword: { type: "String!", defaultValue: "" }
-        medium: { type: "String", defaultValue: "*" }
+        medium: { type: "String" }
         major_periods: { type: "[String]" }
         partner_id: { type: "ID" }
         for_sale: { type: "Boolean" }

--- a/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
+++ b/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
@@ -67,7 +67,8 @@ export class SearchResultAuctionsRoute extends React.Component<
   }
 
   renderAuctions() {
-    const { viewer } = this.props
+    const { viewer, location } = this.props
+    const { term } = get(location, l => l.query)
     const { search: searchConnection } = viewer
 
     const sales = get(viewer, v => v.search.edges, []).map(e => e.node)
@@ -83,6 +84,9 @@ export class SearchResultAuctionsRoute extends React.Component<
                 href={auction.href}
                 imageUrl={auction.imageUrl}
                 entityType="Auction"
+                index={index}
+                term={term}
+                id={auction._id}
               />
               {index < sales.length - 1 ? (
                 <>
@@ -157,6 +161,7 @@ export const SearchResultsAuctionsRouteRouteFragmentContainer = createRefetchCon
                 description
                 displayLabel
                 href
+                _id
                 imageUrl
                 searchableType
               }

--- a/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
+++ b/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
@@ -66,7 +66,8 @@ export class SearchResultCategoriesRoute extends React.Component<
   }
 
   renderCategories() {
-    const { viewer } = this.props
+    const { viewer, location } = this.props
+    const { term } = get(location, l => l.query)
     const { search: searchConnection } = viewer
 
     const genes = get(viewer, v => v.search.edges, []).map(e => e.node)
@@ -81,6 +82,9 @@ export class SearchResultCategoriesRoute extends React.Component<
                 href={gene.href}
                 imageUrl={gene.imageUrl}
                 entityType="Category"
+                index={index}
+                term={term}
+                id={gene._id}
               />
               {index < genes.length - 1 ? (
                 <>
@@ -155,6 +159,7 @@ export const SearchResultsCategoriesRouteRouteFragmentContainer = createRefetchC
                 description
                 displayLabel
                 href
+                _id
                 imageUrl
                 searchableType
               }

--- a/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
+++ b/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
@@ -66,7 +66,8 @@ export class SearchResultsCollectionsRoute extends React.Component<
   }
 
   renderCollections() {
-    const { viewer } = this.props
+    const { viewer, location } = this.props
+    const { term } = get(location, l => l.query)
     const { search: searchConnection } = viewer
 
     const collections = get(viewer, v => v.search.edges, []).map(e => e.node)
@@ -82,6 +83,9 @@ export class SearchResultsCollectionsRoute extends React.Component<
                 href={collection.href}
                 imageUrl={collection.imageUrl}
                 entityType="Collection"
+                index={index}
+                term={term}
+                id={collection._id}
               />
               {index < collections.length - 1 ? (
                 <>
@@ -155,6 +159,7 @@ export const SearchResultsCollectionsRouteFragmentContainer = createRefetchConta
                 description
                 displayLabel
                 href
+                _id
                 imageUrl
                 searchableType
               }

--- a/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
+++ b/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
@@ -66,7 +66,8 @@ export class SearchResultsGalleriesRoute extends React.Component<
   }
 
   renderGalleries() {
-    const { viewer } = this.props
+    const { viewer, location } = this.props
+    const { term } = get(location, l => l.query)
     const { search: searchConnection } = viewer
     const galleries = get(viewer, v => v.search.edges, []).map(e => e.node)
 
@@ -81,6 +82,9 @@ export class SearchResultsGalleriesRoute extends React.Component<
                 href={gallery.href}
                 imageUrl={gallery.imageUrl}
                 entityType="Gallery"
+                index={index}
+                term={term}
+                id={gallery._id}
               />
               {index < galleries.length - 1 ? (
                 <>
@@ -154,6 +158,7 @@ export const SearchResultsGalleriesRouteRouteFragmentContainer = createRefetchCo
                 description
                 displayLabel
                 href
+                _id
                 imageUrl
                 searchableType
               }

--- a/src/Apps/Search/Routes/More/SearchResultsMore.tsx
+++ b/src/Apps/Search/Routes/More/SearchResultsMore.tsx
@@ -1,7 +1,6 @@
 import { Box, Separator, Spacer } from "@artsy/palette"
-import { SearchResultsAuctions_viewer } from "__generated__/SearchResultsAuctions_viewer.graphql"
+import { SearchResultsMore_viewer } from "__generated__/SearchResultsMore_viewer.graphql"
 import { GenericSearchResultItem } from "Apps/Search/Components/GenericSearchResultItem"
-
 import { ZeroState } from "Apps/Search/Components/ZeroState"
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
@@ -11,7 +10,7 @@ import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { get } from "Utils/get"
 
 export interface Props {
-  viewer: SearchResultsAuctions_viewer
+  viewer: SearchResultsMore_viewer
   relay: RelayRefetchProp
   location: Location
 }
@@ -67,7 +66,8 @@ export class SearchResultMoreRoute extends React.Component<
   }
 
   renderItems() {
-    const { viewer } = this.props
+    const { viewer, location } = this.props
+    const { term } = get(location, l => l.query)
     const { search: searchConnection } = viewer
 
     const items = get(viewer, v => v.search.edges, []).map(e => e.node)
@@ -82,6 +82,9 @@ export class SearchResultMoreRoute extends React.Component<
                 href={searchableItem.href}
                 imageUrl={searchableItem.imageUrl}
                 entityType={searchableItem.searchableType}
+                index={index}
+                term={term}
+                id={searchableItem._id}
               />
               {index < items.length - 1 ? (
                 <>
@@ -156,6 +159,7 @@ export const SearchResultsMoreRouteRouteFragmentContainer = createRefetchContain
                 description
                 displayLabel
                 href
+                _id
                 imageUrl
                 searchableType
               }

--- a/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
+++ b/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
@@ -66,7 +66,8 @@ export class SearchResultsShowsRoute extends React.Component<
   }
 
   renderShows() {
-    const { viewer } = this.props
+    const { viewer, location } = this.props
+    const { term } = get(location, l => l.query)
     const { search: searchConnection } = viewer
 
     const shows = get(viewer, v => v.search.edges, []).map(e => e.node)
@@ -81,6 +82,9 @@ export class SearchResultsShowsRoute extends React.Component<
                 href={show.href}
                 imageUrl={show.imageUrl}
                 entityType="Show"
+                index={index}
+                term={term}
+                id={show._id}
               />
               {index < shows.length - 1 ? (
                 <>
@@ -155,6 +159,7 @@ export const SearchResultsShowsRouteRouteFragmentContainer = createRefetchContai
                 description
                 displayLabel
                 href
+                _id
                 imageUrl
                 searchableType
               }

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -4,6 +4,8 @@ import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Search/Components/NavigationTabs"
 import { SearchMeta } from "Apps/Search/Components/SearchMeta"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import {
   Footer,
   RecentlyViewedQueryRenderer as RecentlyViewed,
@@ -13,12 +15,15 @@ import React from "react"
 import { LazyLoadComponent } from "react-lazy-load-image-component"
 import { createFragmentContainer, graphql } from "react-relay"
 
-export interface ArtistAppProps {
+export interface Props {
   viewer: SearchApp_viewer
   location: Location
 }
 
-export class SearchApp extends React.Component<ArtistAppProps> {
+@track({
+  context_page: Schema.PageName.SearchPage,
+})
+export class SearchApp extends React.Component<Props> {
   render() {
     const { viewer, location } = this.props
     const { search } = viewer

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -57,6 +57,6 @@ storiesOf("Apps", module)
   })
   .add("Search Results page", () => {
     return (
-      <MockRouter routes={searchRoutes} initialRoute="/search2?term=sdsdfs" />
+      <MockRouter routes={searchRoutes} initialRoute="/search2?term=andy" />
     )
   })

--- a/src/Artsy/Analytics/Schema/ContextPage.ts
+++ b/src/Artsy/Analytics/Schema/ContextPage.ts
@@ -9,13 +9,13 @@ export interface ContextPage {
   /**
    * The type of the entity that this page represents.
    */
-  context_page_owner_type: OwnerType
+  context_page_owner_type?: OwnerType
 
   /**
    * The database ID of the owner. E.g. in the case of an entity that comes out
    * of Gravity this should be its Mongo ID.
    */
-  context_page_owner_id: string
+  context_page_owner_id?: string
 
   /**
    * The slug of the entity, if it has one.

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -5,6 +5,7 @@ export enum PageName {
   ArticlePage = "Article",
   ArtistPage = "Artist",
   ArtworkPage = "Artwork page",
+  SearchPage = "Search page",
 }
 
 /**

--- a/src/Artsy/Router/Components/Boot.tsx
+++ b/src/Artsy/Router/Components/Boot.tsx
@@ -35,7 +35,9 @@ const { GlobalStyles } = injectGlobalStyles<{
 }>()
 
 @track(null, {
-  dispatch: data => Events.postEvent(data),
+  dispatch: data => {
+    Events.postEvent(data)
+  },
 })
 export class Boot extends React.Component<BootProps> {
   componentDidMount() {

--- a/src/__generated__/SearchResultsArticlesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsArticlesQuery.graphql.ts
@@ -47,7 +47,7 @@ fragment SearchResultsArticles_viewer_4c14dZ on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          _id
           displayLabel
           href
           imageUrl
@@ -147,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsArticlesQuery",
   "id": null,
-  "text": "query SearchResultsArticlesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArticles_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsArticlesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArticles_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          _id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -385,7 +385,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsArticles_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArticles_viewer.graphql.ts
@@ -15,7 +15,7 @@ export type SearchResultsArticles_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly id?: string;
+                readonly _id?: string;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
@@ -187,7 +187,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "id",
+                      "name": "_id",
                       "args": null,
                       "storageKey": null
                     },
@@ -229,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '05e1afe2699e33d3f4d70aa01a9db155';
+(node as any).hash = '9a8531bd79617025ad1fa51451d0e729';
 export default node;

--- a/src/__generated__/SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsArtistsQuery.graphql.ts
@@ -48,6 +48,7 @@ fragment SearchResultsArtists_viewer_4c14dZ on Viewer {
         __typename
         ... on Artist {
           name
+          _id
           href
           imageUrl
           bio
@@ -146,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsArtistsQuery",
   "id": null,
-  "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArtists_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTIST]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArtists_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTIST]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          _id\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -385,6 +386,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "name",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsArtists_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArtists_viewer.graphql.ts
@@ -16,6 +16,7 @@ export type SearchResultsArtists_viewer = {
         readonly edges: ReadonlyArray<({
             readonly node: ({
                 readonly name?: string | null;
+                readonly _id?: string;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
                 readonly bio?: string | null;
@@ -193,6 +194,13 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "_id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "href",
                       "args": null,
                       "storageKey": null
@@ -221,5 +229,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'c006f68a2be37e7be01026155fc8fc66';
+(node as any).hash = '89f52fa5b4c4d98a1299ffa9c01247b4';
 export default node;

--- a/src/__generated__/SearchResultsArtworks_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArtworks_viewer.graphql.ts
@@ -27,7 +27,7 @@ const node: ConcreteFragment = {
       "kind": "LocalArgument",
       "name": "medium",
       "type": "String",
-      "defaultValue": "*"
+      "defaultValue": null
     },
     {
       "kind": "LocalArgument",
@@ -228,5 +228,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '5c8094420b3578ef13b89361ba7a2fbd';
+(node as any).hash = '7cfcecddba9d351e7645c7af98dd1aec';
 export default node;

--- a/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
@@ -50,6 +50,7 @@ fragment SearchResultsAuctions_viewer_4c14dZ on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -147,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -400,6 +401,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
@@ -18,6 +18,7 @@ export type SearchResultsAuctions_viewer = {
                 readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
+                readonly _id?: string;
                 readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
@@ -208,6 +209,13 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "_id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "imageUrl",
                       "args": null,
                       "storageKey": null
@@ -229,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '0ff35562fda42f98c9076a2740d05306';
+(node as any).hash = 'c7f47380a6868205741da4d08c771ece';
 export default node;

--- a/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
@@ -50,6 +50,7 @@ fragment SearchResultsCategories_viewer_4c14dZ on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -147,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -400,6 +401,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsCategories_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCategories_viewer.graphql.ts
@@ -18,6 +18,7 @@ export type SearchResultsCategories_viewer = {
                 readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
+                readonly _id?: string;
                 readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
@@ -208,6 +209,13 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "_id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "imageUrl",
                       "args": null,
                       "storageKey": null
@@ -229,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '08d3e3aa8e22cc82ad28fb73bb3b25f7';
+(node as any).hash = '8a5db7bf4ebd66a2bebc2bd5a24532fd';
 export default node;

--- a/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
@@ -50,6 +50,7 @@ fragment SearchResultsCollections_viewer_4c14dZ on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -147,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -400,6 +401,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsCollections_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCollections_viewer.graphql.ts
@@ -18,6 +18,7 @@ export type SearchResultsCollections_viewer = {
                 readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
+                readonly _id?: string;
                 readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
@@ -208,6 +209,13 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "_id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "imageUrl",
                       "args": null,
                       "storageKey": null
@@ -229,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'ad1ed82c761d47e4f62d5adecfc0a8bb';
+(node as any).hash = '410a0c1f644056d3a36a426273d060f6';
 export default node;

--- a/src/__generated__/SearchResultsFilterContainer_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsFilterContainer_viewer.graphql.ts
@@ -39,7 +39,7 @@ return {
       "kind": "LocalArgument",
       "name": "medium",
       "type": "String",
-      "defaultValue": "*"
+      "defaultValue": null
     },
     {
       "kind": "LocalArgument",
@@ -316,5 +316,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'eb4ce8cc44a104ddc32cb6b1dd9b0ffd';
+(node as any).hash = 'c11a1c8e0c39cbf677c15980fcd030b6';
 export default node;

--- a/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
@@ -50,6 +50,7 @@ fragment SearchResultsGalleries_viewer_4c14dZ on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -147,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -400,6 +401,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
@@ -18,6 +18,7 @@ export type SearchResultsGalleries_viewer = {
                 readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
+                readonly _id?: string;
                 readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
@@ -208,6 +209,13 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "_id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "imageUrl",
                       "args": null,
                       "storageKey": null
@@ -229,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '98ee017a72c0726e0ca3fffb708b8ac2';
+(node as any).hash = '7c3916c60eba5e054e7e845b039372bd';
 export default node;

--- a/src/__generated__/SearchResultsMoreQuery.graphql.ts
+++ b/src/__generated__/SearchResultsMoreQuery.graphql.ts
@@ -50,6 +50,7 @@ fragment SearchResultsMore_viewer_4c14dZ on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -147,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsMoreQuery",
   "id": null,
-  "text": "query SearchResultsMoreQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsMore_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsMoreQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsMore_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -404,6 +405,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsMore_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsMore_viewer.graphql.ts
@@ -18,6 +18,7 @@ export type SearchResultsMore_viewer = {
                 readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
+                readonly _id?: string;
                 readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
@@ -212,6 +213,13 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "_id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "imageUrl",
                       "args": null,
                       "storageKey": null
@@ -233,5 +241,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '8d03f2b4be9e4ae455da699f9a22f794';
+(node as any).hash = '62192ed7900635db4eb362028503cfdb';
 export default node;

--- a/src/__generated__/SearchResultsRefetch_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsRefetch_viewer.graphql.ts
@@ -23,7 +23,7 @@ const node: ConcreteFragment = {
       "kind": "LocalArgument",
       "name": "medium",
       "type": "String",
-      "defaultValue": "*"
+      "defaultValue": null
     },
     {
       "kind": "LocalArgument",
@@ -253,5 +253,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '32106b0949c623673a44bbdb3d4b0a44';
+(node as any).hash = 'ebd437ac353b964fd0bb654654474141';
 export default node;

--- a/src/__generated__/SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsShowsQuery.graphql.ts
@@ -50,6 +50,7 @@ fragment SearchResultsShows_viewer_4c14dZ on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -147,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsShowsQuery",
   "id": null,
-  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -400,6 +401,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/SearchResultsShows_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsShows_viewer.graphql.ts
@@ -18,6 +18,7 @@ export type SearchResultsShows_viewer = {
                 readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
+                readonly _id?: string;
                 readonly imageUrl?: string | null;
                 readonly searchableType?: string | null;
             }) | null;
@@ -208,6 +209,13 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "_id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "imageUrl",
                       "args": null,
                       "storageKey": null
@@ -229,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '2001fd869ba4b5fdbc8ec2be7270ea2d';
+(node as any).hash = '9b44d18a92e4e2c3c9ab86d0f40d7b6b';
 export default node;

--- a/src/__generated__/routes_SearchResultsArticlesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArticlesQuery.graphql.ts
@@ -39,7 +39,7 @@ fragment SearchResultsArticles_viewer_4hh6ED on Viewer {
       node {
         __typename
         ... on SearchableItem {
-          id
+          _id
           displayLabel
           href
           imageUrl
@@ -115,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArticlesQuery",
   "id": null,
-  "text": "query routes_SearchResultsArticlesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArticles_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsArticlesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArticles_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          _id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -311,7 +311,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "id",
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
@@ -40,6 +40,7 @@ fragment SearchResultsArtists_viewer_4hh6ED on Viewer {
         __typename
         ... on Artist {
           name
+          _id
           href
           imageUrl
           bio
@@ -114,7 +115,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArtistsQuery",
   "id": null,
-  "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArtists_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTIST]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArtists_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTIST]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          _id\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -311,6 +312,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "name",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
@@ -42,6 +42,7 @@ fragment SearchResultsAuctions_viewer_4hh6ED on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -115,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -326,6 +327,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
@@ -42,6 +42,7 @@ fragment SearchResultsCategories_viewer_4hh6ED on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -115,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -326,6 +327,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
@@ -42,6 +42,7 @@ fragment SearchResultsCollections_viewer_4hh6ED on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -115,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -326,6 +327,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
@@ -42,6 +42,7 @@ fragment SearchResultsGalleries_viewer_4hh6ED on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -115,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -326,6 +327,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsMoreQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsMoreQuery.graphql.ts
@@ -42,6 +42,7 @@ fragment SearchResultsMore_viewer_4hh6ED on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -115,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsMoreQuery",
   "id": null,
-  "text": "query routes_SearchResultsMoreQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsMore_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsMoreQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsMore_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -330,6 +331,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
@@ -42,6 +42,7 @@ fragment SearchResultsShows_viewer_4hh6ED on Viewer {
           description
           displayLabel
           href
+          _id
           imageUrl
           searchableType
         }
@@ -115,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsShowsQuery",
   "id": null,
-  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -326,6 +327,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "href",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "_id",
                             "args": null,
                             "storageKey": null
                           },


### PR DESCRIPTION
- Implements tracking on clicking tabs
- Implements tracking on clicking search results
- Implements full tracking on filter

All tracking was accomplished via `@track` decorators. The diff is largely due to changing lots of components that were just simple `FC` instances into actual classes, so that decorators could be added to `onClick`, and things like that.

I did notice one issue with the radio buttons on the filter. They seemed to not render properly (they would be selected and immediately unselected, but switching to a `RadioGroup` fixed that).