### PR TITLE
Render artwork page artist info component server-side

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -7,7 +7,7 @@ import { ArtworkApp_artwork } from "__generated__/ArtworkApp_artwork.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 
-import { ArtistInfoQueryRenderer as ArtistInfo } from "./Components/ArtistInfo"
+import { ArtistInfoFragmentContainer as ArtistInfo } from "./Components/ArtistInfo"
 import { ArtworkBannerFragmentContainer as ArtworkBanner } from "./Components/ArtworkBanner"
 import { ArtworkDetailsFragmentContainer as ArtworkDetails } from "./Components/ArtworkDetails"
 import { ArtworkImageBrowserFragmentContainer as ArtworkImageBrowser } from "./Components/ArtworkImageBrowser"
@@ -108,7 +108,7 @@ export class ArtworkApp extends React.Component<Props> {
             <>
               <Row key={artist.id}>
                 <Col>
-                  <ArtistInfo artistID={artist.id} />
+                  <ArtistInfo artist={artist} />
                 </Col>
               </Row>
               {addSpacer && <Spacer mb={2} />}
@@ -219,11 +219,11 @@ export const ArtworkAppFragmentContainer = createFragmentContainer(ArtworkApp, {
       price
       is_in_auction
       artists {
-        _id
         id
+        ...ArtistInfo_artist
       }
       artist {
-        id
+        ...ArtistInfo_artist
       }
       ...ArtworkRelatedArtists_artwork
       ...ArtworkMeta_artwork

--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -29,7 +29,6 @@ import { AuthModalIntent, openAuthModal } from "Utils/openAuthModal"
 
 interface ArtistInfoProps {
   artist: ArtistInfo_artist
-  user: User
   mediator?: Mediator
 }
 

--- a/src/Apps/Artwork/Components/__tests__/ArtistInfo.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtistInfo.test.tsx
@@ -85,11 +85,8 @@ describe("ArtistInfo", () => {
 
   describe("Analytics", () => {
     it("tracks click on 'Show artist insights' button", () => {
-      const user = {}
       const { Component, dispatch } = mockTracking(ArtistInfo)
-      const component = mount(
-        <Component user={user} artist={ArtistInfoFixture as any} />
-      )
+      const component = mount(<Component artist={ArtistInfoFixture as any} />)
       const button = component.find("Button")
       button.simulate("click")
       expect(dispatch).toBeCalledWith({

--- a/src/__generated__/ArtworkApp_artwork.graphql.ts
+++ b/src/__generated__/ArtworkApp_artwork.graphql.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
+import { ArtistInfo_artist$ref } from "./ArtistInfo_artist.graphql";
 import { ArtworkBanner_artwork$ref } from "./ArtworkBanner_artwork.graphql";
 import { ArtworkDetails_artwork$ref } from "./ArtworkDetails_artwork.graphql";
 import { ArtworkImageBrowser_artwork$ref } from "./ArtworkImageBrowser_artwork.graphql";
@@ -20,11 +21,11 @@ export type ArtworkApp_artwork = {
     readonly price: string | null;
     readonly is_in_auction: boolean | null;
     readonly artists: ReadonlyArray<({
-        readonly _id: string;
         readonly id: string;
+        readonly " $fragmentRefs": ArtistInfo_artist$ref;
     }) | null> | null;
     readonly artist: ({
-        readonly id: string;
+        readonly " $fragmentRefs": ArtistInfo_artist$ref;
     }) | null;
     readonly " $fragmentRefs": ArtworkRelatedArtists_artwork$ref & ArtworkMeta_artwork$ref & ArtworkBanner_artwork$ref & ArtworkSidebar_artwork$ref & ArtworkDetails_artwork$ref & ArtworkImageBrowser_artwork$ref & OtherWorks_artwork$ref & PricingContext_artwork$ref;
     readonly " $refType": ArtworkApp_artwork$ref;
@@ -41,11 +42,9 @@ var v0 = {
   "storageKey": null
 },
 v1 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "_id",
-  "args": null,
-  "storageKey": null
+  "kind": "FragmentSpread",
+  "name": "ArtistInfo_artist",
+  "args": null
 },
 v2 = {
   "kind": "ScalarField",
@@ -111,8 +110,8 @@ return {
       "concreteType": "Artist",
       "plural": true,
       "selections": [
-        v1,
         v0,
+        v1,
         v2
       ]
     },
@@ -125,11 +124,17 @@ return {
       "concreteType": "Artist",
       "plural": false,
       "selections": [
-        v0,
+        v1,
         v2
       ]
     },
-    v1,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "_id",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "FragmentSpread",
       "name": "ArtworkMeta_artwork",
@@ -169,5 +174,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '1489c8cbafe01a68af8e29a53c65ed08';
+(node as any).hash = '5097a7c9d398cce1abd797fc91661166';
 export default node;

--- a/src/__generated__/routes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/routes_ArtworkQuery.graphql.ts
@@ -38,12 +38,12 @@ fragment ArtworkApp_artwork on Artwork {
   price
   is_in_auction
   artists {
-    _id
     id
+    ...ArtistInfo_artist
     __id
   }
   artist {
-    id
+    ...ArtistInfo_artist
     __id
   }
   ...ArtworkRelatedArtists_artwork
@@ -54,6 +54,57 @@ fragment ArtworkApp_artwork on Artwork {
   ...ArtworkImageBrowser_artwork
   ...OtherWorks_artwork
   ...PricingContext_artwork
+  __id
+}
+
+fragment ArtistInfo_artist on Artist {
+  _id
+  id
+  name
+  href
+  image {
+    cropped(width: 100, height: 100) {
+      url
+    }
+  }
+  formatted_nationality_and_birthday
+  counts {
+    partner_shows
+  }
+  exhibition_highlights(size: 3) {
+    ...SelectedExhibitions_exhibitions
+    __id
+  }
+  collections
+  highlights {
+    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: ["blue-chip", "top-established", "top-emerging"]) {
+      edges {
+        node {
+          categories {
+            id
+          }
+          __id
+        }
+        __id
+      }
+    }
+  }
+  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {
+    edges {
+      node {
+        price_realized {
+          display(format: "0a")
+        }
+        __id
+      }
+    }
+  }
+  ...ArtistBio_bio
+  ...ArtistMarketInsights_artist
+  ...FollowArtistButton_artist
+  biography_blurb(format: HTML, partner_bio: true) {
+    text
+  }
   __id
 }
 
@@ -760,6 +811,70 @@ fragment FollowArtistButton_artist on Artist {
     follows
   }
 }
+
+fragment SelectedExhibitions_exhibitions on Show {
+  partner {
+    __typename
+    ... on ExternalPartner {
+      name
+      __id
+    }
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      __id
+    }
+  }
+  name
+  start_at(format: "YYYY")
+  cover_image {
+    cropped(width: 800, height: 600) {
+      url
+    }
+  }
+  city
+  __id
+}
+
+fragment ArtistBio_bio on Artist {
+  biography_blurb(format: HTML, partner_bio: true) {
+    text
+    credit
+  }
+  __id
+}
+
+fragment ArtistMarketInsights_artist on Artist {
+  _id
+  collections
+  highlights {
+    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: ["blue-chip", "top-established", "top-emerging"]) {
+      edges {
+        node {
+          categories {
+            id
+          }
+          __id
+        }
+        __id
+      }
+    }
+  }
+  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {
+    edges {
+      node {
+        price_realized {
+          display(format: "0a")
+        }
+        organization
+        sale_date(format: "YYYY")
+        __id
+      }
+    }
+  }
+  __id
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -823,7 +938,7 @@ v6 = {
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "_id",
+  "name": "collections",
   "args": null,
   "storageKey": null
 },
@@ -844,11 +959,62 @@ v9 = {
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "is_followed",
+  "name": "url",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v11 = [
+  v10
+],
+v12 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "cropped",
+      "storageKey": "cropped(height:100,width:100)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "height",
+          "value": 100,
+          "type": "Int!"
+        },
+        {
+          "kind": "Literal",
+          "name": "width",
+          "value": 100,
+          "type": "Int!"
+        }
+      ],
+      "concreteType": "CroppedImageUrl",
+      "plural": false,
+      "selections": v11
+    }
+  ]
+},
+v13 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "formatted_nationality_and_birthday",
+  "args": null,
+  "storageKey": null
+},
+v14 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "follows",
+  "args": null,
+  "storageKey": null
+},
+v15 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "counts",
@@ -860,72 +1026,398 @@ v11 = {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "follows",
+      "name": "partner_shows",
       "args": null,
       "storageKey": null
-    }
+    },
+    v14
   ]
 },
-v12 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "url",
-  "args": null,
-  "storageKey": null
-},
-v13 = [
-  v12
-],
-v14 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "sale_message",
-  "args": null,
-  "storageKey": null
-},
-v15 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "type",
-  "args": null,
-  "storageKey": null
-},
 v16 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "initials",
