### PR TITLE
HOLD: Use displayType vs searchableType

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -8261,7 +8261,8 @@ type SearchableItem implements Node & Searchable {
   displayLabel: String
   imageUrl: String
   href: String
-  searchableType: String
+  searchableType: String @deprecated(reason: "Switch to use `displayType`")
+  displayType: String
 }
 
 enum SearchAggregation {

--- a/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
+++ b/src/Apps/Search/Routes/Articles/SearchResultsArticles.tsx
@@ -74,18 +74,18 @@ export class SearchResultsArticlesRoute extends React.Component<
 
     return (
       <>
-        {articles.map((article, index) => {
+        {articles.map((searchableItem, index) => {
           return (
             <Box key={index}>
               <GenericSearchResultItem
-                name={article.displayLabel}
-                href={article.href}
-                description=""
-                imageUrl={article.imageUrl}
-                entityType="Article"
+                name={searchableItem.displayLabel}
+                href={searchableItem.href}
+                description={searchableItem.description}
+                imageUrl={searchableItem.imageUrl}
+                entityType={searchableItem.displayType}
                 index={index}
                 term={term}
-                id={article._id}
+                id={searchableItem._id}
               />
               {index < articles.length - 1 ? (
                 <>
@@ -157,10 +157,11 @@ export const SearchResultsArticlesRouteRouteFragmentContainer = createRefetchCon
             node {
               ... on SearchableItem {
                 _id
+                description
                 displayLabel
                 href
                 imageUrl
-                searchableType
+                displayType
               }
             }
           }

--- a/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -96,18 +96,18 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
 
     return (
       <>
-        {artists.map((artist, index) => {
+        {artists.map((searchableItem, index) => {
           return (
             <Box key={index}>
               <GenericSearchResultItem
-                name={artist.name}
-                description={artist.bio}
-                imageUrl={artist.imageUrl}
-                entityType="Artist"
-                href={artist.href}
+                name={searchableItem.displayLabel}
+                description={searchableItem.description}
+                imageUrl={searchableItem.imageUrl}
+                entityType={searchableItem.displayType}
+                href={searchableItem.href}
                 index={index}
                 term={term}
-                id={artist._id}
+                id={searchableItem._id}
               />
               {index < artists.length - 1 ? (
                 <>
@@ -180,12 +180,13 @@ export const SearchResultsArtistsRouteFragmentContainer = createRefetchContainer
           }
           edges {
             node {
-              ... on Artist {
-                name
+              ... on SearchableItem {
+                displayLabel
                 _id
                 href
                 imageUrl
-                bio
+                displayType
+                description
               }
             }
           }

--- a/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
+++ b/src/Apps/Search/Routes/Auctions/SearchResultsAuctions.tsx
@@ -75,18 +75,18 @@ export class SearchResultAuctionsRoute extends React.Component<
 
     return (
       <>
-        {sales.map((auction, index) => {
+        {sales.map((searchableItem, index) => {
           return (
             <Box key={index}>
               <GenericSearchResultItem
-                name={auction.displayLabel}
-                description={auction.description}
-                href={auction.href}
-                imageUrl={auction.imageUrl}
-                entityType="Auction"
+                name={searchableItem.displayLabel}
+                description={searchableItem.description}
+                href={searchableItem.href}
+                imageUrl={searchableItem.imageUrl}
+                entityType={searchableItem.displayType}
                 index={index}
                 term={term}
-                id={auction._id}
+                id={searchableItem._id}
               />
               {index < sales.length - 1 ? (
                 <>
@@ -163,7 +163,7 @@ export const SearchResultsAuctionsRouteRouteFragmentContainer = createRefetchCon
                 href
                 _id
                 imageUrl
-                searchableType
+                displayType
               }
             }
           }

--- a/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
+++ b/src/Apps/Search/Routes/Categories/SearchResultsCategories.tsx
@@ -73,18 +73,18 @@ export class SearchResultCategoriesRoute extends React.Component<
     const genes = get(viewer, v => v.search.edges, []).map(e => e.node)
     return (
       <>
-        {genes.map((gene, index) => {
+        {genes.map((searchableItem, index) => {
           return (
             <Box key={index}>
               <GenericSearchResultItem
-                name={gene.displayLabel}
-                description={gene.description}
-                href={gene.href}
-                imageUrl={gene.imageUrl}
-                entityType="Category"
+                name={searchableItem.displayLabel}
+                description={searchableItem.description}
+                href={searchableItem.href}
+                imageUrl={searchableItem.imageUrl}
+                entityType={searchableItem.displayType}
                 index={index}
                 term={term}
-                id={gene._id}
+                id={searchableItem._id}
               />
               {index < genes.length - 1 ? (
                 <>
@@ -161,7 +161,7 @@ export const SearchResultsCategoriesRouteRouteFragmentContainer = createRefetchC
                 href
                 _id
                 imageUrl
-                searchableType
+                displayType
               }
             }
           }

--- a/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
+++ b/src/Apps/Search/Routes/Collections/SearchResultsCollections.tsx
@@ -74,18 +74,18 @@ export class SearchResultsCollectionsRoute extends React.Component<
 
     return (
       <>
-        {collections.map((collection, index) => {
+        {collections.map((searchableItem, index) => {
           return (
             <Box key={index}>
               <GenericSearchResultItem
-                name={collection.displayLabel}
-                description={collection.description}
-                href={collection.href}
-                imageUrl={collection.imageUrl}
-                entityType="Collection"
+                name={searchableItem.displayLabel}
+                description={searchableItem.description}
+                href={searchableItem.href}
+                imageUrl={searchableItem.imageUrl}
+                entityType={searchableItem.displayType}
                 index={index}
                 term={term}
-                id={collection._id}
+                id={searchableItem._id}
               />
               {index < collections.length - 1 ? (
                 <>
@@ -161,7 +161,7 @@ export const SearchResultsCollectionsRouteFragmentContainer = createRefetchConta
                 href
                 _id
                 imageUrl
-                searchableType
+                displayType
               }
             }
           }

--- a/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
+++ b/src/Apps/Search/Routes/Galleries/SearchResultsGalleries.tsx
@@ -73,18 +73,18 @@ export class SearchResultsGalleriesRoute extends React.Component<
 
     return (
       <>
-        {galleries.map((gallery, index) => {
+        {galleries.map((searchableItem, index) => {
           return (
             <Box key={index}>
               <GenericSearchResultItem
-                name={gallery.displayLabel}
-                description={gallery.description}
-                href={gallery.href}
-                imageUrl={gallery.imageUrl}
-                entityType="Gallery"
+                name={searchableItem.displayLabel}
+                description={searchableItem.description}
+                href={searchableItem.href}
+                imageUrl={searchableItem.imageUrl}
+                entityType={searchableItem.displayType}
                 index={index}
                 term={term}
-                id={gallery._id}
+                id={searchableItem._id}
               />
               {index < galleries.length - 1 ? (
                 <>
@@ -160,7 +160,7 @@ export const SearchResultsGalleriesRouteRouteFragmentContainer = createRefetchCo
                 href
                 _id
                 imageUrl
-                searchableType
+                displayType
               }
             }
           }

--- a/src/Apps/Search/Routes/More/SearchResultsMore.tsx
+++ b/src/Apps/Search/Routes/More/SearchResultsMore.tsx
@@ -81,7 +81,7 @@ export class SearchResultMoreRoute extends React.Component<
                 description={searchableItem.description}
                 href={searchableItem.href}
                 imageUrl={searchableItem.imageUrl}
-                entityType={searchableItem.searchableType}
+                entityType={searchableItem.displayType}
                 index={index}
                 term={term}
                 id={searchableItem._id}
@@ -161,7 +161,7 @@ export const SearchResultsMoreRouteRouteFragmentContainer = createRefetchContain
                 href
                 _id
                 imageUrl
-                searchableType
+                displayType
               }
             }
           }

--- a/src/Apps/Search/Routes/More/__tests__/SearchResultsMore.test.tsx
+++ b/src/Apps/Search/Routes/More/__tests__/SearchResultsMore.test.tsx
@@ -26,7 +26,7 @@ describe("SearchResultsMore", () => {
               id: "percy",
               displayLabel: "Cat",
               href: "/cat/percy",
-              searchableType: "Artistic Cats",
+              displayType: "Artistic Cat",
             },
           },
         ],

--- a/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
+++ b/src/Apps/Search/Routes/Shows/SearchResultsShows.tsx
@@ -73,18 +73,18 @@ export class SearchResultsShowsRoute extends React.Component<
     const shows = get(viewer, v => v.search.edges, []).map(e => e.node)
     return (
       <>
-        {shows.map((show, index) => {
+        {shows.map((searchableItem, index) => {
           return (
             <Box key={index}>
               <GenericSearchResultItem
-                name={show.displayLabel}
-                description={show.description}
-                href={show.href}
-                imageUrl={show.imageUrl}
-                entityType="Show"
+                name={searchableItem.displayLabel}
+                description={searchableItem.description}
+                href={searchableItem.href}
+                imageUrl={searchableItem.imageUrl}
+                entityType={searchableItem.displayType}
                 index={index}
                 term={term}
-                id={show._id}
+                id={searchableItem._id}
               />
               {index < shows.length - 1 ? (
                 <>
@@ -161,7 +161,7 @@ export const SearchResultsShowsRouteRouteFragmentContainer = createRefetchContai
                 href
                 _id
                 imageUrl
-                searchableType
+                displayType
               }
             }
           }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -101,7 +101,7 @@ export class SearchBar extends Component<Props, State> {
     if (!suggestion) return
 
     const {
-      node: { searchableType: entityType, id: entityID },
+      node: { displayType: entityType, id: entityID },
     } = suggestion
 
     if (entityType === "FirstItem") return
@@ -216,7 +216,7 @@ export class SearchBar extends Component<Props, State> {
       [
         {
           suggestion: {
-            node: { href, searchableType, id },
+            node: { href, displayType, id },
           },
           suggestionIndex,
         },
@@ -225,7 +225,7 @@ export class SearchBar extends Component<Props, State> {
       action_type: Schema.ActionType.SelectedItemFromSearch,
       query: state.term,
       destination_path: href,
-      item_type: searchableType,
+      item_type: displayType,
       item_id: id,
       item_number: suggestionIndex,
     })
@@ -273,7 +273,7 @@ export class SearchBar extends Component<Props, State> {
   }
 
   renderSuggestion = (
-    { node: { displayLabel, searchableType, href } },
+    { node: { displayLabel, displayType, href } },
     { query, isHighlighted }
   ) => {
     return (
@@ -281,7 +281,7 @@ export class SearchBar extends Component<Props, State> {
         display={displayLabel}
         href={href}
         isHighlighted={isHighlighted}
-        label={searchableType}
+        label={displayType}
         query={query}
       />
     )
@@ -304,7 +304,7 @@ export class SearchBar extends Component<Props, State> {
 
     const firstSuggestionPlaceholder = {
       node: {
-        searchableType: "FirstItem",
+        displayType: "FirstItem",
         displayLabel: term,
         href: `/search?q=${term}`,
       },
@@ -364,7 +364,7 @@ export const SearchBarRefetchContainer = createRefetchContainer(
               displayLabel
               href
               ... on SearchableItem {
-                searchableType
+                displayType
                 id
               }
             }

--- a/src/Components/Search/__tests__/SearchBar.test.tsx
+++ b/src/Components/Search/__tests__/SearchBar.test.tsx
@@ -17,7 +17,7 @@ const searchResults = {
         node: {
           displayLabel: "Percy Z",
           href: "/cat/percy-z",
-          searchableType: "Cat",
+          displayType: "Cat",
           id: "percy-z",
         },
       },

--- a/src/__generated__/SearchBarRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchBarRefetchQuery.graphql.ts
@@ -36,7 +36,7 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
         displayLabel
         href
         ... on SearchableItem {
-          searchableType
+          displayType
           id
         }
         ... on Node {
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarRefetchQuery",
   "id": null,
-  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -208,7 +208,7 @@ return {
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
-                                "name": "searchableType",
+                                "name": "displayType",
                                 "args": null,
                                 "storageKey": null
                               },

--- a/src/__generated__/SearchBarSuggestQuery.graphql.ts
+++ b/src/__generated__/SearchBarSuggestQuery.graphql.ts
@@ -36,7 +36,7 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
         displayLabel
         href
         ... on SearchableItem {
-          searchableType
+          displayType
           id
         }
         ... on Node {
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarSuggestQuery",
   "id": null,
-  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -208,7 +208,7 @@ return {
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
-                                "name": "searchableType",
+                                "name": "displayType",
                                 "args": null,
                                 "storageKey": null
                               },

--- a/src/__generated__/SearchBarTestQuery.graphql.ts
+++ b/src/__generated__/SearchBarTestQuery.graphql.ts
@@ -36,7 +36,7 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
         displayLabel
         href
         ... on SearchableItem {
-          searchableType
+          displayType
           id
         }
         ... on Node {
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarTestQuery",
   "id": null,
-  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -208,7 +208,7 @@ return {
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
-                                "name": "searchableType",
+                                "name": "displayType",
                                 "args": null,
                                 "storageKey": null
                               },

--- a/src/__generated__/SearchBar_viewer.graphql.ts
+++ b/src/__generated__/SearchBar_viewer.graphql.ts
@@ -9,7 +9,7 @@ export type SearchBar_viewer = {
             readonly node: ({
                 readonly displayLabel: string | null;
                 readonly href: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
                 readonly id?: string;
             }) | null;
         }) | null> | null;
@@ -118,7 +118,7 @@ const node: ConcreteFragment = {
                         {
                           "kind": "ScalarField",
                           "alias": null,
-                          "name": "searchableType",
+                          "name": "displayType",
                           "args": null,
                           "storageKey": null
                         },
@@ -141,5 +141,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'e649d07e62973aefbb0d83d8c32d5031';
+(node as any).hash = '4dcffe86d167506ae2899dd1d5b0ef19';
 export default node;

--- a/src/__generated__/SearchResultsArticlesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsArticlesQuery.graphql.ts
@@ -48,10 +48,11 @@ fragment SearchResultsArticles_viewer_4c14dZ on Viewer {
         __typename
         ... on SearchableItem {
           _id
+          description
           displayLabel
           href
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -147,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsArticlesQuery",
   "id": null,
-  "text": "query SearchResultsArticlesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArticles_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          _id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsArticlesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsArticles_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          _id\n          description\n          displayLabel\n          href\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -392,6 +393,13 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
+                            "name": "description",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
                             "name": "displayLabel",
                             "args": null,
                             "storageKey": null
@@ -413,7 +421,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsArticles_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArticles_viewer.graphql.ts
@@ -16,10 +16,11 @@ export type SearchResultsArticles_viewer = {
         readonly edges: ReadonlyArray<({
             readonly node: ({
                 readonly _id?: string;
+                readonly description?: string | null;
                 readonly displayLabel?: string | null;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -194,6 +195,13 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
+                      "name": "description",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
                       "name": "displayLabel",
                       "args": null,
                       "storageKey": null
@@ -215,7 +223,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -229,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '9a8531bd79617025ad1fa51451d0e729';
+(node as any).hash = '3b2386d6b01d557a1f7656226f148202';
 export default node;

--- a/src/__generated__/SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsArtistsQuery.graphql.ts
@@ -48,12 +48,13 @@ fragment SearchResultsArtists_viewer_3D3mrw on Viewer {
     edges {
       node {
         __typename
-        ... on Artist {
-          name
+        ... on SearchableItem {
+          displayLabel
           _id
           href
           imageUrl
-          bio
+          displayType
+          description
         }
         ... on Node {
           __id
@@ -155,7 +156,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsArtistsQuery",
   "id": null,
-  "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_3D3mrw\n  }\n}\n\nfragment SearchResultsArtists_viewer_3D3mrw on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: [ARTIST]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          _id\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_3D3mrw\n  }\n}\n\nfragment SearchResultsArtists_viewer_3D3mrw on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: [ARTIST]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          displayLabel\n          _id\n          href\n          imageUrl\n          displayType\n          description\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -400,12 +401,12 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "type": "Artist",
+                        "type": "SearchableItem",
                         "selections": [
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "name",
+                            "name": "displayLabel",
                             "args": null,
                             "storageKey": null
                           },
@@ -433,7 +434,14 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "bio",
+                            "name": "displayType",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsArtists_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArtists_viewer.graphql.ts
@@ -15,11 +15,12 @@ export type SearchResultsArtists_viewer = {
         }) | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
-                readonly name?: string | null;
+                readonly displayLabel?: string | null;
                 readonly _id?: string;
                 readonly href?: string | null;
                 readonly imageUrl?: string | null;
-                readonly bio?: string | null;
+                readonly displayType?: string | null;
+                readonly description?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -194,12 +195,12 @@ const node: ConcreteFragment = {
                 },
                 {
                   "kind": "InlineFragment",
-                  "type": "Artist",
+                  "type": "SearchableItem",
                   "selections": [
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "name",
+                      "name": "displayLabel",
                       "args": null,
                       "storageKey": null
                     },
@@ -227,7 +228,14 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "bio",
+                      "name": "displayType",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "description",
                       "args": null,
                       "storageKey": null
                     }
@@ -241,5 +249,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '424f7979f455210cfd54d1c1e2f75071';
+(node as any).hash = '2aa0888506b14f86093bbc6fbc9f487c';
 export default node;

--- a/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsAuctionsQuery.graphql.ts
@@ -52,7 +52,7 @@ fragment SearchResultsAuctions_viewer_4c14dZ on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -148,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsAuctionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -421,7 +421,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsAuctions_viewer.graphql.ts
@@ -20,7 +20,7 @@ export type SearchResultsAuctions_viewer = {
                 readonly href?: string | null;
                 readonly _id?: string;
                 readonly imageUrl?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -223,7 +223,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -237,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'c7f47380a6868205741da4d08c771ece';
+(node as any).hash = 'c3b77308636590f14d42ea42102eaef9';
 export default node;

--- a/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCategoriesQuery.graphql.ts
@@ -52,7 +52,7 @@ fragment SearchResultsCategories_viewer_4c14dZ on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -148,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCategoriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCategories_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -421,7 +421,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsCategories_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCategories_viewer.graphql.ts
@@ -20,7 +20,7 @@ export type SearchResultsCategories_viewer = {
                 readonly href?: string | null;
                 readonly _id?: string;
                 readonly imageUrl?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -223,7 +223,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -237,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '8a5db7bf4ebd66a2bebc2bd5a24532fd';
+(node as any).hash = '76f760efe188a284168fe43bef10e139';
 export default node;

--- a/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsCollectionsQuery.graphql.ts
@@ -52,7 +52,7 @@ fragment SearchResultsCollections_viewer_4c14dZ on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -148,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsCollectionsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsCollections_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -421,7 +421,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsCollections_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsCollections_viewer.graphql.ts
@@ -20,7 +20,7 @@ export type SearchResultsCollections_viewer = {
                 readonly href?: string | null;
                 readonly _id?: string;
                 readonly imageUrl?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -223,7 +223,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -237,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '410a0c1f644056d3a36a426273d060f6';
+(node as any).hash = '634fd5495357b8852d61fd14fd50908e';
 export default node;

--- a/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/SearchResultsGalleriesQuery.graphql.ts
@@ -52,7 +52,7 @@ fragment SearchResultsGalleries_viewer_4c14dZ on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -148,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsGalleriesQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -421,7 +421,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsGalleries_viewer.graphql.ts
@@ -20,7 +20,7 @@ export type SearchResultsGalleries_viewer = {
                 readonly href?: string | null;
                 readonly _id?: string;
                 readonly imageUrl?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -223,7 +223,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -237,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '7c3916c60eba5e054e7e845b039372bd';
+(node as any).hash = 'e0c5cc0965c9f478bb29c02c68900ad7';
 export default node;

--- a/src/__generated__/SearchResultsMoreQuery.graphql.ts
+++ b/src/__generated__/SearchResultsMoreQuery.graphql.ts
@@ -52,7 +52,7 @@ fragment SearchResultsMore_viewer_4c14dZ on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -148,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsMoreQuery",
   "id": null,
-  "text": "query SearchResultsMoreQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsMore_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsMoreQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsMore_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -425,7 +425,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsMore_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsMore_viewer.graphql.ts
@@ -20,7 +20,7 @@ export type SearchResultsMore_viewer = {
                 readonly href?: string | null;
                 readonly _id?: string;
                 readonly imageUrl?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -227,7 +227,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -241,5 +241,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '62192ed7900635db4eb362028503cfdb';
+(node as any).hash = 'b5e98b941b62e08d25f488a51b54c024';
 export default node;

--- a/src/__generated__/SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsShowsQuery.graphql.ts
@@ -52,7 +52,7 @@ fragment SearchResultsShows_viewer_4c14dZ on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -148,7 +148,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsShowsQuery",
   "id": null,
-  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsShowsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4c14dZ\n  }\n}\n\nfragment SearchResultsShows_viewer_4c14dZ on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -421,7 +421,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsShows_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsShows_viewer.graphql.ts
@@ -20,7 +20,7 @@ export type SearchResultsShows_viewer = {
                 readonly href?: string | null;
                 readonly _id?: string;
                 readonly imageUrl?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -223,7 +223,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -237,5 +237,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '9b44d18a92e4e2c3c9ab86d0f40d7b6b';
+(node as any).hash = '94d6690028cca70e096887a7a1caebb1';
 export default node;

--- a/src/__generated__/routes_SearchResultsArticlesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArticlesQuery.graphql.ts
@@ -40,10 +40,11 @@ fragment SearchResultsArticles_viewer_4hh6ED on Viewer {
         __typename
         ... on SearchableItem {
           _id
+          description
           displayLabel
           href
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -115,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArticlesQuery",
   "id": null,
-  "text": "query routes_SearchResultsArticlesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArticles_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          _id\n          displayLabel\n          href\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsArticlesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsArticles_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsArticles_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [ARTICLE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          _id\n          description\n          displayLabel\n          href\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -318,6 +319,13 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
+                            "name": "description",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
                             "name": "displayLabel",
                             "args": null,
                             "storageKey": null
@@ -339,7 +347,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
@@ -40,12 +40,13 @@ fragment SearchResultsArtists_viewer_2iLyA0 on Viewer {
     edges {
       node {
         __typename
-        ... on Artist {
-          name
+        ... on SearchableItem {
+          displayLabel
           _id
           href
           imageUrl
-          bio
+          displayType
+          description
         }
         ... on Node {
           __id
@@ -123,7 +124,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArtistsQuery",
   "id": null,
-  "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2iLyA0\n  }\n}\n\nfragment SearchResultsArtists_viewer_2iLyA0 on Viewer {\n  search(query: $term, first: 10, page: $page, entities: [ARTIST]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          _id\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2iLyA0\n  }\n}\n\nfragment SearchResultsArtists_viewer_2iLyA0 on Viewer {\n  search(query: $term, first: 10, page: $page, entities: [ARTIST]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          displayLabel\n          _id\n          href\n          imageUrl\n          displayType\n          description\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -326,12 +327,12 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "type": "Artist",
+                        "type": "SearchableItem",
                         "selections": [
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "name",
+                            "name": "displayLabel",
                             "args": null,
                             "storageKey": null
                           },
@@ -359,7 +360,14 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "bio",
+                            "name": "displayType",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "description",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsAuctionsQuery.graphql.ts
@@ -44,7 +44,7 @@ fragment SearchResultsAuctions_viewer_4hh6ED on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -116,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsAuctionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsAuctionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsAuctions_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsAuctions_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SALE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -347,7 +347,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCategoriesQuery.graphql.ts
@@ -44,7 +44,7 @@ fragment SearchResultsCategories_viewer_4hh6ED on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -116,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCategoriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCategoriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCategories_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCategories_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GENE]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -347,7 +347,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsCollectionsQuery.graphql.ts
@@ -44,7 +44,7 @@ fragment SearchResultsCollections_viewer_4hh6ED on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -116,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsCollectionsQuery",
   "id": null,
-  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsCollectionsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsCollections_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsCollections_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [COLLECTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -347,7 +347,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsGalleriesQuery.graphql.ts
@@ -44,7 +44,7 @@ fragment SearchResultsGalleries_viewer_4hh6ED on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -116,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsGalleriesQuery",
   "id": null,
-  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsGalleriesQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsGalleries_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsGalleries_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [GALLERY]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -347,7 +347,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsMoreQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsMoreQuery.graphql.ts
@@ -44,7 +44,7 @@ fragment SearchResultsMore_viewer_4hh6ED on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -116,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsMoreQuery",
   "id": null,
-  "text": "query routes_SearchResultsMoreQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsMore_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsMoreQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsMore_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsMore_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [TAG, CITY, FAIR, FEATURE, INSTITUTION]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -351,7 +351,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsShowsQuery.graphql.ts
@@ -44,7 +44,7 @@ fragment SearchResultsShows_viewer_4hh6ED on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -116,7 +116,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsShowsQuery",
   "id": null,
-  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsShowsQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchResultsShows_viewer_4hh6ED\n  }\n}\n\nfragment SearchResultsShows_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 10, entities: [SHOW]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -347,7 +347,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }


### PR DESCRIPTION
Use `displayType` attribute for presentation vs deprecated `searchableType` attribute.

This will group `Show` and `Booth` display types of `PartnerShow` entities together on the Shows tab.

Depends on https://github.com/artsy/metaphysics/pull/1638