### PR TITLE
[DISCO-1023] Adds parens to result counts.

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -68,7 +68,7 @@ export class NavigationTabs extends React.Component<Props> {
           {text}
           {count != null && (
             <Sans ml={0.5} size="3t" weight="regular">
-              {count}
+              ({count})
             </Sans>
           )}
         </Flex>


### PR DESCRIPTION
Simple PR to add (parens) to the result counts in the search bar:

<img width="812" alt="Screen Shot 2019-05-15 at 4 07 45 PM" src="https://user-images.githubusercontent.com/498212/57806048-516ee800-772c-11e9-9fd2-f70f1fa03f68.png">


Fixes DISCO-1023.