### PR TITLE
Move new hosted ads to their own components in Standard Articles

### DIFF
--- a/src/Components/Publishing/Display/Canvas/index.tsx
+++ b/src/Components/Publishing/Display/Canvas/index.tsx
@@ -1,7 +1,5 @@
 import { color } from "@artsy/palette"
 import { avantgarde, garamond } from "Assets/Fonts"
-import { isHTLAdEnabled } from "Components/Publishing/Ads/EnabledAd"
-import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import { get } from "lodash"
 import React from "react"
 import track from "react-tracking"
@@ -20,8 +18,6 @@ interface DisplayCanvasProps {
   article?: any
   renderTime?: number
   tracking?: any
-  adUnit?: AdUnit
-  adDimension?: AdDimension
 }
 
 interface DivProps extends React.HTMLProps<HTMLDivElement> {
@@ -47,31 +43,12 @@ export class DisplayCanvas extends React.Component<DisplayCanvasProps> {
   }
 
   renderCanvasContent() {
-    const {
-      unit,
-      campaign,
-      article,
-      adUnit,
-      adDimension,
-      renderTime,
-    } = this.props
+    const { unit, campaign, article, renderTime } = this.props
     const url = unit.link ? get(unit, "link.url", "") : ""
     const disclaimer = (
       <Disclaimer layout={unit.layout}>{unit.disclaimer}</Disclaimer>
     )
 
-    // TODO: Remove the allowlist and env checks after externally served ads are implemented
-    if (isHTLAdEnabled()) {
-      return (
-        <div
-          className="htl-ad"
-          data-unit={adUnit}
-          data-sizes={adDimension}
-          data-eager
-        />
-      )
-    }
-    // TODO: Determine how to handle DisplayContainer layout and tracking when this component no longer receives unit prop
     return (
       <>
         <a

--- a/src/Components/Publishing/Display/DisplayPanel.tsx
+++ b/src/Components/Publishing/Display/DisplayPanel.tsx
@@ -1,6 +1,4 @@
 import { avantgarde, garamond, unica } from "Assets/Fonts"
-import { isHTLAdEnabled } from "Components/Publishing/Ads/EnabledAd"
-import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import { get, memoize } from "lodash"
 import React, { Component, HTMLProps } from "react"
 import track, { TrackingProp } from "react-tracking"
@@ -23,8 +21,6 @@ export interface DisplayPanelProps extends React.HTMLProps<HTMLDivElement> {
   unit: any
   tracking?: TrackingProp
   renderTime?: number
-  adUnit?: AdUnit
-  adDimension?: AdDimension
 }
 
 export interface DisplayPanelState {
@@ -365,23 +361,10 @@ export class DisplayPanel extends Component<
   }
 
   renderPanelContent() {
-    const { unit, campaign, adDimension, adUnit, renderTime } = this.props
+    const { unit, campaign, renderTime } = this.props
     const isVideo = this.isVideo()
     const url = get(unit.assets, "0.url", "")
 
-    // TODO: Remove the allowlist and env checks after externally served ads are implemented
-    if (isHTLAdEnabled()) {
-      return (
-        <div
-          className="htl-ad"
-          data-unit={adUnit}
-          data-sizes={adDimension}
-          data-eager
-        />
-      )
-    }
-
-    // TODO: Determine how to handle DisplayContainer layout and tracking when this component no longer receives unit prop
     return (
       <>
         {isVideo ? (

--- a/src/Components/Publishing/Display/NewDisplayCanvas.tsx
+++ b/src/Components/Publishing/Display/NewDisplayCanvas.tsx
@@ -1,0 +1,46 @@
+import { Flex } from "@artsy/palette"
+import { ErrorBoundary } from "Components/ErrorBoundary"
+import { isHTLAdEnabled } from "Components/Publishing/Ads/EnabledAd"
+import { AdDimension, AdUnit } from "Components/Publishing/Typings"
+import React, { SFC } from "react"
+import styled from "styled-components"
+
+interface DisplayCanvasProps {
+  adUnit?: AdUnit
+  adDimension?: AdDimension
+}
+
+export const NewDisplayCanvas: SFC<DisplayCanvasProps> = props => {
+  const { adUnit, adDimension } = props
+
+  if (!isHTLAdEnabled()) {
+    return null
+  }
+
+  return (
+    <ErrorBoundary>
+      <DisplayCanvasContainer
+        flexDirection="column"
+        width="100%"
+        m={"0 auto"}
+        maxWidth="1250px"
+      >
+        <div
+          className="htl-ad"
+          data-unit={adUnit}
+          data-sizes={adDimension}
+          data-eager
+        />
+      </DisplayCanvasContainer>
+    </ErrorBoundary>
+  )
+}
+
+const DisplayCanvasContainer = styled(Flex)`
+  min-height: fit-content;
+  max-width: 1250px;
+  box-sizing: border-box;
+`
+
+// Set names for tests and DOM
+DisplayCanvasContainer.displayName = "DisplayCanvasContainer"

--- a/src/Components/Publishing/Display/NewDisplayPanel.tsx
+++ b/src/Components/Publishing/Display/NewDisplayPanel.tsx
@@ -1,0 +1,54 @@
+import { Box, color, Flex } from "@artsy/palette"
+import { isHTLAdEnabled } from "Components/Publishing/Ads/EnabledAd"
+import { AdDimension, AdUnit } from "Components/Publishing/Typings"
+import React, { SFC } from "react"
+import styled from "styled-components"
+import { ErrorBoundary } from "../../ErrorBoundary"
+
+export interface DisplayPanelProps extends React.HTMLProps<HTMLDivElement> {
+  adUnit?: AdUnit
+  adDimension?: AdDimension
+}
+
+export const NewDisplayPanel: SFC<DisplayPanelProps> = props => {
+  const { adDimension, adUnit } = props
+
+  if (!isHTLAdEnabled()) {
+    return null
+  }
+
+  return (
+    <ErrorBoundary>
+      <Wrapper m={["auto", "0 auto", "auto"]} color="black100">
+        <DisplayPanelContainer
+          flexDirection="column"
+          className="DisplayPanel__DisplayPanelContainer"
+          p={2}
+          m={["auto", "auto", "auto", "inherit"]}
+        >
+          <div
+            className="htl-ad"
+            data-unit={adUnit}
+            data-sizes={adDimension}
+            data-eager
+          />
+        </DisplayPanelContainer>
+      </Wrapper>
+    </ErrorBoundary>
+  )
+}
+
+const Wrapper = styled(Box)`
+  cursor: pointer;
+  text-decoration: none;
+  max-width: 360px;
+`
+const DisplayPanelContainer = styled(Flex)`
+  border: 1px solid ${color("black10")};
+  max-width: 360px;
+  box-sizing: border-box;
+`
+
+// Set names for tests and DOM
+DisplayPanelContainer.displayName = "DisplayPanelContainer"
+Wrapper.displayName = "Wrapper"

--- a/src/Components/Publishing/Display/__tests__/DisplayCanvas.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayCanvas.test.tsx
@@ -11,7 +11,6 @@ import { CanvasVideo } from "../Canvas/CanvasVideo"
 
 import {
   Campaign,
-  StandardArticleHostedAdCanvas,
   UnitCanvasImage,
   UnitCanvasOverlay,
   UnitCanvasSlideshow,
@@ -19,69 +18,31 @@ import {
   UnitCanvasVideo,
 } from "../../Fixtures/Components"
 
-jest.mock("sharify", () => ({
-  data: {
-    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
-    CURRENT_USER: {
-      type: "Non-Admin",
-      email: "someuser@email.com",
-    },
-  },
-}))
-
 describe("snapshot", () => {
   it("renders the canvas in standard layout with image", () => {
     const component = renderer
-      .create(
-        <DisplayCanvas
-          unit={UnitCanvasImage}
-          campaign={Campaign}
-          adUnit={StandardArticleHostedAdCanvas.adUnit}
-          adDimension={StandardArticleHostedAdCanvas.adDimension}
-        />
-      )
+      .create(<DisplayCanvas unit={UnitCanvasImage} campaign={Campaign} />)
       .toJSON()
     expect(component).toMatchSnapshot()
   })
 
   it("renders the canvas in standard layout with video", () => {
     const component = renderer
-      .create(
-        <DisplayCanvas
-          unit={UnitCanvasVideo}
-          campaign={Campaign}
-          adUnit={StandardArticleHostedAdCanvas.adUnit}
-          adDimension={StandardArticleHostedAdCanvas.adDimension}
-        />
-      )
+      .create(<DisplayCanvas unit={UnitCanvasVideo} campaign={Campaign} />)
       .toJSON()
     expect(component).toMatchSnapshot()
   })
 
   it("renders the canvas in overlay layout", () => {
     const component = renderer
-      .create(
-        <DisplayCanvas
-          unit={UnitCanvasOverlay}
-          campaign={Campaign}
-          adUnit={StandardArticleHostedAdCanvas.adUnit}
-          adDimension={StandardArticleHostedAdCanvas.adDimension}
-        />
-      )
+      .create(<DisplayCanvas unit={UnitCanvasOverlay} campaign={Campaign} />)
       .toJSON()
     expect(component).toMatchSnapshot()
   })
 
   it("renders the canvas in slideshow layout", () => {
     const component = renderer
-      .create(
-        <DisplayCanvas
-          unit={UnitCanvasSlideshow}
-          campaign={Campaign}
-          adUnit={StandardArticleHostedAdCanvas.adUnit}
-          adDimension={StandardArticleHostedAdCanvas.adDimension}
-        />
-      )
+      .create(<DisplayCanvas unit={UnitCanvasSlideshow} campaign={Campaign} />)
       .toJSON()
     expect(component).toMatchSnapshot()
   })
@@ -98,20 +59,13 @@ describe("unit", () => {
           trackEvent,
         }}
         renderTime={12345}
-        adUnit={StandardArticleHostedAdCanvas.adUnit}
-        adDimension={StandardArticleHostedAdCanvas.adDimension}
       />
     )
   }
 
   it("renders the unit data", () => {
     const canvas = mount(
-      <DisplayCanvas
-        unit={UnitCanvasImage}
-        campaign={Campaign}
-        adUnit={StandardArticleHostedAdCanvas.adUnit}
-        adDimension={StandardArticleHostedAdCanvas.adDimension}
-      />
+      <DisplayCanvas unit={UnitCanvasImage} campaign={Campaign} />
     )
     expect(canvas.html()).toMatch(UnitCanvasImage.disclaimer)
     expect(canvas.html()).toMatch(UnitCanvasImage.headline)
@@ -126,24 +80,14 @@ describe("unit", () => {
 
   it("renders the video component if standard layout with video", () => {
     const canvas = mount(
-      <DisplayCanvas
-        unit={UnitCanvasVideo}
-        campaign={Campaign}
-        adUnit={StandardArticleHostedAdCanvas.adUnit}
-        adDimension={StandardArticleHostedAdCanvas.adDimension}
-      />
+      <DisplayCanvas unit={UnitCanvasVideo} campaign={Campaign} />
     )
     expect(canvas.find(CanvasVideo).length).toBe(1)
   })
 
   it("renders the slideshow component if slideshow layout", () => {
     const canvas = mount(
-      <DisplayCanvas
-        unit={UnitCanvasSlideshow}
-        campaign={Campaign}
-        adUnit={StandardArticleHostedAdCanvas.adUnit}
-        adDimension={StandardArticleHostedAdCanvas.adDimension}
-      />
+      <DisplayCanvas unit={UnitCanvasSlideshow} campaign={Campaign} />
     )
     expect(canvas.find(CanvasSlideshow).length).toBe(1)
   })

--- a/src/Components/Publishing/Display/__tests__/DisplayPanel.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayPanel.test.tsx
@@ -8,47 +8,22 @@ import { DisplayPanel } from "../DisplayPanel"
 
 import {
   Campaign,
-  StandardArticleHostedAdPanel,
   UnitPanel,
   UnitPanelTracked,
   UnitPanelVideo,
 } from "Components/Publishing/Fixtures/Components"
 
-jest.mock("sharify", () => ({
-  data: {
-    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
-    CURRENT_USER: {
-      type: "Non-Admin",
-      email: "someuser@email.com",
-    },
-  },
-}))
-
 describe("snapshots", () => {
   it("renders the display panel with an image", () => {
     const displayPanel = renderer
-      .create(
-        <DisplayPanel
-          unit={UnitPanel}
-          campaign={Campaign}
-          adDimension={StandardArticleHostedAdPanel.adDimension}
-          adUnit={StandardArticleHostedAdPanel.adUnit}
-        />
-      )
+      .create(<DisplayPanel unit={UnitPanel} campaign={Campaign} />)
       .toJSON()
     expect(displayPanel).toMatchSnapshot()
   })
 
   it("renders the display panel with video", () => {
     const displayPanel = renderer
-      .create(
-        <DisplayPanel
-          unit={UnitPanelVideo}
-          campaign={Campaign}
-          adDimension={StandardArticleHostedAdPanel.adDimension}
-          adUnit={StandardArticleHostedAdPanel.adUnit}
-        />
-      )
+      .create(<DisplayPanel unit={UnitPanelVideo} campaign={Campaign} />)
       .toJSON()
     expect(displayPanel).toMatchSnapshot()
   })
@@ -68,8 +43,6 @@ describe("units", () => {
       <DisplayPanel
         unit={unit}
         campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
         renderTime={12345}
         {...rest}
       />

--- a/src/Components/Publishing/Display/__tests__/NewDisplayCanvas.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/NewDisplayCanvas.test.tsx
@@ -1,0 +1,51 @@
+import { NewDisplayCanvas } from "Components/Publishing/Display/NewDisplayCanvas"
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import renderer from "react-test-renderer"
+
+import { StandardArticleHostedAdCanvas } from "../../Fixtures/Components"
+
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ENABLED: true,
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Admin",
+      email: "alloweduser@email.com",
+    },
+  },
+}))
+
+describe("snapshot", () => {
+  it("renders the new canvas in standard layout", () => {
+    const component = renderer
+      .create(
+        <NewDisplayCanvas
+          adDimension={StandardArticleHostedAdCanvas.adDimension}
+          adUnit={StandardArticleHostedAdCanvas.adUnit}
+        />
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
+})
+
+describe("data", () => {
+  it("renders the component with the correct data and properties in standard layout articles", () => {
+    const canvas = mount(
+      <NewDisplayCanvas
+        adDimension={StandardArticleHostedAdCanvas.adDimension}
+        adUnit={StandardArticleHostedAdCanvas.adUnit}
+      />
+    )
+
+    expect(canvas.props().adDimension).toEqual("970x250")
+    expect(canvas.props().adUnit).toEqual("Desktop_TopLeaderboard")
+    expect(canvas).toHaveLength(1)
+    canvas.find({ className: "htl-ad" })
+    canvas.find({ "data-sizes": "970x250" })
+    canvas.find({ "data-eager": true })
+    canvas.find({ "data-unit": "Desktop_TopLeaderboard" })
+  })
+})

--- a/src/Components/Publishing/Display/__tests__/NewDisplayPanel.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/NewDisplayPanel.test.tsx
@@ -1,0 +1,50 @@
+import { NewDisplayPanel } from "Components/Publishing/Display/NewDisplayPanel"
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import renderer from "react-test-renderer"
+
+import { StandardArticleHostedAdPanel } from "../../Fixtures/Components"
+
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ENABLED: true,
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Admin",
+      email: "alloweduser@email.com",
+    },
+  },
+}))
+
+describe("snapshot", () => {
+  it("renders the new canvas in standard layout", () => {
+    const component = renderer
+      .create(
+        <NewDisplayPanel
+          adDimension={StandardArticleHostedAdPanel.adDimension}
+          adUnit={StandardArticleHostedAdPanel.adUnit}
+        />
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
+})
+
+describe("data", () => {
+  it("renders the component with the correct data and properties in standard layout articles", () => {
+    const panel = mount(
+      <NewDisplayPanel
+        adDimension={StandardArticleHostedAdPanel.adDimension}
+        adUnit={StandardArticleHostedAdPanel.adUnit}
+      />
+    )
+
+    expect(panel.props().adDimension).toEqual("300x250")
+    expect(panel.props().adUnit).toEqual("Desktop_RightRail1")
+    panel.find({ className: "htl-ad" })
+    panel.find({ "data-sizes": "300x250" })
+    panel.find({ "data-eager": true })
+    panel.find({ "data-unit": "Desktop_RightRail1" })
+  })
+})

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayCanvas.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot renders the new canvas in standard layout 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 1250px;
+  margin: 0 auto;
+  width: 100%;
+  min-height: -webkit-fit-content;
+  min-height: -moz-fit-content;
+  min-height: fit-content;
+  max-width: 1250px;
+  box-sizing: border-box;
+}
+
+<div
+  className="c0"
+  width="100%"
+>
+  <div
+    className="htl-ad"
+    data-eager={true}
+    data-sizes="970x250"
+    data-unit="Desktop_TopLeaderboard"
+  />
+</div>
+`;

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayPanel.test.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot renders the new canvas in standard layout 1`] = `
+.c0 {
+  color: black100;
+  margin: auto;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  max-width: 360px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: auto;
+  padding: 8px;
+  border: 1px solid #E5E5E5;
+  max-width: 360px;
+  box-sizing: border-box;
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    margin: 0 auto;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c0 {
+    margin: auto;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    margin: auto;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c1 {
+    margin: inherit;
+  }
+}
+
+<div
+  className="c0"
+  color="black100"
+>
+  <div
+    className="DisplayPanel__DisplayPanelContainer c1"
+  >
+    <div
+      className="htl-ad"
+      data-eager={true}
+      data-sizes="300x250"
+      data-unit="Desktop_RightRail1"
+    />
+  </div>
+</div>
+`;

--- a/src/Components/Publishing/Layouts/Components/CanvasFooter.tsx
+++ b/src/Components/Publishing/Layouts/Components/CanvasFooter.tsx
@@ -7,7 +7,6 @@ import {
 } from "Components/Publishing//Typings"
 import { DisplayCanvas } from "Components/Publishing/Display/Canvas"
 import { RelatedArticlesCanvas } from "Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas"
-import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
 
@@ -17,19 +16,10 @@ export interface CanvasFooterProps {
   article: ArticleData
   renderTime?: number
   showCollectionsRail?: boolean
-  adUnit?: AdUnit
-  adDimension?: AdDimension
 }
 
 export const CanvasFooter: React.SFC<CanvasFooterProps> = props => {
-  const {
-    article,
-    display,
-    relatedArticles,
-    renderTime,
-    adDimension,
-    adUnit,
-  } = props
+  const { article, display, relatedArticles, renderTime } = props
 
   return (
     <CanvasFooterContainer>
@@ -47,15 +37,16 @@ export const CanvasFooter: React.SFC<CanvasFooterProps> = props => {
         </div>
       )}
 
-      {display && (
+      {/**
+       * FIXME: Remove DisplayCanvas component from footer when ad migration to GAM is complete
+       */
+      display && (
         <DisplayContainer hasBorder={relatedArticles ? true : false}>
           <DisplayCanvas
             unit={display.canvas}
             campaign={display}
             article={article}
             renderTime={renderTime}
-            adUnit={adUnit}
-            adDimension={adDimension}
           />
         </DisplayContainer>
       )}

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -26,16 +26,6 @@ jest.mock(
   })
 )
 
-jest.mock("sharify", () => ({
-  data: {
-    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
-    CURRENT_USER: {
-      type: "Non-Admin",
-      email: "someuser@email.com",
-    },
-  },
-}))
-
 describe("Standard Article", () => {
   const getWrapper = _props => {
     return mount(<StandardLayout {..._props} />)
@@ -50,6 +40,18 @@ describe("Standard Article", () => {
       relatedArticlesForCanvas: RelatedCanvas,
       relatedArticlesForPanel: RelatedPanel,
     }
+    jest.doMock("sharify", () => ({
+      HASHTAG_LAB_ADS_ENABLED: false,
+      HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+      CURRENT_USER: {
+        email: "someemail@email.com",
+        type: "Non-Admin",
+      },
+    }))
+  })
+
+  afterEach(() => {
+    jest.resetModules()
   })
 
   it("renders sidebar", () => {

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayoutNewAds.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayoutNewAds.test.tsx
@@ -1,0 +1,58 @@
+import { DisplayCanvas } from "Components/Publishing/Display/Canvas"
+import { DisplayPanel } from "Components/Publishing/Display/DisplayPanel"
+import { NewDisplayCanvas } from "Components/Publishing/Display/NewDisplayCanvas"
+import { NewDisplayPanel } from "Components/Publishing/Display/NewDisplayPanel"
+import { StandardArticle } from "Components/Publishing/Fixtures/Articles"
+import {
+  Display,
+  RelatedCanvas,
+  RelatedPanel,
+} from "Components/Publishing/Fixtures/Components"
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import { StandardLayout } from "../StandardLayout"
+
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ENABLED: true,
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    CURRENT_USER: {
+      type: "Admin",
+      email: "alloweduser@email.com",
+    },
+  },
+}))
+
+jest.mock(
+  "Components/Publishing/Sections/FullscreenViewer/withFullScreen",
+  () => ({
+    withFullScreen: x => x,
+  })
+)
+
+describe("Standard Article with new ads hidden behind feature flags", () => {
+  const getWrapper = _props => {
+    return mount(<StandardLayout {..._props} />)
+  }
+
+  let props
+  beforeEach(() => {
+    props = {
+      article: StandardArticle,
+      display: Display("standard"),
+      isTruncated: false,
+      relatedArticlesForCanvas: RelatedCanvas,
+      relatedArticlesForPanel: RelatedPanel,
+    }
+  })
+
+  it("It renders new panel and canvas displays in Standard Layout Articles when feature flagged ads are enabled", () => {
+    const article = getWrapper(props)
+
+    expect(article.find(NewDisplayPanel).length).toBe(1)
+    expect(article.find(NewDisplayCanvas).length).toBe(1)
+    expect(article.find(DisplayPanel).length).toBe(0)
+    expect(article.find(DisplayCanvas).length).toBe(0)
+  })
+})

--- a/src/Components/Publishing/__stories__/Display.story.tsx
+++ b/src/Components/Publishing/__stories__/Display.story.tsx
@@ -1,14 +1,18 @@
 import { storiesOf } from "@storybook/react"
+import { isHTLAdEnabled } from "Components/Publishing/Ads/EnabledAd"
 import { clone, extend } from "lodash"
 import React from "react"
 import { getCurrentUnixTimestamp } from "../Constants"
 import { DisplayCanvas } from "../Display/Canvas"
 import { DisplayPanel } from "../Display/DisplayPanel"
+import { NewDisplayCanvas } from "../Display/NewDisplayCanvas"
+import { NewDisplayPanel } from "../Display/NewDisplayPanel"
 import { StandardArticle } from "../Fixtures/Articles"
 import { Sections } from "../Sections/Sections"
 
 import {
   Campaign,
+  StandardArticleHostedAdCanvas,
   StandardArticleHostedAdPanel,
   UnitCanvasImage,
   UnitCanvasOverlay,
@@ -22,69 +26,63 @@ import {
 
 const story = storiesOf("Publishing/Display/Panel", module)
   .add("Panel", () => {
-    return (
-      <DisplayPanel
-        unit={UnitPanel}
-        campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
-      />
-    )
+    return <DisplayPanel unit={UnitPanel} campaign={Campaign} />
   })
   .add("Panel with 3rd party tracking", () => {
-    return (
+    return isHTLAdEnabled() ? (
+      <NewDisplayPanel
+        adUnit={StandardArticleHostedAdPanel.adUnit}
+        adDimension={StandardArticleHostedAdPanel.adDimension}
+      />
+    ) : (
       <DisplayPanel
         unit={UnitPanelTracked}
         campaign={Campaign}
         renderTime={getCurrentUnixTimestamp()}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
       />
     )
   })
   .add("Mobile Panel", () => {
-    return (
-      <DisplayPanel
-        unit={UnitPanel}
-        campaign={Campaign}
-        isMobile
-        adDimension={StandardArticleHostedAdPanel.adDimension}
+    return isHTLAdEnabled() ? (
+      <NewDisplayPanel
         adUnit={StandardArticleHostedAdPanel.adUnit}
+        adDimension={StandardArticleHostedAdPanel.adDimension}
       />
+    ) : (
+      <DisplayPanel unit={UnitPanel} campaign={Campaign} isMobile />
     )
   })
   .add("Without logo", () => {
     const unit = extend({}, UnitPanel, {
       logo: "",
     })
-    return (
-      <DisplayPanel
-        unit={unit}
-        campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
+    return isHTLAdEnabled() ? (
+      <NewDisplayPanel
         adUnit={StandardArticleHostedAdPanel.adUnit}
+        adDimension={StandardArticleHostedAdPanel.adDimension}
       />
+    ) : (
+      <DisplayPanel unit={unit} campaign={Campaign} />
     )
   })
   .add("Video", () => {
-    return (
-      <DisplayPanel
-        unit={UnitPanelVideo}
-        campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
+    return isHTLAdEnabled() ? (
+      <NewDisplayPanel
         adUnit={StandardArticleHostedAdPanel.adUnit}
+        adDimension={StandardArticleHostedAdPanel.adDimension}
       />
+    ) : (
+      <DisplayPanel unit={UnitPanelVideo} campaign={Campaign} />
     )
   })
   .add("Video (mobile)", () => {
-    return (
-      <DisplayPanel
-        unit={UnitPanelVideo}
-        campaign={Campaign}
-        isMobile
-        adDimension={StandardArticleHostedAdPanel.adDimension}
+    return isHTLAdEnabled() ? (
+      <NewDisplayPanel
         adUnit={StandardArticleHostedAdPanel.adUnit}
+        adDimension={StandardArticleHostedAdPanel.adDimension}
       />
+    ) : (
+      <DisplayPanel unit={UnitPanelVideo} campaign={Campaign} isMobile />
     )
   })
 
@@ -94,15 +92,15 @@ mobileAdInsertions.forEach(([label, unit]) => {
   story.add(`${label} injected into mobile body`, () => {
     const article = clone(StandardArticle)
 
-    const DisplayPanelAd = () => (
-      <DisplayPanel
-        isMobile
-        unit={unit}
-        campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
-      />
-    )
+    const DisplayPanelAd = () =>
+      isHTLAdEnabled ? (
+        <NewDisplayPanel
+          adUnit={StandardArticleHostedAdPanel.adUnit}
+          adDimension={StandardArticleHostedAdPanel.adDimension}
+        />
+      ) : (
+        <DisplayPanel isMobile unit={unit} campaign={Campaign} />
+      )
 
     return <Sections isMobile DisplayPanel={DisplayPanelAd} article={article} />
   })
@@ -110,53 +108,56 @@ mobileAdInsertions.forEach(([label, unit]) => {
 
 storiesOf("Publishing/Display/Canvas", module)
   .add("Overlay", () => {
-    return (
-      <DisplayCanvas
-        unit={UnitCanvasOverlay}
-        campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
+    return isHTLAdEnabled() ? (
+      <NewDisplayCanvas
+        adUnit={StandardArticleHostedAdCanvas.adUnit}
+        adDimension={StandardArticleHostedAdCanvas.adDimension}
       />
+    ) : (
+      <DisplayCanvas unit={UnitCanvasOverlay} campaign={Campaign} />
     )
   })
   .add("Overlay with 3rd party tracking", () => {
-    return (
+    return isHTLAdEnabled() ? (
+      <NewDisplayCanvas
+        adUnit={StandardArticleHostedAdCanvas.adUnit}
+        adDimension={StandardArticleHostedAdCanvas.adDimension}
+      />
+    ) : (
       <DisplayCanvas
         unit={UnitCanvasTracked}
         campaign={Campaign}
         renderTime={getCurrentUnixTimestamp()}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
       />
     )
   })
   .add("Image", () => {
-    return (
-      <DisplayCanvas
-        unit={UnitCanvasImage}
-        campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
+    return isHTLAdEnabled() ? (
+      <NewDisplayCanvas
+        adUnit={StandardArticleHostedAdCanvas.adUnit}
+        adDimension={StandardArticleHostedAdCanvas.adDimension}
       />
+    ) : (
+      <DisplayCanvas unit={UnitCanvasImage} campaign={Campaign} />
     )
   })
   .add("Video", () => {
-    return (
-      <DisplayCanvas
-        unit={UnitCanvasVideo}
-        campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
+    return isHTLAdEnabled() ? (
+      <NewDisplayCanvas
+        adUnit={StandardArticleHostedAdCanvas.adUnit}
+        adDimension={StandardArticleHostedAdCanvas.adDimension}
       />
+    ) : (
+      <DisplayCanvas unit={UnitCanvasVideo} campaign={Campaign} />
     )
   })
   .add("Slideshow", () => {
-    return (
-      <DisplayCanvas
-        unit={UnitCanvasSlideshow}
-        campaign={Campaign}
-        adDimension={StandardArticleHostedAdPanel.adDimension}
-        adUnit={StandardArticleHostedAdPanel.adUnit}
+    return isHTLAdEnabled() ? (
+      <NewDisplayCanvas
+        adUnit={StandardArticleHostedAdCanvas.adUnit}
+        adDimension={StandardArticleHostedAdCanvas.adDimension}
       />
+    ) : (
+      <DisplayCanvas unit={UnitCanvasSlideshow} campaign={Campaign} />
     )
   })


### PR DESCRIPTION
External testers were not seeing the new Google Ad Manager (GAM) hosted ads on 100% of articles because how often ads appear is contingent upon the Share of Voice (SOV) percentage.  One ad campaign has an SOV of 20%, this means that in order to see the new ads on 100% of articles we would have to activate 5 campaigns in the Staging Artsy Writer each day (as Staging Artsy Writer data is overwritten with Production data every night). Rather than doing this and having the logic of how new ads (GAM hosted ads) and current ads intertwined, this PR moves the new ads into their own component. Now the new ads will render on 100% of Standard Articles, on Staging, but they remain only viewable to Admin and/or Allowlisted users. 
![Kapture 2019-05-14 at 15 11 00](https://user-images.githubusercontent.com/10385964/57725464-33858280-765b-11e9-9328-a006df307435.gif)
