### PR TITLE
Dont display pageDots if only one image

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -29,15 +29,6 @@ export const ArtworkImageBrowser = (props: ArtworkBrowserProps) => {
 export class LargeArtworkImageBrowser extends React.Component<
   ArtworkBrowserProps
 > {
-  options = {
-    prevNextButtons: false,
-    wrapAround: true,
-    pageDots: true,
-    cellAlign: "left",
-    draggable: false,
-    lazyLoad: true,
-  }
-
   render() {
     const hasMultipleImages = this.props.images.length > 1
     const { imageAlt, images, setFlickityRef } = this.props
@@ -46,11 +37,20 @@ export class LargeArtworkImageBrowser extends React.Component<
     // of SSR support in Flickity.
     const carouselImages = typeof window === "undefined" ? [images[0]] : images
 
+    const options = {
+      prevNextButtons: false,
+      wrapAround: true,
+      pageDots: hasMultipleImages,
+      cellAlign: "left",
+      draggable: false,
+      lazyLoad: true,
+    }
+
     return (
       <Container>
         <Carousel
           showArrows={hasMultipleImages}
-          options={this.options}
+          options={options}
           oneSlideVisible
           height="60vh"
           setFlickityRef={setFlickityRef}


### PR DESCRIPTION
- This PR removes page dots from the `LargeCarousel` from `ArtworkImageBrowser` if there's only one image.

## Before

<img width="848" alt="Screen Shot 2019-05-16 at 5 29 44 AM" src="https://user-images.githubusercontent.com/21182806/57843099-b01f7a80-779b-11e9-9a20-7eb7749dcce5.png">


## After

<img width="841" alt="Screen Shot 2019-05-16 at 5 29 27 AM" src="https://user-images.githubusercontent.com/21182806/57843120-b6adf200-779b-11e9-9ccf-e9a99c5d14fc.png">
