### PR TITLE
Changes adUnit and adDimension props from required to optional

### DIFF
--- a/src/Components/Publishing/Display/Canvas/index.tsx
+++ b/src/Components/Publishing/Display/Canvas/index.tsx
@@ -20,8 +20,8 @@ interface DisplayCanvasProps {
   article?: any
   renderTime?: number
   tracking?: any
-  adUnit: AdUnit
-  adDimension: AdDimension
+  adUnit?: AdUnit
+  adDimension?: AdDimension
 }
 
 interface DivProps extends React.HTMLProps<HTMLDivElement> {

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -23,8 +23,8 @@ export interface DisplayPanelProps extends React.HTMLProps<HTMLDivElement> {
   unit: any
   tracking?: TrackingProp
   renderTime?: number
-  adUnit: AdUnit
-  adDimension: AdDimension
+  adUnit?: AdUnit
+  adDimension?: AdDimension
 }
 
 export interface DisplayPanelState {

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -171,8 +171,8 @@ export interface MediaData {
 }
 
 export interface HostedAdData {
-  adUnit: AdUnit
-  adDimension: AdDimension
+  adUnit?: AdUnit
+  adDimension?: AdDimension
 }
 
 export interface DisplayUnitData {


### PR DESCRIPTION
The work to migrate ads to Google Ad Manager (GAM) is still in progress, so for now the props used to populate ad components with GAM hosted data does not need to be required until the migration is complete. 
