### PR TITLE
Show fallback icon when search result item has no image url

### DIFF
--- a/src/Apps/Search/Components/FallbackIcon.tsx
+++ b/src/Apps/Search/Components/FallbackIcon.tsx
@@ -1,0 +1,33 @@
+import {
+  AuctionIcon,
+  FairIcon,
+  InstitutionIcon,
+  MapPinIcon,
+  NoImageIcon,
+  PageIcon,
+  PublicationIcon,
+  TagIcon,
+  UserSingleIcon,
+} from "@artsy/palette"
+import React, { SFC } from "react"
+
+const iconMapping = {
+  Auction: AuctionIcon,
+  Article: PublicationIcon,
+  Artist: UserSingleIcon,
+  City: MapPinIcon,
+  Fair: FairIcon,
+  Institution: InstitutionIcon,
+  Page: PageIcon,
+  Tag: TagIcon,
+}
+
+interface FallbackIcon {
+  entityType: string
+}
+
+export const FallbackIcon: SFC<FallbackIcon> = ({ entityType }) => {
+  const Icon = iconMapping[entityType] || NoImageIcon
+
+  return <Icon height={28} width={28} opacity={0.4} />
+}

--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -3,6 +3,7 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { Truncator } from "Components/Truncator"
 import React from "react"
+import { FallbackIcon } from "./FallbackIcon"
 
 interface GenericSearchResultItemProps {
   imageUrl: string
@@ -52,7 +53,13 @@ export class GenericSearchResultItem extends React.Component<
             }}
           >
             <Box height={70} width={70} mr={2} bg="black5">
-              {imageUrl && <Image width={70} height={70} src={imageUrl} />}
+              <Flex height="100%" justifyContent="center" alignItems="center">
+                {imageUrl ? (
+                  <Image width={70} height={70} src={imageUrl} />
+                ) : (
+                  <FallbackIcon entityType={entityType} />
+                )}
+              </Flex>
             </Box>
           </Link>
           <Box>


### PR DESCRIPTION
We're supporting specific fallback icons for Auction, Article, Artist, City, Fair, Institution, Page, and Tag entity types. All others will fallback to the NoImageIcon.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-864