### PR TITLE
Sort recommended artworks by published date descending

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
@@ -164,7 +164,7 @@ export const RecommendedArtistFragmentContainer = createFragmentContainer(
             url
           }
         }
-        artworks_connection(first: 20) {
+        artworks_connection(first: 20, sort: PUBLISHED_AT_DESC) {
           edges {
             node {
               __id

--- a/src/__generated__/ArtistRecommendationsQuery.graphql.ts
+++ b/src/__generated__/ArtistRecommendationsQuery.graphql.ts
@@ -53,7 +53,7 @@ fragment RecommendedArtist_artist on Artist {
       url
     }
   }
-  artworks_connection(first: 20) {
+  artworks_connection(first: 20, sort: PUBLISHED_AT_DESC) {
     edges {
       node {
         __id
@@ -245,7 +245,7 @@ return {
   "operationKind": "query",
   "name": "ArtistRecommendationsQuery",
   "id": null,
-  "text": "query ArtistRecommendationsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistRecommendations_artist\n    __id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  name\n  related {\n    artists(first: 3) {\n      edges {\n        node {\n          __id\n          ...RecommendedArtist_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment RecommendedArtist_artist on Artist {\n  id\n  _id\n  name\n  formatted_nationality_and_birthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection(first: 20) {\n    edges {\n      node {\n        __id\n        image {\n          aspect_ratio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query ArtistRecommendationsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistRecommendations_artist\n    __id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  name\n  related {\n    artists(first: 3) {\n      edges {\n        node {\n          __id\n          ...RecommendedArtist_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment RecommendedArtist_artist on Artist {\n  id\n  _id\n  name\n  formatted_nationality_and_birthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection(first: 20, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        __id\n        image {\n          aspect_ratio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -389,13 +389,19 @@ return {
                             "kind": "LinkedField",
                             "alias": null,
                             "name": "artworks_connection",
-                            "storageKey": "artworks_connection(first:20)",
+                            "storageKey": "artworks_connection(first:20,sort:\"PUBLISHED_AT_DESC\")",
                             "args": [
                               {
                                 "kind": "Literal",
                                 "name": "first",
                                 "value": 20,
                                 "type": "Int"
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "sort",
+                                "value": "PUBLISHED_AT_DESC",
+                                "type": "ArtworkSorts"
                               }
                             ],
                             "concreteType": "ArtworkConnection",

--- a/src/__generated__/ArtistRecommendations_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistRecommendations_Test_Query.graphql.ts
@@ -49,7 +49,7 @@ fragment RecommendedArtist_artist on Artist {
       url
     }
   }
-  artworks_connection(first: 20) {
+  artworks_connection(first: 20, sort: PUBLISHED_AT_DESC) {
     edges {
       node {
         __id
@@ -233,7 +233,7 @@ return {
   "operationKind": "query",
   "name": "ArtistRecommendations_Test_Query",
   "id": null,
-  "text": "query ArtistRecommendations_Test_Query {\n  artist(id: \"andy-warhol\") {\n    ...ArtistRecommendations_artist\n    __id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  name\n  related {\n    artists(first: 3) {\n      edges {\n        node {\n          __id\n          ...RecommendedArtist_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment RecommendedArtist_artist on Artist {\n  id\n  _id\n  name\n  formatted_nationality_and_birthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection(first: 20) {\n    edges {\n      node {\n        __id\n        image {\n          aspect_ratio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query ArtistRecommendations_Test_Query {\n  artist(id: \"andy-warhol\") {\n    ...ArtistRecommendations_artist\n    __id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  name\n  related {\n    artists(first: 3) {\n      edges {\n        node {\n          __id\n          ...RecommendedArtist_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment RecommendedArtist_artist on Artist {\n  id\n  _id\n  name\n  formatted_nationality_and_birthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection(first: 20, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        __id\n        image {\n          aspect_ratio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    display_timely_at\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -377,13 +377,19 @@ return {
                             "kind": "LinkedField",
                             "alias": null,
                             "name": "artworks_connection",
-                            "storageKey": "artworks_connection(first:20)",
+                            "storageKey": "artworks_connection(first:20,sort:\"PUBLISHED_AT_DESC\")",
                             "args": [
                               {
                                 "kind": "Literal",
                                 "name": "first",
                                 "value": 20,
                                 "type": "Int"
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "sort",
+                                "value": "PUBLISHED_AT_DESC",
+                                "type": "ArtworkSorts"
                               }
                             ],
                             "concreteType": "ArtworkConnection",

--- a/src/__generated__/RecommendedArtist_artist.graphql.ts
+++ b/src/__generated__/RecommendedArtist_artist.graphql.ts
@@ -129,13 +129,19 @@ return {
       "kind": "LinkedField",
       "alias": null,
       "name": "artworks_connection",
-      "storageKey": "artworks_connection(first:20)",
+      "storageKey": "artworks_connection(first:20,sort:\"PUBLISHED_AT_DESC\")",
       "args": [
         {
           "kind": "Literal",
           "name": "first",
           "value": 20,
           "type": "Int"
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "PUBLISHED_AT_DESC",
+          "type": "ArtworkSorts"
         }
       ],
       "concreteType": "ArtworkConnection",
@@ -198,5 +204,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '60350f72595d74f2476540383b5ebe62';
+(node as any).hash = 'bac237869e325729a567d00bf3a3780e';
 export default node;


### PR DESCRIPTION
This addresses https://artsyproduct.atlassian.net/browse/DISCO-907.

Feedback from @cavvia was that we should be sorting artworks within artist recommendations by published date descending; this change makes that happen.