-  "args": null,
-  "storageKey": null
-},
-v17 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "width",
-  "args": null,
-  "storageKey": null
-},
-v18 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "height",
-  "args": null,
-  "storageKey": null
-},
-v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
+v17 = [
+  v8
+],
+v18 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "YYYY",
+    "type": "String"
+  }
+],
+v19 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "city",
+  "args": null,
+  "storageKey": null
+},
 v20 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "exhibition_highlights",
+  "storageKey": "exhibition_highlights(size:3)",
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "size",
+      "value": 3,
+      "type": "Int"
+    }
+  ],
+  "concreteType": "Show",
+  "plural": true,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "partner",
+      "storageKey": null,
+      "args": null,
+      "concreteType": null,
+      "plural": false,
+      "selections": [
+        v16,
+        v2,
+        {
+          "kind": "InlineFragment",
+          "type": "Partner",
+          "selections": v17
+        },
+        {
+          "kind": "InlineFragment",
+          "type": "ExternalPartner",
+          "selections": v17
+        }
+      ]
+    },
+    v8,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "start_at",
+      "args": v18,
+      "storageKey": "start_at(format:\"YYYY\")"
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "cover_image",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Image",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "cropped",
+          "storageKey": "cropped(height:600,width:800)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 600,
+              "type": "Int!"
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 800,
+              "type": "Int!"
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "plural": false,
+          "selections": v11
+        }
+      ]
+    },
+    v19,
+    v2
+  ]
+},
+v21 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "_id",
+  "args": null,
+  "storageKey": null
+},
+v22 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "highlights",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "ArtistHighlights",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "partners",
+      "storageKey": "partners(display_on_partner_profile:true,first:10,partner_category:[\"blue-chip\",\"top-established\",\"top-emerging\"],represented_by:true)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "display_on_partner_profile",
+          "value": true,
+          "type": "Boolean"
+        },
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10,
+          "type": "Int"
+        },
+        {
+          "kind": "Literal",
+          "name": "partner_category",
+          "value": [
+            "blue-chip",
+            "top-established",
+            "top-emerging"
+          ],
+          "type": "[String]"
+        },
+        {
+          "kind": "Literal",
+          "name": "represented_by",
+          "value": true,
+          "type": "Boolean"
+        }
+      ],
+      "concreteType": "PartnerArtistConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PartnerArtistEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Partner",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "categories",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Category",
+                  "plural": true,
+                  "selections": [
+                    v4
+                  ]
+                },
+                v2
+              ]
+            },
+            v2
+          ]
+        }
+      ]
+    }
+  ]
+},
+v23 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "auctionResults",
+  "storageKey": "auctionResults(first:1,recordsTrusted:true,sort:\"PRICE_AND_DATE_DESC\")",
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 1,
+      "type": "Int"
+    },
+    {
+      "kind": "Literal",
+      "name": "recordsTrusted",
+      "value": true,
+      "type": "Boolean"
+    },
+    {
+      "kind": "Literal",
+      "name": "sort",
+      "value": "PRICE_AND_DATE_DESC",
+      "type": "AuctionResultSorts"
+    }
+  ],
+  "concreteType": "AuctionResultConnection",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "edges",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "AuctionResultEdge",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "node",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "AuctionResult",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "price_realized",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "AuctionResultPriceRealized",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "display",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "format",
+                      "value": "0a",
+                      "type": "String"
+                    }
+                  ],
+                  "storageKey": "display(format:\"0a\")"
+                }
+              ]
+            },
+            v2,
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "organization",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "sale_date",
+              "args": v18,
+              "storageKey": "sale_date(format:\"YYYY\")"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+},
+v24 = {
+  "kind": "Literal",
+  "name": "format",
+  "value": "HTML",
+  "type": "Format"
+},
+v25 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "biography_blurb",
+  "storageKey": "biography_blurb(format:\"HTML\",partner_bio:true)",
+  "args": [
+    v24,
+    {
+      "kind": "Literal",
+      "name": "partner_bio",
+      "value": true,
+      "type": "Boolean"
+    }
+  ],
+  "concreteType": "ArtistBlurb",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "text",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "credit",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v26 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_followed",
+  "args": null,
+  "storageKey": null
+},
+v27 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "sale_message",
+  "args": null,
+  "storageKey": null
+},
+v28 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "type",
+  "args": null,
+  "storageKey": null
+},
+v29 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "initials",
+  "args": null,
+  "storageKey": null
+},
+v30 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "width",
+  "args": null,
+  "storageKey": null
+},
+v31 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "height",
+  "args": null,
+  "storageKey": null
+},
+v32 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "category",
   "args": null,
   "storageKey": null
 },
