### PR TITLE
[PATCH] fix qa items

### DIFF
--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionEntity.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionEntity.tsx
@@ -50,7 +50,15 @@ export class ArtistCollectionEntity extends React.Component<CollectionProps> {
               bgImages.map((url, i) => {
                 const alt = `${hits[i].artist.name}, ${hits[i].title}`
                 return (
-                  <ArtworkImage key={i} src={url} width={imageSize} alt={alt} />
+                  <SingleImgContainer key={i}>
+                    <ImgOverlay width={imageSize} />
+                    <ArtworkImage
+                      key={i}
+                      src={url}
+                      width={imageSize}
+                      alt={alt}
+                    />
+                  </SingleImgContainer>
                 )
               })
             ) : (
@@ -80,6 +88,7 @@ const CollectionTitle = styled(Serif)`
 
 export const StyledLink = styled(Link)`
   text-decoration: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 
   &:hover {
     text-decoration: none;
@@ -89,6 +98,25 @@ export const StyledLink = styled(Link)`
   }
 `
 
+const SingleImgContainer = styled(Box)`
+  position: relative;
+  margin-right: 2px;
+
+  &:last-child {
+    margin-right: 0;
+  }
+`
+
+const ImgOverlay = styled(Box)<{ width: number }>`
+  height: 125px;
+  background-color: ${color("black30")};
+  opacity: 0.1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 7;
+`
+
 export const ArtworkImage = styled.img<{ width: number }>`
   width: ${({ width }) => width}px;
   height: 125px;
@@ -96,11 +124,6 @@ export const ArtworkImage = styled.img<{ width: number }>`
   object-fit: cover;
   object-position: center;
   opacity: 0.9;
-  padding-right: 2px;
-
-  &:last-child {
-    padding-right: 0;
-  }
 `
 
 const ImgWrapper = styled(Flex)`

--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -48,7 +48,7 @@ export class ArtistCollectionsRail extends React.Component<
         <Box>
           <Waypoint onEnter={once(this.trackImpression.bind(this))} />
           <Sans size="3" weight="medium">
-            Browse by series
+            Browse by iconic collections
           </Sans>
           <Spacer pb={1} />
 

--- a/src/Components/Artist/ArtistCollectionsRail/__tests__/ArtistCollectionsRail.test.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/__tests__/ArtistCollectionsRail.test.tsx
@@ -25,7 +25,7 @@ describe("CollectionsRail", () => {
 
   it("Renders expected fields", () => {
     const component = getWrapper()
-    expect(component.text()).toMatch("Browse by series")
+    expect(component.text()).toMatch("Browse by iconic collections")
     expect(component.find(ArtistCollectionEntity).length).toBe(8)
     expect(component.text()).toMatch("Flags")
     expect(component.text()).toMatch("From $1,000")


### PR DESCRIPTION
Addresses: [GROW-1185](https://artsyproduct.atlassian.net/browse/GROW-1185)

- Adds proper overlay and removes gray margins in between images
- Removes gray highlight when tapping rail links
- Changes copy from "Browse by series" to "Browse by iconic collections"

![artist collections rail](https://user-images.githubusercontent.com/5201004/56063089-57903400-5d3c-11e9-9016-515db2cb06c8.gif)
