### PR TITLE
[Carousel] Add arrow render callback

### DIFF
--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -5,11 +5,17 @@ import styled from "styled-components"
 import { left, LeftProps, right, RightProps } from "styled-system"
 import { Media } from "Utils/Responsive"
 
+type Arrow = (
+  props: { Arrow: React.ReactType; getSlick: () => any } & Props
+) => React.ReactNode
+
 interface Props {
   settings?: Settings
   height?: number
   data: object[] // This is designed to handle any shape of data passed, as long as its an array
   render: (slide) => ReactNode
+  renderLeftArrow?: Arrow
+  renderRightArrow?: Arrow
   onArrowClick?: () => void
 }
 
@@ -45,13 +51,8 @@ export const LargeCarousel = (props: Props) => {
 
   let slickRef = null
 
-  return (
-    <Flex
-      flexDirection="row"
-      justifyContent="space-around"
-      alignItems="center"
-      height={props.height}
-    >
+  const LeftArrow = () => {
+    return (
       <ArrowButton
         left={-8}
         onClick={() => {
@@ -61,15 +62,11 @@ export const LargeCarousel = (props: Props) => {
       >
         <ChevronIcon direction="left" fill="black100" width={30} height={30} />
       </ArrowButton>
+    )
+  }
 
-      <CarouselContainer height={props.height}>
-        <Slick {...slickConfig} ref={slider => (slickRef = slider)}>
-          {props.data.map((slide, index) => {
-            return <Box key={index}>{props.render(slide)}</Box>
-          })}
-        </Slick>
-      </CarouselContainer>
-
+  const RightArrow = () => {
+    return (
       <ArrowButton
         right={-8}
         onClick={() => {
@@ -79,6 +76,43 @@ export const LargeCarousel = (props: Props) => {
       >
         <ChevronIcon direction="right" fill="black100" width={30} height={30} />
       </ArrowButton>
+    )
+  }
+
+  return (
+    <Flex
+      flexDirection="row"
+      justifyContent="space-around"
+      alignItems="center"
+      height={props.height}
+    >
+      {props.renderLeftArrow ? (
+        props.renderLeftArrow({
+          Arrow: LeftArrow,
+          getSlick: () => slickRef,
+          ...props,
+        })
+      ) : (
+        <LeftArrow />
+      )}
+
+      <CarouselContainer height={props.height}>
+        <Slick {...slickConfig} ref={slider => (slickRef = slider)}>
+          {props.data.map((slide, index) => {
+            return <Box key={index}>{props.render(slide)}</Box>
+          })}
+        </Slick>
+      </CarouselContainer>
+
+      {props.renderRightArrow ? (
+        props.renderRightArrow({
+          Arrow: RightArrow,
+          getSlick: () => slickRef,
+          ...props,
+        })
+      ) : (
+        <RightArrow />
+      )}
     </Flex>
   )
 }

--- a/src/Components/v2/__stories__/Carousel.story.tsx
+++ b/src/Components/v2/__stories__/Carousel.story.tsx
@@ -88,6 +88,76 @@ storiesOf("Styleguide/Components", module).add("Carousel", () => {
           </RelayStubProvider>
         </Box>
       </Section>
+      <Section title="Custom Arrows with defaults">
+        <Box width="70%">
+          <Carousel
+            data={images}
+            render={props => {
+              return (
+                <Image
+                  px={5}
+                  src={props.resized.url}
+                  width={props.resized.width}
+                  height={props.resized.height}
+                />
+              )
+            }}
+            renderLeftArrow={({ Arrow }) => {
+              return (
+                <Box top={10} position="relative" bg="black10">
+                  <Arrow />
+                </Box>
+              )
+            }}
+            renderRightArrow={({ Arrow }) => {
+              return (
+                <Box top={10} position="relative" bg="black10">
+                  <Arrow />
+                </Box>
+              )
+            }}
+          />
+        </Box>
+      </Section>
+      <Section title="Custom Arrows ">
+        <Box width="70%">
+          <Carousel
+            data={images}
+            render={props => {
+              return (
+                <Image
+                  px={5}
+                  src={props.resized.url}
+                  width={props.resized.width}
+                  height={props.resized.height}
+                />
+              )
+            }}
+            renderLeftArrow={({ getSlick }) => {
+              return (
+                <Box
+                  onClick={() => {
+                    getSlick().slickPrev()
+                  }}
+                >
+                  Prev
+                </Box>
+              )
+            }}
+            renderRightArrow={({ getSlick }) => {
+              return (
+                <Box
+                  onClick={() => {
+                    getSlick().slickNext()
+                  }}
+                >
+                  Next
+                </Box>
+              )
+            }}
+          />
+        </Box>
+      </Section>
     </React.Fragment>
   )
 })


### PR DESCRIPTION
Follow up to https://github.com/artsy/reaction/pull/2279

Makes the Carousel slighly more customizable by providing `renderArrow` callbacks with a ref to the carousel and some defaults. 

![customarrows](https://user-images.githubusercontent.com/236943/55831389-d4ff3e80-5ac7-11e9-8f06-13dd19436ee9.gif)
