### PR TITLE
[Artist] don't trigger tracking event in control group

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -10,7 +10,6 @@ import { ArtistCollectionsRailContent as ArtistCollectionsRail } from "Component
 import { hasSections as showMarketInsights } from "Components/Artist/MarketInsights/MarketInsights"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { data as sd } from "sharify"
 import { userHasLabFeature } from "Utils/getUser"
 import { ArtistRecommendationsQueryRenderer as ArtistRecommendations } from "./Components/ArtistRecommendations"
 import { CurrentEventFragmentContainer as CurrentEvent } from "./Components/CurrentEvent"
@@ -37,10 +36,6 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     isReadMoreExpanded: false,
   }
 
-  componentDidMount() {
-    this.trackingCollectionsRailTest()
-  }
-
   @track<OverviewRouteProps>(props => ({
     action_type: Schema.ActionType.Click,
     // TODO: Feel like these should become enums too
@@ -56,24 +51,6 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     const hasNoBio = !this.props.artist.biography_blurb.text
 
     return isReadMoreExpanded || hasNoBio
-  }
-
-  @track<OverviewRouteProps>(props => {
-    // TODO: remove after CollectionsRail a/b test
-    const experiment = "artist_collections_rail"
-    const variation = sd.ARTIST_COLLECTIONS_RAIL
-
-    return {
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    }
-  })
-  trackingCollectionsRailTest() {
-    // no-op
   }
 
   render() {

--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -7,6 +7,7 @@ import { once } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import Waypoint from "react-waypoint"
+import { data as sd } from "sharify"
 import styled from "styled-components"
 import Events from "Utils/Events"
 import { ArtistCollectionEntityFragmentContainer as ArtistCollectionEntity } from "./ArtistCollectionEntity"
@@ -21,6 +22,30 @@ interface ArtistCollectionsRailProps {
 export class ArtistCollectionsRail extends React.Component<
   ArtistCollectionsRailProps
 > {
+  componentDidMount() {
+    if (this.props.collections && this.props.collections.length > 0) {
+      this.trackingCollectionsRailTest()
+    }
+  }
+
+  @track(() => {
+    // TODO: remove after CollectionsRail a/b test
+    const experiment = "artist_collections_rail"
+    const variation = sd.ARTIST_COLLECTIONS_RAIL
+
+    return {
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    }
+  })
+  trackingCollectionsRailTest() {
+    // no-op
+  }
+
   @track({
     action_type: Schema.ActionType.Impression,
     context_module: Schema.ContextModule.CollectionsRail,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1214

Added a condition around the impression tracking event: if there are no collections (Artist page in control group) don't fire the event.

Here's the full list of 54 artist pages that the test should only fire on: https://www.notion.so/artsy/Artist-pages-that-include-series-collections-rail-in-A-B-Test-5945e7d8d6f146b4b6bdf4fc6a76147f