### PR TITLE
Check if user exists before diving

### DIFF
--- a/src/Components/Publishing/Ads/EnabledAd.ts
+++ b/src/Components/Publishing/Ads/EnabledAd.ts
@@ -11,9 +11,10 @@ export const isHTLAdEnabled = () => {
   const allowedUsers = (sd.HASHTAG_LAB_ADS_ALLOWLIST || "")
     .split(",")
     .filter(Boolean)
-  const currentUser = sd.CURRENT_USER.email // FIXME: Remove after externally served ads are implemented
+  const currentUser = sd.CURRENT_USER && sd.CURRENT_USER.email // FIXME: Remove after externally served ads are implemented
   const isAllowedUser = allowedUsers.includes(currentUser)
-  const isAdminUser = sd.CURRENT_USER.type === "Admin" || false
+  const isAdminUser =
+    (sd.CURRENT_USER && sd.CURRENT_USER.type === "Admin") || false
 
   if (!sd.HASHTAG_LAB_ADS_ENABLED) {
     return false


### PR DESCRIPTION
Latest master fails in Force/Reaction due to missing current user: https://circleci.com/gh/artsy/positron/3634
https://circleci.com/gh/artsy/force/23904#tests/containers/1

Adds a check to confirm user exists before looking for properties on it.