-v21 = {
+v33 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "dimensions",
@@ -950,48 +1442,48 @@ v21 = {
     }
   ]
 },
-v22 = {
+v34 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_auction",
   "args": null,
   "storageKey": null
 },
-v23 = {
+v35 = {
   "kind": "Literal",
   "name": "version",
   "value": "square",
   "type": "[String]"
 },
-v24 = {
+v36 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_closed",
   "args": null,
   "storageKey": null
 },
-v25 = {
+v37 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_open",
   "args": null,
   "storageKey": null
 },
-v26 = {
+v38 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "live_start_at",
   "args": null,
   "storageKey": null
 },
-v27 = {
+v39 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "end_at",
   "args": null,
   "storageKey": null
 },
-v28 = [
+v40 = [
   {
     "kind": "LinkedField",
     "alias": "img",
@@ -1004,7 +1496,7 @@ v28 = [
         "value": 70,
         "type": "Int"
       },
-      v23,
+      v35,
       {
         "kind": "Literal",
         "name": "width",
@@ -1014,46 +1506,41 @@ v28 = [
     ],
     "concreteType": "ResizedImageUrl",
     "plural": false,
-    "selections": v13
+    "selections": v11
   }
 ],
-v29 = {
+v41 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "edition_of",
   "args": null,
   "storageKey": null
 },
-v30 = {
+v42 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
   "args": null,
   "storageKey": null
 },
-v31 = {
+v43 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cents",
   "args": null,
   "storageKey": null
 },
-v32 = {
+v44 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_winning",
   "args": null,
   "storageKey": null
 },
-v33 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "HTML",
-    "type": "Format"
-  }
+v45 = [
+  v24
 ],
-v34 = [
+v46 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -1074,7 +1561,7 @@ return {
   "operationKind": "query",
   "name": "routes_ArtworkQuery",
   "id": null,
-  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n  $enablePricingContext: Boolean!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_offerable\n  availability\n  price\n  is_in_auction\n  artists {\n    _id\n    id\n    __id\n  }\n  artist {\n    id\n    __id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  ...PricingContext_artwork\n  __id\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  artist {\n    href\n    related {\n      artists(kind: MAIN, first: 4) {\n        edges {\n          node {\n            ...ArtistCard_artist\n            __id\n          }\n        }\n      }\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  _id\n  date\n  artist_names\n  sale_message\n  partner {\n    name\n    __id\n  }\n  image_rights\n  is_in_auction\n  is_acquireable\n  is_shareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on ArtworkContextFair {\n      id\n      name\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  ...SeoDataForArtwork_artwork\n  __id\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  sale {\n    is_auction\n    is_benefit\n    cover_image {\n      url(version: \"square\")\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  sale {\n    is_closed\n    ...AuctionTimer_sale\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  href\n  ...ArtworkActions_artwork\n  image {\n    id\n    url(version: \"larger\")\n    height\n    width\n  }\n  images {\n    id\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    is_default\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment OtherWorks_artwork on Artwork {\n  id\n  _id\n  sale {\n    is_closed\n    __id\n  }\n  context {\n    __typename\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment PricingContext_artwork on Artwork {\n  priceCents {\n    min\n    max\n  }\n  artists {\n    id\n    __id\n  }\n  category\n  pricingContext @include(if: $enablePricingContext) {\n    appliedFiltersDisplay\n    appliedFilters {\n      dimension\n      category\n    }\n    bins {\n      maxPrice\n      maxPriceCents\n      minPrice\n      minPriceCents\n      numArtworks\n    }\n  }\n  __id\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    __id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  id\n  image {\n    id\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable\n  is_hangable\n  partner {\n    id\n    __id\n  }\n  title\n  sale {\n    is_closed\n    is_auction\n    __id\n  }\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information(format: HTML)\n  sale {\n    is_benefit\n    __id\n  }\n  partner {\n    _id\n    id\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    is_default_profile_public\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker\n  artists {\n    __id\n    _id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  _id\n  sale {\n    is_closed\n    is_live_open\n    __id\n  }\n  sale_artwork {\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      __id\n    }\n    most_recent_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid {\n      max_bid {\n        cents\n      }\n      __id\n    }\n  }\n  id\n  _id\n  sale {\n    id\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      cents\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_inquireable\n  is_offerable\n  sale_message\n  shippingInfo\n  shippingOrigin\n  edition_sets {\n    id\n    __id\n    is_acquireable\n    is_offerable\n    sale_message\n    ...ArtworkSidebarSizeInfo_piece\n  }\n  __id\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at\n  end_at\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          _id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden\n  is_price_range\n  price\n  price_currency\n  sale_message\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      __id\n    }\n    __id\n  }\n  artist_names\n  availability\n  category\n  dimensions {\n    in\n  }\n  __id\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  id\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n  $enablePricingContext: Boolean!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkApp_artwork\n    __id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_offerable\n  availability\n  price\n  is_in_auction\n  artists {\n    id\n    ...ArtistInfo_artist\n    __id\n  }\n  artist {\n    ...ArtistInfo_artist\n    __id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  ...PricingContext_artwork\n  __id\n}\n\nfragment ArtistInfo_artist on Artist {\n  _id\n  id\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday\n  counts {\n    partner_shows\n  }\n  exhibition_highlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    __id\n  }\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        __id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n  }\n  __id\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  artist {\n    href\n    related {\n      artists(kind: MAIN, first: 4) {\n        edges {\n          node {\n            ...ArtistCard_artist\n            __id\n          }\n        }\n      }\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  _id\n  date\n  artist_names\n  sale_message\n  partner {\n    name\n    __id\n  }\n  image_rights\n  is_in_auction\n  is_acquireable\n  is_shareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on ArtworkContextFair {\n      id\n      name\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  ...SeoDataForArtwork_artwork\n  __id\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    type\n    name\n    initials\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      href\n      __id\n    }\n    __id\n  }\n  sale {\n    is_auction\n    is_benefit\n    cover_image {\n      url(version: \"square\")\n    }\n    __id\n  }\n  artworkContextAuction: context {\n    __typename\n    ... on ArtworkContextAuction {\n      name\n      href\n      is_auction\n      is_closed\n      is_open\n      live_start_at\n      live_url_if_open\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  artworkContextFair: context {\n    __typename\n    ... on ArtworkContextFair {\n      name\n      href\n      is_active\n      start_at\n      end_at\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        __id\n      }\n      __id\n    }\n    ... on Node {\n      __id\n    }\n  }\n  artworkContextPartnerShow: context {\n    __typename\n    ... on ArtworkContextPartnerShow {\n      name\n      href\n      type\n      status\n      thumbnail: cover_image {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  sale {\n    is_closed\n    ...AuctionTimer_sale\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    id\n    __id\n  }\n  literature(format: HTML)\n  exhibition_history(format: HTML)\n  provenance(format: HTML)\n  __id\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  title\n  image_alt: to_s\n  image_title\n  href\n  ...ArtworkActions_artwork\n  image {\n    id\n    url(version: \"larger\")\n    height\n    width\n  }\n  images {\n    id\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio: aspect_ratio\n    is_zoomable\n    is_default\n    deepZoom: deep_zoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment OtherWorks_artwork on Artwork {\n  id\n  _id\n  sale {\n    is_closed\n    __id\n  }\n  context {\n    __typename\n    ... on Node {\n      __id\n    }\n    ... on ArtworkContextFair {\n      __id\n    }\n  }\n  __id\n}\n\nfragment PricingContext_artwork on Artwork {\n  priceCents {\n    min\n    max\n  }\n  artists {\n    id\n    __id\n  }\n  category\n  pricingContext @include(if: $enablePricingContext) {\n    appliedFiltersDisplay\n    appliedFilters {\n      dimension\n      category\n    }\n    bins {\n      maxPrice\n      maxPriceCents\n      minPrice\n      minPriceCents\n      numArtworks\n    }\n  }\n  __id\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    __id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  id\n  image {\n    id\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable\n  is_hangable\n  partner {\n    id\n    __id\n  }\n  title\n  sale {\n    is_closed\n    is_auction\n    __id\n  }\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n  __id\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information(format: HTML)\n  sale {\n    is_benefit\n    __id\n  }\n  partner {\n    _id\n    id\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      __id\n    }\n    is_default_profile_public\n    profile {\n      ...FollowProfileButton_profile\n      id\n      icon {\n        url(version: \"square140\")\n      }\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  __id\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      __id\n    }\n    href\n    published_at(format: \"MMM Do, YYYY\")\n    thumbnail_image {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title\n    __id\n  }\n  __id\n}\n\nfragment FollowProfileButton_profile on Profile {\n  __id\n  id\n  is_followed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker\n  artists {\n    __id\n    _id\n    id\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n  __id\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable\n  edition_sets {\n    __id\n  }\n  sale_artwork {\n    lot_label\n    __id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n  __id\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  _id\n  partner {\n    _id\n    name\n    __id\n  }\n  sale_artwork {\n    estimate\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    is_with_buyers_premium\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  _id\n  sale {\n    is_closed\n    is_live_open\n    __id\n  }\n  sale_artwork {\n    is_with_reserve\n    reserve_message\n    reserve_status\n    current_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  myLotStanding(live: true) {\n    active_bid {\n      is_winning\n      __id\n    }\n    most_recent_bid {\n      is_winning\n      max_bid {\n        display\n      }\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid {\n      max_bid {\n        cents\n      }\n      __id\n    }\n  }\n  id\n  _id\n  sale {\n    id\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    is_preview\n    is_open\n    is_live_open\n    is_closed\n    is_registration_closed\n    __id\n  }\n  sale_artwork {\n    increments {\n      cents\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  id\n  _id\n  is_acquireable\n  is_inquireable\n  is_offerable\n  sale_message\n  shippingInfo\n  shippingOrigin\n  edition_sets {\n    id\n    __id\n    is_acquireable\n    is_offerable\n    sale_message\n    ...ArtworkSidebarSizeInfo_piece\n  }\n  __id\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    __id\n    name\n    href\n    locations {\n      city\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  _id\n  is_in_auction\n  is_for_sale\n  is_acquireable\n  is_inquireable\n  artists {\n    _id\n    is_consignable\n    __id\n  }\n  sale {\n    _id\n    is_closed\n    __id\n  }\n  __id\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at\n  end_at\n  __id\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of\n  ... on Node {\n    __id\n  }\n  ... on EditionSet {\n    __id\n  }\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n  __id\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class {\n    short_description\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_suggested\n}\n\nfragment FollowArtistPopover_suggested on Artist {\n  related {\n    suggested(first: 3, exclude_followed_artists: true) {\n      edges {\n        node {\n          __id\n          _id\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  id\n  _id\n  __id\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden\n  is_price_range\n  price\n  price_currency\n  sale_message\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      __id\n    }\n    __id\n  }\n  artist_names\n  availability\n  category\n  dimensions {\n    in\n  }\n  __id\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  id\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      __id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n  }\n  name\n  start_at(format: \"YYYY\")\n  cover_image {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n  __id\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb(format: HTML, partner_bio: true) {\n    text\n    credit\n  }\n  __id\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  _id\n  collections\n  highlights {\n    partners(first: 10, display_on_partner_profile: true, represented_by: true, partner_category: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  auctionResults(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date(format: \"YYYY\")\n        __id\n      }\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -1152,11 +1639,18 @@ return {
             "selections": [
               v7,
               v4,
-              v2,
               v8,
               v9,
-              v10,
-              v11,
+              v12,
+              v13,
+              v15,
+              v20,
+              v21,
+              v22,
+              v23,
+              v25,
+              v2,
+              v26,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1207,7 +1701,7 @@ return {
                             "plural": false,
                             "selections": [
                               v2,
-                              v7,
+                              v21,
                               v4,
                               v8,
                               {
@@ -1240,7 +1734,7 @@ return {
                                     ],
                                     "concreteType": "CroppedImageUrl",
                                     "plural": false,
-                                    "selections": v13
+                                    "selections": v11
                                   }
                                 ]
                               }
@@ -1270,9 +1764,20 @@ return {
             "concreteType": "Artist",
             "plural": false,
             "selections": [
-              v4,
-              v2,
+              v20,
+              v21,
+              v8,
               v9,
+              v12,
+              v13,
+              v15,
+              v4,
+              v7,
+              v22,
+              v23,
+              v25,
+              v2,
+              v26,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1355,20 +1860,25 @@ return {
                                     ],
                                     "concreteType": "CroppedImageUrl",
                                     "plural": false,
-                                    "selections": v13
+                                    "selections": v11
                                   }
                                 ]
                               },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "formatted_nationality_and_birthday",
-                                "args": null,
-                                "storageKey": null
-                              },
+                              v13,
                               v2,
-                              v10,
-                              v11
+                              v26,
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "counts",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "ArtistCounts",
+                                "plural": false,
+                                "selections": [
+                                  v14
+                                ]
+                              }
                             ]
                           }
                         ]
@@ -1395,7 +1905,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          v14,
+          v27,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1407,7 +1917,7 @@ return {
             "selections": [
               v8,
               v2,
-              v15,
+              v28,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1455,7 +1965,7 @@ return {
                         ],
                         "concreteType": "ResizedImageUrl",
                         "plural": false,
-                        "selections": v13
+                        "selections": v11
                       }
                     ]
                   },
@@ -1487,11 +1997,11 @@ return {
                   },
                   v9,
                   v4,
-                  v10
+                  v26
                 ]
               },
-              v16,
-              v7,
+              v29,
+              v21,
               v9,
               {
                 "kind": "LinkedField",
@@ -1502,13 +2012,7 @@ return {
                 "concreteType": "Location",
                 "plural": true,
                 "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "city",
-                    "args": null,
-                    "storageKey": null
-                  },
+                  v19,
                   v2
                 ]
               },
@@ -1577,9 +2081,9 @@ return {
                 "concreteType": "ResizedImageUrl",
                 "plural": false,
                 "selections": [
-                  v17,
-                  v18,
-                  v12
+                  v30,
+                  v31,
+                  v10
                 ]
               }
             ]
@@ -1633,7 +2137,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v19,
+              v16,
               v2,
               {
                 "kind": "InlineFragment",
@@ -1666,8 +2170,8 @@ return {
             "args": null,
             "storageKey": null
           },
-          v20,
-          v21,
+          v32,
+          v33,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1684,7 +2188,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v22,
+              v34,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1699,15 +2203,15 @@ return {
                     "alias": null,
                     "name": "url",
                     "args": [
-                      v23
+                      v35
                     ],
                     "storageKey": "url(version:\"square\")"
                   }
                 ]
               },
               v2,
