### PR TITLE
Uses <Img> instead of <div> for SSR artwork image

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -5,15 +5,7 @@ import Slider, { Settings } from "react-slick"
 import styled from "styled-components"
 import { Media } from "Utils/Responsive"
 
-import {
-  Box,
-  ChevronIcon,
-  Col,
-  color,
-  Flex,
-  ResponsiveImage,
-  Row,
-} from "@artsy/palette"
+import { Box, ChevronIcon, Col, color, Flex, Image, Row } from "@artsy/palette"
 
 interface ArtworkBrowserProps {
   imageAlt: string
@@ -89,8 +81,11 @@ export class LargeArtworkImageBrowser extends React.Component<
                       deepZoom={image.deepZoom}
                       enabled={image.is_zoomable}
                       isDefault={image.is_default}
+                      src={image.uri}
                     >
-                      <DesktopImage src={image.uri} width="100%" />
+                      <Flex justifyContent="center" alignItems="center">
+                        <DesktopImage alt={imageAlt} src={image.uri} />
+                      </Flex>
                     </Lightbox>
                   </Flex>
                 )
@@ -138,10 +133,11 @@ export class SmallArtworkImageBrowser extends React.Component<
   }
 
   render() {
+    const { sliderRef, imageAlt, images } = this.props
     return (
       <Container>
-        <Slider {...this.settings} ref={this.props.sliderRef}>
-          {this.props.images.map(image => {
+        <Slider {...this.settings} ref={sliderRef}>
+          {images.map(image => {
             return (
               <Flex
                 flexDirection="column"
@@ -150,12 +146,13 @@ export class SmallArtworkImageBrowser extends React.Component<
                 key={image.id}
               >
                 <Lightbox
-                  imageAlt={this.props.imageAlt}
+                  imageAlt={imageAlt}
                   deepZoom={image.deepZoom}
                   enabled={!this.state.isLocked && image.is_zoomable}
                   isDefault={image.is_default}
+                  src={image.uri}
                 >
-                  <ResponsiveImage src={image.uri} width="100%" />
+                  <Image alt={imageAlt} src={image.uri} width="100%" />
                 </Lightbox>
               </Flex>
             )
@@ -209,8 +206,9 @@ const Container = styled(Box)`
   }
 `
 
-const DesktopImage = styled(ResponsiveImage)`
-  padding-bottom: 60vh; /* Responsive max height */
+const DesktopImage = styled(Image)`
+  max-height: 60vh;
+  max-width: 100%;
 `
 
 const PageIndicator = styled.span`
@@ -221,5 +219,4 @@ const PageIndicator = styled.span`
 
 DesktopImage.displayName = "DesktopImage"
 // @ts-ignore
-ResponsiveImage.displayName = "ResponsiveImage"
 PageIndicator.displayName = "PageIndicator"

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -5,7 +5,7 @@ import Slider, { Settings } from "react-slick"
 import styled from "styled-components"
 import { Media } from "Utils/Responsive"
 
-import { Box, ChevronIcon, Col, color, Flex, Image, Row } from "@artsy/palette"
+import { Box, ChevronIcon, Col, color, Flex, Row } from "@artsy/palette"
 
 interface ArtworkBrowserProps {
   imageAlt: string
@@ -82,11 +82,8 @@ export class LargeArtworkImageBrowser extends React.Component<
                       enabled={image.is_zoomable}
                       isDefault={image.is_default}
                       src={image.uri}
-                    >
-                      <Flex justifyContent="center" alignItems="center">
-                        <DesktopImage alt={imageAlt} src={image.uri} />
-                      </Flex>
-                    </Lightbox>
+                      initialHeight="60vh"
+                    />
                   </Flex>
                 )
               })}
@@ -151,9 +148,8 @@ export class SmallArtworkImageBrowser extends React.Component<
                   enabled={!this.state.isLocked && image.is_zoomable}
                   isDefault={image.is_default}
                   src={image.uri}
-                >
-                  <Image alt={imageAlt} src={image.uri} width="100%" />
-                </Lightbox>
+                  initialHeight="45vh"
+                />
               </Flex>
             )
           })}
@@ -206,17 +202,11 @@ const Container = styled(Box)`
   }
 `
 
-const DesktopImage = styled(Image)`
-  max-height: 60vh;
-  max-width: 100%;
-`
-
 const PageIndicator = styled.span`
   &::after {
     content: "•";
   }
 `
 
-DesktopImage.displayName = "DesktopImage"
 // @ts-ignore
 PageIndicator.displayName = "PageIndicator"

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.test.tsx
@@ -65,7 +65,7 @@ describe("ArtworkImageBrowser", () => {
     })
 
     it("renders correct number of images", () => {
-      expect(wrapper.find("ResponsiveImage").length).toBe(4)
+      expect(wrapper.find("Image").length).toBe(4)
     })
 
     it("renders custom pagination dots", () => {

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.test.tsx
@@ -33,7 +33,7 @@ describe("ArtworkImageBrowser", () => {
     })
 
     it("renders correct number of images", () => {
-      expect(wrapper.find("DesktopImage").length).toBe(4)
+      expect(wrapper.find("Image").length).toBe(4)
     })
 
     it("renders custom pagination dots", () => {

--- a/src/Components/v2/Lightbox/Lightbox.tsx
+++ b/src/Components/v2/Lightbox/Lightbox.tsx
@@ -49,6 +49,7 @@ export interface LightboxProps {
   enabled?: boolean
   isDefault?: boolean
   src: string
+  initialHeight?: string
 
   /**
    * Id of the element to render the lightbox in
@@ -279,39 +280,36 @@ export class Lightbox extends React.Component<LightboxProps, LightboxState> {
   }
 
   render() {
-    const { children, enabled, isDefault, imageAlt, src } = this.props
+    const { enabled, isDefault, imageAlt, src, initialHeight } = this.props
+    const height = initialHeight || "auto"
 
     // Only render client-side
     if (!this.state.element) {
-      return children
+      return (
+        <Flex justifyContent="center" height={height} alignItems="center">
+          <StyledImage alt={imageAlt} src={src} />
+        </Flex>
+      )
     }
 
-    const modifiedChildren = React.Children.map(
-      children,
-      (child: React.ReactElement<any>) => {
-        return (
-          enabled && (
-            <Flex
-              justifyContent="center"
-              alignItems="center"
-              height="60vh"
-              onClick={this.show.bind(this)}
-            >
-              <StyledImage
-                src={src}
-                alt={imageAlt}
-                data-type="artwork-image"
-                data-is-default={isDefault}
-              />
-            </Flex>
-          )
-        )
-      }
-    )
     return (
       <React.Fragment>
         {this.renderPortal()}
-        {modifiedChildren}
+        {enabled && (
+          <Flex
+            justifyContent="center"
+            alignItems="center"
+            height={height}
+            onClick={this.show.bind(this)}
+          >
+            <StyledImage
+              src={src}
+              alt={imageAlt}
+              data-type="artwork-image"
+              data-is-default={isDefault}
+            />
+          </Flex>
+        )}
       </React.Fragment>
     )
   }

--- a/src/Components/v2/Lightbox/Lightbox.tsx
+++ b/src/Components/v2/Lightbox/Lightbox.tsx
@@ -48,6 +48,7 @@ export interface LightboxProps {
   deepZoom: DeepZoomProps
   enabled?: boolean
   isDefault?: boolean
+  src: string
 
   /**
    * Id of the element to render the lightbox in
@@ -278,7 +279,7 @@ export class Lightbox extends React.Component<LightboxProps, LightboxState> {
   }
 
   render() {
-    const { children, enabled, isDefault, imageAlt } = this.props
+    const { children, enabled, isDefault, imageAlt, src } = this.props
 
     // Only render client-side
     if (!this.state.element) {
@@ -288,9 +289,6 @@ export class Lightbox extends React.Component<LightboxProps, LightboxState> {
     const modifiedChildren = React.Children.map(
       children,
       (child: React.ReactElement<any>) => {
-        const {
-          props: { src },
-        } = child
         return (
           enabled && (
             <Flex

--- a/src/Components/v2/__stories__/Lightbox.story.tsx
+++ b/src/Components/v2/__stories__/Lightbox.story.tsx
@@ -27,7 +27,11 @@ storiesOf("Styleguide/Components", module).add("Lightbox", () => {
   return (
     <React.Fragment>
       <Section title="Lightbox">
-        <Lightbox imageAlt="Kieran Gillen, Untitled, 1984" deepZoom={deepZoom}>
+        <Lightbox
+          src={image("large")}
+          imageAlt="Arya Stark, Untitled, 1984"
+          deepZoom={deepZoom}
+        >
           <Image width={width} height={height} src={image("large")} />
         </Lightbox>
       </Section>

--- a/src/Components/v2/__stories__/Lightbox.story.tsx
+++ b/src/Components/v2/__stories__/Lightbox.story.tsx
@@ -1,4 +1,3 @@
-import { Image } from "@artsy/palette"
 import { Lightbox } from "Components/v2"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
@@ -6,8 +5,6 @@ import { Section } from "Utils/Section"
 
 const image = size =>
   `https://d32dm0rphc51dk.cloudfront.net/88LaQZxzQdksn76f0LGFoQ/${size}.jpg`
-const width = 912
-const height = 608
 const deepZoom = {
   Image: {
     xmlns: "http://schemas.microsoft.com/deepzoom/2008",
@@ -31,9 +28,7 @@ storiesOf("Styleguide/Components", module).add("Lightbox", () => {
           src={image("large")}
           imageAlt="Arya Stark, Untitled, 1984"
           deepZoom={deepZoom}
-        >
-          <Image width={width} height={height} src={image("large")} />
-        </Lightbox>
+        />
       </Section>
       <div id="lightbox-container" />
     </React.Fragment>


### PR DESCRIPTION
- Followup to https://github.com/artsy/reaction/pull/2365
- Artwork SSR images were still rendering as `<div>`, this PR renders them in `<img>` elements for SEO purposes and adds an `alt` to the image.
- https://artsyproduct.atlassian.net/browse/DISCO-920


## SSR (JS disabled rendering)

<img width="1585" alt="Screen Shot 2019-05-06 at 11 31 07 AM" src="https://user-images.githubusercontent.com/21182806/57236988-3990b900-6ff4-11e9-9386-b7ea1445e5df.png">

<img width="1517" alt="Screen Shot 2019-05-06 at 11 32 05 AM" src="https://user-images.githubusercontent.com/21182806/57237014-47ded500-6ff4-11e9-8d51-a9823ba67493.png">

