### PR TITLE
changed logic for displaying 'Show artist insights' button to account for minimum exhibitions

### DIFF
--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -97,7 +97,7 @@ export class ArtistInfo extends Component<ArtistInfoProps, ArtistInfoState> {
     const imageUrl = get(this.props, p => image.cropped.url)
     const showArtistInsightsButton =
       (artist.exhibition_highlights &&
-        artist.exhibition_highlights.length > 0) ||
+        artist.exhibition_highlights.length > 1) ||
       (artist.auctionResults && artist.auctionResults.edges.length > 0) ||
       (artist.collections && artist.collections.length > 0) ||
       (artist.highlights.partners &&

--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -14,18 +14,18 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
-import React, { Component } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { data as sd } from "sharify"
-import { get } from "Utils/get"
-import { AuthModalIntent, openAuthModal } from "Utils/openAuthModal"
-
 import {
   ArtistBioFragmentContainer as ArtistBio,
   ArtistMarketInsightsFragmentContainer as ArtistMarketInsights,
   SelectedExhibitionFragmentContainer as SelectedExhibitions,
 } from "Components/v2"
+import { MIN_EXHIBITIONS } from "Components/v2/SelectedExhibitions"
+import React, { Component } from "react"
+import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { data as sd } from "sharify"
 import Events from "Utils/Events"
+import { get } from "Utils/get"
+import { AuthModalIntent, openAuthModal } from "Utils/openAuthModal"
 
 interface ArtistInfoProps {
   artist: ArtistInfo_artist
@@ -97,7 +97,7 @@ export class ArtistInfo extends Component<ArtistInfoProps, ArtistInfoState> {
     const imageUrl = get(this.props, p => image.cropped.url)
     const showArtistInsightsButton =
       (artist.exhibition_highlights &&
-        artist.exhibition_highlights.length > 1) ||
+        artist.exhibition_highlights.length >= MIN_EXHIBITIONS) ||
       (artist.auctionResults && artist.auctionResults.edges.length > 0) ||
       (artist.collections && artist.collections.length > 0) ||
       (artist.highlights.partners &&

--- a/src/Apps/Artwork/Components/__tests__/ArtistInfo.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtistInfo.test.tsx
@@ -47,6 +47,16 @@ describe("ArtistInfo", () => {
       expect(component.find("Button").length).toBe(0)
     })
 
+    it("Hides 'Show artist insights' button if exhibition count does not meet minimum", async () => {
+      const artist = cloneDeep(ArtistInfoFixture)
+      artist.highlights.partners = null
+      artist.collections = null
+      artist.auctionResults = null
+      artist.exhibition_highlights.length = 1
+      const component = getWrapper({ artist })
+      expect(component.find("Button").length).toBe(0)
+    })
+
     it("hides ArtistBio if no data", async () => {
       const artist = cloneDeep(ArtistInfoFixture)
       artist.biography_blurb.text = null

--- a/src/Components/v2/SelectedExhibitions.tsx
+++ b/src/Components/v2/SelectedExhibitions.tsx
@@ -7,7 +7,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "Utils/Responsive"
 
 const MIN_FOR_SELECTED_EXHIBITIONS = 3
-const MIN_EXHIBITIONS = 2
+export const MIN_EXHIBITIONS = 2
 
 export type Year = string
 


### PR DESCRIPTION
If an artist doesn't have artist insights, don't show the button
https://cl.ly/3dbfd53503a3
https://www.artsy.net/artwork/suzanne-heintz-the-tree

The "Show artist insights" button was displaying when the MarketInsights and SelectedExhibitions were not for the above artist and possible others.

It turned out that the artist in question did have an exhibition, but the SelectedExhibitions component had a minimum number of exhibitions (2) or it wouldn't render. I adjusted the logic controlling the "Show artist insights" button so that it wouldn't render if the number of exhibitions did not meet the minimum.