### PR TITLE
Transition uses of `searchableType` to `displayType`

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -8261,7 +8261,8 @@ type SearchableItem implements Node & Searchable {
   displayLabel: String
   imageUrl: String
   href: String
-  searchableType: String
+  searchableType: String @deprecated(reason: "Switch to use `displayType`")
+  displayType: String
 }
 
 enum SearchAggregation {

--- a/src/Apps/Search/Routes/Entity/SearchResultsEntity.tsx
+++ b/src/Apps/Search/Routes/Entity/SearchResultsEntity.tsx
@@ -106,7 +106,7 @@ export class SearchResultsEntityRoute extends React.Component<Props, State> {
                 description={searchableItem.description}
                 href={searchableItem.href}
                 imageUrl={searchableItem.imageUrl}
-                entityType={searchableItem.searchableType}
+                entityType={searchableItem.displayType}
                 index={index}
                 term={term}
                 id={searchableItem._id}
@@ -189,7 +189,7 @@ export const SearchResultsEntityRouteFragmentContainer = createRefetchContainer(
                 href
                 _id
                 imageUrl
-                searchableType
+                displayType
               }
             }
           }

--- a/src/Apps/Search/Routes/Entity/__tests__/SearchResultsEntity.test.tsx
+++ b/src/Apps/Search/Routes/Entity/__tests__/SearchResultsEntity.test.tsx
@@ -27,7 +27,7 @@ describe("SearchResultsEntity", () => {
               id: "percy",
               displayLabel: "Cat",
               href: "/cat/percy",
-              searchableType: "Artistic Cats",
+              displayType: "Artistic Cats",
             },
           },
         ],

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -82,7 +82,7 @@ export const SearchAppFragmentContainer = createFragmentContainer(SearchApp, {
             ... on SearchableItem {
               id
               displayLabel
-              searchableType
+              displayType
             }
           }
         }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -101,7 +101,7 @@ export class SearchBar extends Component<Props, State> {
     if (!suggestion) return
 
     const {
-      node: { searchableType: entityType, id: entityID },
+      node: { displayType: entityType, id: entityID },
     } = suggestion
 
     if (entityType === "FirstItem") return
@@ -216,7 +216,7 @@ export class SearchBar extends Component<Props, State> {
       [
         {
           suggestion: {
-            node: { href, searchableType, id },
+            node: { href, displayType, id },
           },
           suggestionIndex,
         },
@@ -225,7 +225,7 @@ export class SearchBar extends Component<Props, State> {
       action_type: Schema.ActionType.SelectedItemFromSearch,
       query: state.term,
       destination_path: href,
-      item_type: searchableType,
+      item_type: displayType,
       item_id: id,
       item_number: suggestionIndex,
     })
@@ -273,7 +273,7 @@ export class SearchBar extends Component<Props, State> {
   }
 
   renderSuggestion = (
-    { node: { displayLabel, searchableType, href } },
+    { node: { displayLabel, displayType, href } },
     { query, isHighlighted }
   ) => {
     return (
@@ -281,7 +281,7 @@ export class SearchBar extends Component<Props, State> {
         display={displayLabel}
         href={href}
         isHighlighted={isHighlighted}
-        label={searchableType}
+        label={displayType}
         query={query}
       />
     )
@@ -304,7 +304,7 @@ export class SearchBar extends Component<Props, State> {
 
     const firstSuggestionPlaceholder = {
       node: {
-        searchableType: "FirstItem",
+        displayType: "FirstItem",
         displayLabel: term,
         href: `/search?q=${term}`,
       },
@@ -364,7 +364,7 @@ export const SearchBarRefetchContainer = createRefetchContainer(
               displayLabel
               href
               ... on SearchableItem {
-                searchableType
+                displayType
                 id
               }
             }

--- a/src/Components/Search/__tests__/SearchBar.test.tsx
+++ b/src/Components/Search/__tests__/SearchBar.test.tsx
@@ -17,7 +17,7 @@ const searchResults = {
         node: {
           displayLabel: "Percy Z",
           href: "/cat/percy-z",
-          searchableType: "Cat",
+          displayType: "Cat",
           id: "percy-z",
         },
       },

--- a/src/__generated__/SearchApp_viewer.graphql.ts
+++ b/src/__generated__/SearchApp_viewer.graphql.ts
@@ -11,7 +11,7 @@ export type SearchApp_viewer = {
             readonly node: ({
                 readonly id?: string;
                 readonly displayLabel?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
         readonly " $fragmentRefs": NavigationTabs_searchableConnection$ref;
@@ -123,7 +123,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -137,5 +137,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'c7337eb9cc0b3d6722f1d77660ed2fb9';
+(node as any).hash = 'f26d9caeace9103dd98b540e94ead020';
 export default node;

--- a/src/__generated__/SearchBarRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchBarRefetchQuery.graphql.ts
@@ -36,7 +36,7 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
         displayLabel
         href
         ... on SearchableItem {
-          searchableType
+          displayType
           id
         }
         ... on Node {
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarRefetchQuery",
   "id": null,
-  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -208,7 +208,7 @@ return {
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
-                                "name": "searchableType",
+                                "name": "displayType",
                                 "args": null,
                                 "storageKey": null
                               },

--- a/src/__generated__/SearchBarSuggestQuery.graphql.ts
+++ b/src/__generated__/SearchBarSuggestQuery.graphql.ts
@@ -36,7 +36,7 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
         displayLabel
         href
         ... on SearchableItem {
-          searchableType
+          displayType
           id
         }
         ... on Node {
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarSuggestQuery",
   "id": null,
-  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -208,7 +208,7 @@ return {
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
-                                "name": "searchableType",
+                                "name": "displayType",
                                 "args": null,
                                 "storageKey": null
                               },

--- a/src/__generated__/SearchBarTestQuery.graphql.ts
+++ b/src/__generated__/SearchBarTestQuery.graphql.ts
@@ -36,7 +36,7 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
         displayLabel
         href
         ... on SearchableItem {
-          searchableType
+          displayType
           id
         }
         ... on Node {
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarTestQuery",
   "id": null,
-  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          searchableType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -208,7 +208,7 @@ return {
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
-                                "name": "searchableType",
+                                "name": "displayType",
                                 "args": null,
                                 "storageKey": null
                               },

--- a/src/__generated__/SearchBar_viewer.graphql.ts
+++ b/src/__generated__/SearchBar_viewer.graphql.ts
@@ -9,7 +9,7 @@ export type SearchBar_viewer = {
             readonly node: ({
                 readonly displayLabel: string | null;
                 readonly href: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
                 readonly id?: string;
             }) | null;
         }) | null> | null;
@@ -118,7 +118,7 @@ const node: ConcreteFragment = {
                         {
                           "kind": "ScalarField",
                           "alias": null,
-                          "name": "searchableType",
+                          "name": "displayType",
                           "args": null,
                           "storageKey": null
                         },
@@ -141,5 +141,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'e649d07e62973aefbb0d83d8c32d5031';
+(node as any).hash = '4dcffe86d167506ae2899dd1d5b0ef19';
 export default node;

--- a/src/__generated__/SearchResultsEntityQuery.graphql.ts
+++ b/src/__generated__/SearchResultsEntityQuery.graphql.ts
@@ -57,7 +57,7 @@ fragment SearchResultsEntity_viewer_4tOGvB on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -165,7 +165,7 @@ return {
   "operationKind": "query",
   "name": "SearchResultsEntityQuery",
   "id": null,
-  "text": "query SearchResultsEntityQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_4tOGvB\n  }\n}\n\nfragment SearchResultsEntity_viewer_4tOGvB on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: $entities) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query SearchResultsEntityQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_4tOGvB\n  }\n}\n\nfragment SearchResultsEntity_viewer_4tOGvB on Viewer {\n  search(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: $entities) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -454,7 +454,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/SearchResultsEntity_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsEntity_viewer.graphql.ts
@@ -20,7 +20,7 @@ export type SearchResultsEntity_viewer = {
                 readonly href?: string | null;
                 readonly _id?: string;
                 readonly imageUrl?: string | null;
-                readonly searchableType?: string | null;
+                readonly displayType?: string | null;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -239,7 +239,7 @@ const node: ConcreteFragment = {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "searchableType",
+                      "name": "displayType",
                       "args": null,
                       "storageKey": null
                     }
@@ -253,5 +253,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '15e987e5ecf8fb8d52499d2b797b8d08';
+(node as any).hash = '0e9c176d249f4e29782b877fa4bde961';
 export default node;

--- a/src/__generated__/routes_SearchBarTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_SearchBarTopLevelQuery.graphql.ts
@@ -36,7 +36,7 @@ fragment SearchApp_viewer_4hh6ED on Viewer {
         ... on SearchableItem {
           id
           displayLabel
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -79,7 +79,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchBarTopLevelQuery",
   "id": null,
-  "text": "query routes_SearchBarTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 1, aggregations: [TYPE]) {\n    totalCount\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      __id\n    }\n  }\n}\n",
+  "text": "query routes_SearchBarTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 1, aggregations: [TYPE]) {\n    totalCount\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      __id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -255,7 +255,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }

--- a/src/__generated__/routes_SearchResultsEntityQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsEntityQuery.graphql.ts
@@ -49,7 +49,7 @@ fragment SearchResultsEntity_viewer_1qCJIT on Viewer {
           href
           _id
           imageUrl
-          searchableType
+          displayType
         }
         ... on Node {
           __id
@@ -133,7 +133,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsEntityQuery",
   "id": null,
-  "text": "query routes_SearchResultsEntityQuery(\n  $term: String!\n  $entities: [SearchEntity]\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_1qCJIT\n  }\n}\n\nfragment SearchResultsEntity_viewer_1qCJIT on Viewer {\n  search(query: $term, first: 10, page: $page, entities: $entities) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          searchableType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+  "text": "query routes_SearchResultsEntityQuery(\n  $term: String!\n  $entities: [SearchEntity]\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_1qCJIT\n  }\n}\n\nfragment SearchResultsEntity_viewer_1qCJIT on Viewer {\n  search(query: $term, first: 10, page: $page, entities: $entities) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          _id\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -380,7 +380,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "searchableType",
+                            "name": "displayType",
                             "args": null,
                             "storageKey": null
                           }


### PR DESCRIPTION
"displayType" more accurately reflects the purpose of the attribute, to be a presentation value vs the underlying type of the item.