### PR TITLE
DISCO-886: Search bar QA

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -357,7 +357,7 @@ export const SearchBarRefetchContainer = createRefetchContainer(
           term: { type: "String!", defaultValue: "" }
           hasTerm: { type: "Boolean!", defaultValue: false }
         ) {
-        search(query: $term, mode: AUTOSUGGEST, first: 5)
+        search(query: $term, mode: AUTOSUGGEST, first: 7)
           @include(if: $hasTerm) {
           edges {
             node {

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -8,6 +8,7 @@ import colors from "Assets/Colors"
 import Input from "Components/Input"
 import {
   EmptySuggestion,
+  FirstSuggestionItem,
   PLACEHOLDER,
   PLACEHOLDER_XS,
   SuggestionItem,
@@ -272,10 +273,29 @@ export class SearchBar extends Component<Props, State> {
     return displayLabel
   }
 
-  renderSuggestion = (
-    { node: { displayLabel, displayType, href } },
-    { query, isHighlighted }
-  ) => {
+  renderSuggestion = (edge, rest) => {
+    const renderer = edge.node.isFirstItem
+      ? this.renderFirstSuggestion
+      : this.renderDefaultSuggestion
+    const item = renderer(edge, rest)
+    return item
+  }
+
+  renderFirstSuggestion = (edge, { query, isHighlighted }) => {
+    const { displayLabel, displayType, href } = edge.node
+    return (
+      <FirstSuggestionItem
+        display={displayLabel}
+        href={href}
+        isHighlighted={isHighlighted}
+        label={displayType}
+        query={query}
+      />
+    )
+  }
+
+  renderDefaultSuggestion = (edge, { query, isHighlighted }) => {
+    const { displayLabel, displayType, href } = edge.node
     return (
       <SuggestionItem
         display={displayLabel}
@@ -304,6 +324,7 @@ export class SearchBar extends Component<Props, State> {
 
     const firstSuggestionPlaceholder = {
       node: {
+        isFirstItem: true,
         displayType: "FirstItem",
         displayLabel: term,
         href: `/search?q=${term}`,

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -30,11 +30,6 @@ export const SuggestionItem: SFC<Props> = props => {
           >
             <Suggestion {...props} />
           </InnerWrapper>
-          {isHighlighted && (
-            <Flex flexGrow="0" px={2}>
-              <HighlightIcon />
-            </Flex>
-          )}
         </SuggestionWrapper>
       </Link>
     </Box>
@@ -82,16 +77,3 @@ const SuggestionTitle = styled(Serif)`
   overflow: hidden;
   text-overflow: ellipsis;
 `
-
-const HighlightIcon = () => (
-  <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg">
-    <g fill="none" fillRule="evenodd">
-      <path fill="none" d="M0 0h18v18H0z" />
-      <path
-        d="M4.883 11.244l3.108 3.068-.693.688L3 10.758l4.299-4.23.692.689-3.106 3.056h9.134V3H15v8.244H4.883z"
-        fill="#000"
-        fillRule="nonzero"
-      />
-    </g>
-  </svg>
-)

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -54,7 +54,7 @@ export const EmptySuggestion = () => (
 )
 
 const SuggestionWrapper = props => (
-  <Flex alignItems="center" flexDirection="row" height="62px" pl={3}>
+  <Flex alignItems="center" flexDirection="row" height="62px" pl={2}>
     {props.children}
   </Flex>
 )

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -54,7 +54,7 @@ const SuggestionWrapper = props => (
   </Flex>
 )
 
-const FirstSuggestion = ({ query }) => <>Search "{query}"</>
+const FirstSuggestion = ({ query }) => <>See full results for "{query}"</>
 
 const DefaultSuggestion = ({ display, label, query }) => {
   const matches = match(display, query)

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -18,10 +18,8 @@ export const SuggestionItem: SFC<Props> = props => {
   const Suggestion = label === "FirstItem" ? FirstSuggestion : DefaultSuggestion
 
   return (
-    // Note: we've specified a color on the Link below to ensure an underline
-    // is suppressed on hover - technically the value does not matter.
     <Box bg={isHighlighted ? "black5" : "white100"}>
-      <Link color="black100" href={href} noUnderline>
+      <Link color="black100" href={href} underlineBehavior="none">
         <SuggestionWrapper>
           <InnerWrapper
             flexDirection="column"

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -14,11 +14,14 @@ interface Props {
 
 export const SuggestionItem: SFC<Props> = props => {
   const { label, href, isHighlighted } = props
-
-  const Suggestion = label === "FirstItem" ? FirstSuggestion : DefaultSuggestion
+  const isFirstItem = label === "FirstItem"
+  const boxStyle = {
+    borderBottom: isFirstItem && `1px solid ${color("black10")}`,
+  }
+  const Suggestion = isFirstItem ? FirstSuggestion : DefaultSuggestion
 
   return (
-    <Box bg={isHighlighted ? "black5" : "white100"}>
+    <Box bg={isHighlighted ? "black5" : "white100"} style={boxStyle}>
       <Link color="black100" href={href} underlineBehavior="none">
         <SuggestionWrapper>
           <InnerWrapper

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -12,13 +12,11 @@ interface Props {
   query: string
 }
 
-export const SuggestionItem: SFC<Props> = props => {
-  const { label, href, isHighlighted } = props
-  const isFirstItem = label === "FirstItem"
+export const FirstSuggestionItem: SFC<Props> = props => {
+  const { href, isHighlighted, query } = props
   const boxStyle = {
-    borderBottom: isFirstItem && `1px solid ${color("black10")}`,
+    borderBottom: `1px solid ${color("black10")}`,
   }
-  const Suggestion = isFirstItem ? FirstSuggestion : DefaultSuggestion
 
   return (
     <Box bg={isHighlighted ? "black5" : "white100"} style={boxStyle}>
@@ -29,7 +27,27 @@ export const SuggestionItem: SFC<Props> = props => {
             flexGrow="1"
             justifyContent="center"
           >
-            <Suggestion {...props} />
+            See full results for "{query}"
+          </InnerWrapper>
+        </SuggestionWrapper>
+      </Link>
+    </Box>
+  )
+}
+
+export const SuggestionItem: SFC<Props> = props => {
+  const { href, isHighlighted } = props
+
+  return (
+    <Box bg={isHighlighted ? "black5" : "white100"}>
+      <Link color="black100" href={href} underlineBehavior="none">
+        <SuggestionWrapper>
+          <InnerWrapper
+            flexDirection="column"
+            flexGrow="1"
+            justifyContent="center"
+          >
+            <DefaultSuggestion {...props} />
           </InnerWrapper>
         </SuggestionWrapper>
       </Link>
@@ -54,8 +72,6 @@ const SuggestionWrapper = props => (
     {props.children}
   </Flex>
 )
-
-const FirstSuggestion = ({ query }) => <>See full results for "{query}"</>
 
 const DefaultSuggestion = ({ display, label, query }) => {
   const matches = match(display, query)

--- a/src/Components/Search/__tests__/SearchBar.test.tsx
+++ b/src/Components/Search/__tests__/SearchBar.test.tsx
@@ -97,7 +97,7 @@ describe("SearchBar", () => {
     window.location.assign = jest.fn()
     component
       .find(SuggestionItem)
-      .at(1) // at 0 is the firstSuggestionPlaceholder
+      .at(0)
       .simulate("click")
 
     expect(window.location.assign).toHaveBeenCalledWith("/cat/percy-z")

--- a/src/__generated__/SearchBarRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchBarRefetchQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarRefetchQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarRefetchQuery",
   "id": null,
-  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 5,
+                    "value": 7,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBarSuggestQuery.graphql.ts
+++ b/src/__generated__/SearchBarSuggestQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarSuggestQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarSuggestQuery",
   "id": null,
-  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 5,
+                    "value": 7,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBarTestQuery.graphql.ts
+++ b/src/__generated__/SearchBarTestQuery.graphql.ts
@@ -29,7 +29,7 @@ query SearchBarTestQuery(
 }
 
 fragment SearchBar_viewer_2Mejjw on Viewer {
-  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {
+  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
         __typename
@@ -68,7 +68,7 @@ return {
   "operationKind": "query",
   "name": "SearchBarTestQuery",
   "id": null,
-  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 5) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  search(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          id\n        }\n        ... on Node {\n          __id\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -136,7 +136,7 @@ return {
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 5,
+                    "value": 7,
                     "type": "Int"
                   },
                   {

--- a/src/__generated__/SearchBar_viewer.graphql.ts
+++ b/src/__generated__/SearchBar_viewer.graphql.ts
@@ -53,7 +53,7 @@ const node: ConcreteFragment = {
             {
               "kind": "Literal",
               "name": "first",
-              "value": 5,
+              "value": 7,
               "type": "Int"
             },
             {
@@ -141,5 +141,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '4dcffe86d167506ae2899dd1d5b0ef19';
+(node as any).hash = '7d0a79e6f397dc366681ef647a0a5d50';
 export default node;


### PR DESCRIPTION
This is a QA PR so here's the ticket:

https://artsyproduct.atlassian.net/browse/DISCO-886

And here's my visual proof:

<img width="604" alt="Screen Shot 2019-04-02 at 3 52 30 PM" src="https://user-images.githubusercontent.com/79799/55435733-19d32480-5560-11e9-98d3-926f12ae284e.png">

The only code thing that might be worth considering is the way I split up the rendering of the first suggestion from the rest. I ended up adding the `totalCount` to the first suggestion item and then split up the `SuggestionItem` into a `FirstSuggestionItem` so that I could more easily render these things differently.

That leave us with some duplication in `src/Components/Search/Suggestions/SuggestionItem.tsx`, but it's the sort of duplication that offends me least - open to other ideas though!

Finally, I did not address adding a comma to the total count - is there a MP helper for this? /cc @damassi 