### PR TITLE
@damassi => [Collect] Fix radio buttons which double fire when clicking the label

### DIFF
--- a/src/Apps/Collect/CollectApp.tsx
+++ b/src/Apps/Collect/CollectApp.tsx
@@ -1,6 +1,8 @@
 import { Box, Flex, Sans, Serif } from "@artsy/palette"
 import { CollectApp_viewer } from "__generated__/CollectApp_viewer.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import { FrameWithRecentlyViewed } from "Components/FrameWithRecentlyViewed"
 import { BreadCrumbList } from "Components/v2/Seo"
 import React, { Component } from "react"
@@ -18,6 +20,9 @@ export interface CollectAppProps {
   }
 }
 
+@track({
+  context_page: Schema.PageName.CollectPage,
+})
 export class CollectApp extends Component<CollectAppProps> {
   render() {
     const {

--- a/src/Apps/Collect/Components/Filters/MediumFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/MediumFilter.tsx
@@ -1,4 +1,4 @@
-import { Radio } from "@artsy/palette"
+import { Radio, RadioGroup } from "@artsy/palette"
 import { ContextConsumer } from "Artsy/SystemContext"
 import React from "react"
 import { FilterState } from "../../FilterState"
@@ -11,10 +11,11 @@ export const MediumFilter: React.SFC<{
   }>
 }> = ({ filters, mediums }) => {
   const allowedMediums = mediums && mediums.length ? mediums : hardcodedMediums
+
   return (
     <ContextConsumer>
-      {({ mediator }) =>
-        allowedMediums.map((medium, index) => {
+      {({ mediator }) => {
+        const radioButtons = allowedMediums.map((medium, index) => {
           const isSelected = filters.state.medium === medium.id
 
           return (
@@ -22,19 +23,21 @@ export const MediumFilter: React.SFC<{
               my={0.3}
               selected={isSelected}
               value={medium.id}
-              onSelect={({ selected }) => {
-                if (selected) {
-                  return filters.setFilter("medium", medium.id, mediator)
-                } else {
-                  return filters.unsetFilter("medium", mediator)
-                }
-              }}
               key={index}
               label={medium.name}
             />
           )
         })
-      }
+        return (
+          <RadioGroup
+            onSelect={selectedOption => {
+              filters.setFilter("medium", selectedOption, mediator)
+            }}
+          >
+            {radioButtons}
+          </RadioGroup>
+        )
+      }}
     </ContextConsumer>
   )
 }

--- a/src/Apps/Collect/Components/Filters/TimePeriodFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/TimePeriodFilter.tsx
@@ -2,41 +2,41 @@ import { ContextConsumer } from "Artsy/SystemContext"
 import React from "react"
 import { FilterState } from "../../FilterState"
 
-import { Radio } from "@artsy/palette"
+import { Radio, RadioGroup } from "@artsy/palette"
 
 export const TimePeriodFilter: React.SFC<{
   filters: FilterState
   timePeriods?: string[]
 }> = ({ filters, timePeriods }) => (
   <ContextConsumer>
-    {({ mediator }) =>
-      (timePeriods || allowedPeriods)
-        .filter(timePeriod => allowedPeriods.includes(timePeriod))
-        .map((timePeriod, index) => {
-          const isSelected = filters.state.major_periods[0] === timePeriod
+    {({ mediator }) => {
+      const periods = (timePeriods || allowedPeriods).filter(timePeriod =>
+        allowedPeriods.includes(timePeriod)
+      )
 
-          return (
-            <Radio
-              my={0.3}
-              selected={isSelected}
-              value={timePeriod}
-              onSelect={({ selected }) => {
-                if (selected) {
-                  return filters.setFilter(
-                    "major_periods",
-                    timePeriod,
-                    mediator
-                  )
-                } else {
-                  return filters.unsetFilter("major_periods", mediator)
-                }
-              }}
-              key={index}
-              label={timePeriod}
-            />
-          )
-        })
-    }
+      const radioButtons = periods.map((timePeriod, index) => {
+        const isSelected = filters.state.major_periods[0] === timePeriod
+
+        return (
+          <Radio
+            my={0.3}
+            selected={isSelected}
+            value={timePeriod}
+            key={index}
+            label={timePeriod}
+          />
+        )
+      })
+      return (
+        <RadioGroup
+          onSelect={selectedOption => {
+            filters.setFilter("major_periods", selectedOption, mediator)
+          }}
+        >
+          {radioButtons}
+        </RadioGroup>
+      )
+    }}
   </ContextConsumer>
 )
 

--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -41,6 +41,12 @@ export const initialState = {
   color: null,
 }
 
+// These filters aren't tracked via the `tracking` prop passed in here.
+// Instead, they are tracked using decorators in the collect page.
+// Once all filters are switched to be tracked using decorators this can
+// be removed.
+export const untrackedFilters = ["medium", "major_periods"]
+
 export class FilterState extends Container<State> {
   state = cloneDeep(initialState)
   tracking: any
@@ -166,6 +172,7 @@ export class FilterState extends Container<State> {
     this.setState(newPartialState, () => {
       mediator.trigger("collect:filter:changed", this.filteredState)
 
+      if (untrackedFilters.includes(filter)) return
       this.tracking &&
         this.tracking.trackEvent({
           action: "Commercial filter: params changed",

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -5,6 +5,7 @@ export enum PageName {
   ArticlePage = "Article",
   ArtistPage = "Artist",
   ArtworkPage = "Artwork page",
+  CollectPage = "Collect page",
   SearchPage = "Search page",
 }
 


### PR DESCRIPTION
Very...rabbit-hole-y!

If you go to www.artsy.net/collect, and click a radio button filter (Medium, or Time Period), and select it by clicking the label- you see something strange. It immediately selects and de-selects. There seems to be an `onSelect`/`onClick` being fired twice for the `<Radio>` component, but only when clicking the label portion.

Switching to using `<RadioGroup>` _still_ results in a double fire, but due to a friendlier API you can accomplish the desired goal of the UI being consistent (it remains checked once you select it, vs checking on and off previously).

This implements that here for Collect. However, when doing so I ran into an issue that the analytics tracking would be fired twice (😭 ). So, I refactored that a bit to use decorators.