### PR TITLE
Prevents search bar from submitting with empty query.

### DIFF
--- a/src/Components/Search/SearchInputContainer.tsx
+++ b/src/Components/Search/SearchInputContainer.tsx
@@ -1,5 +1,6 @@
 import { Box, color } from "@artsy/palette"
 import Input from "Components/Input"
+import { isEmpty } from "lodash"
 import React from "react"
 import styled from "styled-components"
 
@@ -31,7 +32,14 @@ export const SearchInputContainer: React.ExoticComponent<
   return (
     <Box style={{ position: "relative" }}>
       <Input ref={ref} style={{ width: "100%" }} {...props} />
-      <SearchButton>
+      <SearchButton
+        onClick={event => {
+          ;(event.target as HTMLElement).parentElement.blur()
+          if (isEmpty(props.value)) {
+            event.preventDefault()
+          }
+        }}
+      >
         <svg
           width="18"
           height="18"


### PR DESCRIPTION
I was hoping to be able to specify form-level enabled-ness, but the form itself is housed in Force, so instead we have to add the following logic:

- When blurring from search because the icon button was clicked, only mark a descendant as being clicked if the search query is non-empty.
- When pressing enter to submit the form, only submit the search form if the query is non-empty.
- When handling click events on the icon button, only submit the search form if the query is non-empty.

This kind of DOM manipulation is kind of tricky to test, or at least I'm unfamiliar with it and there weren't any existing tests at this level of granularity. If tests would be appropriate for this PR, maybe we could pair on them? 

Follow-up from #2298. Fixes DISCO-934.