### PR TITLE
[NavBar] Fix padding around spinner fetch

### DIFF
--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -16,6 +16,13 @@ const SpinnerContainer = styled.figure`
   flex-direction: column;
   justify-content: center;
   position: relative;
+
+  /*
+    Noticed some weird behavior in force due to figure margin being set to 0
+    in global css. Adding padding of 22 gets things back to visual default.
+  */
+  margin: unset;
+  padding: 22px;
 `
 
 export const LoadingClassName = "relay-loading"

--- a/src/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -84,6 +84,10 @@ export const NotificationMenuItems: React.FC<
   )
 }
 
+/**
+ * The <Menu /> component renders a QueryRenderer inside of it, which fetches
+ * individual MenuItems for display. During fetch there is a loading spinner.
+ */
 export const NotificationsMenu: React.FC = () => {
   return (
     <Menu title="Actvity">


### PR DESCRIPTION
Fixed a weird issue with collapsing `<figure>` element in force, due to global css defining a margin of 0, which differs in reaction (reaction has not set css on the figure element at all). The `padding: 22px` could probably be done better, but for now it works and only impacts the Spinner component as rendered within `fetchWithLoaderProgress`. 

#trivial 