### PR TITLE
User can see top three recommended artists

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtistRecommendations.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistRecommendations.tsx
@@ -36,7 +36,7 @@ export const ArtistRecommendationsFragmentContainer = createFragmentContainer(
     fragment ArtistRecommendations_artist on Artist {
       name
       related {
-        artists(first: 1) {
+        artists(first: 3) {
           edges {
             node {
               __id

--- a/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
@@ -126,6 +126,7 @@ const RecommendedArtist: FC<
       <Spacer mb={3} />
 
       <Carousel
+        height={240}
         data={get(artist, a => a.artworks_connection.edges, []) as object[]}
         render={artwork => {
           const aspect_ratio = get(artwork, a => a.node.image.aspect_ratio, 1)

--- a/src/__generated__/ArtistRecommendationsQuery.graphql.ts
+++ b/src/__generated__/ArtistRecommendationsQuery.graphql.ts
@@ -30,7 +30,7 @@ query ArtistRecommendationsQuery(
 fragment ArtistRecommendations_artist on Artist {
   name
   related {
-    artists(first: 1) {
+    artists(first: 3) {
       edges {
         node {
           __id
@@ -245,7 +245,7 @@ return {
   "operationKind": "query",
   "name": "ArtistRecommendationsQuery",
   "id": null,
-  "text": "query ArtistRecommendationsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistRecommendations_artist\n    __id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  name\n  related {\n    artists(first: 1) {\n      edges {\n        node {\n          __id\n          ...RecommendedArtist_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment RecommendedArtist_artist on Artist {\n  id\n  _id\n  name\n  formatted_nationality_and_birthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection(first: 20) {\n    edges {\n      node {\n        __id\n        image {\n          aspect_ratio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query ArtistRecommendationsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistRecommendations_artist\n    __id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  name\n  related {\n    artists(first: 3) {\n      edges {\n        node {\n          __id\n          ...RecommendedArtist_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment RecommendedArtist_artist on Artist {\n  id\n  _id\n  name\n  formatted_nationality_and_birthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection(first: 20) {\n    edges {\n      node {\n        __id\n        image {\n          aspect_ratio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -301,12 +301,12 @@ return {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "artists",
-                "storageKey": "artists(first:1)",
+                "storageKey": "artists(first:3)",
                 "args": [
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 1,
+                    "value": 3,
                     "type": "Int"
                   }
                 ],

--- a/src/__generated__/ArtistRecommendations_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistRecommendations_Test_Query.graphql.ts
@@ -26,7 +26,7 @@ query ArtistRecommendations_Test_Query {
 fragment ArtistRecommendations_artist on Artist {
   name
   related {
-    artists(first: 1) {
+    artists(first: 3) {
       edges {
         node {
           __id
@@ -233,7 +233,7 @@ return {
   "operationKind": "query",
   "name": "ArtistRecommendations_Test_Query",
   "id": null,
-  "text": "query ArtistRecommendations_Test_Query {\n  artist(id: \"andy-warhol\") {\n    ...ArtistRecommendations_artist\n    __id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  name\n  related {\n    artists(first: 1) {\n      edges {\n        node {\n          __id\n          ...RecommendedArtist_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment RecommendedArtist_artist on Artist {\n  id\n  _id\n  name\n  formatted_nationality_and_birthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection(first: 20) {\n    edges {\n      node {\n        __id\n        image {\n          aspect_ratio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query ArtistRecommendations_Test_Query {\n  artist(id: \"andy-warhol\") {\n    ...ArtistRecommendations_artist\n    __id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  name\n  related {\n    artists(first: 3) {\n      edges {\n        node {\n          __id\n          ...RecommendedArtist_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment RecommendedArtist_artist on Artist {\n  id\n  _id\n  name\n  formatted_nationality_and_birthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection(first: 20) {\n    edges {\n      node {\n        __id\n        image {\n          aspect_ratio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -289,12 +289,12 @@ return {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "artists",
-                "storageKey": "artists(first:1)",
+                "storageKey": "artists(first:3)",
                 "args": [
                   {
                     "kind": "Literal",
                     "name": "first",
-                    "value": 1,
+                    "value": 3,
                     "type": "Int"
                   }
                 ],

--- a/src/__generated__/ArtistRecommendations_artist.graphql.ts
+++ b/src/__generated__/ArtistRecommendations_artist.graphql.ts
@@ -56,12 +56,12 @@ return {
           "kind": "LinkedField",
           "alias": null,
           "name": "artists",
-          "storageKey": "artists(first:1)",
+          "storageKey": "artists(first:3)",
           "args": [
             {
               "kind": "Literal",
               "name": "first",
-              "value": 1,
+              "value": 3,
               "type": "Int"
             }
           ],
@@ -104,5 +104,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'acdbffb47f176f508b9e091fc8239dd8';
+(node as any).hash = '3c7a5c56c5487ae38f2d016e8f08f427';
 export default node;


### PR DESCRIPTION
Addresses

This is a small change to return 3 recommended artists instead of 1. 

Here's what it looks like now! (It's hard to get all three artists in one screenshot, sorry...)

![image](https://user-images.githubusercontent.com/1627089/55637596-0bb51c00-578b-11e9-9938-04148a0e3b75.png)

Here are the metaphysics calls for the "ArtistRecommendations" component now: 

![image](https://user-images.githubusercontent.com/1627089/55637778-6e0e1c80-578b-11e9-9406-837c61d08b16.png)
