### PR TITLE
ensure experiment viewed event is fired

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -38,9 +38,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
   }
 
   componentDidMount() {
-    if (this.props.showCollectionsRail) {
-      this.trackingCollectionsRailTest()
-    }
+    this.trackingCollectionsRailTest()
   }
 
   @track<OverviewRouteProps>(props => ({


### PR DESCRIPTION
Addresses A/B test issue brought up in slack: https://artsy.slack.com/archives/C9SATFLUU/p1556042747076600

The experiment viewed event was not firing for the control group. This was because we were only conditionally firing the event in the `componentDidMount` function. We actual want to fire the experiment viewed event at all times. This PR addresses that. This was likely overlooked in [this refactor](https://github.com/artsy/reaction/pull/2172/files).