### PR TITLE
Removes slick from ArtworkImageBrowser

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -106,7 +106,7 @@ export class LargeArtistHeader extends Component<Props> {
             <Carousel
               height="200px"
               data={carousel.images as object[]}
-              render={(slide: Image, index: number) => {
+              render={(slide: Image) => {
                 return (
                   <a href={slide.href} onClick={() => this.onClickSlide(slide)}>
                     <Image

--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -104,9 +104,9 @@ export class LargeArtistHeader extends Component<Props> {
         {hasImages && (
           <section>
             <Carousel
-              height={200}
+              height="200px"
               data={carousel.images as object[]}
-              render={(slide: Image) => {
+              render={(slide: Image, index: number) => {
                 return (
                   <a href={slide.href} onClick={() => this.onClickSlide(slide)}>
                     <Image
@@ -190,7 +190,7 @@ export class SmallArtistHeader extends Component<Props> {
           <Fragment>
             <Carousel
               data={carousel.images as object[]}
-              height={200}
+              height="200px"
               render={slide => {
                 return (
                   <a href={slide.href} onClick={() => this.onClickSlide(slide)}>

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -105,14 +105,14 @@ export class ArtworkApp extends React.Component<Props> {
         {artists.map((artist, index) => {
           const addSpacer = artists.length > 1 && index < artists.length - 1
           return (
-            <>
+            <React.Fragment key={index}>
               <Row key={artist.id}>
                 <Col>
                   <ArtistInfo artist={artist} />
                 </Col>
               </Row>
               {addSpacer && <Spacer mb={2} />}
-            </>
+            </React.Fragment>
           )
         })}
       </>

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -10,7 +10,7 @@ import { Box, ChevronIcon, Col, color, Flex, space } from "@artsy/palette"
 interface ArtworkBrowserProps {
   imageAlt: string
   images: ArtworkImageBrowser_artwork["images"]
-  flickityRef?: (flickityRef: Flickity) => void
+  setFlickityRef: (flickityRef: Flickity) => void
 }
 
 export const ArtworkImageBrowser = (props: ArtworkBrowserProps) => {
@@ -40,7 +40,7 @@ export class LargeArtworkImageBrowser extends React.Component<
 
   render() {
     const hasMultipleImages = this.props.images.length > 1
-    const { imageAlt, images } = this.props
+    const { imageAlt, images, setFlickityRef } = this.props
 
     // FIXME: During SSR pass want to hide other images. Work around for lack
     // of SSR support in Flickity.
@@ -53,6 +53,7 @@ export class LargeArtworkImageBrowser extends React.Component<
           options={this.options}
           oneSlideVisible
           height="60vh"
+          setFlickityRef={setFlickityRef}
           data={carouselImages}
           renderLeftArrow={({ flickity }) => (
             <Col sm={1}>

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -1,9 +1,9 @@
 import { ArtworkImageBrowser_artwork } from "__generated__/ArtworkImageBrowser_artwork.graphql"
 import { Lightbox } from "Components/v2"
+import { BaseCarousel as Carousel } from "Components/v2/CarouselV3"
 import React from "react"
 import styled from "styled-components"
 import { Media } from "Utils/Responsive"
-import { BaseCarousel as Carousel } from "../../../../Components/v2/CarouselV3"
 
 import { Box, ChevronIcon, Col, color, Flex, space } from "@artsy/palette"
 
@@ -11,10 +11,6 @@ interface ArtworkBrowserProps {
   imageAlt: string
   images: ArtworkImageBrowser_artwork["images"]
   flickityRef?: (flickityRef: Flickity) => void
-}
-
-interface ArtworkBrowserState {
-  isLocked?: boolean
 }
 
 export const ArtworkImageBrowser = (props: ArtworkBrowserProps) => {
@@ -31,8 +27,7 @@ export const ArtworkImageBrowser = (props: ArtworkBrowserProps) => {
 }
 
 export class LargeArtworkImageBrowser extends React.Component<
-  ArtworkBrowserProps,
-  ArtworkBrowserState
+  ArtworkBrowserProps
 > {
   options = {
     prevNextButtons: false,
@@ -102,13 +97,8 @@ export class LargeArtworkImageBrowser extends React.Component<
 }
 
 export class SmallArtworkImageBrowser extends React.Component<
-  ArtworkBrowserProps,
-  ArtworkBrowserState
+  ArtworkBrowserProps
 > {
-  state = {
-    isLocked: false,
-  }
-
   options = {
     prevNextButtons: false,
     wrapAround: true,
@@ -140,7 +130,7 @@ export class SmallArtworkImageBrowser extends React.Component<
                 <Lightbox
                   imageAlt={imageAlt}
                   deepZoom={image.deepZoom}
-                  enabled={!this.state.isLocked && image.is_zoomable}
+                  enabled={image.is_zoomable}
                   isDefault={image.is_default}
                   src={image.uri}
                   initialHeight="45vh"

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -1,11 +1,11 @@
 import { ArtworkImageBrowser_artwork } from "__generated__/ArtworkImageBrowser_artwork.graphql"
 import { Lightbox } from "Components/v2"
-import { Options as FlickityOptions } from "flickity"
 import React from "react"
 import styled from "styled-components"
 import { Media } from "Utils/Responsive"
+import { BaseCarousel as Carousel } from "../../../../Components/v2/CarouselV3"
 
-import { Box, ChevronIcon, Col, color, Flex, Row } from "@artsy/palette"
+import { Box, ChevronIcon, Col, color, Flex, space } from "@artsy/palette"
 
 interface ArtworkBrowserProps {
   imageAlt: string
@@ -15,14 +15,7 @@ interface ArtworkBrowserProps {
 
 interface ArtworkBrowserState {
   isLocked?: boolean
-  mounted: boolean
 }
-
-/*
- * Returns null if no window for SSR
- */
-const isClient = typeof window !== "undefined"
-const Flickity = isClient ? require("react-flickity-component") : () => null
 
 export const ArtworkImageBrowser = (props: ArtworkBrowserProps) => {
   return (
@@ -41,10 +34,6 @@ export class LargeArtworkImageBrowser extends React.Component<
   ArtworkBrowserProps,
   ArtworkBrowserState
 > {
-  state = { mounted: false }
-
-  flickity = null
-
   options = {
     prevNextButtons: false,
     wrapAround: true,
@@ -52,106 +41,61 @@ export class LargeArtworkImageBrowser extends React.Component<
     cellAlign: "left",
     draggable: false,
     lazyLoad: true,
-  } as FlickityOptions
-
-  componentDidMount() {
-    this.setState({
-      mounted: true,
-    })
-    const { flickityRef } = this.props
-    if (this.flickity && flickityRef) {
-      flickityRef(this.flickity)
-    }
-  }
-
-  renderSlide = (image, hasMultipleImages) => {
-    return (
-      <Flex
-        flexDirection="column"
-        justifyContent="center"
-        width="100%"
-        px={hasMultipleImages ? [2, 2, 0] : 0}
-        key={isClient + image.id}
-      >
-        <Lightbox
-          deepZoom={image.deepZoom}
-          enabled={image.is_zoomable}
-          isDefault={image.is_default}
-        >
-          <DesktopImage src={image.uri} width="100%" />
-        </Lightbox>
-      </Flex>
-    )
-  }
-
-  renderCarousel = hasMultipleImages => {
-    return (
-      <Flickity options={this.options} flickityRef={c => (this.flickity = c)}>
-        {this.props.images.map(image => {
-          return this.renderSlide(image, hasMultipleImages)
-        })}
-      </Flickity>
-    )
-  }
-
-  renderServerCarousel = hasMultipleImages => {
-    return (
-      <Flex>
-        {this.props.images.map((image, index) => {
-          const isFirstImage =
-            index === 0 ? this.renderSlide(image, hasMultipleImages) : null
-          return isFirstImage
-        })}
-      </Flex>
-    )
   }
 
   render() {
     const hasMultipleImages = this.props.images.length > 1
     const { imageAlt, images } = this.props
+
+    // FIXME: During SSR pass want to hide other images. Work around for lack
+    // of SSR support in Flickity.
+    const carouselImages = typeof window === "undefined" ? [images[0]] : images
+
     return (
       <Container>
-        <Row>
-          {hasMultipleImages && (
+        <Carousel
+          showArrows={hasMultipleImages}
+          options={this.options}
+          oneSlideVisible
+          height="60vh"
+          data={carouselImages}
+          renderLeftArrow={({ flickity }) => (
             <Col sm={1}>
               <ArrowButton
                 direction="left"
-                onClick={() => this.flickity.previous(false, true)}
+                onClick={() => flickity.previous(false, true)}
               />
             </Col>
           )}
-          <Col sm={hasMultipleImages ? 10 : 12}>
-            <Slider {...this.settings} ref={this.setSliderRef}>
-              {images.map(image => {
-                return (
-                  <Flex
-                    flexDirection="column"
-                    justifyContent="center"
-                    px={hasMultipleImages ? [2, 2, 0] : 0}
-                    key={image.id}
-                  >
-                    <Lightbox
-                      imageAlt={imageAlt}
-                      deepZoom={image.deepZoom}
-                      enabled={image.is_zoomable}
-                      isDefault={image.is_default}
-                      src={image.uri}
-                      initialHeight="60vh"
-                    />
-                  </Flex>
-                )
-              })}
-            </Slider>
-          </Col>
-          {hasMultipleImages && (
+          renderRightArrow={({ flickity }) => (
             <Col sm={1}>
               <ArrowButton
                 direction="right"
-                onClick={() => this.flickity.next(false, true)}
+                onClick={() => flickity.next(false, true)}
               />
             </Col>
           )}
-        </Row>
+          render={image => {
+            return (
+              <Flex
+                flexDirection="column"
+                justifyContent="center"
+                width="100%"
+                px={hasMultipleImages ? [2, 2, 0] : 0}
+                height="60vh"
+              >
+                <Lightbox
+                  imageAlt={imageAlt}
+                  deepZoom={image.deepZoom}
+                  enabled={image.is_zoomable}
+                  isDefault={image.is_default}
+                  src={image.uri}
+                  initialHeight="60vh"
+                />
+              </Flex>
+            )
+          }}
+        />
       </Container>
     )
   }
@@ -163,12 +107,9 @@ export class SmallArtworkImageBrowser extends React.Component<
 > {
   state = {
     isLocked: false,
-    mounted: false,
   }
 
-  flickity = null
-
-  options: FlickityOptions = {
+  options = {
     prevNextButtons: false,
     wrapAround: true,
     draggable: true,
@@ -176,69 +117,25 @@ export class SmallArtworkImageBrowser extends React.Component<
     pageDots: true,
   }
 
-  componentWillMount() {
-    this.setState({
-      mounted: true,
-    })
-  }
-
-  renderCarousel = () => {
-    return (
-      <Flickity
-        options={this.options}
-        key="client"
-        flickityRef={c => (this.flickity = c)}
-      >
-        {this.props.images.map(image => {
-          return this.renderSlide(image)
-        })}
-      </Flickity>
-    )
-  }
-
-  renderServerCarousel = () => {
-    return (
-      <Box key="server">
-        {this.props.images.map((image, index) => {
-          const isFirstImage = index === 0 ? this.renderSlide(image) : null
-          return isFirstImage
-        })}
-      </Box>
-    )
-  }
-
-  renderSlide = image => {
-    return (
-      <Flex
-        flexDirection="column"
-        justifyContent="center"
-        px={1}
-        key={image.id}
-        width="100%"
-      >
-        <Lightbox
-          deepZoom={image.deepZoom}
-          enabled={!this.state.isLocked && image.is_zoomable}
-          isDefault={image.is_default}
-        >
-          <ResponsiveImage src={image.uri} width="100%" />
-        </Lightbox>
-      </Flex>
-    )
-  }
-
   render() {
-    const { sliderRef, imageAlt, images } = this.props
+    const { images, imageAlt } = this.props
+    // FIXME: During SSR pass want to hide other images. Work around for lack
+    // of SSR support in Flickity.
+    const carouselImages = typeof window === "undefined" ? [images[0]] : images
     return (
       <Container>
-        <Slider {...this.settings} ref={sliderRef}>
-          {images.map(image => {
+        <Carousel
+          options={this.options}
+          data={carouselImages}
+          oneSlideVisible
+          render={image => {
             return (
               <Flex
                 flexDirection="column"
                 justifyContent="center"
                 px={1}
-                key={image.id}
+                width="100%"
+                height="260px"
               >
                 <Lightbox
                   imageAlt={imageAlt}
@@ -250,8 +147,8 @@ export class SmallArtworkImageBrowser extends React.Component<
                 />
               </Flex>
             )
-          })}
-        </Slider>
+          }}
+        />
       </Container>
     )
   }
@@ -291,25 +188,26 @@ const Container = styled(Box)`
   .flickity-slider > div {
     margin-left: 5px;
     margin-right: 5px;
+    width: 100%;
   }
 
   .flickity-page-dots {
     text-align: center;
     height: 0;
     padding-top: ${space(1)}px;
-  }
 
-  .dot {
-    width: 4px;
-    height: 4px;
-    border-radius: 100%;
-    display: inline-block;
-    margin: ${space(0.5)}px;
-    background-color: ${color("black10")};
-  }
+    .dot {
+      width: 4px;
+      height: 4px;
+      border-radius: 100%;
+      display: inline-block;
+      margin: ${space(0.5)}px;
+      background-color: ${color("black10")};
+    }
 
-  .dot.is-selected {
-    background-color: ${color("black100")};
+    .dot.is-selected {
+      background-color: ${color("black100")};
+    }
   }
 `
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.test.tsx
@@ -8,24 +8,26 @@ import { Breakpoint } from "Utils/Responsive"
 import { ArtworkImageBrowserFragmentContainer } from "../"
 
 describe("ArtworkImageBrowser", () => {
-  const getWrapper = (
+  const getWrapper = async (
     breakpoint: Breakpoint = "lg",
     data = ArtworkImageBrowserFixture
   ) => {
-    return mount(
+    return await mount(
       <RelayStubProvider>
         <MockBoot breakpoint={breakpoint}>
           <ArtworkImageBrowserFragmentContainer artwork={data.artwork as any} />
         </MockBoot>
       </RelayStubProvider>
-    )
+    ).renderUntil(n => {
+      return n.html().search("is-selected") > 0
+    })
   }
 
   describe("desktop", () => {
     let wrapper: ReactWrapper
 
-    beforeAll(() => {
-      wrapper = getWrapper()
+    beforeAll(async () => {
+      wrapper = await getWrapper()
     })
 
     it("renders correct container components", () => {
@@ -34,10 +36,6 @@ describe("ArtworkImageBrowser", () => {
 
     it("renders correct number of images", () => {
       expect(wrapper.find("Image").length).toBe(4)
-    })
-
-    it("renders custom pagination dots", () => {
-      expect(wrapper.find("PageIndicator").length).toBe(4)
     })
 
     it("renders directional arrows", () => {
@@ -47,7 +45,15 @@ describe("ArtworkImageBrowser", () => {
     it("returns null if missing images", () => {
       const data = cloneDeep(ArtworkImageBrowserFixture) as any
       data.artwork.images = []
-      wrapper = getWrapper("lg", data)
+      wrapper = mount(
+        <RelayStubProvider>
+          <MockBoot breakpoint="lg">
+            <ArtworkImageBrowserFragmentContainer
+              artwork={data.artwork as any}
+            />
+          </MockBoot>
+        </RelayStubProvider>
+      )
       expect(wrapper.find("ArtworkImageBrowser").length).toBe(0)
       expect(wrapper.find("ArtworkActions").length).toBe(0)
     })
@@ -56,8 +62,8 @@ describe("ArtworkImageBrowser", () => {
   describe("mobile", () => {
     let wrapper: ReactWrapper
 
-    beforeAll(() => {
-      wrapper = getWrapper("xs")
+    beforeAll(async () => {
+      wrapper = await getWrapper("xs")
     })
 
     it("renders correct container components", () => {
@@ -66,10 +72,6 @@ describe("ArtworkImageBrowser", () => {
 
     it("renders correct number of images", () => {
       expect(wrapper.find("Image").length).toBe(4)
-    })
-
-    it("renders custom pagination dots", () => {
-      expect(wrapper.find("PageIndicator").length).toBe(4)
     })
 
     it("renders does not render directional arrows", () => {

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
@@ -23,9 +23,14 @@ export class ArtworkImageBrowserContainer extends React.Component<
     }
 
     const defaultImageIndex = images.findIndex(e => e.id === image.id)
+    console.log("defaultImageIndex", defaultImageIndex)
     return (
       <>
-        <ArtworkImageBrowser images={images} imageAlt={image_alt} />
+        <ArtworkImageBrowser
+          setFlickityRef={f => (this.flickity = f)}
+          images={images}
+          imageAlt={image_alt}
+        />
         <ArtworkActions
           selectDefaultSlide={() => {
             this.flickity.select(defaultImageIndex, false, true)

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
@@ -25,16 +25,10 @@ export class ArtworkImageBrowserContainer extends React.Component<
     const defaultImageIndex = images.findIndex(e => e.id === image.id)
     return (
       <>
-        <ArtworkImageBrowser
-          images={images}
-          imageAlt={image_alt}
-          sliderRef={slider => (this.slider = slider)}
-        />
+        <ArtworkImageBrowser images={images} imageAlt={image_alt} />
         <ArtworkActions
           selectDefaultSlide={() => {
-            if (this.flickity) {
-              this.flickity.select(defaultImageIndex, false, true)
-            }
+            this.flickity.select(defaultImageIndex, false, true)
           }}
           artwork={this.props.artwork}
         />

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
@@ -1,11 +1,9 @@
-import React, { useContext } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-
 import { ArtworkImageBrowser_artwork } from "__generated__/ArtworkImageBrowser_artwork.graphql"
 import { ArtworkImageBrowserQuery } from "__generated__/ArtworkImageBrowserQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import Slider from "react-slick"
+import React, { useContext } from "react"
+import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { ArtworkActionsFragmentContainer as ArtworkActions } from "./ArtworkActions"
 import { ArtworkImageBrowser } from "./ArtworkImageBrowser"
 
@@ -16,7 +14,7 @@ export interface ImageBrowserProps {
 export class ArtworkImageBrowserContainer extends React.Component<
   ImageBrowserProps
 > {
-  slider: Slider
+  flickity = null
 
   render() {
     const { images, image, image_alt } = this.props.artwork
@@ -34,7 +32,9 @@ export class ArtworkImageBrowserContainer extends React.Component<
         />
         <ArtworkActions
           selectDefaultSlide={() => {
-            this.slider.slickGoTo(defaultImageIndex)
+            if (this.flickity) {
+              this.flickity.select(defaultImageIndex, false, true)
+            }
           }}
           artwork={this.props.artwork}
         />

--- a/src/Components/v2/CarouselV2.tsx
+++ b/src/Components/v2/CarouselV2.tsx
@@ -220,7 +220,7 @@ export const LargeCarousel = (props: Props) => {
 export const SmallCarousel = (props: Props) => {
   const options = {
     draggable: true,
-    freeScroll: true,
+    freeScroll: false,
     wrapAround: false,
     lazyLoad: true,
     cellAlign: "left",

--- a/src/Components/v2/CarouselV2.tsx
+++ b/src/Components/v2/CarouselV2.tsx
@@ -220,7 +220,7 @@ export const LargeCarousel = (props: Props) => {
 export const SmallCarousel = (props: Props) => {
   const options = {
     draggable: true,
-    freeScroll: false,
+    freeScroll: true,
     wrapAround: false,
     lazyLoad: true,
     cellAlign: "left",

--- a/src/Components/v2/CarouselV3.tsx
+++ b/src/Components/v2/CarouselV3.tsx
@@ -1,4 +1,4 @@
-import { ChevronIcon, Flex, space } from "@artsy/palette"
+import { ChevronIcon, color, Flex, space } from "@artsy/palette"
 import React, { Fragment } from "react"
 import { FlickityOptions } from "react-flickity-component"
 import styled from "styled-components"
@@ -24,7 +24,7 @@ interface CarouselProps {
   /**
    * The width of the carousel
    */
-  width?: number
+  width?: string
 
   /**
    * Callback when forward / backward arrows are clicked
@@ -34,7 +34,7 @@ interface CarouselProps {
   /**
    * The render callback returns an image to display
    */
-  render?: (slide, index) => React.ReactNode
+  render: (slide) => React.ReactNode
 
   /**
    * Flickity options
@@ -114,6 +114,7 @@ export const SmallCarousel: React.FC<CarouselProps> = props => {
         cellAlign: "left",
         draggable: true,
         freeScroll: false,
+        contain: true,
         friction: 0.3,
         pageDots: true,
         prevNextButtons: false,
@@ -314,7 +315,7 @@ export class BaseCarousel extends React.Component<
               flickityRef={c => (this.flickity = c)}
             >
               {carouselImages.map((slide, index) => {
-                return <Fragment key={index}>{render(slide, index)}</Fragment>
+                return <Fragment key={index}>{render(slide)}</Fragment>
               })}
             </FlickityCarousel>
           </CarouselContainer>
@@ -341,6 +342,25 @@ const CarouselContainer = styled.div<{
   .flickity-slider {
     img {
       user-select: none;
+    }
+  }
+
+  .flickity-page-dots {
+    text-align: center;
+    height: 0;
+    padding-top: ${space(1)}px;
+
+    .dot {
+      width: 4px;
+      height: 4px;
+      border-radius: 100%;
+      display: inline-block;
+      margin: ${space(0.5)}px;
+      background-color: ${color("black10")};
+    }
+
+    .dot.is-selected {
+      background-color: ${color("black100")};
     }
   }
 

--- a/src/Components/v2/CarouselV3.tsx
+++ b/src/Components/v2/CarouselV3.tsx
@@ -12,6 +12,11 @@ interface CarouselProps {
   data: any
 
   /**
+   * Passes flickityRef
+   */
+  setFlickityRef?: (flickityRef) => void
+
+  /**
    * If this carousel contains only one visible image on render set to true (for SSR)
    */
   oneSlideVisible?: boolean
@@ -172,6 +177,7 @@ export class BaseCarousel extends React.Component<
    * client has mounted. During the server-side pass we use a Flex wrapper instead.
    */
   componentDidMount() {
+    const { setFlickityRef } = this.props
     const Flickity = require("react-flickity-component")
 
     this.setState(
@@ -180,6 +186,9 @@ export class BaseCarousel extends React.Component<
         isMounted: true,
       },
       () => {
+        if (setFlickityRef) {
+          setFlickityRef(this.flickity)
+        }
         this.flickity.on("select", this.handleSlideChange)
       }
     )

--- a/src/Components/v2/__stories__/CarouselV3.story.tsx
+++ b/src/Components/v2/__stories__/CarouselV3.story.tsx
@@ -57,7 +57,7 @@ storiesOf("Styleguide/Components/CarouselV3", module)
       <Container>
         <LargeCarousel
           data={images}
-          height={300}
+          height="300px"
           render={props => {
             return (
               <Image
@@ -79,7 +79,7 @@ storiesOf("Styleguide/Components/CarouselV3", module)
         <LargeCarousel
           showArrows
           data={images}
-          height={300}
+          height="300px"
           options={{ wrapAround: true }}
           render={props => {
             return (
@@ -108,7 +108,6 @@ storiesOf("Styleguide/Components/CarouselV3", module)
                   image: { aspect_ratio },
                 },
               } = artwork
-
               return (
                 <FillwidthItem
                   artwork={artwork.node}

--- a/src/Components/v2/__tests__/Carousel.test.tsx
+++ b/src/Components/v2/__tests__/Carousel.test.tsx
@@ -13,7 +13,7 @@ describe("Carousel", () => {
       <MockBoot breakpoint="xs">
         <Carousel
           data={[{ name: "foo" }]}
-          render={props => {
+          render={() => {
             return <div />
           }}
         />
@@ -25,7 +25,7 @@ describe("Carousel", () => {
       <MockBoot breakpoint="lg">
         <Carousel
           data={[{ name: "foo" }]}
-          render={props => {
+          render={() => {
             return <div />
           }}
         />


### PR DESCRIPTION
- Updates ArtworkImageBrowser to use `Flickity`
- Adds page dots to small carouselV3 

## Page dots

<img width="475" alt="Screen Shot 2019-05-08 at 4 43 20 PM" src="https://user-images.githubusercontent.com/21182806/57408968-15300a80-71b5-11e9-8113-35f6f6e88b90.png">

## Client

![Screen Shot 2019-05-01 at 4 53 58 PM](https://user-images.githubusercontent.com/21182806/57043058-734c7300-6c34-11e9-861a-5b0c0dd524ba.png)

![Screen Shot 2019-05-01 at 4 53 18 PM](https://user-images.githubusercontent.com/21182806/57043075-83fce900-6c34-11e9-91c0-65ff2756ef34.png)

## SSR
![Screen Shot 2019-05-01 at 4 53 40 PM](https://user-images.githubusercontent.com/21182806/57043060-734c7300-6c34-11e9-8639-649fdbc1eb7d.png)

![Screen Shot 2019-05-01 at 4 53 29 PM](https://user-images.githubusercontent.com/21182806/57043069-7fd0cb80-6c34-11e9-8c68-8fc09e329aa0.png)
