### PR TITLE
Update responsive grid styling for search results skeleton

### DIFF
--- a/src/Apps/Search/Components/SearchResultsSkeleton/index.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/index.tsx
@@ -1,6 +1,5 @@
 import { Box, Col, Flex, Grid, Row } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
-import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import React from "react"
 import { FilterSidebar } from "./FilterSidebar"
 import { GridItem } from "./GridItem"
@@ -9,34 +8,32 @@ import { Header } from "./Header"
 export const SearchResultsSkeleton: React.FC<any> = props => {
   return (
     <AppContainer>
-      <HorizontalPadding>
-        <Box>
-          <Header />
-          <Flex>
-            <FilterSidebar />
-            <Box width={["100%", "75%"]}>
-              <Grid fluid>
-                <Row>
-                  <Col sm={4} pr={1}>
-                    <GridItem height={200} />
-                    <GridItem height={400} />
-                    <GridItem height={240} />
-                  </Col>
-                  <Col sm={4} pr={1}>
-                    <GridItem height={300} />
-                    <GridItem height={200} />
-                    <GridItem height={320} />
-                  </Col>
-                  <Col sm={4}>
-                    <GridItem height={240} />
-                    <GridItem height={400} />
-                  </Col>
-                </Row>
-              </Grid>
-            </Box>
-          </Flex>
-        </Box>
-      </HorizontalPadding>
+      <Box pl={20}>
+        <Header />
+        <Flex>
+          <FilterSidebar />
+          <Box width={["100%", "75%"]}>
+            <Grid fluid>
+              <Row>
+                <Col xs="6" sm="6" md="6" lg="4">
+                  <GridItem height={200} />
+                  <GridItem height={400} />
+                  <GridItem height={240} />
+                </Col>
+                <Col xs="6" sm="6" md="6" lg="4">
+                  <GridItem height={300} />
+                  <GridItem height={200} />
+                  <GridItem height={320} />
+                </Col>
+                <Col xs="6" sm="6" md="6" lg="4">
+                  <GridItem height={240} />
+                  <GridItem height={400} />
+                </Col>
+              </Row>
+            </Grid>
+          </Box>
+        </Flex>
+      </Box>
     </AppContainer>
   )
 }


### PR DESCRIPTION
This commit updates styling for various responsive breakpoints.

![2019-04-25-142931_1059x1117_scrot](https://user-images.githubusercontent.com/123595/56759292-a3909f00-6766-11e9-993a-34083d9947f1.png)
![2019-04-25-142941_1380x1150_scrot](https://user-images.githubusercontent.com/123595/56759296-a4c1cc00-6766-11e9-8e94-b3b048ee0c21.png)
![2019-04-25-142953_1716x1196_scrot](https://user-images.githubusercontent.com/123595/56759299-a5f2f900-6766-11e9-970a-11f8514f6359.png)