-              v7,
-              v24,
+              v21,
+              v36,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1749,7 +2253,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v25,
+              v37,
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1757,8 +2261,8 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v26,
-              v27
+              v38,
+              v39
             ]
           },
           {
@@ -1770,7 +2274,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v19,
+              v16,
               v2,
               {
                 "kind": "InlineFragment",
@@ -1778,10 +2282,10 @@ return {
                 "selections": [
                   v8,
                   v9,
-                  v22,
-                  v24,
-                  v25,
-                  v26,
+                  v34,
+                  v36,
+                  v37,
+                  v38,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1802,7 +2306,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v19,
+              v16,
               v2,
               {
                 "kind": "InlineFragment",
@@ -1824,7 +2328,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v27,
+                  v39,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -1834,7 +2338,7 @@ return {
                     "concreteType": "Profile",
                     "plural": false,
                     "selections": [
-                      v16,
+                      v29,
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1843,7 +2347,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": false,
-                        "selections": v28
+                        "selections": v40
                       },
                       v2
                     ]
@@ -1861,7 +2365,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v19,
+              v16,
               v2,
               {
                 "kind": "InlineFragment",
@@ -1869,7 +2373,7 @@ return {
                 "selections": [
                   v8,
                   v9,
-                  v15,
+                  v28,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1885,7 +2389,7 @@ return {
                     "args": null,
                     "concreteType": "Image",
                     "plural": false,
-                    "selections": v28
+                    "selections": v40
                   }
                 ]
               }
@@ -1918,9 +2422,9 @@ return {
               v4,
               v5,
               v6,
-              v14,
-              v21,
-              v29
+              v27,
+              v33,
+              v41
             ]
           },
           {
@@ -1977,7 +2481,7 @@ return {
                 "concreteType": "SaleArtworkCurrentBid",
                 "plural": false,
                 "selections": [
-                  v30
+                  v42
                 ]
               },
               {
@@ -2007,13 +2511,13 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
-                  v31,
-                  v30
+                  v43,
+                  v42
                 ]
               }
             ]
           },
-          v7,
+          v21,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -2021,7 +2525,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          v29,
+          v41,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -2090,7 +2594,7 @@ return {
                 "concreteType": "BidderPosition",
                 "plural": false,
                 "selections": [
-                  v32,
+                  v44,
                   v2
                 ]
               },
@@ -2103,7 +2607,7 @@ return {
                 "concreteType": "BidderPosition",
                 "plural": false,
                 "selections": [
-                  v32,
+                  v44,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -2113,8 +2617,8 @@ return {
                     "concreteType": "BidderPositionMaxBid",
                     "plural": false,
                     "selections": [
-                      v30,
-                      v31
+                      v42,
+                      v43
                     ]
                   },
                   v2
@@ -2154,14 +2658,14 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "description",
-            "args": v33,
+            "args": v45,
             "storageKey": "description(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "additional_information",
-            "args": v33,
+            "args": v45,
             "storageKey": "additional_information(format:\"HTML\")"
           },
           {
@@ -2193,7 +2697,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": v34
+            "selections": v46
           },
           {
             "kind": "LinkedField",
@@ -2203,7 +2707,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": v34
+            "selections": v46
           },
           {
             "kind": "LinkedField",
@@ -2213,7 +2717,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": v34
+            "selections": v46
           },
           {
             "kind": "LinkedField",
@@ -2223,7 +2727,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": v34
+            "selections": v46
           },
           {
             "kind": "LinkedField",
@@ -2293,7 +2797,7 @@ return {
                     ],
                     "concreteType": "ResizedImageUrl",
                     "plural": false,
-                    "selections": v13
+                    "selections": v11
                   }
                 ]
               },
@@ -2312,21 +2816,21 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "literature",
-            "args": v33,
+            "args": v45,
             "storageKey": "literature(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "exhibition_history",
-            "args": v33,
+            "args": v45,
             "storageKey": "exhibition_history(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "provenance",
-            "args": v33,
+            "args": v45,
             "storageKey": "provenance(format:\"HTML\")"
           },
           {
@@ -2359,7 +2863,7 @@ return {
             "concreteType": "Image",
             "plural": true,
             "selections": [
-              v12,
+              v10,
               v4,
               {
                 "kind": "ScalarField",
@@ -2404,7 +2908,7 @@ return {
                 ],
                 "concreteType": "ResizedImageUrl",
                 "plural": false,
-                "selections": v13
+                "selections": v11
               },
               {
                 "kind": "ScalarField",
@@ -2553,8 +3057,8 @@ return {
                 ],
                 "storageKey": "url(version:\"larger\")"
               },
-              v18,
-              v17
+              v31,
+              v30
             ]
           },
           {
@@ -2608,7 +3112,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      v20
+                      v32
                     ]
                   },
                   {


### PR DESCRIPTION
This commit removes the nested QueryRenderer for the ArtistInfo component on the Artwork page, allowing the component to render server-side. This allows search engines to index the data.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-953 :lock: