### PR TITLE
Add space between 2nd and 3rd paragraph in FAQ modal

### DIFF
--- a/src/Apps/Artwork/Components/PricingContextModal.tsx
+++ b/src/Apps/Artwork/Components/PricingContextModal.tsx
@@ -69,6 +69,7 @@ export class PricingContextModal extends React.Component<State> {
             similar in size and category to the work you're viewing. The prices
             included in the graph are only from galleries and dealers on Artsy.
           </Serif>
+          <Spacer mt={2} />
           <Serif size="3" color={"black80"}>
             Artwork prices are affected by{" "}
             <Link


### PR DESCRIPTION
__Before:__
<img width="469" alt="Screen Shot 2019-05-02 at 4 22 26 PM" src="https://user-images.githubusercontent.com/5643895/57104652-e8807c80-6cf6-11e9-9fa0-b4872405d208.png">

__After:__
<img width="487" alt="Screen Shot 2019-05-02 at 4 21 45 PM" src="https://user-images.githubusercontent.com/5643895/57104659-f1714e00-6cf6-11e9-83e9-f3a0ed2435c1.png">
