### PR TITLE
address qa items for artist collections rail

### DIFF
--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionEntity.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionEntity.tsx
@@ -61,7 +61,7 @@ export class ArtistCollectionEntity extends React.Component<CollectionProps> {
           <CollectionTitle size="3">{formattedTitle}</CollectionTitle>
           {price_guidance && (
             <Sans size="2" color="black60">
-              Works from $
+              From $
               {currency(price_guidance, {
                 separator: ",",
                 precision: 0,
@@ -92,6 +92,7 @@ export const ArtworkImage = styled.img<{ width: number }>`
   background-color: ${color("black10")};
   object-fit: cover;
   object-position: center;
+  opacity: 0.9;
 
   &:last-child {
     padding-right: 0;

--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionEntity.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionEntity.tsx
@@ -83,6 +83,9 @@ export const StyledLink = styled(Link)`
 
   &:hover {
     text-decoration: none;
+    ${CollectionTitle} {
+      text-decoration: underline;
+    }
   }
 `
 
@@ -93,6 +96,7 @@ export const ArtworkImage = styled.img<{ width: number }>`
   object-fit: cover;
   object-position: center;
   opacity: 0.9;
+  padding-right: 2px;
 
   &:last-child {
     padding-right: 0;
@@ -101,7 +105,6 @@ export const ArtworkImage = styled.img<{ width: number }>`
 
 const ImgWrapper = styled(Flex)`
   width: 265px;
-  justify-content: space-between;
 `
 
 export const ArtistCollectionEntityFragmentContainer = createFragmentContainer(

--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -56,12 +56,14 @@ export class ArtistCollectionsRail extends React.Component<
             height={200}
             settings={{
               slidesToScroll: 1,
+              infinite: true,
             }}
             onArrowClick={this.trackCarouselNav.bind(this)}
             data={collections as object[]} // type required by slider
             render={slide => {
               return <ArtistCollectionEntity collection={slide} />
             }}
+            arrowHeight={130}
           />
         </RailWrapper>
       )

--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -45,7 +45,7 @@ export class ArtistCollectionsRail extends React.Component<
     const { collections } = this.props
     if (collections.length > 3) {
       return (
-        <RailWrapper>
+        <Box>
           <Waypoint onEnter={once(this.trackImpression.bind(this))} />
           <Sans size="3" weight="medium">
             Browse by series
@@ -63,9 +63,22 @@ export class ArtistCollectionsRail extends React.Component<
             render={slide => {
               return <ArtistCollectionEntity collection={slide} />
             }}
-            arrowHeight={130}
+            renderLeftArrow={({ Arrow }) => {
+              return (
+                <ArrowContainer>
+                  <Arrow />
+                </ArrowContainer>
+              )
+            }}
+            renderRightArrow={({ Arrow }) => {
+              return (
+                <ArrowContainer>
+                  <Arrow />
+                </ArrowContainer>
+              )
+            }}
           />
-        </RailWrapper>
+        </Box>
       )
     } else {
       return null
@@ -73,7 +86,8 @@ export class ArtistCollectionsRail extends React.Component<
   }
 }
 
-const RailWrapper = styled(Box)`
+const ArrowContainer = styled(Box)`
+  align-self: flex-start;
   ${ArrowButton} {
     min-height: 130px;
     align-self: flex-start;

--- a/src/Components/Artist/ArtistCollectionsRail/__tests__/ArtistCollectionEntity.test.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/__tests__/ArtistCollectionEntity.test.tsx
@@ -23,7 +23,7 @@ describe("ArtistCollectionEntity", () => {
 
     expect(component.text()).not.toMatch("Jasper Johns:")
     expect(component.text()).toMatch("Flags")
-    expect(component.text()).toMatch("Works from $1,000")
+    expect(component.text()).toMatch("From $1,000")
     expect(component.find(ArtworkImage).length).toBe(3)
     const artworkImage = component
       .find(ArtworkImage)

--- a/src/Components/Artist/ArtistCollectionsRail/__tests__/ArtistCollectionsRail.test.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/__tests__/ArtistCollectionsRail.test.tsx
@@ -28,9 +28,9 @@ describe("CollectionsRail", () => {
     expect(component.text()).toMatch("Browse by series")
     expect(component.find(ArtistCollectionEntity).length).toBe(8)
     expect(component.text()).toMatch("Flags")
-    expect(component.text()).toMatch("Works from $1,000")
+    expect(component.text()).toMatch("From $1,000")
     expect(component.text()).toMatch("Street Art Now")
-    expect(component.text()).toMatch("Works from $200")
+    expect(component.text()).toMatch("From $200")
   })
 
   it("Does not render carousel if less than 4 entries", () => {

--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -17,7 +17,6 @@ interface Props {
   renderLeftArrow?: Arrow
   renderRightArrow?: Arrow
   onArrowClick?: () => void
-  arrowHeight?: number
 }
 
 export class Carousel extends React.Component<Props> {
@@ -60,7 +59,6 @@ export const LargeCarousel = (props: Props) => {
           slickRef.slickPrev && slickRef.slickPrev() // check existence for tests
           props.onArrowClick && props.onArrowClick()
         }}
-        arrowHeight={props.arrowHeight}
       >
         <ChevronIcon direction="left" fill="black100" width={30} height={30} />
       </ArrowButton>
@@ -75,7 +73,6 @@ export const LargeCarousel = (props: Props) => {
           slickRef.slickNext && slickRef.slickNext() // check existence for tests
           props.onArrowClick && props.onArrowClick()
         }}
-        arrowHeight={props.arrowHeight}
       >
         <ChevronIcon direction="right" fill="black100" width={30} height={30} />
       </ArrowButton>
@@ -204,7 +201,7 @@ const CarouselContainer = styled.div<{ height?: number }>`
 `
 
 export const ArrowButton = styled(Flex)<
-  LeftProps & RightProps & { height?: number; arrowHeight?: number }
+  LeftProps & RightProps & { height?: number }
 >`
   position: relative;
   cursor: pointer;
@@ -214,8 +211,7 @@ export const ArrowButton = styled(Flex)<
   opacity: 0.1;
 
   transition: opacity 0.25s;
-  min-height: ${p => p.height || p.arrowHeight || 200}px;
-  align-self: ${p => (p.arrowHeight ? "flex-start" : "")};
+  min-height: ${p => p.height || 200}px;
 
   &:hover {
     opacity: 1;

--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -17,6 +17,7 @@ interface Props {
   renderLeftArrow?: Arrow
   renderRightArrow?: Arrow
   onArrowClick?: () => void
+  arrowHeight?: number
 }
 
 export class Carousel extends React.Component<Props> {
@@ -59,6 +60,7 @@ export const LargeCarousel = (props: Props) => {
           slickRef.slickPrev && slickRef.slickPrev() // check existence for tests
           props.onArrowClick && props.onArrowClick()
         }}
+        arrowHeight={props.arrowHeight}
       >
         <ChevronIcon direction="left" fill="black100" width={30} height={30} />
       </ArrowButton>
@@ -73,6 +75,7 @@ export const LargeCarousel = (props: Props) => {
           slickRef.slickNext && slickRef.slickNext() // check existence for tests
           props.onArrowClick && props.onArrowClick()
         }}
+        arrowHeight={props.arrowHeight}
       >
         <ChevronIcon direction="right" fill="black100" width={30} height={30} />
       </ArrowButton>
@@ -201,7 +204,7 @@ const CarouselContainer = styled.div<{ height?: number }>`
 `
 
 export const ArrowButton = styled(Flex)<
-  LeftProps & RightProps & { height?: number }
+  LeftProps & RightProps & { height?: number; arrowHeight?: number }
 >`
   position: relative;
   cursor: pointer;
@@ -211,7 +214,8 @@ export const ArrowButton = styled(Flex)<
   opacity: 0.1;
 
   transition: opacity 0.25s;
-  min-height: ${p => p.height || 200}px;
+  min-height: ${p => p.height || p.arrowHeight || 200}px;
+  align-self: ${p => (p.arrowHeight ? "flex-start" : "")};
 
   &:hover {
     opacity: 1;


### PR DESCRIPTION
Addresses: [GROW-1167](https://artsyproduct.atlassian.net/browse/GROW-1167)

- Center carousel arrow based on image
- Allow for carousel items to scroll infinitely
- Add overlay to images
- Remove "works" text in "works from $$$"

<img width="1263" alt="Screen Shot 2019-04-09 at 2 11 41 PM" src="https://user-images.githubusercontent.com/5201004/55824231-7b037680-5ad1-11e9-99a5-ebc28d0c7d80.png">
