### PR TITLE
Preserve search term in SearchBar, based on window.location.search

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -14,6 +14,7 @@ import {
   SuggestionItem,
 } from "Components/Search/Suggestions/SuggestionItem"
 import { throttle } from "lodash"
+import qs from "qs"
 import React, { Component, useContext } from "react"
 import Autosuggest from "react-autosuggest"
 import {
@@ -90,7 +91,7 @@ export class SearchBar extends Component<Props, State> {
   private userClickedOnDescendant: boolean
 
   state = {
-    term: "",
+    term: getSearchTerm(window.location),
     entityID: null,
     entityType: null,
     focused: false,
@@ -427,4 +428,16 @@ export const SearchBarQueryRenderer: React.FC = () => {
       }}
     />
   )
+}
+
+export function getSearchTerm(location: Location): string {
+  const term = get(
+    qs,
+    querystring => querystring.parse(location.search.slice(1)).term,
+    ""
+  )
+  if (Array.isArray(term)) {
+    return term[0]
+  }
+  return term
 }

--- a/src/Components/Search/__tests__/SearchBar.test.tsx
+++ b/src/Components/Search/__tests__/SearchBar.test.tsx
@@ -1,5 +1,8 @@
 import Input from "Components/Input"
-import { SearchBarRefetchContainer as SearchBar } from "Components/Search/SearchBar"
+import {
+  getSearchTerm,
+  SearchBarRefetchContainer as SearchBar,
+} from "Components/Search/SearchBar"
 import { SuggestionItem } from "Components/Search/Suggestions/SuggestionItem"
 import { renderRelayTree } from "DevTools"
 import { MockBoot } from "DevTools/MockBoot"
@@ -110,5 +113,59 @@ describe("SearchBar", () => {
     await flushPromiseQueue()
 
     expect(component.html()).toContain("<strong>Perc</strong>y Z")
+  })
+})
+
+describe("getSearchTerm", () => {
+  function buildLocationWithQueryString(queryString: string): Location {
+    return {
+      ancestorOrigins: undefined,
+      host: undefined,
+      hostname: undefined,
+      href: undefined,
+      origin: undefined,
+      port: undefined,
+      protocol: undefined,
+      assign: undefined,
+      hash: undefined,
+      pathname: undefined,
+      reload: undefined,
+      replace: undefined,
+      search: queryString,
+    }
+  }
+
+  it("returns empty string if there is no term", () => {
+    const location = buildLocationWithQueryString(undefined)
+
+    const result = getSearchTerm(location)
+
+    expect(result).toEqual("")
+  })
+
+  it("returns empty string if there is an empty term", () => {
+    const location = buildLocationWithQueryString("")
+
+    const result = getSearchTerm(location)
+
+    expect(result).toEqual("")
+  })
+
+  it("returns the term if there is a single one", () => {
+    const location = buildLocationWithQueryString("?term=monkey")
+
+    const result = getSearchTerm(location)
+
+    expect(result).toEqual("monkey")
+  })
+
+  it("returns the first term if there are multiple", () => {
+    // This is not really a concern in real-life, but TypeScript says
+    //  it can happen, so we should cover it.
+    const location = buildLocationWithQueryString("?term=monkey&term=elephant")
+
+    const result = getSearchTerm(location)
+
+    expect(result).toEqual("monkey")
   })
 })


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-925.

* I'm checking against window.location for the current query string, instead of using the `found` router, because this component is stitched in via Force. As far as I can tell, it is not a child of the router, so it doesn't have access to its location. I don't feel great about this approach, but I'm hopeful it is only temporary until @damassi gets the NavBar rewritten.
* I've added what I think is adequate test coverage to the function that parses the term from the query string...let me know if you think any cases are missing.
* I left the `getSearchTerm` function as part of `SearchBar.tsx` because I didn't want to glorify it with its own file. This function feels like a sub-optimal way to identify the current route, and hiding it in this file feels like the least I can do to discourage people using it.