### PR TITLE
@pepopowitz => Adjust filter tracking on artist page, make sure to cover all filters

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterRefetch.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterRefetch.tsx
@@ -1,4 +1,6 @@
 import { ArtworkFilterRefetch_artist } from "__generated__/ArtworkFilterRefetch_artist.graphql"
+import { track } from "Artsy"
+import * as Schema from "Artsy/Analytics/Schema"
 import React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { ArtworkGridRefetchContainer as ArtworkGrid } from "./ArtworkFilterArtworkGrid"
@@ -11,6 +13,7 @@ interface Props {
   artistID: string
 }
 
+@track()
 class ArtworkGridRefetchContainerWrapper extends React.Component<Props> {
   state = {
     isLoading: false, // trigger update to children
@@ -26,12 +29,20 @@ class ArtworkGridRefetchContainerWrapper extends React.Component<Props> {
         key !== "page" &&
         this.props.filters[key] !== prevProps.filters[key]
       ) {
-        this.loadFilter()
+        if (this.isLoading) return
+        this.loadFilter(key)
       }
     })
   }
 
-  loadFilter = () => {
+  @track((props: Props, _state, [key]) => {
+    return {
+      action_type: Schema.ActionType.CommercialFilterParamsChanged,
+      changed: { [key]: props.filters[key] },
+      current: { ...props.filters },
+    }
+  })
+  loadFilter(_key: string) {
     if (!this.isLoading) {
       this.setState({
         isLoading: true,

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -161,13 +161,6 @@ class Filter extends Component<Props> {
     )
   }
 
-  @track((props: Props, _state, [_selected, category, count]) => {
-    return {
-      action_type: Schema.ActionType.ClickedCommercialFilter,
-      changed: { [category]: count.id },
-      current: { ...props.filterState.state },
-    }
-  })
   handleCategorySelect(selected, category, count) {
     const { filterState, mediator } = this.props
 

--- a/src/Apps/Collect/Components/Base/CollectRefetch.tsx
+++ b/src/Apps/Collect/Components/Base/CollectRefetch.tsx
@@ -32,7 +32,7 @@ export class CollectRefetch extends Component<CollectRefetchProps> {
 
   @track((props: CollectRefetchProps, _state, [key]) => {
     return {
-      action_type: Schema.ActionType.ClickedCommercialFilter,
+      action_type: Schema.ActionType.CommercialFilterParamsChanged,
       changed: { [key]: props.filtersState[key] },
       current: { ...props.filtersState },
     }

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx
@@ -32,7 +32,7 @@ export class SearchResultsRefetch extends Component<SearchRefetchProps> {
 
   @track((props: SearchRefetchProps, _state, [key]) => {
     return {
-      action_type: Schema.ActionType.ClickedCommercialFilter,
+      action_type: Schema.ActionType.CommercialFilterParamsChanged,
       changed: { [key]: props.filtersState[key] },
       current: { ...props.filtersState },
     }

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -56,7 +56,7 @@ export enum ActionType {
    */
   ClickedReadMore = "Clicked read more",
 
-  ClickedCommercialFilter = "Clicked commercial filter params",
+  CommercialFilterParamsChanged = "Commercial filter params changed",
 
   /**
    * A/B Test Experiments


### PR DESCRIPTION
This one was fairly simple, we were missing tracking on 'Ways to Buy' and also the price range slider. When going to add them individually (as the one for the radio button category filter was added), I realized there's a central place we refetch a new filter result set from, so that's the best and most generic place to put the tracking code, and it will cover all the filters w/o needing to add tracking individually to all of them.

This winds up matching how we do it on search results: https://github.com/artsy/reaction/blob/312fcabafe19e2414e2a51d834cc37b764eedeef/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx#L33

Also, renames the event name to match the current schema.

Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-739
