### PR TITLE
Temporarily adds CURRENT_USER to Sharify Global Data 

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -19,6 +19,7 @@ const {
   CI,
   CMS_URL,
   APP_URL,
+  CURRENT_USER, // FIXME: Remove after externally served ads are implemented
   FACEBOOK_APP_NAMESPACE,
   PREDICTION_URL,
   FORCE_CLOUDFRONT_URL,
@@ -50,6 +51,7 @@ const notOnCI = value => (isCI ? [] : [value])
 const sharifyPath = sharify({
   APP_URL,
   CMS_URL,
+  CURRENT_USER, // FIXME: Remove after externally served ads are implemented
   FACEBOOK_APP_NAMESPACE,
   FORCE_CLOUDFRONT_URL,
   GEMINI_CLOUDFRONT_URL,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
   "tslint.autoFixOnSave": true,
   "typescript.tsdk": "./node_modules/typescript/lib",
   "cSpell.words": [
+    "ALLOWLIST",
     "Fillwidth",
     "Lifecycle",
     "Mastercard",

--- a/src/Components/Publishing/Ads/EnabledAd.ts
+++ b/src/Components/Publishing/Ads/EnabledAd.ts
@@ -1,4 +1,3 @@
-import { get } from "lodash"
 import { data as sd } from "sharify"
 
 /**
@@ -12,10 +11,9 @@ export const isHTLAdEnabled = () => {
   const allowedUsers = (sd.HASHTAG_LAB_ADS_ALLOWLIST || "")
     .split(",")
     .filter(Boolean)
-  const currentUser = get(sd, "CURRENT_USER.email", "")
+  const currentUser = sd.CURRENT_USER.email // FIXME: Remove after externally served ads are implemented
   const isAllowedUser = allowedUsers.includes(currentUser)
-  const isAdminUser =
-    get(sd, "CURRENT_USER.type", "") === "Admin" ? true : false
+  const isAdminUser = sd.CURRENT_USER.type === "Admin" || false
 
   if (!sd.HASHTAG_LAB_ADS_ENABLED) {
     return false

--- a/src/Components/Publishing/Ads/__tests__/EnabledAd.test.ts
+++ b/src/Components/Publishing/Ads/__tests__/EnabledAd.test.ts
@@ -4,6 +4,10 @@ import { data as sd } from "sharify"
 jest.mock("sharify", () => ({
   data: {
     HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
   },
 }))
 
@@ -20,6 +24,5 @@ describe("enabled ads feature flag", () => {
 
   it("checks for enabled ads", () => {
     expect(isHTLAdEnabled()).toBe(false)
-    expect(isHTLAdEnabled()).not.toBe(true)
   })
 })

--- a/src/Components/Publishing/Display/__tests__/DisplayCanvas.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayCanvas.test.tsx
@@ -22,6 +22,10 @@ import {
 jest.mock("sharify", () => ({
   data: {
     HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
   },
 }))
 

--- a/src/Components/Publishing/Display/__tests__/DisplayPanel.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayPanel.test.tsx
@@ -17,6 +17,10 @@ import {
 jest.mock("sharify", () => ({
   data: {
     HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
   },
 }))
 

--- a/src/Components/Publishing/Layouts/Components/__tests__/CanvasFooter.test.tsx
+++ b/src/Components/Publishing/Layouts/Components/__tests__/CanvasFooter.test.tsx
@@ -11,6 +11,16 @@ import "jest-styled-components"
 import React from "react"
 import { CanvasFooter } from "../CanvasFooter"
 
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
+  },
+}))
+
 describe("CanvasFooter", () => {
   let props
   const getWrapper = (passedProps = props) => {

--- a/src/Components/Publishing/Layouts/__tests__/ArticleWithFullScreen.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/ArticleWithFullScreen.test.tsx
@@ -26,6 +26,16 @@ jest.mock("Components/Publishing/ToolTip/TooltipsDataLoader", () => ({
   TooltipsData: props => props.children,
 }))
 
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
+  },
+}))
+
 it("indexes and titles images", () => {
   const article = mount(
     <ArticleWithFullScreen article={StandardArticle} />

--- a/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
@@ -25,6 +25,16 @@ jest.mock(
   })
 )
 
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
+  },
+}))
+
 it("renders RelatedArticlesCanvas if article is not super or in a series", () => {
   const article = mount(
     <FeatureLayout

--- a/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.tsx
@@ -21,6 +21,16 @@ global.fetch = jest.fn(() =>
   })
 )
 
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
+  },
+}))
+
 describe("News Layout", () => {
   const dateNow = Date.now
 

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -26,6 +26,16 @@ jest.mock(
   })
 )
 
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
+  },
+}))
+
 describe("Standard Article", () => {
   const getWrapper = _props => {
     return mount(<StandardLayout {..._props} />)

--- a/typings/gravity.d.ts
+++ b/typings/gravity.d.ts
@@ -4,4 +4,5 @@ interface User {
   id?: string
   lab_features?: string[]
   type?: string
+  email?: string
 }

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -19,14 +19,15 @@ declare module "sharify" {
       readonly APP_URL: string
       readonly ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test
       readonly ARTIST_COLLECTIONS_RAIL_IDS: string[]
+      readonly CURRENT_USER?: User // FIXME: Remove after externally served ads are implemented
       readonly CMS_URL: string
       readonly FACEBOOK_APP_NAMESPACE: string
       readonly FORCE_CLOUDFRONT_URL: string
       readonly GEMINI_CLOUDFRONT_URL: string
       readonly GENOME_URL: string
       readonly GOOGLE_ADWORDS_ID: string
-      readonly HASHTAG_LAB_ADS_ALLOWLIST: string // TODO: Remove after externally served ads are implemented
-      readonly HASHTAG_LAB_ADS_ENABLED: string // TODO: Remove after externally served ads are implemented
+      readonly HASHTAG_LAB_ADS_ALLOWLIST: string // FIXME: Remove after externally served ads are implemented
+      readonly HASHTAG_LAB_ADS_ENABLED: string // FIXME: Remove after externally served ads are implemented
       readonly IMAGE_LAZY_LOADING: boolean
       readonly IS_MOBILE: boolean
       readonly METAPHYSICS_ENDPOINT: string
@@ -40,7 +41,7 @@ declare module "sharify" {
     }
 
     export interface ResponseLocalData extends GlobalData {
-      readonly CURRENT_USER?: User
+      readonly CURRENT_USER?: User // FIXME: Remove after externally served ads are implemented
       RELAY_DATA?: any
       SUBMIT_URL?: string
       APP_TOKEN?: string


### PR DESCRIPTION
This PR temporarily adds the CURRENT_USER field to the Sharify Global Data object. Currently Typescript throws an error because CURRENT_USER isn't a property of the Global Data object. To work around this we have to use Lodash's Get method, which disallows the other type checking benefits of Typescript. As we only need the CURRENT_USER to check if a CURRENT_USER is either an Admin or Allowlisted user to hide the new externally hosted ads, this change is temporary. Once the new ad implementation is production ready, we won't need to hide it behind these checks or feature flags.