### PR TITLE
[Toolchain] Add @storybook/viewport plugin

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,1 +1,2 @@
 import "@storybook/addon-options/register"
+import "@storybook/addon-viewport/register"

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -48,19 +48,15 @@ type AggregationCount {
 type AnalyticsArtworksPublishedStats {
   percentageChanged: Int!
   period: AnalyticsQueryPeriodEnum!
-
-  # Time series data on number of artworks published
-  timeSeries(
-    samplingFrequency: AnalyticsSamplingFrequencyEnum
-  ): [AnalyticsArtworksPublishedTimeSeriesStats!]
+  timeSeries: [AnalyticsArtworksPublishedTimeSeriesStats!]
   totalCount: Int!
 }
 
 # Publish artwork Series Stats
 type AnalyticsArtworksPublishedTimeSeriesStats implements AnalyticsPartnerTimeSeriesStats {
   count: Int
-  samplingFrequency: AnalyticsSamplingFrequencyEnum!
-  time: AnalyticsDateTime
+  endTime: AnalyticsDateTime
+  startTime: AnalyticsDateTime
 }
 
 # An ISO 8601 datetime
@@ -132,8 +128,8 @@ type AnalyticsPartnerStats {
 
 # Partner Time Series Stats
 interface AnalyticsPartnerTimeSeriesStats {
-  samplingFrequency: AnalyticsSamplingFrequencyEnum!
-  time: AnalyticsDateTime
+  endTime: AnalyticsDateTime
+  startTime: AnalyticsDateTime
 }
 
 # Price Context Filter Type
@@ -146,7 +142,6 @@ type AnalyticsPriceContextFilterType {
 type AnalyticsPricingContext {
   appliedFilters: AnalyticsPriceContextFilterType!
   bins: [AnalyticsHistogramBin!]!
-  filterDescription: String! @deprecated(reason: "switch to applied_filters")
   appliedFiltersDisplay: String
 }
 
@@ -229,17 +224,6 @@ enum AnalyticsQueryPeriodEnum {
 
   # Sixteen weeks
   SIXTEEN_WEEKS
-}
-
-enum AnalyticsSamplingFrequencyEnum {
-  # Daily
-  DAILY
-
-  # Monthly
-  MONTHLY
-
-  # Weekly
-  WEEKLY
 }
 
 # Top artworks from a partner
@@ -1110,7 +1094,8 @@ type Artwork implements Node & Searchable & Sellable {
   ): Partner
   pickup_available: Boolean
   price: String
-  priceCents: PriceCents
+  priceCents: PriceCents @deprecated(reason: "Prefer `listPrice` instead.")
+  listPrice: ListPrice
   price_currency: String
 
   # Is this work available for shipping only within the Contenental US?
@@ -1160,6 +1145,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field
   heightCm: Float
+
+  # score assigned to an artwork based on its dimensions
+  sizeScore: Float
   pricingContext: AnalyticsPricingContext
 }
 
@@ -1984,7 +1972,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
   ): Partner
   pickup_available: Boolean
   price: String
-  priceCents: PriceCents
+  priceCents: PriceCents @deprecated(reason: "Prefer `listPrice` instead.")
+  listPrice: ListPrice
   price_currency: String
 
   # Is this work available for shipping only within the Contenental US?
@@ -2034,6 +2023,9 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field
   heightCm: Float
+
+  # score assigned to an artwork based on its dimensions
+  sizeScore: Float
 }
 
 type ArtworkLayer {
@@ -4631,7 +4623,17 @@ type EditionSet implements Sellable {
   is_for_sale: Boolean
   is_sold: Boolean
   price: String @deprecated(reason: "Prefer to use `sale_message`.")
+  listPrice: ListPrice
+
+  # score assigned to an artwork based on its dimensions
+  sizeScore: Float
   sale_message: String
+
+  # If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field
+  widthCm: Float
+
+  # If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field
+  heightCm: Float
 }
 
 enum EditionSetSorts {
@@ -4671,6 +4673,10 @@ enum EventStatus {
 
   # Special filtering option which is used to show running and upcoming shows
   RUNNING_AND_UPCOMING
+}
+
+type ExactPrice {
+  priceCents: Int!
 }
 
 type ExternalPartner {
@@ -6463,6 +6469,8 @@ type LatLng {
   lat: Float
   lng: Float
 }
+
+union ListPrice = PriceRange | ExactPrice
 
 type Location {
   # A globally unique ID.
@@ -8460,6 +8468,11 @@ type PriceCents {
   min: Int
   max: Int
   exact: Boolean
+}
+
+type PriceRange {
+  minPriceCents: Int!
+  maxPriceCents: Int!
 }
 
 type Profile {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@sentry/browser": "^4.2.3",
     "@storybook/addon-info": "^5.0.11",
     "@storybook/addon-options": "^5.0.11",
+    "@storybook/addon-viewport": "^5.0.11",
     "@storybook/addons": "^5.0.11",
     "@storybook/cli": "^5.0.11",
     "@storybook/react": "^5.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,6 +1592,22 @@
     core-js "^2.6.5"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-viewport@^5.0.11":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-5.0.11.tgz#93b1d6db2c06b7a9282ee96a9a4d1dd2c4ba8849"
+  integrity sha512-dOq+L7Crxh8B3KrdkbKhCGX466k+0x1t5/VuZjztxfVQPpjIn8L7Zxo+nYouvlbXtHaKh7Xon4bq61HPksrJAw==
+  dependencies:
+    "@storybook/addons" "5.0.11"
+    "@storybook/client-logger" "5.0.11"
+    "@storybook/components" "5.0.11"
+    "@storybook/core-events" "5.0.11"
+    "@storybook/theming" "5.0.11"
+    core-js "^2.6.5"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    prop-types "^15.6.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/addons@5.0.11", "@storybook/addons@^5.0.11":
   version "5.0.11"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.0.11.tgz#86de70747e0a692d9dd8ea431daa1147d8785697"
@@ -2033,7 +2049,7 @@
     "@types/react" "*"
 
 "@types/flickity@^2.1.0":
-  version "2.1.0"
+  version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/flickity/-/flickity-2.2.0.tgz#aff71ca3e6a61d17c990464f4cfdef2505e3ee80"
   integrity sha512-CqBikpvByNOMDycFqlSEfZMs9Td0X94ro/d/q//LiASkdF58wvT1tfauqYn5PnuUQIYPLq8+W0mAyLQi/sx5tA==
 


### PR DESCRIPTION
As we're writing more styled-system responsive-prop-based components these days we need a way to  trigger breakpoint layouts within storybooks. Thankfully there's an official storybooks plugin, [@storybook/addon-viewport]( https://github.com/storybooks/storybook/tree/master/addons/viewport). 

Users can select a device mode from the dropdown, or more usefully assign a device mode to a given story via config parameter: 

```js
storiesOf("Components/NavBar", module).add("Mobile NavBar", () => {
  return <NavBar />
}, {
  viewport: { 
    defaultViewport: 'iphonex' 
  }
})
```

A list of available defaults can be [found here](https://github.com/storybooks/storybook/blob/master/addons/viewport/src/defaults.js). 

![viewport](https://user-images.githubusercontent.com/236943/56938403-8e917400-6ab6-11e9-9c0f-86b38a5e3bd6.png)
