### PR TITLE
Force search result items of City type to use FallbackIcon

### DIFF
--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -54,7 +54,7 @@ export class GenericSearchResultItem extends React.Component<
           >
             <Box height={70} width={70} mr={2} bg="black5">
               <Flex height="100%" justifyContent="center" alignItems="center">
-                {imageUrl ? (
+                {imageUrl && entityType !== "City" ? (
                   <Image width={70} height={70} src={imageUrl} />
                 ) : (
                   <FallbackIcon entityType={entityType} />


### PR DESCRIPTION
The image returned from Metaphysics isn't desired by the design comps so always render the FallbackIcon for City entity types.

We could also make a change upstream but that would affect both old and new search result pages. We can follow up with that upstream change to Metaphysics once this new page fully rolls out.