### PR TITLE
@damassi => [SearchResults] Add loading spinner when navigating to entity tab

### DIFF
--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -1,3 +1,4 @@
+import { renderSpinner } from "Artsy/Router/Utils/Route"
 import { RouteConfig } from "found"
 import React from "react"
 import { graphql } from "react-relay"
@@ -27,9 +28,7 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
     path: key,
     Component: SearchResultsEntityRoute,
     render: ({ props, Component }) => {
-      if (!props) {
-        return null
-      }
+      if (!props) return renderSpinner()
       return <Component {...props} tab={key} entities={entities} />
     },
     prepareVariables: (_params, { location }) => {

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -42,7 +42,5 @@ storiesOf("Apps", module)
     )
   })
   .add("Search Results page", () => {
-    return (
-      <MockRouter routes={searchRoutes} initialRoute="/search?term=gagosian" />
-    )
+    return <MockRouter routes={searchRoutes} initialRoute="/search?term=andy" />
   })

--- a/src/Artsy/Router/Utils/Route.tsx
+++ b/src/Artsy/Router/Utils/Route.tsx
@@ -19,6 +19,14 @@ const SpinnerContainer = styled.figure`
   position: relative;
 `
 
+export const renderSpinner = () => {
+  return (
+    <SpinnerContainer className={LoadingClassName}>
+      <Spinner />
+    </SpinnerContainer>
+  )
+}
+
 // When popping a route (navigate back), use the data in the store.
 // function defaultGetDataFrom({ location }) {
 //   return location.action === "POP" ? "STORE_OR_NETWORK" : "STORE_THEN_NETWORK"
@@ -49,13 +57,7 @@ function createRender({ prerender, render, renderFetched }) {
     }
 
     // This should only ever show when doing client-side routing.
-    if (!props) {
-      return (
-        <SpinnerContainer className={LoadingClassName}>
-          <Spinner />
-        </SpinnerContainer>
-      )
-    }
+    if (!props) return renderSpinner()
 
     if (renderFetched) {
       return renderFetched(renderArgs)


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-911

Since we have a custom `render`, we don't get the nice `if (!props) Spinner...` behavior from the default `Route`, so we need to provide that.