### PR TITLE
Update search results loading skeleton

### DIFF
--- a/src/Apps/Search/Components/SearchResultsSkeleton/FilterSidebar.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/FilterSidebar.tsx
@@ -35,11 +35,11 @@ const FilterSidebarSection: React.SFC<any> = props => {
 
 export const FilterSidebar: React.SFC<any> = props => {
   return (
-    <Box style={{ width: "25%" }}>
+    <Box width="25%" pr={10} mr={10}>
       <FilterSidebarSection />
-      <Separator mt={2} />
+      <Separator mt={2} mb={2} />
       <FilterSidebarSection />
-      <Separator mt={2} />
+      <Separator mt={2} mb={2} />
       <FilterSidebarSection />
     </Box>
   )

--- a/src/Apps/Search/Components/SearchResultsSkeleton/GridItem.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/GridItem.tsx
@@ -28,7 +28,7 @@ const Placeholder = styled(Box)<BoxProps & BorderRadiusProps>`
 
 export const GridItem: React.SFC<BoxProps> = props => {
   return (
-    <Box style={{ margin: "0 5px 30px 5px" }}>
+    <Box mb={30} pr={20}>
       <Placeholder
         height={props.height}
         style={{ backgroundColor: color("black10") }}

--- a/src/Apps/Search/Components/SearchResultsSkeleton/Header.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/Header.tsx
@@ -1,68 +1,53 @@
-import { Box, color } from "@artsy/palette"
+import { Box, color, Separator } from "@artsy/palette"
 import React from "react"
 
 export const Header: React.SFC<any> = props => {
   return (
-    <Box height={100}>
+    <Box height={100} mb={30} mt={120}>
+      <Box mb={40} background={color("black10")} width={320} height={20} />
       <Box
-        width={380}
-        height={14}
-        style={{ margin: "20px 0 20px 0", backgroundColor: color("black10") }}
+        width={80}
+        height={12}
+        mr={3}
+        display="inline-block"
+        background={color("black10")}
       />
       <Box
-        width={100}
-        height={6}
-        style={{
-          display: "inline-block",
-          marginRight: 10,
-          backgroundColor: color("black10"),
-        }}
+        width={80}
+        height={12}
+        mr={3}
+        display="inline-block"
+        background={color("black10")}
       />
       <Box
-        width={100}
-        height={6}
-        style={{
-          display: "inline-block",
-          marginRight: 10,
-          backgroundColor: color("black10"),
-        }}
+        width={80}
+        height={12}
+        mr={3}
+        display="inline-block"
+        background={color("black10")}
       />
       <Box
-        width={100}
-        height={6}
-        style={{
-          display: "inline-block",
-          marginRight: 10,
-          backgroundColor: color("black10"),
-        }}
+        width={80}
+        height={12}
+        mr={3}
+        display="inline-block"
+        background={color("black10")}
       />
       <Box
-        width={100}
-        height={6}
-        style={{
-          display: "inline-block",
-          marginRight: 10,
-          backgroundColor: color("black10"),
-        }}
+        width={80}
+        height={12}
+        mr={3}
+        display="inline-block"
+        background={color("black10")}
       />
       <Box
-        width={100}
-        height={6}
-        style={{
-          display: "inline-block",
-          marginRight: 10,
-          backgroundColor: color("black10"),
-        }}
+        width={80}
+        height={12}
+        mr={3}
+        display="inline-block"
+        background={color("black10")}
       />
-      <Box
-        width={100}
-        height={6}
-        style={{
-          display: "inline-block",
-          marginRight: 10,
-          backgroundColor: color("black10"),
-        }}
-      />
+      <Separator mt={10} />
     </Box>
   )
 }

--- a/src/Apps/Search/Components/SearchResultsSkeleton/index.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Col, Flex, Grid, Row } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import React from "react"
-import { Media } from "Utils/Responsive"
 import { FilterSidebar } from "./FilterSidebar"
 import { GridItem } from "./GridItem"
 import { Header } from "./Header"
@@ -9,32 +9,32 @@ import { Header } from "./Header"
 export const SearchResultsSkeleton: React.FC<any> = props => {
   return (
     <AppContainer>
-      <Box>
-        <Header />
-        <Flex>
-          <Media greaterThan="xs">
+      <HorizontalPadding>
+        <Box>
+          <Header />
+          <Flex>
             <FilterSidebar />
-          </Media>
-          <Grid fluid style={{ width: "75%", padding: "0 50px 0 50px" }}>
-            <Row>
-              <Col sm={4} pr={1}>
-                <GridItem height={200} />
-                <GridItem height={400} />
-                <GridItem height={240} />
-              </Col>
-              <Col sm={4} pr={1}>
-                <GridItem height={300} />
-                <GridItem height={200} />
-                <GridItem height={320} />
-              </Col>
-              <Col sm={4}>
-                <GridItem height={240} />
-                <GridItem height={400} />
-              </Col>
-            </Row>
-          </Grid>
-        </Flex>
-      </Box>
+            <Grid fluid style={{ width: "75%" }}>
+              <Row>
+                <Col sm={4} pr={1}>
+                  <GridItem height={200} />
+                  <GridItem height={400} />
+                  <GridItem height={240} />
+                </Col>
+                <Col sm={4} pr={1}>
+                  <GridItem height={300} />
+                  <GridItem height={200} />
+                  <GridItem height={320} />
+                </Col>
+                <Col sm={4}>
+                  <GridItem height={240} />
+                  <GridItem height={400} />
+                </Col>
+              </Row>
+            </Grid>
+          </Flex>
+        </Box>
+      </HorizontalPadding>
     </AppContainer>
   )
 }


### PR DESCRIPTION
Re-position the loading skeleton to more closely match the layout rendered by the hydrated search results app.

![2019-04-19-162732_1799x1100_scrot](https://user-images.githubusercontent.com/123595/56442823-0fcf5680-62c0-11e9-8089-b617cb1e6531.png)
![2019-04-19-162739_1836x1103_scrot](https://user-images.githubusercontent.com/123595/56442824-11991a00-62c0-11e9-915e-206f3ae3f47d.png)
