### PR TITLE
Enable smallCarousel pageDots & draggable only when length > 1

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -100,23 +100,23 @@ export class LargeArtworkImageBrowser extends React.Component<
 export class SmallArtworkImageBrowser extends React.Component<
   ArtworkBrowserProps
 > {
-  options = {
-    prevNextButtons: false,
-    wrapAround: true,
-    draggable: true,
-    groupCells: 1,
-    pageDots: true,
-  }
-
   render() {
     const { images, imageAlt, setFlickityRef } = this.props
     // FIXME: During SSR pass want to hide other images. Work around for lack
     // of SSR support in Flickity.
     const carouselImages = typeof window === "undefined" ? [images[0]] : images
+    const hasMultipleImages = this.props.images.length > 1
+    const options = {
+      prevNextButtons: false,
+      wrapAround: true,
+      draggable: hasMultipleImages,
+      groupCells: 1,
+      pageDots: hasMultipleImages,
+    }
     return (
       <Container>
         <Carousel
-          options={this.options}
+          options={options}
           data={carouselImages}
           oneSlideVisible
           setFlickityRef={setFlickityRef}

--- a/src/Components/v2/CarouselV3.tsx
+++ b/src/Components/v2/CarouselV3.tsx
@@ -112,16 +112,18 @@ export const LargeCarousel: React.FC<CarouselProps> = props => {
 }
 
 export const SmallCarousel: React.FC<CarouselProps> = props => {
+  // Only render pageDots and enable draggable if more than one slide
+  const hasMultipleSlides = props.data.length > 1
   return (
     <BaseCarousel
       showArrows={false}
       options={{
         cellAlign: "left",
-        draggable: true,
+        draggable: hasMultipleSlides,
         freeScroll: false,
         contain: true,
         friction: 0.3,
-        pageDots: true,
+        pageDots: hasMultipleSlides,
         prevNextButtons: false,
         wrapAround: false,
         ...props.options,


### PR DESCRIPTION
- Disables small carousel when only one slide by setting `draggable` and `pageDots` to false 