### PR TITLE
[Toolchain] Make Storybooks hooks-safe

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -114,6 +114,7 @@ module.exports = async ({ config, mode }) => {
     alias: {
       sharify: sharifyPath.replace(/\.js$/, ""),
       "styled-components": path.resolve("./node_modules/styled-components"),
+      react: path.resolve("./node_modules/react"),
     },
   }
   config.plugins = [...config.plugins, ...plugins]


### PR DESCRIPTION
Just noticed the dreaded [hooks error](https://github.com/facebook/react/issues/13991) yesterday -- this should fix it. 