### PR TITLE
DISCO-1035 - Set the `major_periods` state property correctly when constructing the Artist, Collect, and Search apps.

### DIFF
--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -94,9 +94,7 @@ export class FilterState extends Container<State> {
     if (props) {
       Object.keys(this.state).forEach(filter => {
         if (props[filter]) {
-          if (filter === "major_periods") {
-            this.state[filter] = [props[filter]]
-          } else if (
+          if (
             [
               "for_sale",
               "acquireable",

--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -114,9 +114,6 @@ export class FilterState extends Container<State> {
         }
 
         switch (filter) {
-          case "major_periods":
-            this.state[filter] = [value]
-            break
           case "page":
             this.state[filter] = Number(value)
             break

--- a/src/Apps/Collect/__tests__/FilterState.test.tsx
+++ b/src/Apps/Collect/__tests__/FilterState.test.tsx
@@ -18,7 +18,7 @@ describe("FilterState", () => {
   })
 
   it("Gets initialized properly", () => {
-    expect(instance.state).toEqual({ ...initialState, major_periods: [[]] })
+    expect(instance.state).toEqual({ ...initialState, major_periods: [] })
   })
 
   it("updates it's state properly if a filter is changed", () => {

--- a/src/Apps/Search/FilterState.tsx
+++ b/src/Apps/Search/FilterState.tsx
@@ -103,9 +103,6 @@ export class FilterState extends Container<State> {
         }
 
         switch (filter) {
-          case "major_periods":
-            this.state[filter] = [value]
-            break
           case "page":
             this.state[filter] = Number(value)
             break

--- a/src/Apps/Search/__tests__/FilterState.test.ts
+++ b/src/Apps/Search/__tests__/FilterState.test.ts
@@ -8,7 +8,7 @@ describe("FilterState", () => {
   })
 
   it("Gets initialized properly", () => {
-    expect(instance.state).toEqual({ ...initialState, major_periods: [[]] })
+    expect(instance.state).toEqual({ ...initialState, major_periods: [] })
   })
 
   it("updates it's state properly if a filter is changed", () => {


### PR DESCRIPTION
This PR addresses https://artsyproduct.atlassian.net/browse/DISCO-1035.

At any of these URLs: /collect, /collection/:id, /artist/:id, or /search...
If you would select a time period filter, then click back, then click forward, the page would stop working or the results would stop updating. This was because in the constructors of the state containers for these Apps, we were initializing the `major_periods` state property improperly. 

We were setting it to an array of the value passed in through props. Unfortunately, the value passed in through props was _already_ an array, so it was effectively initializing the `major_periods` state property to `[ [ "1990" ] ]` (if I had selected 1990). This caused GraphQL to yell about the type - it was expecting an `Array<string>`, not an `Array<Array<string>>`. 
