### PR TITLE
Auth footer updates

### DIFF
--- a/src/Components/Authentication/Desktop/ForgotPasswordForm.tsx
+++ b/src/Components/Authentication/Desktop/ForgotPasswordForm.tsx
@@ -69,7 +69,7 @@ export class ForgotPasswordForm extends Component<
                 handleTypeChange={() =>
                   this.props.handleTypeChange(ModalType.login)
                 }
-                mode="forgot"
+                mode={"forgot" as ModalType}
               />
             </Form>
           )

--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -1,7 +1,4 @@
-import { Formik, FormikProps } from "formik"
-import React, { Component } from "react"
-import styled from "styled-components"
-
+import { Flex } from "@artsy/palette"
 import {
   Error,
   Footer,
@@ -17,12 +14,8 @@ import {
 import { LoginValidator } from "Components/Authentication/Validators"
 import PasswordInput from "Components/PasswordInput"
 import QuickInput from "Components/QuickInput"
-
-const Row = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`
+import { Formik, FormikProps } from "formik"
+import React, { Component } from "react"
 
 export interface LoginFormState {
   error: string
@@ -61,7 +54,7 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
           }
 
           return (
-            <Form onSubmit={handleSubmit} height={320}>
+            <Form onSubmit={handleSubmit}>
               <QuickInput
                 block
                 error={touched.email && errors.email}
@@ -84,20 +77,19 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
                 onChange={handleChange}
                 onBlur={handleBlur}
               />
-              <Row>
+              <Flex alignItems="center" justifyContent="flex-end">
                 <ForgotPassword
                   onClick={() => this.props.handleTypeChange(ModalType.forgot)}
                 />
-              </Row>
+              </Flex>
               {globalError && <Error show>{globalError}</Error>}
               <SubmitButton loading={isSubmitting}>Log in</SubmitButton>
               <Footer
                 handleTypeChange={() =>
                   this.props.handleTypeChange(ModalType.signup)
                 }
-                mode="login"
+                mode={"login" as ModalType}
                 onFacebookLogin={this.props.onFacebookLogin}
-                onTwitterLogin={this.props.onTwitterLogin}
                 inline
               />
             </Form>

--- a/src/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/Components/Authentication/Desktop/ModalManager.tsx
@@ -31,6 +31,7 @@ export interface ModalManagerProps {
   onSocialAuthEvent?: (options) => void
   onModalOpen?: () => void
   onModalClose?: () => void
+  showRecaptchaDisclaimer?: boolean
 }
 
 export interface ModalManagerState {
@@ -133,6 +134,7 @@ export class ModalManager extends Component<
           options={options}
           handleTypeChange={this.handleTypeChange}
           onSocialAuthEvent={this.props.onSocialAuthEvent}
+          showRecaptchaDisclaimer={this.props.showRecaptchaDisclaimer}
         />
       </DesktopModal>
     )

--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -115,6 +115,7 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
                   }
                 }}
                 inline
+                showRecaptchaDisclaimer={this.props.showRecaptchaDisclaimer}
               />
             </Form>
           )

--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -52,7 +52,7 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
           }
 
           return (
-            <Form onSubmit={handleSubmit} height={430}>
+            <Form onSubmit={handleSubmit}>
               <QuickInput
                 block
                 error={touched.email && errors.email}
@@ -114,7 +114,6 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
                     this.props.onFacebookLogin(e)
                   }
                 }}
-                onTwitterLogin={this.props.onTwitterLogin}
                 inline
               />
             </Form>

--- a/src/Components/Authentication/Footer.tsx
+++ b/src/Components/Authentication/Footer.tsx
@@ -1,68 +1,87 @@
+import { Box, Flex, Link } from "@artsy/palette"
 import React from "react"
-import styled from "styled-components"
+import { CaptchaTerms, FooterText } from "./commonElements"
+import { ModalType } from "./Types"
 
-import { SmallText, SmallTextLink } from "./commonElements"
-
-interface Props {
+interface FooterProps {
+  handleTypeChange?: (modalType: ModalType) => void
   inline?: boolean
+  mode?: ModalType
+  onFacebookLogin?: any
 }
 
-const FooterContainer = styled.div`
-  display: ${(props: Props) => (props.inline ? "inline" : "flex")};
-  flex-direction: column;
-`
-// TODO: Remove twitter logic once deprecated
-export const Footer = props => {
+export const Footer = (props: FooterProps) => {
   const { onFacebookLogin, handleTypeChange, mode, inline } = props
 
   switch (mode) {
     case "login": {
       return (
-        <FooterContainer inline={inline}>
-          <SmallText>
+        <Flex flexDirection={inline ? "row" : "column"} justifyContent="center">
+          <FooterText>
             {"Log in using "}
-            <SmallTextLink onClick={onFacebookLogin}>Facebook</SmallTextLink>
+            <Link color="black60" onClick={onFacebookLogin}>
+              Facebook
+            </Link>
             {". "}
-          </SmallText>
-
-          <SmallText>
-            {" Don’t have an account? "}
-            <SmallTextLink onClick={() => handleTypeChange("signup")}>
+          </FooterText>
+          <FooterText>
+            {"Don’t have an account? "}
+            <Link
+              color="black60"
+              onClick={() => handleTypeChange("signup" as ModalType)}
+            >
               Sign up.
-            </SmallTextLink>
-          </SmallText>
-        </FooterContainer>
+            </Link>
+          </FooterText>
+        </Flex>
       )
     }
     case "forgot": {
       return (
-        <FooterContainer inline={inline}>
-          <SmallText>
+        <Box textAlign="center">
+          <FooterText>
             {"Don’t need to reset? "}
-            <SmallTextLink onClick={() => handleTypeChange("login")}>
+            <Link
+              color="black60"
+              onClick={() => handleTypeChange("login" as ModalType)}
+            >
               Log in
-            </SmallTextLink>
+            </Link>
             {" or "}
-            <SmallTextLink onClick={() => handleTypeChange("signup")}>
+            <Link
+              color="black60"
+              onClick={() => handleTypeChange("signup" as ModalType)}
+            >
               sign up.
-            </SmallTextLink>
-          </SmallText>
-        </FooterContainer>
+            </Link>
+          </FooterText>
+        </Box>
       )
     }
     default: {
       return (
-        <FooterContainer inline={inline}>
-          <SmallTextLink onClick={onFacebookLogin}>
-            Sign up using Facebook.
-          </SmallTextLink>
-          <SmallText>
-            {" Already have an account? "}
-            <SmallTextLink onClick={() => handleTypeChange("login")}>
-              Log in.
-            </SmallTextLink>
-          </SmallText>
-        </FooterContainer>
+        <Box>
+          <Flex
+            flexDirection={inline ? "row" : "column"}
+            justifyContent="center"
+          >
+            <FooterText>
+              <Link color="black60" onClick={onFacebookLogin}>
+                Sign up using Facebook.
+              </Link>{" "}
+            </FooterText>
+            <FooterText>
+              {"Already have an account? "}
+              <Link
+                color="black60"
+                onClick={() => handleTypeChange("login" as ModalType)}
+              >
+                Log in.
+              </Link>
+            </FooterText>
+          </Flex>
+          <CaptchaTerms />
+        </Box>
       )
     }
   }

--- a/src/Components/Authentication/Footer.tsx
+++ b/src/Components/Authentication/Footer.tsx
@@ -7,7 +7,7 @@ interface FooterProps {
   handleTypeChange?: (modalType: ModalType) => void
   inline?: boolean
   mode?: ModalType
-  onFacebookLogin?: any
+  onFacebookLogin?: (e: any) => void
   showRecaptchaDisclaimer?: boolean
 }
 

--- a/src/Components/Authentication/Footer.tsx
+++ b/src/Components/Authentication/Footer.tsx
@@ -8,10 +8,17 @@ interface FooterProps {
   inline?: boolean
   mode?: ModalType
   onFacebookLogin?: any
+  showRecaptchaDisclaimer?: boolean
 }
 
 export const Footer = (props: FooterProps) => {
-  const { onFacebookLogin, handleTypeChange, mode, inline } = props
+  const {
+    handleTypeChange,
+    inline,
+    mode,
+    onFacebookLogin,
+    showRecaptchaDisclaimer,
+  } = props
 
   switch (mode) {
     case "login": {
@@ -80,7 +87,7 @@ export const Footer = (props: FooterProps) => {
               </Link>
             </FooterText>
           </Flex>
-          <CaptchaTerms />
+          {showRecaptchaDisclaimer && <CaptchaTerms />}
         </Box>
       )
     }

--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -28,12 +28,13 @@ export interface FormSwitcherProps {
   onTwitterLogin?: (e: Event) => void
   options: ModalOptions
   title?: string
-  tracking?: TrackingProp
-  type: ModalType
+  showRecaptchaDisclaimer?: boolean
   submitUrls?: { [P in ModalType]: string } & {
     facebook?: string
     twitter?: string
   }
+  tracking?: TrackingProp
+  type: ModalType
   values?: InputValues
   onSocialAuthEvent?: (options) => void
   onBackButtonClicked?: (e: Event) => void
@@ -118,7 +119,13 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
   }
 
   render() {
-    const { error, isMobile, title, options } = this.props
+    const {
+      error,
+      isMobile,
+      title,
+      options,
+      showRecaptchaDisclaimer,
+    } = this.props
 
     const queryData = Object.assign(
       {},
@@ -191,19 +198,7 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
                 "&service=facebook"
             }
           }}
-          onTwitterLogin={() => {
-            if (this.props.onSocialAuthEvent) {
-              this.props.onSocialAuthEvent({
-                ...options,
-                service: "twitter",
-              })
-            }
-
-            if (typeof window !== "undefined") {
-              window.location.href =
-                this.props.submitUrls + `?${authQueryData}` + "&service=twitter"
-            }
-          }}
+          showRecaptchaDisclaimer={showRecaptchaDisclaimer}
         />
       </Theme>
     )

--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -1,3 +1,4 @@
+import { Theme } from "@artsy/palette"
 import qs from "querystring"
 import React from "react"
 import track, { TrackingProp } from "react-tracking"
@@ -165,44 +166,46 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
     }
 
     return (
-      <Form
-        title={title}
-        contextModule={options.contextModule}
-        error={error}
-        values={defaultValues}
-        handleTypeChange={this.handleTypeChange}
-        handleSubmit={handleSubmit}
-        intent={options.intent}
-        onBackButtonClicked={onBackButtonClicked}
-        onFacebookLogin={() => {
-          if (this.props.onSocialAuthEvent) {
-            this.props.onSocialAuthEvent({
-              ...options,
-              service: "facebook",
-            })
-          }
+      <Theme>
+        <Form
+          title={title}
+          contextModule={options.contextModule}
+          error={error}
+          values={defaultValues}
+          handleTypeChange={this.handleTypeChange}
+          handleSubmit={handleSubmit}
+          intent={options.intent}
+          onBackButtonClicked={onBackButtonClicked}
+          onFacebookLogin={() => {
+            if (this.props.onSocialAuthEvent) {
+              this.props.onSocialAuthEvent({
+                ...options,
+                service: "facebook",
+              })
+            }
 
-          if (typeof window !== "undefined") {
-            window.location.href =
-              this.props.submitUrls.facebook +
-              `?${authQueryData}` +
-              "&service=facebook"
-          }
-        }}
-        onTwitterLogin={() => {
-          if (this.props.onSocialAuthEvent) {
-            this.props.onSocialAuthEvent({
-              ...options,
-              service: "twitter",
-            })
-          }
+            if (typeof window !== "undefined") {
+              window.location.href =
+                this.props.submitUrls.facebook +
+                `?${authQueryData}` +
+                "&service=facebook"
+            }
+          }}
+          onTwitterLogin={() => {
+            if (this.props.onSocialAuthEvent) {
+              this.props.onSocialAuthEvent({
+                ...options,
+                service: "twitter",
+              })
+            }
 
-          if (typeof window !== "undefined") {
-            window.location.href =
-              this.props.submitUrls + `?${authQueryData}` + "&service=twitter"
-          }
-        }}
-      />
+            if (typeof window !== "undefined") {
+              window.location.href =
+                this.props.submitUrls + `?${authQueryData}` + "&service=twitter"
+            }
+          }}
+        />
+      </Theme>
     )
   }
 }

--- a/src/Components/Authentication/Mobile/ForgotPasswordForm.tsx
+++ b/src/Components/Authentication/Mobile/ForgotPasswordForm.tsx
@@ -10,7 +10,7 @@ import {
 import QuickInput from "Components/QuickInput"
 import { Formik, FormikProps } from "formik"
 import React from "react"
-import { FormComponentType, InputValues } from "../Types"
+import { FormComponentType, InputValues, ModalType } from "../Types"
 import { ForgotPasswordValidator } from "../Validators"
 
 export const MobileForgotPasswordForm: FormComponentType = props => {
@@ -56,7 +56,7 @@ export const MobileForgotPasswordForm: FormComponentType = props => {
                 </SubmitButton>
                 <Footer
                   handleTypeChange={props.handleTypeChange}
-                  mode="forgot"
+                  mode={"forgot" as ModalType}
                 />
               </Form>
             </MobileInnerWrapper>

--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -1,12 +1,12 @@
+import { Flex } from "@artsy/palette"
 import Colors from "Assets/Colors"
 import { checkEmail } from "Components/Authentication/helpers"
+import Icon from "Components/Icon"
+import PasswordInput from "Components/PasswordInput"
+import { ProgressIndicator } from "Components/ProgressIndicator"
+import QuickInput from "Components/QuickInput"
+import { Step, Wizard } from "Components/Wizard"
 import React, { Component, Fragment } from "react"
-import styled from "styled-components"
-import Icon from "../../Icon"
-import PasswordInput from "../../PasswordInput"
-import { ProgressIndicator } from "../../ProgressIndicator"
-import QuickInput from "../../QuickInput"
-import { Step, Wizard } from "../../Wizard"
 import {
   BackButton,
   Error,
@@ -17,7 +17,7 @@ import {
   MobileInnerWrapper,
   SubmitButton,
 } from "../commonElements"
-import { FormProps } from "../Types"
+import { FormProps, ModalType } from "../Types"
 import { MobileLoginValidator } from "../Validators"
 
 export class MobileLoginForm extends Component<FormProps> {
@@ -93,9 +93,9 @@ export class MobileLoginForm extends Component<FormProps> {
               setTouched={setTouched}
               touchedOnChange={false}
             />
-            <Row>
+            <Flex alignItems="center" justifyContent="flex-end">
               <ForgotPassword onClick={() => (location.href = "/forgot")} />
-            </Row>
+            </Flex>
           </Fragment>
         )}
       </Step>,
@@ -137,10 +137,9 @@ export class MobileLoginForm extends Component<FormProps> {
                   {isLastStep ? "Log in" : "Next"}
                 </SubmitButton>
                 <Footer
-                  mode="login"
+                  mode={"login" as ModalType}
                   handleTypeChange={this.props.handleTypeChange}
                   onFacebookLogin={this.props.onFacebookLogin}
-                  onTwitterLogin={this.props.onTwitterLogin}
                 />
               </MobileInnerWrapper>
             </MobileContainer>
@@ -150,9 +149,3 @@ export class MobileLoginForm extends Component<FormProps> {
     )
   }
 }
-
-const Row = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -215,6 +215,7 @@ export class MobileSignUpForm extends Component<
                     }
                   }}
                   handleTypeChange={this.props.handleTypeChange}
+                  showRecaptchaDisclaimer={this.props.showRecaptchaDisclaimer}
                 />
               </MobileInnerWrapper>
             </MobileContainer>

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -1,6 +1,5 @@
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
-import Colors from "Assets/Colors"
 import {
   BackButton,
   Error,
@@ -12,7 +11,7 @@ import {
   TermsOfServiceCheckbox,
 } from "Components/Authentication/commonElements"
 import { checkEmail } from "Components/Authentication/helpers"
-import { FormProps } from "Components/Authentication/Types"
+import { FormProps, ModalType } from "Components/Authentication/Types"
 import { MobileSignUpValidator } from "Components/Authentication/Validators"
 import Icon from "Components/Icon"
 import PasswordInput from "Components/PasswordInput"
@@ -166,11 +165,7 @@ export class MobileSignUpForm extends Component<
                       : wizard.previous(e, values)
                   }
                 >
-                  <Icon
-                    name="chevron-left"
-                    color={Colors.graySemibold}
-                    fontSize="16px"
-                  />
+                  <Icon name="chevron-left" color="black60" fontSize="16px" />
                 </BackButton>
                 <MobileHeader>
                   {this.props.title || "Sign up for Artsy"}
@@ -200,7 +195,7 @@ export class MobileSignUpForm extends Component<
                   {isLastStep ? "Create account" : "Next"}
                 </SubmitButton>
                 <Footer
-                  mode="signup"
+                  mode={"signup" as ModalType}
                   onFacebookLogin={e => {
                     if (!values.accepted_terms_of_service) {
                       this.setState(
@@ -219,7 +214,6 @@ export class MobileSignUpForm extends Component<
                       }
                     }
                   }}
-                  onTwitterLogin={this.props.onTwitterLogin}
                   handleTypeChange={this.props.handleTypeChange}
                 />
               </MobileInnerWrapper>

--- a/src/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -1,6 +1,5 @@
-import Colors from "Assets/Colors"
+import { Link, Serif } from "@artsy/palette"
 import Checkbox from "Components/Checkbox"
-import Text from "Components/Text"
 import React from "react"
 import styled from "styled-components"
 
@@ -12,20 +11,24 @@ export const TermsOfServiceCheckbox = ({
   value,
   ...props
 }) => {
-  const color = error && !value ? Colors.redMedium : Colors.graySemibold
+  const color = error && !value ? "red100" : "black60"
   return (
     <StyledCheckbox {...{ checked: value, error, onChange, onBlur, name }}>
-      <TOSText color={color}>
+      <Serif color={color} size="3t" ml={0.5}>
         {"I agree to Artsy’s "}
-        <A href="https://www.artsy.net/terms" target="_blank" color={color}>
+        <Link href="https://www.artsy.net/terms" target="_blank" color={color}>
           Terms of Use
-        </A>
+        </Link>
         {" and "}
-        <A href="https://www.artsy.net/privacy" target="_blank" color={color}>
+        <Link
+          href="https://www.artsy.net/privacy"
+          target="_blank"
+          color={color}
+        >
           Privacy Policy
-        </A>
+        </Link>
         {", and to receive emails from Artsy."}
-      </TOSText>
+      </Serif>
     </StyledCheckbox>
   )
 }
@@ -33,12 +36,4 @@ export const TermsOfServiceCheckbox = ({
 const StyledCheckbox = styled(Checkbox)`
   margin: 5px 0;
   align-items: flex-start;
-`
-const A = styled.a`
-  color: ${props => props.color};
-`
-
-export const TOSText = styled(Text)`
-  margin: 0 0 0 5px;
-  line-height: 22px;
 `

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -30,10 +30,10 @@ export interface FormProps {
   handleTypeChange?: (modalType: ModalType) => void
   intent?: string
   onFacebookLogin?: (e: Event) => void
-  onTwitterLogin?: (e: Event) => void
   onBackButtonClicked?: (e: Event) => void
   title?: string
   entityName?: string
+  showRecaptchaDisclaimer?: boolean
 }
 
 interface AfterSignUpAction {

--- a/src/Components/Authentication/__tests__/Desktop/SignUpForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Desktop/SignUpForm.test.tsx
@@ -4,22 +4,28 @@ import { Formik } from "formik"
 import React from "react"
 
 describe("SignUpForm", () => {
-  xit("calls handleSubmit with the right params", done => {
-    const props = {
+  let props
+
+  beforeEach(() => {
+    props = {
       handleSubmit: jest.fn(),
     }
+  })
 
+  const getWrapper = (passedProps = props) => {
+    return mount(<SignUpForm {...passedProps} />)
+  }
+
+  xit("calls handleSubmit with the right params", done => {
     const values = {
       email: "foo@bar.com",
       password: "password123",
       name: "John Doe",
       acceptedTermsOfService: true,
     }
+    props.values = values
 
-    const wrapper = mount(
-      <SignUpForm values={values} handleSubmit={props.handleSubmit} />
-    )
-
+    const wrapper = getWrapper()
     const formik = wrapper.find(Formik).instance() as any
     formik.submitForm()
     wrapper.update()
@@ -33,8 +39,16 @@ describe("SignUpForm", () => {
     })
   })
 
+  it("renders captcha disclaimer if showRecaptchaDisclaimer", () => {
+    props.showRecaptchaDisclaimer = true
+    const wrapper = getWrapper()
+    expect(wrapper.text()).toMatch(
+      "This site is protected by reCAPTCHA and the Google Privacy Policy Terms of Service apply."
+    )
+  })
+
   it("renders errors", done => {
-    const wrapper = mount(<SignUpForm handleSubmit={jest.fn()} />)
+    const wrapper = getWrapper()
     const button = wrapper.find(`input[name="email"]`)
     button.simulate("blur")
     wrapper.update()
@@ -45,9 +59,8 @@ describe("SignUpForm", () => {
   })
 
   it("clears error after input change", done => {
-    const wrapper = mount(
-      <SignUpForm error="Some global server error" handleSubmit={jest.fn()} />
-    )
+    props.error = "Some global server error"
+    const wrapper = getWrapper()
     const input = wrapper.find(`input[name="email"]`)
     expect((wrapper.state() as any).error).toEqual("Some global server error")
     input.simulate("change")
@@ -59,15 +72,13 @@ describe("SignUpForm", () => {
   })
 
   it("renders spinner", done => {
-    const values = {
+    props.values = {
       email: "foo@bar.com",
       password: "password123",
       name: "John Doe",
       acceptedTermsOfService: true,
     }
-    const wrapper = mount(
-      <SignUpForm handleSubmit={jest.fn()} values={values} />
-    )
+    const wrapper = getWrapper()
 
     const input = wrapper.find(`Formik`)
     input.simulate("submit")

--- a/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
+++ b/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
@@ -1,6 +1,6 @@
+import { Link } from "@artsy/palette"
 import { mount } from "enzyme"
 import React from "react"
-// import { SmallTextLink } from "../commonElements"
 import { ForgotPasswordForm } from "../Desktop/ForgotPasswordForm"
 import { LoginForm } from "../Desktop/LoginForm"
 import { SignUpForm } from "../Desktop/SignUpForm"
@@ -70,30 +70,30 @@ describe("FormSwitcher", () => {
     beforeEach(() => {
       window.location.assign = jest.fn()
     })
-    // it("redirects to a url if static or mobile", () => {
-    //   const wrapper = getWrapper({
-    //     type: ModalType.login,
-    //     isMobile: true,
-    //   })
+    it("redirects to a url if static or mobile", () => {
+      const wrapper = getWrapper({
+        type: ModalType.login,
+        isMobile: true,
+      })
 
-    //   wrapper
-    //     .find(SmallTextLink)
-    //     .at(1)
-    //     .simulate("click")
+      wrapper
+        .find(Link)
+        .at(1)
+        .simulate("click")
 
-    //   expect((window.location.assign as any).mock.calls[0][0]).toEqual(
-    //     "/signup?contextModule=Header&copy=Foo%20Bar&destination=%2Fcollect&intent=follow%20artist&redirectTo=%2Ffoo&trigger=timed&triggerSeconds=1"
-    //   )
-    // })
+      expect((window.location.assign as any).mock.calls[0][0]).toEqual(
+        "/signup?contextModule=Header&copy=Foo%20Bar&destination=%2Fcollect&intent=follow%20artist&redirectTo=%2Ffoo&trigger=timed&triggerSeconds=1"
+      )
+    })
 
-    xit("sets type and notifies parent component when type is changed", () => {
+    it("sets type and notifies parent component when type is changed", () => {
       const wrapper = getWrapper({
         type: ModalType.login,
       })
 
       wrapper
-        .find("SmallTextLink")
-        .at(1)
+        .find(Link)
+        .at(2)
         .simulate("click")
 
       expect((wrapper.state() as any).type).toMatch("signup")

--- a/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
+++ b/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { SmallTextLink } from "../commonElements"
+// import { SmallTextLink } from "../commonElements"
 import { ForgotPasswordForm } from "../Desktop/ForgotPasswordForm"
 import { LoginForm } from "../Desktop/LoginForm"
 import { SignUpForm } from "../Desktop/SignUpForm"
@@ -70,23 +70,23 @@ describe("FormSwitcher", () => {
     beforeEach(() => {
       window.location.assign = jest.fn()
     })
-    it("redirects to a url if static or mobile", () => {
-      const wrapper = getWrapper({
-        type: ModalType.login,
-        isMobile: true,
-      })
+    // it("redirects to a url if static or mobile", () => {
+    //   const wrapper = getWrapper({
+    //     type: ModalType.login,
+    //     isMobile: true,
+    //   })
 
-      wrapper
-        .find(SmallTextLink)
-        .at(1)
-        .simulate("click")
+    //   wrapper
+    //     .find(SmallTextLink)
+    //     .at(1)
+    //     .simulate("click")
 
-      expect((window.location.assign as any).mock.calls[0][0]).toEqual(
-        "/signup?contextModule=Header&copy=Foo%20Bar&destination=%2Fcollect&intent=follow%20artist&redirectTo=%2Ffoo&trigger=timed&triggerSeconds=1"
-      )
-    })
+    //   expect((window.location.assign as any).mock.calls[0][0]).toEqual(
+    //     "/signup?contextModule=Header&copy=Foo%20Bar&destination=%2Fcollect&intent=follow%20artist&redirectTo=%2Ffoo&trigger=timed&triggerSeconds=1"
+    //   )
+    // })
 
-    it("sets type and notifies parent component when type is changed", () => {
+    xit("sets type and notifies parent component when type is changed", () => {
       const wrapper = getWrapper({
         type: ModalType.login,
       })

--- a/src/Components/Authentication/__tests__/Mobile/SignUpForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Mobile/SignUpForm.test.tsx
@@ -4,27 +4,38 @@ import { mount } from "enzyme"
 import React from "react"
 
 describe("MobileSignUpForm", () => {
-  const handleSubmit = jest.fn()
-  const getWrapper = props =>
-    mount(
-      <MobileSignUpForm
-        {...props}
-        values={props.values || {}}
-        handleSubmit={handleSubmit}
-        handleTypeChange={jest.fn()}
-      />
-    )
+  let props
+
+  const getWrapper = (passedProps = props) => {
+    return mount(<MobileSignUpForm {...passedProps} />)
+  }
+
+  beforeEach(() => {
+    props = {
+      values: {},
+      handleSubmit: jest.fn(),
+      handleTypeChange: jest.fn(),
+    }
+  })
 
   it("renders the first step", () => {
-    const wrapper = getWrapper({})
+    const wrapper = getWrapper()
     const input = wrapper.find(QuickInput)
     expect(input.length).toBe(1)
     expect(input.props().type).toEqual("email")
     expect(wrapper.text()).toContain("Sign up for Artsy")
   })
 
+  it("renders captcha disclaimer if showRecaptchaDisclaimer", () => {
+    props.showRecaptchaDisclaimer = true
+    const wrapper = getWrapper()
+    expect(wrapper.text()).toMatch(
+      "This site is protected by reCAPTCHA and the Google Privacy Policy Terms of Service apply."
+    )
+  })
+
   it("renders errors", done => {
-    const wrapper = getWrapper({})
+    const wrapper = getWrapper()
     const button = wrapper.find("button")
     button.simulate("submit")
     wrapper.update()
@@ -35,7 +46,8 @@ describe("MobileSignUpForm", () => {
   })
 
   it("renders password error", () => {
-    const wrapper = getWrapper({ values: { email: "kajsdlfjk" } })
+    props.values = { email: "kajsdlfjk" }
+    const wrapper = getWrapper()
     const formik: any = wrapper.find("Formik").instance()
     formik.setStatus({ error: "some password error" })
     wrapper.update()
@@ -43,18 +55,14 @@ describe("MobileSignUpForm", () => {
   })
 
   it("renders the specified title", () => {
-    const wrapper = getWrapper({ title: "Sign up to follow Andy Warhol" })
-
+    props.title = "Sign up to follow Andy Warhol"
+    const wrapper = getWrapper()
     expect(wrapper.text()).toContain("Sign up to follow Andy Warhol")
   })
 
   it("renders global errors", () => {
-    const wrapper = mount(
-      <MobileSignUpForm
-        error="Some global server error"
-        handleSubmit={jest.fn()}
-      />
-    )
+    props.error = "Some global server error"
+    const wrapper = getWrapper()
     wrapper.update()
     expect(wrapper.html()).toMatch("Some global server error")
   })

--- a/src/Components/Authentication/commonElements.tsx
+++ b/src/Components/Authentication/commonElements.tsx
@@ -73,8 +73,8 @@ export const MobileHeader = (props: {
   </Flex>
 )
 
-export const FooterText = (props: { children: any }) => (
-  <Sans size="2" color="black60" mt={1} mr={0.5} textAlign="center">
+export const FooterText = (props: { children: any; mt?: number }) => (
+  <Sans size="2" color="black60" mt={props.mt || 1} mr={0.5} textAlign="center">
     {props.children}
   </Sans>
 )
@@ -95,7 +95,7 @@ export const SubmitButton = (props: ButtonProps) => (
 
 export const CaptchaTerms = () => {
   return (
-    <FooterText>
+    <FooterText mt={2}>
       This site is protected by reCAPTCHA and the Google{" "}
       <Link color="black60" href="https://policies.google.com/privacy">
         Privacy Policy

--- a/src/Components/Authentication/commonElements.tsx
+++ b/src/Components/Authentication/commonElements.tsx
@@ -1,57 +1,22 @@
 import { growAndFadeIn } from "Assets/Animations"
-import { garamond, unica } from "Assets/Fonts"
 import React from "react"
 import styled from "styled-components"
 export { Footer } from "./Footer"
 export { TermsOfServiceCheckbox } from "./TermsOfServiceCheckbox"
-import { Button, ButtonProps, color } from "@artsy/palette"
+import {
+  Box,
+  Button,
+  ButtonProps,
+  Flex,
+  Link,
+  Sans,
+  Serif,
+} from "@artsy/palette"
 
-interface FormProps {
-  height?: number
-}
-
-export const FormContainer = styled.form`
+export const FormContainer = styled.form<{ height?: number }>`
   display: flex;
   flex-direction: column;
-  height: ${(p: FormProps) => (p.height ? p.height + "px" : "auto")};
-`
-
-export const SmallTextLink = styled.a`
-  color: ${color("black60")};
-  text-decoration: underline;
-  cursor: pointer;
-  ${unica("s12")};
-`
-
-SmallTextLink.displayName = "SmallTextLink"
-
-export const SmallText = styled.span`
-  margin: 0;
-  color: ${color("black60")};
-  ${unica("s12")};
-  line-height: 2.25em;
-`
-
-export const MobileHeader = styled.div`
-  display: flex;
-  text-align: center;
-  justify-content: center;
-  flex-direction: row;
-  padding: 10px;
-  margin: 20px 0 0;
-  ${garamond("s23")};
-  font-weight: bold;
-`
-
-export const Error = styled.div.attrs<{ show: boolean }>({})`
-  ${unica("s12")};
-  margin-top: ${p => (p.show ? "auto" : "0")};
-  margin-bottom: 10px;
-  color: ${color("red100")};
-  visibility: ${p => (p.show ? "visible" : "hidden")};
-  transition: visibility 0.2s linear;
-  animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
-  height: ${p => (p.show ? "auto" : "0")};
+  min-height: ${p => (p.height ? p.height + "px" : "auto")};
 `
 
 export const MobileInnerWrapper = styled.div`
@@ -82,13 +47,44 @@ export const BackButton = styled.div`
   cursor: pointer;
 `
 
-const ForgotPasswordLink = styled(SmallTextLink)`
-  margin-left: auto;
-  color: ${color("black60")};
+export const ErrorContainer = styled(Box)<{ show: boolean }>`
+  margin-top: ${p => (p.show ? "auto" : "0")};
+  visibility: ${p => (p.show ? "visible" : "hidden")};
+  transition: visibility 0.2s linear;
+  animation: ${p => p.show && growAndFadeIn("16px")} 0.25s linear;
+  height: ${p => (p.show ? "auto" : "0")};
 `
 
-export const ForgotPassword = props => (
-  <ForgotPasswordLink {...props}>Forgot Password?</ForgotPasswordLink>
+export const Error = (props: { children: any; show: boolean }) => (
+  <ErrorContainer show={props.show} mb={1}>
+    <Sans size="2" color="red100">
+      {props.children}
+    </Sans>
+  </ErrorContainer>
+)
+
+export const MobileHeader = (props: {
+  children: React.ReactElement | string
+}) => (
+  <Flex p={1} mt={2} justifyContent="center">
+    <Serif size="5t" weight="semibold" textAlign="center">
+      {props.children}
+    </Serif>
+  </Flex>
+)
+
+export const FooterText = (props: { children: any }) => (
+  <Sans size="2" color="black60" mt={1} mr={0.5} textAlign="center">
+    {props.children}
+  </Sans>
+)
+
+export const ForgotPassword = (props: { onClick: () => void }) => (
+  <Sans size="2">
+    <Link color="black60" {...props}>
+      Forgot Password?
+    </Link>
+  </Sans>
 )
 
 export const SubmitButton = (props: ButtonProps) => (
@@ -96,3 +92,18 @@ export const SubmitButton = (props: ButtonProps) => (
     {props.children}
   </Button>
 )
+
+export const CaptchaTerms = () => {
+  return (
+    <FooterText>
+      This site is protected by reCAPTCHA and the Google{" "}
+      <Link color="black60" href="https://policies.google.com/privacy">
+        Privacy Policy
+      </Link>{" "}
+      <Link color="black60" href="https://policies.google.com/terms">
+        Terms of Service
+      </Link>{" "}
+      apply.
+    </FooterText>
+  )
+}

--- a/src/Components/__stories__/Authentication.story.tsx
+++ b/src/Components/__stories__/Authentication.story.tsx
@@ -97,19 +97,21 @@ storiesOf("Components/Authentication/Mobile", module)
 storiesOf("Components/Authentication/Common Elements", module)
   .add("Footer - Signup", () => (
     <div>
-      <Footer mode="signup" />
+      <Footer mode={"signup" as ModalType} />
       <br />
-      <Footer mode="signup" inline />
+      <Footer mode={"signup" as ModalType} inline />
     </div>
   ))
   .add("Footer - Login", () => (
     <div>
-      <Footer mode="login" />
+      <Footer mode={"login" as ModalType} />
       <br />
-      <Footer mode="login" inline />
+      <Footer mode={"login" as ModalType} inline />
     </div>
   ))
-  .add("Footer - Forgot Password", () => <Footer mode="forgot" />)
+  .add("Footer - Forgot Password", () => (
+    <Footer mode={"forgot" as ModalType} />
+  ))
   .add("TermsOfServiceCheckbox", () => (
     <TermsOfServiceCheckbox
       error={null}


### PR DESCRIPTION
Related to work adding reCAPTCHA to auth forms, this PR adds an optional google disclaimer text.  Currently this is only available on the signup form, and uses a prop from Force to be turned on when we are ready.

Some updates were made to the footer text generally (design point-person: Jeffrey), with some minor refactoring to replace fonts and colors from `/Assets` with their Palette equivalents. 

Props for `onTwitterLogin` have been removed, because we no longer have the links to allow login/signup with this method.

Also added `ModalType` in a few places, which kills some errors that appear when linking Reaction and Force.  

<img width="465" alt="Screen Shot 2019-05-08 at 2 55 54 PM" src="https://user-images.githubusercontent.com/1497424/57400501-a0070a00-71a1-11e9-8b6d-4607ffee1e64.png">
<img width="407" alt="Screen Shot 2019-05-08 at 2 54 54 PM" src="https://user-images.githubusercontent.com/1497424/57400509-a4cbbe00-71a1-11e9-90c3-9d915b7f7014.png">
