### PR TITLE
Fixes search bar button press getting redirected to homepage

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -190,14 +190,23 @@ export class SearchBar extends Component<Props, State> {
     this.setState({ focused: true })
   }
 
-  onBlur = e => {
+  onBlur = event => {
+    if (
+      event.relatedTarget &&
+      event.relatedTarget.form &&
+      event.relatedTarget.form === event.target.form
+    ) {
+      this.userClickedOnDescendant = true
+      return
+    }
     this.setState({ focused: false })
   }
 
-  onSuggestionsClearRequested = () => {
-    // This event _also_ fires when a user clicks on a link in the preview pane.
-    //  If we initialize state when that happens, the link will get removed
-    //  from the DOM before the browser has a chance to follow it.
+  onSuggestionsClearRequested = e => {
+    // This event _also_ fires when a user clicks on a link in the preview pane
+    //  or the magnifying glass icon. If we initialize state when that happens,
+    //  the link will get removed from the DOM before the browser has a chance
+    //  to follow it.
     if (!this.userClickedOnDescendant) {
       this.setState({ term: "", entityID: null, entityType: null })
     }


### PR DESCRIPTION
When tapping the magnifying glass icon, users were getting directed to the homepage instead of the search results page. What was happening was: [react-autosuggest](https://github.com/moroshko/react-autosuggest) was intercepting `onBlur` from the input and calling `onSuggestionsClearRequested`, which cleared the search bar of text. _Then_ the button press would submit the form, directing to `/search?term=`, which Force redirects back to `/`. 

Because of how `SearchInputContainer` and `Autosuggest` refs work, checking the `form` property was the easiest way to make ignore button-press events (this piggy-backed on existing code to ignore other click events). I'm open to suggestions, though!

Fixes [DISCO-934](https://artsyproduct.atlassian.net/browse/DISCO-934).