### PR TITLE
Add basic docs for createTestEnv

### DIFF
--- a/src/DevTools/README.md
+++ b/src/DevTools/README.md
@@ -1,6 +1,7 @@
 # Guide to mocking relay data using `renderRelayTree`, `mockData`, and `mockMutationResults`
 
 ## The basics
+
 If your are testing a component that makes a query to metaphysics, you can use the `renderRelayTree` helper to mock out the data that would be returned by metaphysics. Previously this was done with the `mockResolvers` prop, but now we have an easier and less confusing way: `mockData` and `mockMutationResults`. The idea is that these properties should match the exact data shape that metaphysics would return.
 
 e.g. if you have a component with a query fragment like so:
@@ -50,8 +51,8 @@ Then your `mockData` can be like
 mockData = {
   artist: {
     birthYear: "1987",
-    birthdayFull: "12th April 1987"
-  }
+    birthdayFull: "12th April 1987",
+  },
 }
 ```
 
@@ -152,3 +153,148 @@ mockMutationResults = {
   },
 }
 ```
+
+## Guide to `createTestEnv`
+
+`createTestEnv` creates a higher level interface to `renderRelayTree` which takes care of some basic plumbing that can be useful in tests that deal with page-level components:
+
+- Mocking network failures
+- Surfacing resolver errors that would otherwise be swallowed by user-facing error handling.
+- Modifying mocked mutation results on the fly
+- Managing mock resets
+- Testing route transitions
+- Using query/mutation variables in assertions
+
+It also aims to act as a platform on which to add more useful plumbing as use-cases emerge.
+
+Because `createTestEnv` is mostly concerned with page-level components it asks you to first create a 'test page' class by extending `RootTestPage`.
+
+### Test pages
+
+A test page is a class which implicitly wraps an enzyme `ReactWrapper`. It is supposed to clean up your test logic by hiding common operations and element selections. Here's an example
+
+```ts
+class CounterTestPage extends RootTestPage {
+  get incrementButton() {
+    return this.find("button").filterWhere(btn => btn.text().match(/increment/))
+  }
+  get decrementButton() {
+    return this.find("button").filterWhere(btn => btn.text().match(/decrement/))
+  }
+  async clickIncrement() {
+    this.incrementButton.simulate("click")
+    await this.update()
+  }
+  async clickDecrement() {
+    this.decrementbutton.simulate("click")
+    await this.update()
+  }
+  get currentCount() {
+    return Number(this.text().match(/The current count is (\d+)\./)[1])
+  }
+}
+```
+
+You use a test page class to construct a test env.
+
+```ts
+const env = createTestEnv({
+  // `TestPage` is the interface to the ReactWrapper that you use during tests
+  TestPage: CounterTestPage,
+  // `Component` is the page itself. Assumed to be a fragment container
+  Component: CounterPage,
+  // `query` is the page's query. Normally this will be a simple query with a
+  // single fragment spread.
+  query: graphql`
+    query {
+      counter(id: "1234") {
+        count
+      }
+    }
+  `,
+  // `defaultData` is the default data to resolve for the query when rendering
+  // the Component
+  defaultData: {
+    /* mock fixtures */
+    counter: {
+      count: 0,
+    },
+  },
+  // `defaultMutationResults` (optional) is the default data to resolve for mutations executed
+  // with `commitMutation`
+  defaultMutationResults: {
+    /* mock fixtures */
+  },
+})
+```
+
+You can then use the test env to construct pages to use in tests
+
+```ts
+const page = await env.buildPage()
+expect(page.currentCount).toBe(0)
+await page.clickIncrement()
+expect(page.currentCount).toBe(1)
+```
+
+If you need to modify the data used to construct a page, you can pass it into
+`buildPage`.
+
+```ts
+const page = await env.buildPage({
+  mockData: { /* different mock fixtures */ }
+  mockMutationResult: { /* different mutation mocks */ }
+})
+```
+
+### Dynamic things
+
+If you need to modify the the mutation results on-the-fly, you can use `env.mutations`
+
+```ts
+const page = await env.buildPage()
+env.mutations.useResultsOnce({
+  incrementCounter: {
+    ...
+  }
+})
+```
+
+If you need to check the contents of the last mutation variables you can do this
+
+```ts
+expect(env.mutations.lastFetchVariables).toMathObject({
+  input: {
+    nextCount: 1,
+  },
+})
+```
+
+You can also get at the underlying mock fetch function if you need it
+
+```ts
+expect(env.mutations.mockFetch).toHaveBeenCalledTimes(0)
+await page.clickIncrement()
+expect(env.mutations.mockFetch).toHaveBeenCalledTimes(1)
+```
+
+You can mock network failures
+
+```ts
+env.mutations.mockNetworkFailureOnce()
+await page.clickIncrement()
+expect(page.text()).toMatch("Netork error. Try again later.")
+await page.clickIncrement()
+expect(page.text()).not.toMatch("Netork error. Try again later.")
+```
+
+You can check whether a route change was requested
+
+```ts
+expect(env.routes.mockPushRoute).toHaveBeenCalledWith("/home")
+```
+
+### Going forward
+
+If you discover usage patterns that would be well-suited to hoisting into `createTestEnv`, do so!
+The end goal is to make it faster and then release it as a standalone library for the relay community.


### PR DESCRIPTION
This was a little past-due 😬 

Realised when writing this that it doesn't support query variables yet 😞 I guess we never needed them in the order app. Should be pretty trivial to add when needed.