### PR TITLE
DISCO 1029 - Consolidate url history management in state containers

### DIFF
--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -159,10 +159,15 @@ export class FilterState extends Container<State> {
   }
 
   resetFilters = () => {
-    this.setState({
-      ...initialState,
-      showActionSheet: true,
-    })
+    this.setState(
+      {
+        ...initialState,
+        showActionSheet: true,
+      },
+      () => {
+        this.pushHistory()
+      }
+    )
   }
 
   unsetFilter(filter) {

--- a/src/Apps/Collect/Components/Base/CollectArtworkGrid.tsx
+++ b/src/Apps/Collect/Components/Base/CollectArtworkGrid.tsx
@@ -1,6 +1,6 @@
 import { Box, Spacer } from "@artsy/palette"
 import { ArtworkFilterArtworkGrid_filtered_artworks } from "__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql"
-import { FilterState, urlFragmentFromState } from "Apps/Collect/FilterState"
+import { FilterState } from "Apps/Collect/FilterState"
 import { SystemContextConsumer } from "Artsy"
 import ArtworkGrid from "Components/ArtworkGrid"
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
@@ -54,16 +54,7 @@ class CollectArtworkGrid extends Component<Props, LoadingAreaState> {
       error => {
         this.toggleLoading(false)
         filters.setPage(page, mediator)
-        const { state } = filters
-        const urlFragment = urlFragmentFromState(state, { page })
 
-        // Using window.history.pushState instead of router.push, because
-        //   we just want to add to the history, not navigate to another route.
-        window.history.pushState(
-          {},
-          null,
-          `${window.location.pathname}?${urlFragment}`
-        )
         if (error) {
           logger.error(error)
         }

--- a/src/Apps/Collect/Components/Base/CollectRefetch.tsx
+++ b/src/Apps/Collect/Components/Base/CollectRefetch.tsx
@@ -1,9 +1,5 @@
 import { CollectRefetch_viewer } from "__generated__/CollectRefetch_viewer.graphql"
-import {
-  FilterState,
-  untrackedFilters,
-  urlFragmentFromState,
-} from "Apps/Collect/FilterState"
+import { FilterState, untrackedFilters } from "Apps/Collect/FilterState"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { isEqual } from "lodash"
@@ -66,16 +62,6 @@ export class CollectRefetch extends Component<CollectRefetchProps> {
           if (error) {
             logger.error(error)
           }
-
-          // Using window.history.pushState instead of router.push, because
-          //   we just want to add to the history, not navigate to another route.
-          window.history.pushState(
-            {},
-            null,
-            `${window.location.pathname}?${urlFragmentFromState(
-              this.props.filtersState
-            )}`
-          )
 
           this.setState({
             isLoading: false,

--- a/src/Apps/Collect/Components/Collection/CollectionRefetch.tsx
+++ b/src/Apps/Collect/Components/Collection/CollectionRefetch.tsx
@@ -1,6 +1,5 @@
 import { CollectionRefetch_collection } from "__generated__/CollectionRefetch_collection.graphql"
 import { FilterState } from "Apps/Collect/FilterState"
-import { urlFragmentFromState } from "Apps/Search/FilterState"
 import { isEqual } from "lodash"
 import React, { Component } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
@@ -49,16 +48,6 @@ export class CollectionRefetch extends Component<CollectionRefetchProps> {
           if (error) {
             logger.error(error)
           }
-
-          // Using window.history.pushState instead of router.push, because
-          //   we just want to add to the history, not navigate to another route.
-          window.history.pushState(
-            {},
-            null,
-            `${window.location.pathname}?${urlFragmentFromState(
-              this.props.filtersState
-            )}`
-          )
 
           this.setState({
             isLoading: false,

--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -160,9 +160,14 @@ export class FilterState extends Container<State> {
   }
 
   resetFilters = () => {
-    this.setState({
-      ...initialState,
-    })
+    this.setState(
+      {
+        ...initialState,
+      },
+      () => {
+        this.pushHistory()
+      }
+    )
   }
 
   unsetFilter(filter, _mediator) {

--- a/src/Apps/Search/FilterState.tsx
+++ b/src/Apps/Search/FilterState.tsx
@@ -127,16 +127,38 @@ export class FilterState extends Container<State> {
     return omitBy(this.state, isNil)
   }
 
+  previousQueryString = ""
+  pushHistory() {
+    const currentQueryString = urlFragmentFromState(this.state)
+    // PriceRangeFilter's onAfterChange event fires twice; this ensures
+    //   we only push that history event once.
+    if (this.previousQueryString !== currentQueryString) {
+      window.history.pushState(
+        {},
+        null,
+        `${window.location.pathname}?${currentQueryString}`
+      )
+      this.previousQueryString = currentQueryString
+    }
+  }
+
   setPage(page) {
-    this.setState({ page })
+    this.setState({ page }, () => {
+      this.pushHistory()
+    })
   }
 
   resetFilters = () => {
     const { keyword } = this.state
-    this.setState({
-      ...initialState,
-      keyword,
-    })
+    this.setState(
+      {
+        ...initialState,
+        keyword,
+      },
+      () => {
+        this.pushHistory()
+      }
+    )
   }
 
   unsetFilter(filter) {
@@ -164,7 +186,9 @@ export class FilterState extends Container<State> {
       newPartialState = { medium: "*" }
     }
 
-    this.setState(newPartialState)
+    this.setState(newPartialState, () => {
+      this.pushHistory()
+    })
   }
 
   setFilter(filter: keyof State, value) {
@@ -200,7 +224,9 @@ export class FilterState extends Container<State> {
         break
     }
 
-    this.setState({ page: 1, ...newPartialState })
+    this.setState({ page: 1, ...newPartialState }, () => {
+      this.pushHistory()
+    })
   }
 
   isRangeSelected(range: string): boolean {

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsArtworkGrid.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsArtworkGrid.tsx
@@ -1,7 +1,7 @@
 import { Box, Spacer } from "@artsy/palette"
 import { SearchResultsArtworkGrid_filtered_artworks } from "__generated__/SearchResultsArtworkGrid_filtered_artworks.graphql"
 import { ZeroState } from "Apps/Search/Components/ZeroState"
-import { FilterState, urlFragmentFromState } from "Apps/Search/FilterState"
+import { FilterState } from "Apps/Search/FilterState"
 import { SystemContextConsumer } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
@@ -70,13 +70,6 @@ class SearchResultsArtworkGrid extends Component<Props, LoadingAreaState> {
         if (error) {
           console.error(error)
         }
-
-        const { state } = filters
-        const urlFragment = urlFragmentFromState(state, { page })
-
-        // TODO: Look into using router push w/ query params.
-        // this.props.router.replace(`/search?${urlFragment}`)
-        window.history.pushState({}, null, `/search?${urlFragment}`)
       }
     )
   }

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsRefetch.tsx
@@ -1,5 +1,5 @@
 import { SearchResultsRefetch_viewer } from "__generated__/SearchResultsRefetch_viewer.graphql"
-import { FilterState, urlFragmentFromState } from "Apps/Search/FilterState"
+import { FilterState } from "Apps/Search/FilterState"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { isEqual } from "lodash"
@@ -53,13 +53,6 @@ export class SearchResultsRefetch extends Component<SearchRefetchProps> {
           if (error) {
             console.error(error)
           }
-
-          // TODO: Look into using router push w/ query params.
-          window.history.pushState(
-            {},
-            null,
-            `/search?${urlFragmentFromState(this.props.filtersState)}`
-          )
 
           this.setState({
             isLoading: false,

--- a/src/Apps/Search/__tests__/FilterState.test.ts
+++ b/src/Apps/Search/__tests__/FilterState.test.ts
@@ -17,16 +17,19 @@ describe("FilterState", () => {
     instance.setState = jest.fn()
     instance.setFilter("page", 3)
 
-    expect(instance.setState).toBeCalledWith({ page: 3 })
+    expect(instance.setState).toBeCalledWith({ page: 3 }, expect.any(Function))
   })
 
   it("confirms that state is set for price range filter", () => {
     instance.setState = jest.fn()
     instance.setFilter("price_range", "*-43000")
-    expect(instance.setState).toBeCalledWith({
-      page: 1,
-      price_range: "*-43000",
-    })
+    expect(instance.setState).toBeCalledWith(
+      {
+        page: 1,
+        price_range: "*-43000",
+      },
+      expect.any(Function)
+    )
   })
 
   it("confirms that price range filter is set to correct values", () => {
@@ -39,7 +42,10 @@ describe("FilterState", () => {
   it("returns a height range tuple based on filter string", () => {
     instance.setState = jest.fn()
     instance.setFilter("height", "*-50")
-    expect(instance.setState).toBeCalledWith({ page: 1, height: "*-50" })
+    expect(instance.setState).toBeCalledWith(
+      { page: 1, height: "*-50" },
+      expect.any(Function)
+    )
   })
 
   it("returns a height range tuple based on the state", () => {


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-1029.

During my work on pagination for the /collect, /collection/:id, and /artist routes, I learned more about the interactions between these routes and their corresponding state containers. This led me to a pattern in #2392 for managing browser history in the /artist route; I think it does a good job of consolidating "state" changes in one place. This PR applies that pattern to the /collect, /collection/:id, and /search routes. 

I'm also optimistic that these changes will make it easier to apply a fix for https://artsyproduct.atlassian.net/browse/DISCO-1032.