### PR TITLE
Move question icon next to chart title and change color

### DIFF
--- a/src/Apps/Artwork/Components/PricingContext.tsx
+++ b/src/Apps/Artwork/Components/PricingContext.tsx
@@ -70,15 +70,15 @@ export class PricingContext extends React.Component<PricingContextProps> {
     return (
       <BorderBox mb={2} flexDirection="column">
         <Waypoint onEnter={once(this.trackImpression.bind(this))} />
-        <Sans size="2" weight="medium">
-          {artwork.pricingContext.appliedFiltersDisplay}
-        </Sans>
         <Flex>
-          <Link color="black60">
-            <Sans size="2">Browse works in this category</Sans>
-          </Link>
+          <Sans size="2" weight="medium">
+            {artwork.pricingContext.appliedFiltersDisplay}
+          </Sans>
           <PricingContextModal />
         </Flex>
+        <Link color="black60">
+          <Sans size="2">Browse works in this category</Sans>
+        </Link>
         <Spacer mb={[2, 3]} />
         <BarChart
           minLabel="$0"

--- a/src/Apps/Artwork/Components/PricingContextModal.tsx
+++ b/src/Apps/Artwork/Components/PricingContextModal.tsx
@@ -1,5 +1,4 @@
 import {
-  color,
   Link,
   QuestionCircleIcon,
   Serif,
@@ -98,10 +97,5 @@ export class PricingContextModal extends React.Component<State> {
 }
 
 const StyledQuestionCircleIcon = styled(QuestionCircleIcon)`
-  fill: ${color("black60")};
-
-  &:hover {
-    fill: ${color("black100")};
-    cursor: pointer;
-  }
+  cursor: pointer;
 `

--- a/src/Apps/Artwork/Components/PricingContextModal.tsx
+++ b/src/Apps/Artwork/Components/PricingContextModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Link,
   QuestionCircleIcon,
   Serif,
@@ -45,7 +46,7 @@ export class PricingContextModal extends React.Component<State> {
 
   render() {
     return (
-      <>
+      <Box height="10px">
         <Modal
           onClose={this.closeModal}
           show={this.state.isModalOpen}
@@ -91,7 +92,7 @@ export class PricingContextModal extends React.Component<State> {
             onClick={this.openModal.bind(this)}
           />
         </Tooltip>
-      </>
+      </Box>
     )
   }
 }

--- a/src/Apps/Artwork/Components/PricingContextModal.tsx
+++ b/src/Apps/Artwork/Components/PricingContextModal.tsx
@@ -46,7 +46,7 @@ export class PricingContextModal extends React.Component<State> {
 
   render() {
     return (
-      <Box height="10px">
+      <Box height="15px">
         <Modal
           onClose={this.closeModal}
           show={this.state.isModalOpen}


### PR DESCRIPTION
Small positioning and style changes to the question mark icon 

__Before:__
<img width="436" alt="Screen Shot 2019-05-02 at 10 08 24 AM" src="https://user-images.githubusercontent.com/5643895/57086927-0d5ffa00-6ccd-11e9-9e43-7d5843172642.png">
__After:__
<img width="403" alt="Screen Shot 2019-05-02 at 11 26 02 AM" src="https://user-images.githubusercontent.com/5643895/57086950-1a7ce900-6ccd-11e9-92f3-3f6b826a58fa.png">
