### PR TITLE
@pepopowitz => [Gene] Relax paging check which stops paging early

### DIFF
--- a/src/Components/Gene/GeneArtworksContent.tsx
+++ b/src/Components/Gene/GeneArtworksContent.tsx
@@ -17,6 +17,7 @@ interface Props {
 
 interface State {
   loading: boolean
+  page: number
 }
 
 const SpinnerContainer = styled.div`
@@ -32,6 +33,7 @@ export class GeneArtworksContent extends React.Component<Props, State> {
 
   state = {
     loading: false,
+    page: 1,
   }
 
   loadMoreArtworks() {
@@ -43,18 +45,26 @@ export class GeneArtworksContent extends React.Component<Props, State> {
           if (error) {
             console.error(error)
           }
+
+          // Check to see if we're at the max allowable page.
+          const { page } = this.state
+          if (page > 100) {
+            console.error(`Finished paging: ${this.props.geneID}`)
+            this.finishedPaginatingWithError = true
+          }
+
+          // Check to see if no new edges were received.
           const newLength = this.props.filtered_artworks.artworks.edges.length
           const newHasMore = this.props.filtered_artworks.artworks.pageInfo
             .hasNextPage
-          if (newLength - origLength < PageSize && newHasMore) {
+          if (newLength - origLength === 0 && newHasMore) {
             console.error(
-              `Total count inconsistent with actual records returned for gene: ${
-                this.props.geneID
-              }`
+              `No more records returned for gene: ${this.props.geneID}`
             )
             this.finishedPaginatingWithError = true
           }
-          this.setState({ loading: false })
+
+          this.setState({ loading: false, page: page + 1 })
         })
       })
     }

--- a/src/Components/__stories__/Gene.story.tsx
+++ b/src/Components/__stories__/Gene.story.tsx
@@ -34,14 +34,13 @@ storiesOf("Components/Pages/Gene/Contents", module)
       </div>
     )
   })
-  .add("Artworks Mode w/ Pagination Issue - Russia", () => {
+  .add("Artworks Mode w/ Pagination Issue - Abstract Painting", () => {
     return (
       <div>
         <ContextProvider>
           <Contents
-            sort="-year"
-            filters={{ for_sale: true }}
-            geneID="russia"
+            filters={{ for_sale: false }}
+            geneID="abstract-painting"
             mode="artworks"
             onStateChange={console.log}
           />


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-866


## Problem
We used to have 'issues' with infinite scroll where it would start going haywire and eventually start to make requests with really high page numbers. Ship bug to users, have them keep their browser tabs open, and you've just DDOS'ed yourself!

## History
So, we made this very conservative check where: if you ever got back _less_ than the page size, we would just stop paging. The assumption being, even if `hasNextPage` is incorrectly coming back true, once we hit an empty page we would stop.

## Solution
Relax this check somewhat to still protect us against DDOS and the infinite scroll component behaving badly, but allow for some occasional gaps in data and pages (as we seem to currently have).

## Caveats
This is just a band-aid around the fact that for some reason, on page 12 of the [Abstract Painting](https://www.artsy.net/gene/abstract-painting) gene, we wind up having an artwork returned _that already was returned_, and so Relay winds up not including that duplicate in the connection, and thus there's only 119 instead of 120 total artworks after the 12th page is fetched. I'm not sure why that's the case, but this feels like a reasonable change.