### PR TITLE
[WIP] Fix chrome lazy loading issue by removing overflow

### DIFF
--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -15,7 +15,6 @@ const Placeholder = styled.div`
   background-color: ${color("black10")};
   position: relative;
   width: 100%;
-  overflow: hidden;
 `
 
 const Image = styled(BaseImage)`


### PR DESCRIPTION
Fixes [PLATFORM-1313](https://artsyproduct.atlassian.net/browse/PLATFORM-1313).

For reasons I don't fully comprehend, having a overflow hidden on a parent container of an absolute element causes the observer worker in chrome to intermittently not correctly detect that the image is visible. 

It's a weird issue. This fixes the lazy loading issue that was seen in prod. I'll dig through and try to find a more robust solution though. 