### PR TITLE
Update moment-timezone to reduce payload size

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "jsonp": "^0.2.1",
     "lodash": "^4.17.4",
     "memoize-one": "^4.0.3",
-    "moment-timezone": "^0.5.13",
+    "moment-timezone": "^0.5.25",
     "numeral": "^2.0.4",
     "openseadragon": "^2.3.1",
     "prop-types": "^15.5.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9207,10 +9207,17 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
 
-moment-timezone@^0.5.13, moment-timezone@^0.5.23:
+moment-timezone@^0.5.23:
   version "0.5.23"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
   integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
+  dependencies:
+    moment ">= 2.9.0"
+
+moment-timezone@^0.5.25:
+  version "0.5.25"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.25.tgz#a11bfa2f74e088327f2cd4c08b3e7bdf55957810"
+  integrity sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
Latest version has a smaller payload size. 