### PR TITLE
Make FillwidthItem more forgiving of empty artwork images

### DIFF
--- a/src/Components/Artwork/FillwidthItem.tsx
+++ b/src/Components/Artwork/FillwidthItem.tsx
@@ -13,6 +13,10 @@ import { Mediator } from "Artsy"
 
 // @ts-ignore
 import styled, { StyledComponentClass } from "styled-components"
+import { get } from "Utils/get"
+import createLogger from "Utils/logger"
+
+const logger = createLogger("FillwidthItem.tsx")
 
 const IMAGE_QUALITY = 80
 
@@ -96,6 +100,13 @@ export class FillwidthItemContainer extends React.Component<
     let userSpread = {}
     if (user) {
       userSpread = { user }
+    }
+
+    const image = get(this.props, p => p.artwork.image)
+    if (!image) {
+      const href = get(this.props, p => p.artwork.href, "(unknown href)")
+      logger.error(new Error(`Artwork at ${href} does not have an image!`))
+      return null
     }
 
     return (

--- a/src/Components/Artwork/__tests__/FillwidthItem.test.tsx
+++ b/src/Components/Artwork/__tests__/FillwidthItem.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "enzyme"
+import React from "react"
+import { FillwidthItem } from "../FillwidthItem"
+
+describe("FillwidthItem", () => {
+  // This scenario _should not_ happen. But it did. Every artwork should have
+  //   an image, but somehow one snuck through in production and broke pages.
+  describe("No image associated with an artwork", () => {
+    it("Doesn't blow up when there is no image associated with an artwork", () => {
+      const artwork = {
+        " $fragmentRefs": null,
+        href: "my/artwork",
+      }
+
+      // @ts-ignore
+      const wrapper = render(<FillwidthItem artwork={artwork} />)
+
+      expect(wrapper.html()).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
This PR prevents the FillwidthItem from blowing up when there is no image associated. 

## Context

We had an issue today where a specific artwork was published with no image. We think that our system protects this from happening, but it happened somehow.

As a result, users were seeing a blank page when they visited https://artsy.net/artist/nadezda-nikolova-kratzer. (You can currently see this in staging - https://staging.artsy.net/artist/nadezda-nikolova-kratzer - at least, until data is sync'ed down from production, or this PR is deployed.)

![image](https://user-images.githubusercontent.com/1627089/57808174-6c3f5d80-7728-11e9-8d81-d22bf8e9de4a.png)

Investigation into how this artwork was published with no images is happening separately.