### PR TITLE
Do not fire reCAPTCHA actions unless sd.key is present

### DIFF
--- a/src/Utils/repcaptcha.ts
+++ b/src/Utils/repcaptcha.ts
@@ -1,17 +1,21 @@
 import { data as sd } from "sharify"
 
 export const repcaptcha = (action: RepcaptchaAction, cb?: any) => {
-  window.grecaptcha.ready(async () => {
-    try {
-      const token = await window.grecaptcha.execute(sd.RECAPTCHA_KEY, {
-        action,
-      })
-      cb && cb(token)
-    } catch (e) {
-      console.log(e)
-      cb && cb()
-    }
-  })
+  if (sd.RECAPTCHA_KEY) {
+    window.grecaptcha.ready(async () => {
+      try {
+        const token = await window.grecaptcha.execute(sd.RECAPTCHA_KEY, {
+          action,
+        })
+        cb && cb(token)
+      } catch (e) {
+        console.log(e)
+        cb && cb()
+      }
+    })
+  } else {
+    cb && cb()
+  }
 }
 
 export type RepcaptchaAction =


### PR DESCRIPTION
Disables firing of recaptcha events if `sd.RECAPTCHA_KEY` is missing.