### PR TITLE
Address feedback for #2420

### DIFF
--- a/src/Components/Artwork/FillwidthItem.tsx
+++ b/src/Components/Artwork/FillwidthItem.tsx
@@ -105,7 +105,7 @@ export class FillwidthItemContainer extends React.Component<
     const image = get(this.props, p => p.artwork.image)
     if (!image) {
       const href = get(this.props, p => p.artwork.href, "(unknown href)")
-      logger.error(new Error(`Artwork at ${href} does not have an image!`))
+      logger.error(`Artwork at ${href} does not have an image!`)
       return null
     }
 

--- a/src/Components/Artwork/__tests__/FillwidthItem.test.tsx
+++ b/src/Components/Artwork/__tests__/FillwidthItem.test.tsx
@@ -12,8 +12,7 @@ describe("FillwidthItem", () => {
         href: "my/artwork",
       }
 
-      // @ts-ignore
-      const wrapper = render(<FillwidthItem artwork={artwork} />)
+      const wrapper = render(<FillwidthItem artwork={artwork as any} />)
 
       expect(wrapper.html()).toBeNull()
     })


### PR DESCRIPTION
This PR addresses some feedback on PR #2420. 

* Call logger.error with string instead of Error, so that missing image data errors don’t pollute Sentry
* Use a smaller hammer to pass an invalid artwork (without an image) to FillwidthItem