### PR TITLE
@mzikherman => [Autosuggest] Use term when linking to search results

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -327,7 +327,7 @@ export class SearchBar extends Component<Props, State> {
         isFirstItem: true,
         displayType: "FirstItem",
         displayLabel: term,
-        href: `/search?q=${term}`,
+        href: `/search?term=${term}`,
       },
     }
 


### PR DESCRIPTION
New search results page accepts `term`