### PR TITLE
@mzikherman => [Search] Bring back Filter for xs breakpoint

### DIFF
--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/FilterContainer.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/FilterContainer.tsx
@@ -12,7 +12,15 @@ import { SizeRangeFilters } from "./SizeRangeFilters"
 import { TimePeriodFilter } from "./TimePeriodFilter"
 import { WaysToBuyFilter } from "./WaysToBuyFilter"
 
-import { Box, Flex, Separator, Toggle } from "@artsy/palette"
+import {
+  Box,
+  Button,
+  FilterIcon,
+  Flex,
+  Separator,
+  Spacer,
+  Toggle,
+} from "@artsy/palette"
 import { Media } from "Utils/Responsive"
 
 export interface FilterContainerProps {
@@ -98,6 +106,23 @@ export class FilterContainer extends React.Component<
                   )}
 
                   <span id="jump--searchArtworkGrid" />
+                  <Flex justifyContent="flex-end" alignItems="center">
+                    <Button
+                      size="small"
+                      mt={-1}
+                      onClick={() =>
+                        this.setState({ showMobileActionSheet: true })
+                      }
+                    >
+                      <Flex justifyContent="space-between" alignItems="center">
+                        <FilterIcon fill="white100" />
+                        <Spacer mr={0.5} />
+                        Filter
+                      </Flex>
+                    </Button>
+                  </Flex>
+
+                  <Spacer mb={2} />
 
                   {this.props.children(filters)}
                 </Mobile>


### PR DESCRIPTION
Oddly enough this was part of the `Sort` component, which was removed (no sorting for V1). This should just be part of the container and not the sort component.