### PR TITLE
@cavvia => [Search] Make sure to get artwork tab count from filter endpoint aggregation

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -10,6 +10,7 @@ import { get } from "Utils/get"
 interface Props {
   searchableConnection: NavigationTabs_searchableConnection
   term: string
+  artworkCount: number
 }
 
 const MORE_TABS = [
@@ -67,17 +68,12 @@ export class NavigationTabs extends React.Component<Props> {
   }
 
   renderTabs() {
-    const { term } = this.props
+    const { term, artworkCount } = this.props
 
     const route = tab => `/search2${tab}?term=${term}`
 
     const artistAggregationCount = get(
       this.aggregationFor("artist"),
-      agg => agg.count,
-      0
-    )
-    const artworkAggregationCount = get(
-      this.aggregationFor("artwork"),
       agg => agg.count,
       0
     )
@@ -124,7 +120,7 @@ export class NavigationTabs extends React.Component<Props> {
 
     return (
       <>
-        {this.renderTab(`Artworks ${artworkAggregationCount}`, route(""), {
+        {this.renderTab(`Artworks ${artworkCount}`, route(""), {
           exact: true,
         })}
         {this.renderTab(`Artists ${artistAggregationCount}`, route("/artists"))}

--- a/src/Apps/Search/__tests__/SearchApp.test.tsx
+++ b/src/Apps/Search/__tests__/SearchApp.test.tsx
@@ -34,16 +34,20 @@ describe("SearchApp", () => {
     },
     viewer: {
       search: {
-        totalCount: 420,
         aggregations: [
           {
             slice: "TYPE",
             counts: [
-              { name: "artwork", count: 100 },
+              { name: "PartnerGallery", count: 100 },
               { name: "artist", count: 320 },
             ],
           },
         ],
+      },
+      filter_artworks: {
+        counts: {
+          total: 100,
+        },
       },
     },
   }
@@ -51,7 +55,7 @@ describe("SearchApp", () => {
   it("includes the total count", () => {
     const wrapper = getWrapper(props) as any
     const html = wrapper.html()
-    expect(html).toContain('420 Results for "andy"')
+    expect(html).toContain('520 Results for "andy"')
   })
 
   it("includes tabs w/ counts", () => {
@@ -59,5 +63,6 @@ describe("SearchApp", () => {
     const html = wrapper.html()
     expect(html).toContain("Artworks 100")
     expect(html).toContain("Artists 320")
+    expect(html).toContain("Galleries 100")
   })
 })

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -57,6 +57,6 @@ storiesOf("Apps", module)
   })
   .add("Search Results page", () => {
     return (
-      <MockRouter routes={searchRoutes} initialRoute="/search2?term=andy" />
+      <MockRouter routes={searchRoutes} initialRoute="/search2?term=gagosian" />
     )
   })

--- a/src/__generated__/SearchApp_viewer.graphql.ts
+++ b/src/__generated__/SearchApp_viewer.graphql.ts
@@ -2,11 +2,18 @@
 
 import { ConcreteFragment } from "relay-runtime";
 import { NavigationTabs_searchableConnection$ref } from "./NavigationTabs_searchableConnection.graphql";
+export type SearchAggregation = "TYPE" | "%future added value";
 declare const _SearchApp_viewer$ref: unique symbol;
 export type SearchApp_viewer$ref = typeof _SearchApp_viewer$ref;
 export type SearchApp_viewer = {
     readonly search: ({
-        readonly totalCount: number | null;
+        readonly aggregations: ReadonlyArray<({
+            readonly slice: SearchAggregation | null;
+            readonly counts: ReadonlyArray<({
+                readonly count: number | null;
+                readonly name: string | null;
+            }) | null> | null;
+        }) | null> | null;
         readonly edges: ReadonlyArray<({
             readonly node: ({
                 readonly id?: string;
@@ -16,12 +23,25 @@ export type SearchApp_viewer = {
         }) | null> | null;
         readonly " $fragmentRefs": NavigationTabs_searchableConnection$ref;
     }) | null;
+    readonly filter_artworks: ({
+        readonly counts: ({
+            readonly total: any | null;
+        }) | null;
+    }) | null;
     readonly " $refType": SearchApp_viewer$ref;
 };
 
 
 
-const node: ConcreteFragment = {
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
   "kind": "Fragment",
   "name": "SearchApp_viewer",
   "type": "Viewer",
@@ -66,11 +86,48 @@ const node: ConcreteFragment = {
       "plural": false,
       "selections": [
         {
-          "kind": "ScalarField",
+          "kind": "LinkedField",
           "alias": null,
-          "name": "totalCount",
+          "name": "aggregations",
+          "storageKey": null,
           "args": null,
-          "storageKey": null
+          "concreteType": "SearchAggregationResults",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "slice",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "counts",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "AggregationCount",
+              "plural": true,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "count",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "name",
+                  "args": null,
+                  "storageKey": null
+                },
+                v0
+              ]
+            }
+          ]
         },
         {
           "kind": "FragmentSpread",
@@ -95,13 +152,7 @@ const node: ConcreteFragment = {
               "concreteType": null,
               "plural": false,
               "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "__id",
-                  "args": null,
-                  "storageKey": null
-                },
+                v0,
                 {
                   "kind": "InlineFragment",
                   "type": "SearchableItem",
@@ -134,8 +185,60 @@ const node: ConcreteFragment = {
           ]
         }
       ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "filter_artworks",
+      "storageKey": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "aggregations",
+          "value": [
+            "TOTAL"
+          ],
+          "type": "[ArtworkAggregation]"
+        },
+        {
+          "kind": "Variable",
+          "name": "keyword",
+          "variableName": "term",
+          "type": "String"
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 0,
+          "type": "Int"
+        }
+      ],
+      "concreteType": "FilterArtworks",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "counts",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "FilterArtworksCounts",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "total",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        v0
+      ]
     }
   ]
 };
-(node as any).hash = 'f26d9caeace9103dd98b540e94ead020';
+})();
+(node as any).hash = '671536b76e6625d241658d8cf32d9d68';
 export default node;

--- a/src/__generated__/routes_SearchBarTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_SearchBarTopLevelQuery.graphql.ts
@@ -28,7 +28,14 @@ query routes_SearchBarTopLevelQuery(
 
 fragment SearchApp_viewer_4hh6ED on Viewer {
   search(query: $term, first: 1, aggregations: [TYPE]) {
-    totalCount
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        __id
+      }
+    }
     ...NavigationTabs_searchableConnection
     edges {
       node {
@@ -43,6 +50,12 @@ fragment SearchApp_viewer_4hh6ED on Viewer {
         }
       }
     }
+  }
+  filter_artworks(keyword: $term, size: 0, aggregations: [TOTAL]) {
+    counts {
+      total
+    }
+    __id
   }
 }
 
@@ -79,7 +92,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchBarTopLevelQuery",
   "id": null,
-  "text": "query routes_SearchBarTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 1, aggregations: [TYPE]) {\n    totalCount\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      __id\n    }\n  }\n}\n",
+  "text": "query routes_SearchBarTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  search(query: $term, first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n        __id\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n  filter_artworks(keyword: $term, size: 0, aggregations: [TOTAL]) {\n    counts {\n      total\n    }\n    __id\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      __id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -157,13 +170,6 @@ return {
             "concreteType": "SearchableConnection",
             "plural": false,
             "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "totalCount",
-                "args": null,
-                "storageKey": null
-              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -265,6 +271,57 @@ return {
                   }
                 ]
               }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "filter_artworks",
+            "storageKey": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "aggregations",
+                "value": [
+                  "TOTAL"
+                ],
+                "type": "[ArtworkAggregation]"
+              },
+              {
+                "kind": "Variable",
+                "name": "keyword",
+                "variableName": "term",
+                "type": "String"
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 0,
+                "type": "Int"
+              }
+            ],
+            "concreteType": "FilterArtworks",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "total",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              v1
             ]
           }
         ]


### PR DESCRIPTION
Good call on this one! We need to fetch the count for artworks separately (since it's from the filter endpoint). This also means we need to get the 'total' for search results differently: namely, summing up the aggregations from search _sans_ artwork, and this more accurate artwork count.

Looking good for 'gagosian' now:

<img width="961" alt="Screen Shot 2019-04-02 at 11 09 04 AM" src="https://user-images.githubusercontent.com/1457859/55413664-c0ef9600-5537-11e9-94db-9a514f418c03.png">

Closes https://artsyproduct.atlassian.net/browse/DISCO-884