### PR TITLE
Fixed error modal for insufficient funds on accept page

### DIFF
--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -99,7 +99,7 @@ export class Accept extends Component<AcceptProps> {
         const parsedData = get(error, e => JSON.parse(e.data), {})
 
         // https://stripe.com/docs/declines/codes
-        if (parsedData.failure_code === "insufficient_funds") {
+        if (parsedData.decline_code === "insufficient_funds") {
           this.showCardFailureDialog({
             title: "Insufficient funds",
             message:

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/acceptOffer.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/acceptOffer.ts
@@ -38,7 +38,7 @@ export const acceptOfferPaymentFailedInsufficientFunds = {
       error: {
         type: "processing",
         code: "capture_failed",
-        data: `{"failure_code": "insufficient_funds"}`,
+        data: `{"decline_code": "insufficient_funds"}`,
       },
     },
   },


### PR DESCRIPTION
changed failure_code to decline_code in check for insufficient funds message