### PR TITLE
Adjust header margin on mobile search results skeleton

### DIFF
--- a/src/Apps/Search/Components/SearchResultsSkeleton/Header.tsx
+++ b/src/Apps/Search/Components/SearchResultsSkeleton/Header.tsx
@@ -3,7 +3,7 @@ import React from "react"
 
 export const Header: React.SFC<any> = props => {
   return (
-    <Box height={100} mb={30} mt={[40, 120]}>
+    <Box height={100} mb={30} mt={120}>
       <Box mb={40} background={color("black10")} width={320} height={20} />
       <Box width={700}>
         <Box


### PR DESCRIPTION
This commit accounts for a minor differences in placement between Storybooks and Force.