### PR TITLE
@kierangillen => [Auction Results] Be defensive about missing images

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionDetailsModal.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionDetailsModal.tsx
@@ -13,6 +13,7 @@ import {
   Serif,
   Spacer,
 } from "@artsy/palette"
+import { get } from "Utils/get"
 
 interface Props {
   hideDetailsModal?: () => void
@@ -62,6 +63,7 @@ const LotDetails: SFC<Props> = props => {
     hideDetailsModal,
     auctionResult: { title, date_text, dimension_text, images, description },
   } = props
+  const imageUrl = get(images, i => i.thumbnail.url, "")
 
   return (
     <>
@@ -87,7 +89,7 @@ const LotDetails: SFC<Props> = props => {
         <Spacer mr={2} />
 
         <Box height="auto">
-          <Image width="100px" src={images.thumbnail.url} />
+          <Image width="100px" src={imageUrl} />
         </Box>
       </Flex>
 

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -18,6 +18,7 @@ import {
   Serif,
   Spacer,
 } from "@artsy/palette"
+import { get } from "Utils/get"
 
 export interface Props extends SystemContextProps {
   auctionResult: ArtistAuctionResultItem_auctionResult
@@ -85,6 +86,7 @@ const LargeAuctionItem: SFC<Props> = props => {
     estimatedPrice,
   } = getProps(props)
 
+  const imageUrl = get(images, i => i.thumbnail.url, "")
   return (
     <Subscribe to={[AuctionResultsState]}>
       {({ state, showDetailsModal }: AuctionResultsState) => {
@@ -92,7 +94,7 @@ const LargeAuctionItem: SFC<Props> = props => {
           <>
             <Col sm={1}>
               <Box height="auto" pr={2}>
-                <Image width="70px" src={images.thumbnail.url} />
+                <Image width="70px" src={imageUrl} />
               </Box>
             </Col>
             <Col sm={4}>
@@ -144,13 +146,14 @@ const SmallAuctionItem: SFC<Props> = props => {
     truncatedDescription,
     estimatedPrice,
   } = getProps(props)
+  const imageUrl = get(images, i => i.thumbnail.url, "")
 
   return (
     <>
       <Col sm={6}>
         <Flex>
           <Box height="auto">
-            <Image width="70px" src={images.thumbnail.url} />
+            <Image width="70px" src={imageUrl} />
           </Box>
 
           <Spacer mr={2} />
@@ -194,13 +197,14 @@ const ExtraSmallAuctionItem: SFC<Props> = props => {
     salePrice,
     estimatedPrice,
   } = getProps(props)
+  const imageUrl = get(images, i => i.thumbnail.url, "")
 
   return (
     <>
       <Col>
         <Flex>
           <Box height="auto">
-            <Image width="70px" src={images.thumbnail.url} />
+            <Image width="70px" src={imageUrl} />
           </Box>
 
           <Spacer mr={2} />

--- a/src/Apps/__stories__/ArtistApp.story.tsx
+++ b/src/Apps/__stories__/ArtistApp.story.tsx
@@ -10,7 +10,7 @@ storiesOf("Apps/Artist Page", module)
     return (
       <MockRouter
         routes={artistRoutes}
-        initialRoute="/artist/pablo-picasso"
+        initialRoute="/artist/andy-warhol"
         context={{
           mediator: {
             trigger: x => x,


### PR DESCRIPTION
Turns out there was still a place in Reaction to be defensive about missing images.

cc @cavvia lots of the newer auction result data has missing images (was causing some issues due to an assumption about images being present), as well as `Sotheby's Manual` being set as the organization:

<img width="912" alt="Screen Shot 2019-04-22 at 3 23 12 PM" src="https://user-images.githubusercontent.com/1457859/56520980-1c97b880-6513-11e9-8516-f4d6078f8625.png">
