### PR TITLE
User can see and click on feedback link in FAQ Modal

### DIFF
--- a/src/Apps/Artwork/Components/PricingContextModal.tsx
+++ b/src/Apps/Artwork/Components/PricingContextModal.tsx
@@ -79,7 +79,9 @@ export class PricingContextModal extends React.Component<State> {
             including the artist's relative position in the art market and the
             artwork's size, condition, rarity, and subject matter. These factors
             are unique to every artwork. As such, this feature is not intended
-            to provide pricing guidance for the artwork being viewed.
+            to provide pricing guidance for the artwork being viewed. If you
+            have feedback or questions{" "}
+            <Link href="mailto:support@artsy.net">let us know</Link>.
           </Serif>
           <Spacer mt={2} />
         </Modal>

--- a/src/Apps/Artwork/Components/__tests__/PricingContextModal.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/PricingContextModal.test.tsx
@@ -34,10 +34,29 @@ describe("PricingContextModal", () => {
 
     component.find(Link)
 
-    expect(component.find(Link).length).toEqual(1)
-    expect(component.find(Link).props().href).toEqual(
-      "https://www.artsy.net/article/artsy-editorial-artworks-prices"
-    )
+    expect(
+      component
+        .find(Link)
+        .at(0)
+        .props().href
+    ).toEqual("https://www.artsy.net/article/artsy-editorial-artworks-prices")
+  })
+
+  it("renders the support mailto link", async () => {
+    const component = mount(<PricingContextModal />)
+    component
+      .find(QuestionCircleIcon)
+      .at(0)
+      .simulate("click")
+
+    component.find(Link)
+
+    expect(
+      component
+        .find(Link)
+        .at(1)
+        .props().href
+    ).toEqual("mailto:support@artsy.net")
   })
 
   it("opens the modal when the question mark icon is clicked", async () => {


### PR DESCRIPTION
__User story__
As a user on an artwork page with a histogram
When I click the ? mark and open the FAQ modal
Then I can see the last line of text that says
"If you have feedback or questions let us know."
And the words "let us know" are a mailto link that goes to support@artsy.net

__Before:__
<img width="464" alt="Screen Shot 2019-04-30 at 5 40 09 PM" src="https://user-images.githubusercontent.com/5643895/56995201-15a22300-6b6f-11e9-9a54-56cca20d50d8.png">

__After:__
<img width="460" alt="Screen Shot 2019-04-30 at 5 40 17 PM" src="https://user-images.githubusercontent.com/5643895/56995213-1cc93100-6b6f-11e9-8bee-397550197b08.png">
