### PR TITLE
Creates patch for react-flickity-component to fix flicker

### DIFF
--- a/patches/react-flickity-component+3.2.0.patch
+++ b/patches/react-flickity-component+3.2.0.patch
@@ -1,0 +1,60 @@
+diff --git a/node_modules/react-flickity-component/lib/index.js b/node_modules/react-flickity-component/lib/index.js
+index 9dfb420..895a2d1 100644
+--- a/node_modules/react-flickity-component/lib/index.js
++++ b/node_modules/react-flickity-component/lib/index.js
+@@ -55,11 +55,11 @@ var FlickityComponent = function (_Component) {
+     key: 'componentDidUpdate',
+     value: function componentDidUpdate(prevProps, prevState) {
+       var _props = this.props,
+-          children = _props.children,
+-          _props$options = _props.options,
+-          draggable = _props$options.draggable,
+-          initialIndex = _props$options.initialIndex,
+-          reloadOnUpdate = _props.reloadOnUpdate;
++        children = _props.children,
++        _props$options = _props.options,
++        draggable = _props$options.draggable,
++        initialIndex = _props$options.initialIndex,
++        reloadOnUpdate = _props.reloadOnUpdate;
+       var flickityReady = this.state.flickityReady;
+ 
+       if (reloadOnUpdate || !prevState.flickityReady && flickityReady) {
+@@ -78,25 +78,18 @@ var FlickityComponent = function (_Component) {
+ 
+       if (!_ExecutionEnvironment.canUseDOM) return null;
+       var _props2 = this.props,
+-          disableImagesLoaded = _props2.disableImagesLoaded,
+-          flickityRef = _props2.flickityRef,
+-          options = _props2.options;
++        disableImagesLoaded = _props2.disableImagesLoaded,
++        flickityRef = _props2.flickityRef,
++        options = _props2.options;
+ 
+       var carousel = this.carousel;
+       this.flkty = new _flickity2.default(carousel, options);
+       var setFlickityToReady = function setFlickityToReady() {
+         return _this2.setState({ flickityReady: true });
+       };
+-      if (disableImagesLoaded) setFlickityToReady();else (0, _imagesloaded2.default)(carousel, setFlickityToReady);
++      if (disableImagesLoaded) setFlickityToReady(); else (0, _imagesloaded2.default)(carousel, setFlickityToReady);
+       if (flickityRef) flickityRef(this.flkty);
+     }
+-  }, {
+-    key: 'renderPortal',
+-    value: function renderPortal() {
+-      if (!this.carousel) return null;
+-      var mountNode = this.carousel.querySelector('.flickity-slider');
+-      if (mountNode) return (0, _reactDom.createPortal)(this.props.children, mountNode);
+-    }
+   }, {
+     key: 'render',
+     value: function render() {
+@@ -107,7 +100,7 @@ var FlickityComponent = function (_Component) {
+         ref: function ref(c) {
+           _this3.carousel = c;
+         }
+-      }, this.renderPortal());
++      }, this.props.children);
+     }
+   }]);
+ 


### PR DESCRIPTION
- Patches Flickity to remove `renderPortal()` to prevent flicker on page load. 
- Will remove this patch once https://github.com/theolampert/react-flickity-component/pull/64 is merged.