### PR TITLE
Use the current URL to determine the paginated URL in a shared component

### DIFF
--- a/src/Apps/Collect/Components/Base/CollectArtworkGrid.tsx
+++ b/src/Apps/Collect/Components/Base/CollectArtworkGrid.tsx
@@ -56,7 +56,11 @@ class CollectArtworkGrid extends Component<Props, LoadingAreaState> {
         const urlFragment = urlFragmentFromState(state, { page })
 
         // TODO: Look into using router push w/ query params.
-        window.history.pushState({}, null, `/collect?${urlFragment}`)
+        window.history.pushState(
+          {},
+          null,
+          `${window.location.pathname}?${urlFragment}`
+        )
         if (error) {
           console.error(error)
         }


### PR DESCRIPTION
There was a small bug in #2369. It made the assumption in `<CollectArtworkGrid>` that the URL was `/collect`...but that component is used by both the `/collect` and `/collection/:collectionId` routes. The result was that paging through results on https://staging.artsy.net/collection/art-of-polka-dots would change the URL to https://staging.artsy.net/collect?page=X. 

This change pulls the path from the current location, instead of a hardcoded value.

For the record, #2369 has been merged & deployed to staging. This fix would ideally also get merged before our next production deploy of Force.
