### PR TITLE
Add featured artist module to collection header

### DIFF
--- a/src/Apps/Collect/CollectionApp.tsx
+++ b/src/Apps/Collect/CollectionApp.tsx
@@ -12,7 +12,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import truncate from "trunc-html"
 import { CollectionFilterFragmentContainer as CollectionFilterContainer } from "./Components/Collection/CollectionFilterContainer"
-import { CollectionHeader } from "./Components/Collection/Header"
+import { CollectionFilterFragmentContainer as CollectionHeader } from "./Components/Collection/Header"
 import { SeoProductsForArtworks } from "./Components/Seo/SeoProductsForArtworks"
 
 interface CollectionAppProps {
@@ -36,6 +36,7 @@ export class CollectionApp extends Component<CollectionAppProps> {
   render() {
     const { collection } = this.props
     const { title, slug, headerImage, description, artworks } = collection
+
     const collectionHref = `${sd.APP_URL}/collection/${slug}`
     const metadataDescription = description
       ? `Buy, bid, and inquire on ${title} on Artsy. ` +
@@ -60,7 +61,10 @@ export class CollectionApp extends Component<CollectionAppProps> {
           />
           <SeoProductsForArtworks artworks={artworks} />
 
-          <CollectionHeader collection={collection} />
+          <CollectionHeader
+            collection={collection}
+            artworks={artworks as any}
+          />
           <Box>
             <CollectionFilterContainer collection={collection} />
           </Box>
@@ -78,7 +82,7 @@ export const CollectionAppFragmentContainer = createFragmentContainer(
         @argumentDefinitions(
           aggregations: {
             type: "[ArtworkAggregation]"
-            defaultValue: [MEDIUM, MAJOR_PERIOD, TOTAL]
+            defaultValue: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]
           }
           medium: { type: "String", defaultValue: "*" }
           major_periods: { type: "[String]" }
@@ -111,6 +115,7 @@ export const CollectionAppFragmentContainer = createFragmentContainer(
           aggregations: $aggregations
           include_medium_filter_in_aggregation: true
         ) {
+          ...Header_artworks
           ...SeoProductsForArtworks_artworks
         }
 

--- a/src/Apps/Collect/Components/Collection/CollectionFilterContainer.tsx
+++ b/src/Apps/Collect/Components/Collection/CollectionFilterContainer.tsx
@@ -49,7 +49,7 @@ export const CollectionFilterFragmentContainer = createFragmentContainer(
         @argumentDefinitions(
           aggregations: {
             type: "[ArtworkAggregation]"
-            defaultValue: [MEDIUM, MAJOR_PERIOD, TOTAL]
+            defaultValue: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]
           }
           medium: { type: "String", defaultValue: "*" }
           major_periods: { type: "[String]" }

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -157,7 +157,7 @@ export class CollectionHeader extends Component<Props> {
                   </Background>
                   <MetaContainer mb={2}>
                     <BreadcrumbContainer size={["2", "3"]}>
-                      <a href="/collect">All artworks</a> /{" "}
+                      <a href="/collect">All works</a> /{" "}
                       <a href={categoryTarget}>{collection.category}</a>
                     </BreadcrumbContainer>
                     <Spacer mt={1} />

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -250,7 +250,7 @@ const BreadcrumbContainer = styled(Sans)`
 const EntityContainer = styled(Box)<{
   isColumnLayout: boolean
 }>`
-  min-width: ${props => (props.isColumnLayout ? "" : "200px")};
+  ${props => (props.isColumnLayout ? "" : "min-width: 200px;")}
 `
 
 const DescriptionContainer = styled(Flex)<{

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -94,6 +94,13 @@ export class CollectionHeader extends Component<Props> {
           const categoryTarget = `/collections#${slugify(collection.category)}`
           const artistsCount = size === "xs" ? 9 : 12
 
+          const hasMultipleArtists =
+            artworks.merchandisable_artists &&
+            artworks.merchandisable_artists.length > 1
+
+          const isColumnLayout =
+            hasMultipleArtists || !collection.description || size === "xs"
+
           const featuredArtists = take(
             artworks.merchandisable_artists,
             artistsCount
@@ -101,7 +108,7 @@ export class CollectionHeader extends Component<Props> {
             return (
               <EntityContainer
                 width={["100%", "25%"]}
-                hasMultipleArtists={hasMultipleArtists}
+                isColumnLayout={isColumnLayout}
                 key={index}
                 pb={20}
               >
@@ -119,9 +126,6 @@ export class CollectionHeader extends Component<Props> {
               </EntityContainer>
             )
           })
-
-          const hasMultipleArtists =
-            featuredArtists.length && featuredArtists.length > 1
 
           return (
             <header>
@@ -154,10 +158,7 @@ export class CollectionHeader extends Component<Props> {
                     <Spacer mt={1} />
                     <Title size={["6", "10"]}>{collection.title}</Title>
                   </MetaContainer>
-                  <DescriptionContainer
-                    hasMultipleArtists={hasMultipleArtists}
-                    mb={5}
-                  >
+                  <DescriptionContainer isColumnLayout={isColumnLayout} mb={5}>
                     <Box>
                       <Grid>
                         <Row>
@@ -178,11 +179,11 @@ export class CollectionHeader extends Component<Props> {
                       </Grid>
                     </Box>
                     {featuredArtists.length && (
-                      <Box pt={hasMultipleArtists ? 20 : 0} pb={10}>
+                      <Box pt={isColumnLayout ? 20 : 0} pb={10}>
                         <Sans size="2" weight="medium" pb={15}>
                           Featured Artists
                         </Sans>
-                        <Flex flexWrap={hasMultipleArtists ? "wrap" : "nowrap"}>
+                        <Flex flexWrap={isColumnLayout ? "wrap" : "nowrap"}>
                           {featuredArtists}
                         </Flex>
                       </Box>
@@ -242,15 +243,15 @@ const BreadcrumbContainer = styled(Sans)`
 `
 
 const EntityContainer = styled(Box)<{
-  hasMultipleArtists: boolean
+  isColumnLayout: boolean
 }>`
-  min-width: ${props => (props.hasMultipleArtists ? "" : "200px")};
+  min-width: ${props => (props.isColumnLayout ? "" : "200px")};
 `
 
 const DescriptionContainer = styled(Flex)<{
-  hasMultipleArtists: boolean
+  isColumnLayout: boolean
 }>`
-  flex-direction: ${props => (props.hasMultipleArtists ? "column" : "row")};
+  flex-direction: ${props => (props.isColumnLayout ? "column" : "row")};
 `
 
 const Title = styled(Serif)`

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -105,6 +105,7 @@ export class CollectionHeader extends Component<Props> {
             artworks.merchandisable_artists,
             artistsCount
           ).map((artist, index) => {
+            const hasArtistMetaData = artist.nationality && artist.birthday
             return (
               <EntityContainer
                 width={["100%", "25%"]}
@@ -115,7 +116,11 @@ export class CollectionHeader extends Component<Props> {
                 <EntityHeader
                   imageUrl={artist.imageUrl}
                   name={artist.name}
-                  meta={`${artist.nationality}, b. ${artist.birthday}`}
+                  meta={
+                    hasArtistMetaData
+                      ? `${artist.nationality}, b. ${artist.birthday}`
+                      : null
+                  }
                   href={`/artist/${artist.id}`}
                   FollowButton={
                     <Sans size="2" weight="medium" color={color("black100")}>
@@ -181,7 +186,7 @@ export class CollectionHeader extends Component<Props> {
                     {featuredArtists.length && (
                       <Box pt={isColumnLayout ? 20 : 0} pb={10}>
                         <Sans size="2" weight="medium" pb={15}>
-                          Featured Artists
+                          {`Featured Artist${hasMultipleArtists ? "s" : ""}`}
                         </Sans>
                         <Flex flexWrap={isColumnLayout ? "wrap" : "nowrap"}>
                           {featuredArtists}

--- a/src/__generated__/CollectionAppTestQuery.graphql.ts
+++ b/src/__generated__/CollectionAppTestQuery.graphql.ts
@@ -37,12 +37,25 @@ fragment CollectionApp_collection on MarketingCollection {
     gene_id
     __id: id
   }
-  artworks(aggregations: [MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {
+  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {
+    ...Header_artworks
     ...SeoProductsForArtworks_artworks
     __id
   }
   ...CollectionFilterContainer_collection_33e20w
   __id: id
+}
+
+fragment Header_artworks on FilterArtworks {
+  merchandisable_artists {
+    id
+    name
+    imageUrl
+    birthday
+    nationality
+    __id
+  }
+  __id
 }
 
 fragment SeoProductsForArtworks_artworks on FilterArtworks {
@@ -97,7 +110,7 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
 }
 
 fragment CollectionFilterContainer_collection_33e20w on MarketingCollection {
-  artworks(aggregations: [MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {
+  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {
     aggregations {
       slice
       counts {
@@ -335,7 +348,21 @@ v5 = {
   "args": null,
   "storageKey": null
 },
-v6 = [
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v8 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -349,38 +376,24 @@ v6 = [
     "type": "Int"
   }
 ],
-v7 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v10 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_acquireable",
-  "args": null,
-  "storageKey": null
-},
 v11 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
@@ -452,7 +465,7 @@ return {
   "operationKind": "query",
   "name": "CollectionAppTestQuery",
   "id": null,
-  "text": "query CollectionAppTestQuery {\n  collection: marketingCollection(slug: \"kaws-companions\") {\n    ...CollectionApp_collection\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  artworks(aggregations: [MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_33e20w\n  __id: id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_33e20w on MarketingCollection {\n  artworks(aggregations: [MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_33e20w\n  __id: id\n}\n\nfragment CollectionRefetch_collection_33e20w on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query CollectionAppTestQuery {\n  collection: marketingCollection(slug: \"kaws-companions\") {\n    ...CollectionApp_collection\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_33e20w\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  merchandisable_artists {\n    id\n    name\n    imageUrl\n    birthday\n    nationality\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_33e20w on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_33e20w\n  __id: id\n}\n\nfragment CollectionRefetch_collection_33e20w on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -556,12 +569,13 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "artworks",
-            "storageKey": "artworks(aggregations:[\"MEDIUM\",\"MAJOR_PERIOD\",\"TOTAL\"],include_medium_filter_in_aggregation:true)",
+            "storageKey": "artworks(aggregations:[\"MERCHANDISABLE_ARTISTS\",\"MEDIUM\",\"MAJOR_PERIOD\",\"TOTAL\"],include_medium_filter_in_aggregation:true)",
             "args": [
               {
                 "kind": "Literal",
                 "name": "aggregations",
                 "value": [
+                  "MERCHANDISABLE_ARTISTS",
                   "MEDIUM",
                   "MAJOR_PERIOD",
                   "TOTAL"
@@ -581,9 +595,45 @@ return {
               {
                 "kind": "LinkedField",
                 "alias": null,
+                "name": "merchandisable_artists",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Artist",
+                "plural": true,
+                "selections": [
+                  v3,
+                  v6,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "imageUrl",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "birthday",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "nationality",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v7
+                ]
+              },
+              v7,
+              {
+                "kind": "LinkedField",
+                "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v6,
+                "args": v8,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -614,9 +664,9 @@ return {
                           },
                           v7,
                           v2,
-                          v8,
                           v9,
                           v10,
+                          v11,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -648,7 +698,7 @@ return {
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v11,
+                              v6,
                               v7
                             ]
                           },
@@ -683,7 +733,7 @@ return {
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v11,
+                              v6,
                               v14,
                               {
                                 "kind": "LinkedField",
@@ -784,7 +834,6 @@ return {
                   }
                 ]
               },
-              v7,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -811,7 +860,7 @@ return {
                     "plural": true,
                     "selections": [
                       v3,
-                      v11,
+                      v6,
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -868,7 +917,7 @@ return {
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v6,
+                "args": v8,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -979,12 +1028,12 @@ return {
                             "plural": true,
                             "selections": [
                               v7,
-                              v9,
-                              v11
+                              v10,
+                              v6
                             ]
                           },
                           v7,
-                          v9,
+                          v10,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1039,7 +1088,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v8,
+                          v9,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1071,8 +1120,8 @@ return {
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v11,
-                              v9,
+                              v6,
+                              v10,
                               v7,
                               v14
                             ]
@@ -1207,7 +1256,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v10,
+                          v11,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/CollectionApp_collection.graphql.ts
+++ b/src/__generated__/CollectionApp_collection.graphql.ts
@@ -2,6 +2,7 @@
 
 import { ConcreteFragment } from "relay-runtime";
 import { CollectionFilterContainer_collection$ref } from "./CollectionFilterContainer_collection.graphql";
+import { Header_artworks$ref } from "./Header_artworks.graphql";
 import { SeoProductsForArtworks_artworks$ref } from "./SeoProductsForArtworks_artworks.graphql";
 declare const _CollectionApp_collection$ref: unique symbol;
 export type CollectionApp_collection$ref = typeof _CollectionApp_collection$ref;
@@ -19,7 +20,7 @@ export type CollectionApp_collection = {
         readonly gene_id: string | null;
     };
     readonly artworks: ({
-        readonly " $fragmentRefs": SeoProductsForArtworks_artworks$ref;
+        readonly " $fragmentRefs": Header_artworks$ref & SeoProductsForArtworks_artworks$ref;
     }) | null;
     readonly " $fragmentRefs": CollectionFilterContainer_collection$ref;
     readonly " $refType": CollectionApp_collection$ref;
@@ -46,6 +47,7 @@ return {
       "name": "aggregations",
       "type": "[ArtworkAggregation]",
       "defaultValue": [
+        "MERCHANDISABLE_ARTISTS",
         "MEDIUM",
         "MAJOR_PERIOD",
         "TOTAL"
@@ -243,6 +245,11 @@ return {
       "selections": [
         {
           "kind": "FragmentSpread",
+          "name": "Header_artworks",
+          "args": null
+        },
+        {
+          "kind": "FragmentSpread",
           "name": "SeoProductsForArtworks_artworks",
           "args": null
         },
@@ -343,5 +350,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '3d52dd0b097c9da84c1bc53e64866dcf';
+(node as any).hash = '25467f46cd5b9dc0cec17ed9b0218272';
 export default node;

--- a/src/__generated__/CollectionFilterContainer_collection.graphql.ts
+++ b/src/__generated__/CollectionFilterContainer_collection.graphql.ts
@@ -41,6 +41,7 @@ return {
       "name": "aggregations",
       "type": "[ArtworkAggregation]",
       "defaultValue": [
+        "MERCHANDISABLE_ARTISTS",
         "MEDIUM",
         "MAJOR_PERIOD",
         "TOTAL"
@@ -296,5 +297,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'e85e4e5b6c383e799119504b4637bf09';
+(node as any).hash = 'b8324b3bc570b04f460e8f7cb050c9f8';
 export default node;

--- a/src/__generated__/Header_artworks.graphql.ts
+++ b/src/__generated__/Header_artworks.graphql.ts
@@ -1,0 +1,86 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+declare const _Header_artworks$ref: unique symbol;
+export type Header_artworks$ref = typeof _Header_artworks$ref;
+export type Header_artworks = {
+    readonly merchandisable_artists: ReadonlyArray<({
+        readonly id: string;
+        readonly name: string | null;
+        readonly imageUrl: string | null;
+        readonly birthday: string | null;
+        readonly nationality: string | null;
+    }) | null> | null;
+    readonly " $refType": Header_artworks$ref;
+};
+
+
+
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Fragment",
+  "name": "Header_artworks",
+  "type": "FilterArtworks",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "merchandisable_artists",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Artist",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "name",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "imageUrl",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "birthday",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "nationality",
+          "args": null,
+          "storageKey": null
+        },
+        v0
+      ]
+    },
+    v0
+  ]
+};
+})();
+(node as any).hash = 'adcbd11100d8128dea736868aa9d975a';
+export default node;

--- a/src/__generated__/routes_MarketingCollectionAppQuery.graphql.ts
+++ b/src/__generated__/routes_MarketingCollectionAppQuery.graphql.ts
@@ -67,12 +67,25 @@ fragment CollectionApp_collection_3tWJc4 on MarketingCollection {
     gene_id
     __id: id
   }
-  artworks(aggregations: [MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {
+  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {
+    ...Header_artworks
     ...SeoProductsForArtworks_artworks
     __id
   }
   ...CollectionFilterContainer_collection_3tWJc4
   __id: id
+}
+
+fragment Header_artworks on FilterArtworks {
+  merchandisable_artists {
+    id
+    name
+    imageUrl
+    birthday
+    nationality
+    __id
+  }
+  __id
 }
 
 fragment SeoProductsForArtworks_artworks on FilterArtworks {
@@ -127,7 +140,7 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
 }
 
 fragment CollectionFilterContainer_collection_3tWJc4 on MarketingCollection {
-  artworks(aggregations: [MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {
+  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {
     aggregations {
       slice
       counts {
@@ -451,7 +464,21 @@ v6 = {
   "args": null,
   "storageKey": null
 },
-v7 = [
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v9 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -465,38 +492,24 @@ v7 = [
     "type": "Int"
   }
 ],
-v8 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v11 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "is_acquireable",
-  "args": null,
-  "storageKey": null
-},
 v12 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
@@ -568,7 +581,7 @@ return {
   "operationKind": "query",
   "name": "routes_MarketingCollectionAppQuery",
   "id": null,
-  "text": "query routes_MarketingCollectionAppQuery(\n  $slug: String!\n  $medium: String\n  $major_periods: [String]\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $color: String\n  $page: Int\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionApp_collection_3tWJc4\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection_3tWJc4 on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  artworks(aggregations: [MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_3tWJc4\n  __id: id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_3tWJc4 on MarketingCollection {\n  artworks(aggregations: [MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_3tWJc4\n  __id: id\n}\n\nfragment CollectionRefetch_collection_3tWJc4 on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, color: $color, page: $page) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_MarketingCollectionAppQuery(\n  $slug: String!\n  $medium: String\n  $major_periods: [String]\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $color: String\n  $page: Int\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionApp_collection_3tWJc4\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection_3tWJc4 on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_3tWJc4\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  merchandisable_artists {\n    id\n    name\n    imageUrl\n    birthday\n    nationality\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_3tWJc4 on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_3tWJc4\n  __id: id\n}\n\nfragment CollectionRefetch_collection_3tWJc4 on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, color: $color, page: $page) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -751,12 +764,13 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "artworks",
-            "storageKey": "artworks(aggregations:[\"MEDIUM\",\"MAJOR_PERIOD\",\"TOTAL\"],include_medium_filter_in_aggregation:true)",
+            "storageKey": "artworks(aggregations:[\"MERCHANDISABLE_ARTISTS\",\"MEDIUM\",\"MAJOR_PERIOD\",\"TOTAL\"],include_medium_filter_in_aggregation:true)",
             "args": [
               {
                 "kind": "Literal",
                 "name": "aggregations",
                 "value": [
+                  "MERCHANDISABLE_ARTISTS",
                   "MEDIUM",
                   "MAJOR_PERIOD",
                   "TOTAL"
@@ -776,9 +790,45 @@ return {
               {
                 "kind": "LinkedField",
                 "alias": null,
+                "name": "merchandisable_artists",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Artist",
+                "plural": true,
+                "selections": [
+                  v4,
+                  v7,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "imageUrl",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "birthday",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "nationality",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v8
+                ]
+              },
+              v8,
+              {
+                "kind": "LinkedField",
+                "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v7,
+                "args": v9,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -809,9 +859,9 @@ return {
                           },
                           v8,
                           v3,
-                          v9,
                           v10,
                           v11,
+                          v12,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -843,7 +893,7 @@ return {
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v12,
+                              v7,
                               v8
                             ]
                           },
@@ -878,7 +928,7 @@ return {
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v12,
+                              v7,
                               v15,
                               {
                                 "kind": "LinkedField",
@@ -979,7 +1029,6 @@ return {
                   }
                 ]
               },
-              v8,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1006,7 +1055,7 @@ return {
                     "plural": true,
                     "selections": [
                       v4,
-                      v12,
+                      v7,
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1129,7 +1178,7 @@ return {
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v7,
+                "args": v9,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -1240,12 +1289,12 @@ return {
                             "plural": true,
                             "selections": [
                               v8,
-                              v10,
-                              v12
+                              v11,
+                              v7
                             ]
                           },
                           v8,
-                          v10,
+                          v11,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1300,7 +1349,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v9,
+                          v10,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1332,8 +1381,8 @@ return {
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v12,
-                              v10,
+                              v7,
+                              v11,
                               v8,
                               v15
                             ]
@@ -1468,7 +1517,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v11,
+                          v12,
                           {
                             "kind": "ScalarField",
                             "alias": null,


### PR DESCRIPTION
Addresses: [GROW-1229](https://artsyproduct.atlassian.net/browse/GROW-1229)

This adds a new header fragment to the collection header that aggregates artists in the collection. It also includes updates for the layout when there are one or multiple artists.

__One artist:__
![Screen Shot 2019-05-10 at 4 10 57 PM](https://user-images.githubusercontent.com/5201004/57554421-6409ab80-733f-11e9-8f7a-459f7c3e4c4a.png)

__Multiple artists:__
![Screen Shot 2019-05-10 at 4 11 11 PM](https://user-images.githubusercontent.com/5201004/57554436-6e2baa00-733f-11e9-92d3-55fcc46613f2.png)


To Do:
- [x] handle when an artist doesn't have a nationality or birthday
- [x] ensure the layout is responsive
- [x] use correct plural/singular for of artist where appropriate

__Correctly handle singular and plural form:__
![Screen Shot 2019-05-13 at 1 37 39 PM](https://user-images.githubusercontent.com/5201004/57642239-d0292100-7584-11e9-8476-256589cb0365.png)

![Screen Shot 2019-05-13 at 1 42 09 PM](https://user-images.githubusercontent.com/5201004/57642296-f6e75780-7584-11e9-8d12-2ef626d0f720.png)

__Handle artist with no metadata:__
![Screen Shot 2019-05-13 at 1 43 50 PM](https://user-images.githubusercontent.com/5201004/57642398-3a41c600-7585-11e9-8742-f0bd9f5a5955.png)

