### PR TITLE
@dblandin => [Search] Tweak display of count within tabs

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@artsy/palette"
+import { Flex, Sans } from "@artsy/palette"
 import { NavigationTabs_searchableConnection } from "__generated__/NavigationTabs_searchableConnection.graphql"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
@@ -40,9 +40,10 @@ export class NavigationTabs extends React.Component<Props> {
     to: string,
     options: {
       exact?: boolean
+      count?: number
     } = {}
   ) => {
-    const { exact } = options
+    const { exact, count } = options
     const tabName = text.replace(/[0-9]/g, "").trim()
     return (
       <RouteTab
@@ -52,7 +53,14 @@ export class NavigationTabs extends React.Component<Props> {
           this.trackClick(tabName, to)
         }}
       >
-        {text}
+        <Flex>
+          {text}
+          {count != null && (
+            <Sans ml={0.5} size="3t" weight="regular">
+              {count}
+            </Sans>
+          )}
+        </Flex>
       </RouteTab>
     )
   }
@@ -120,32 +128,34 @@ export class NavigationTabs extends React.Component<Props> {
 
     return (
       <>
-        {this.renderTab(`Artworks ${artworkCount}`, route(""), {
+        {this.renderTab("Artworks", route(""), {
           exact: true,
+          count: artworkCount,
         })}
-        {this.renderTab(`Artists ${artistAggregationCount}`, route("/artists"))}
-        {this.renderTab(
-          `Collections ${collectionAggregationCount}`,
-          route("/collections")
-        )}
-        {this.renderTab(
-          `Galleries ${galleryAggregationCount}`,
-          route("/galleries")
-        )}
-        {this.renderTab(`Shows ${showAggregationCount}`, route("/shows"))}
-        {this.renderTab(
-          `Categories ${categoriesAggregationCount}`,
-          route("/categories")
-        )}
-        {this.renderTab(
-          `Articles ${articlesAggregationCount}`,
-          route("/articles")
-        )}
-        {this.renderTab(
-          `Auctions ${auctionsAggregationCount}`,
-          route("/auctions")
-        )}
-        {this.renderTab(`More ${restAggregationCount}`, route("/more"))}
+        {this.renderTab("Artists", route("/artists"), {
+          count: artistAggregationCount,
+        })}
+        {this.renderTab("Collections", route("/collections"), {
+          count: collectionAggregationCount,
+        })}
+        {this.renderTab("Galleries", route("/galleries"), {
+          count: galleryAggregationCount,
+        })}
+        {this.renderTab("Shows", route("/shows"), {
+          count: showAggregationCount,
+        })}
+        {this.renderTab("Categories", route("/categories"), {
+          count: categoriesAggregationCount,
+        })}
+        {this.renderTab("Articles", route("/articles"), {
+          count: articlesAggregationCount,
+        })}
+        {this.renderTab("Auctions", route("/auctions"), {
+          count: auctionsAggregationCount,
+        })}
+        {this.renderTab("More", route("/more"), {
+          count: restAggregationCount,
+        })}
       </>
     )
   }

--- a/src/Apps/Search/__tests__/SearchApp.test.tsx
+++ b/src/Apps/Search/__tests__/SearchApp.test.tsx
@@ -4,18 +4,10 @@ import { mount } from "enzyme"
 import React from "react"
 import { SearchApp } from "../SearchApp"
 
-jest.mock("found", () => {
-  return {
-    Link: ({
-      to,
-      children: {
-        props: { children },
-      },
-    }) => {
-      return `<a href=${to}>${children}</a>`
-    },
-  }
-})
+jest.mock("Components/v2/RouteTabs", () => ({
+  RouteTab: ({ children }) => children,
+  RouteTabs: ({ children }) => children,
+}))
 
 describe("SearchApp", () => {
   const getWrapper = (searchProps: any) => {
@@ -61,8 +53,8 @@ describe("SearchApp", () => {
   it("includes tabs w/ counts", () => {
     const wrapper = getWrapper(props) as any
     const html = wrapper.html()
-    expect(html).toContain("Artworks 100")
-    expect(html).toContain("Artists 320")
-    expect(html).toContain("Galleries 100")
+    expect(html).toMatch(/Artworks.*100/)
+    expect(html).toMatch(/Artists.*320/)
+    expect(html).toMatch(/Galleries.*100/)
   })
 })


### PR DESCRIPTION
<img width="991" alt="Screen Shot 2019-04-02 at 6 31 43 PM" src="https://user-images.githubusercontent.com/1457859/55440430-97555f80-5575-11e9-8c61-b9dc1a901f4a.png">

There's a larger story around making these navigation tabs proper Palette components, but that feels like a worthy follow-up or upkeep item, rather than a QA item at this point.

Closes https://artsyproduct.atlassian.net/browse/DISCO-890