### PR TITLE
Add mobile styling for search results page loading skeleton

### DIFF
--- a/src/Apps/Search/Components/SearchResultsSkeleton/FilterSidebar.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/FilterSidebar.tsx
@@ -35,7 +35,7 @@ const FilterSidebarSection: React.SFC<any> = props => {
 
 export const FilterSidebar: React.SFC<any> = props => {
   return (
-    <Box width="25%" pr={10} mr={10}>
+    <Box display={["none", "block"]} width="25%" pr={10} mr={10}>
       <FilterSidebarSection />
       <Separator mt={2} mb={2} />
       <FilterSidebarSection />

--- a/src/Apps/Search/Components/SearchResultsSkeleton/Header.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/Header.tsx
@@ -3,50 +3,52 @@ import React from "react"
 
 export const Header: React.SFC<any> = props => {
   return (
-    <Box height={100} mb={30} mt={120}>
+    <Box height={100} mb={30} mt={[40, 120]}>
       <Box mb={40} background={color("black10")} width={320} height={20} />
-      <Box
-        width={80}
-        height={12}
-        mr={3}
-        display="inline-block"
-        background={color("black10")}
-      />
-      <Box
-        width={80}
-        height={12}
-        mr={3}
-        display="inline-block"
-        background={color("black10")}
-      />
-      <Box
-        width={80}
-        height={12}
-        mr={3}
-        display="inline-block"
-        background={color("black10")}
-      />
-      <Box
-        width={80}
-        height={12}
-        mr={3}
-        display="inline-block"
-        background={color("black10")}
-      />
-      <Box
-        width={80}
-        height={12}
-        mr={3}
-        display="inline-block"
-        background={color("black10")}
-      />
-      <Box
-        width={80}
-        height={12}
-        mr={3}
-        display="inline-block"
-        background={color("black10")}
-      />
+      <Box width={700}>
+        <Box
+          width={80}
+          height={12}
+          mr={3}
+          display="inline-block"
+          background={color("black10")}
+        />
+        <Box
+          width={80}
+          height={12}
+          mr={3}
+          display="inline-block"
+          background={color("black10")}
+        />
+        <Box
+          width={80}
+          height={12}
+          mr={3}
+          display="inline-block"
+          background={color("black10")}
+        />
+        <Box
+          width={80}
+          height={12}
+          mr={3}
+          display="inline-block"
+          background={color("black10")}
+        />
+        <Box
+          width={80}
+          height={12}
+          mr={3}
+          display="inline-block"
+          background={color("black10")}
+        />
+        <Box
+          width={80}
+          height={12}
+          mr={3}
+          display="inline-block"
+          background={color("black10")}
+        />
+      </Box>
       <Separator mt={10} />
     </Box>
   )

--- a/src/Apps/Search/Components/SearchResultsSkeleton/index.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/index.tsx
@@ -14,24 +14,26 @@ export const SearchResultsSkeleton: React.FC<any> = props => {
           <Header />
           <Flex>
             <FilterSidebar />
-            <Grid fluid style={{ width: "75%" }}>
-              <Row>
-                <Col sm={4} pr={1}>
-                  <GridItem height={200} />
-                  <GridItem height={400} />
-                  <GridItem height={240} />
-                </Col>
-                <Col sm={4} pr={1}>
-                  <GridItem height={300} />
-                  <GridItem height={200} />
-                  <GridItem height={320} />
-                </Col>
-                <Col sm={4}>
-                  <GridItem height={240} />
-                  <GridItem height={400} />
-                </Col>
-              </Row>
-            </Grid>
+            <Box width={["100%", "75%"]}>
+              <Grid fluid>
+                <Row>
+                  <Col sm={4} pr={1}>
+                    <GridItem height={200} />
+                    <GridItem height={400} />
+                    <GridItem height={240} />
+                  </Col>
+                  <Col sm={4} pr={1}>
+                    <GridItem height={300} />
+                    <GridItem height={200} />
+                    <GridItem height={320} />
+                  </Col>
+                  <Col sm={4}>
+                    <GridItem height={240} />
+                    <GridItem height={400} />
+                  </Col>
+                </Row>
+              </Grid>
+            </Box>
           </Flex>
         </Box>
       </HorizontalPadding>


### PR DESCRIPTION
This commits adds responsive props to render the loading skeleton optimized for mobile devices.

![2019-04-25-114051_595x788_scrot](https://user-images.githubusercontent.com/123595/56749062-ff4f2e00-674e-11e9-8d33-fef0203bda32.png)
