### PR TITLE
Updates type to be more specific

### DIFF
--- a/src/Components/Search/SearchInputContainer.tsx
+++ b/src/Components/Search/SearchInputContainer.tsx
@@ -25,7 +25,7 @@ const SearchButton = styled.button`
   }
 `
 
-export const SearchInputContainer: React.ExoticComponent<
+export const SearchInputContainer: React.ForwardRefExoticComponent<
   any
 > = React.forwardRef((props, ref) => {
   return (


### PR DESCRIPTION
Added [here](https://github.com/artsy/reaction/commit/ae033ae7011d4b839b6257579c03127fc2ed3df9), the explicit typing was for a supertype of what was actually returned. This makes it more obvious, as discussed in today's Show & Tell.