### PR TITLE
@damassi => [SearchResults] Correct URL behavior for filter interactions

### DIFF
--- a/src/Apps/Search/FilterState.tsx
+++ b/src/Apps/Search/FilterState.tsx
@@ -41,6 +41,27 @@ export const initialState = {
   keyword: null,
 }
 
+// This is used to remove default state params that clutter up URLs.
+export const isDefaultFilter = (filter, value): boolean => {
+  if (filter === "major_periods" || filter === "attribution_class") {
+    return value.length === 0
+  }
+
+  if (filter === "sort") {
+    return value === "-decayed_merch"
+  }
+
+  if (filter === "price_range" || filter === "height" || filter === "width") {
+    return value === "*-*"
+  }
+
+  if (filter === "page") {
+    return value === 1
+  }
+
+  return !value
+}
+
 export class FilterState extends Container<State> {
   state = cloneDeep(initialState)
 

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/MediumFilter.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/MediumFilter.tsx
@@ -17,7 +17,7 @@ export class MediumFilter extends React.Component<Props> {
   }
 
   render() {
-    const { mediums } = this.props
+    const { mediums, filters } = this.props
     const allowedMediums =
       mediums && mediums.length ? mediums : hardcodedMediums
 
@@ -26,8 +26,12 @@ export class MediumFilter extends React.Component<Props> {
         <Radio key={index} my={0.3} value={medium.id} label={medium.name} />
       )
     })
+
+    const selectedMedium = filters.state.medium
+
     return (
       <RadioGroup
+        defaultValue={selectedMedium}
         onSelect={selectedOption => {
           this.onClick(selectedOption)
         }}

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/TimePeriodFilter.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/TimePeriodFilter.tsx
@@ -14,7 +14,7 @@ export class TimePeriodFilter extends React.Component<Props> {
   }
 
   render() {
-    const { timePeriods } = this.props
+    const { timePeriods, filters } = this.props
 
     const periods = (timePeriods || allowedPeriods).filter(timePeriod =>
       allowedPeriods.includes(timePeriod)
@@ -25,8 +25,12 @@ export class TimePeriodFilter extends React.Component<Props> {
         <Radio my={0.3} value={timePeriod} key={index} label={timePeriod} />
       )
     })
+
+    const selectedPeriod = filters.state.major_periods[0]
+
     return (
       <RadioGroup
+        defaultValue={selectedPeriod && selectedPeriod[0]}
         onSelect={selectedOption => {
           this.onClick(selectedOption)
         }}

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx
@@ -1,8 +1,9 @@
 import { SearchResultsRefetch_viewer } from "__generated__/SearchResultsRefetch_viewer.graphql"
-import { FilterState } from "Apps/Search/FilterState"
+import { FilterState, isDefaultFilter } from "Apps/Search/FilterState"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { isEqual } from "lodash"
+import qs from "qs"
 import React, { Component } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { SearchResultsArtworkGridRefreshContainer as SearchArtworkGrid } from "./SearchResultsArtworkGrid"
@@ -53,6 +54,28 @@ export class SearchResultsRefetch extends Component<SearchRefetchProps> {
           if (error) {
             console.error(error)
           }
+
+          const term = this.props.filtersState.keyword
+
+          const filters = Object.entries(this.props.filtersState).reduce(
+            (acc, [key, value]) => {
+              if (isDefaultFilter(key, value) || key === "keyword") {
+                return acc
+              } else {
+                return { ...acc, [key]: value }
+              }
+            },
+            {}
+          )
+
+          const filterQueryParams = qs.stringify({
+            ...filters,
+            term,
+          })
+
+          // TODO: Look into using router push w/ query params.
+          // this.props.router.replace(`/search2?${filterQueryParams}`)
+          window.history.pushState({}, null, `/search2?${filterQueryParams}`)
 
           this.setState({
             isLoading: false,

--- a/src/Apps/Search/Routes/Artworks/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/Artworks/SearchResultsArtworks.tsx
@@ -14,16 +14,15 @@ export interface Props {
 
 export class SearchResultsArtworksRoute extends React.Component<Props> {
   render() {
-    const {
-      viewer,
-      location: { query },
-    } = this.props
+    const { viewer, location } = this.props
+    const { query } = location
     const { term } = query
 
     return (
       <Provider
         inject={[
           new FilterState({
+            ...query,
             keyword: term,
           }),
         ]}


### PR DESCRIPTION
This correctly initializes the filter fetch, as well as the filter UI, based on params from the URL (so clicking a deep link like `/search2?medium=photography&term=kaws` works.

It also uses `window.history.pushState` to update the URL when interacting with the filter. Propagating the `router` prop and doing a `router.push` seems to trigger 'active' navigation and reloading, whereas for these query params a 'shallow' route is desired.