### PR TITLE
@ashfurrow => [Search] Update action for selecting item from tabs

### DIFF
--- a/src/Apps/Search/Components/GenericSearchResultItem.tsx
+++ b/src/Apps/Search/Components/GenericSearchResultItem.tsx
@@ -31,7 +31,7 @@ export class GenericSearchResultItem extends React.Component<
   GenericSearchResultItemProps
 > {
   @track((props: GenericSearchResultItemProps) => ({
-    action_type: Schema.ActionType.SelectedItemFromSearch,
+    action_type: Schema.ActionType.SelectedItemFromSearchPage,
     query: props.term,
     item_number: props.index,
     item_type: props.entityType,

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsArtworkGrid.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsArtworkGrid.tsx
@@ -30,7 +30,7 @@ class SearchResultsArtworkGrid extends Component<Props, LoadingAreaState> {
   }
 
   @track((props: Props, _state, [artwork]) => ({
-    action_type: Schema.ActionType.SelectedItemFromSearch,
+    action_type: Schema.ActionType.SelectedItemFromSearchPage,
     query: props.term,
     item_type: "Artwork",
     item_id: artwork.id,

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -107,6 +107,7 @@ export enum ActionType {
 
   FocusedOnAutosuggestInput = "Focused on search input",
   SelectedItemFromSearch = "Selected item from search",
+  SelectedItemFromSearchPage = "Selected item from search page",
   SearchedAutosuggestWithResults = "Searched from header with results",
   SearchedAutosuggestWithoutResults = "Searched from header with no results",
 }


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-913

We were using the same event name for selecting an item from the search results page as we were for selecting an item from the autosuggest dropdown, so this creates a new entry for the results page.