### PR TITLE
[NavBar] Fix notification count

### DIFF
--- a/src/Artsy/SystemContext.tsx
+++ b/src/Artsy/SystemContext.tsx
@@ -35,6 +35,11 @@ export interface SystemContextProps {
    * and `USER_ACCESS_TOKEN` environment variables if available.
    */
   user?: User
+
+  /**
+   * FIXME: Ask alloy how to pass one-off props like this in from force
+   */
+  notificationCount?: number
 }
 
 export const SystemContext = React.createContext<SystemContextProps>({})

--- a/src/Components/NavBar/NotificationsBadge.tsx
+++ b/src/Components/NavBar/NotificationsBadge.tsx
@@ -1,11 +1,11 @@
 import cookie from "cookies-js"
-import React from "react"
+import React, { useContext } from "react"
 import { ReadyState } from "react-relay"
-import { data as sd } from "sharify"
 import styled from "styled-components"
 
 import { color, Flex, Sans } from "@artsy/palette"
 
+import { SystemContext } from "Artsy"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { NotificationsQueryRenderer } from "./Menus"
@@ -73,7 +73,8 @@ const CircularCount: React.FC<{ notifications?: string }> = ({
 }) => {
   // Check to see if we've got a value from sharify, populated by a cookie on
   // the server.
-  const notificationsLabel = notifications || sd.NOTIFICATION_COUNT
+  const { notificationCount } = useContext(SystemContext)
+  const notificationsLabel = notifications || notificationCount
 
   if (!notificationsLabel) {
     return null


### PR DESCRIPTION
#trivial 

We can't access per-request data via sharify in a static way; needed to pass things in via `SystemContext` from force and access them that way. 