### PR TITLE
PURCHASE-1102 Remove handling of `null` from the `amount` helper in MP

### DIFF
--- a/src/Apps/Artwork/Components/PricingContext.tsx
+++ b/src/Apps/Artwork/Components/PricingContext.tsx
@@ -72,7 +72,6 @@ export class PricingContext extends React.Component<PricingContextProps> {
     }
   }
 
-  // TODO: Investigate why metaphysics is returning null instead of zero for minPrice
   render() {
     const { artwork } = this.props
     if (!artwork.pricingContext) {
@@ -119,10 +118,9 @@ export class PricingContext extends React.Component<PricingContextProps> {
             (bin, index): BarDescriptor => {
               const isFirstBin = index === 0
               const isLastBin = index === artwork.pricingContext.bins.length - 1
-              const binMinPrice = bin.minPrice != null ? bin.minPrice : "$0"
               const title = isLastBin
-                ? `${binMinPrice}+`
-                : `${isFirstBin ? "$0" : binMinPrice}–${bin.maxPrice}`
+                ? `${bin.minPrice}+`
+                : `${isFirstBin ? "$0" : bin.minPrice}–${bin.maxPrice}`
               const artworkFallsInThisBin =
                 (isFirstBin && artworkFallsBeforeFirstBin) ||
                 (isLastBin && artworkFallsAfterLastBin) ||

--- a/src/Apps/Artwork/Components/PricingContext.tsx
+++ b/src/Apps/Artwork/Components/PricingContext.tsx
@@ -109,6 +109,7 @@ export class PricingContext extends React.Component<PricingContextProps> {
         </Link>
         <Spacer mb={[2, 3]} />
         <BarChart
+          // TODO: use artwork's currency
           minLabel="$0"
           maxLabel={
             artwork.pricingContext.bins[artwork.pricingContext.bins.length - 1]
@@ -120,7 +121,8 @@ export class PricingContext extends React.Component<PricingContextProps> {
               const isLastBin = index === artwork.pricingContext.bins.length - 1
               const title = isLastBin
                 ? `${bin.minPrice}+`
-                : `${isFirstBin ? "$0" : bin.minPrice}–${bin.maxPrice}`
+                : // TODO: use artwork's currency
+                  `${isFirstBin ? "$0" : bin.minPrice}–${bin.maxPrice}`
               const artworkFallsInThisBin =
                 (isFirstBin && artworkFallsBeforeFirstBin) ||
                 (isLastBin && artworkFallsAfterLastBin) ||

--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -14,6 +14,8 @@ export interface TransactionDetailsSummaryItemProps
   showOfferNote?: boolean
 }
 
+const emDash = "—"
+
 export class TransactionDetailsSummaryItem extends React.Component<
   TransactionDetailsSummaryItemProps
 > {
@@ -46,18 +48,10 @@ export class TransactionDetailsSummaryItem extends React.Component<
     const { order } = this.props
     switch (order.mode) {
       case "BUY":
-        return (
-          this.formattedAmount(order.shippingTotal, order.shippingTotalCents) ||
-          "—"
-        )
+        return order.shippingTotal || emDash
       case "OFFER":
         const offer = this.getOffer()
-        return offer
-          ? this.formattedAmount(
-              offer.shippingTotal,
-              offer.shippingTotalCents
-            ) || "—"
-          : "—"
+        return (offer && offer.shippingTotal) || emDash
     }
   }
 
@@ -65,12 +59,10 @@ export class TransactionDetailsSummaryItem extends React.Component<
     const { order } = this.props
     switch (order.mode) {
       case "BUY":
-        return this.formattedAmount(order.taxTotal, order.taxTotalCents) || "—"
+        return order.taxTotal || emDash
       case "OFFER":
         const offer = this.getOffer()
-        return offer
-          ? this.formattedAmount(offer.taxTotal, offer.taxTotalCents) || "—"
-          : "—"
+        return (offer && offer.taxTotal) || emDash
     }
   }
 
@@ -98,7 +90,7 @@ export class TransactionDetailsSummaryItem extends React.Component<
       <>
         <Entry
           label={isBuyerOffer ? "Your offer" : "Seller's offer"}
-          value={offerOverride || (offer && offer.amount) || "—"}
+          value={offerOverride || (offer && offer.amount) || emDash}
         />
         {offerContextPrice === "LIST_PRICE" ? (
           <SecondaryEntry label="List price" value={order.totalListPrice} />
@@ -132,15 +124,6 @@ export class TransactionDetailsSummaryItem extends React.Component<
           </Serif>
         </>
       )
-    }
-  }
-
-  formattedAmount = (amount, amountCents) => {
-    // FIXME: Use actual currency code
-    if (amount) {
-      return amount
-    } else {
-      return amountCents === 0 ? "$0.00" : null
     }
   }
 }

--- a/src/Apps/Order/Components/__tests__/TransactionDetailsSummary.test.tsx
+++ b/src/Apps/Order/Components/__tests__/TransactionDetailsSummary.test.tsx
@@ -86,23 +86,6 @@ describe("TransactionDetailsSummaryItem", () => {
       expect(text).toMatch("Tax—")
       expect(text).toMatch("Total$215.25")
     })
-
-    it("shows the shipping and tax price as $0.00 if zero cents", async () => {
-      const transactionSummary = await render({
-        ...transactionSummaryBuyOrder,
-        taxTotal: null,
-        taxTotalCents: 0,
-        shippingTotal: null,
-        shippingTotalCents: 0,
-      } as any)
-
-      const text = transactionSummary.text()
-
-      expect(text).toMatch("Price$200.00")
-      expect(text).toMatch("Shipping$0.00")
-      expect(text).toMatch("Tax$0.00")
-      expect(text).toMatch("Total$215.25")
-    })
   })
 
   describe("OfferOrder", () => {
@@ -138,29 +121,6 @@ describe("TransactionDetailsSummaryItem", () => {
       expect(text).toMatch("Shipping—")
       expect(text).toMatch("Tax—")
       expect(text).toMatch("Total")
-    })
-
-    it("shows the shipping and tax price as $0.00 if zero cents", async () => {
-      const transactionSummary = await render({
-        ...transactionSummaryOfferOrder,
-        myLastOffer: {
-          ...OfferWithTotals,
-          taxTotal: null,
-          taxTotalCents: 0,
-          shippingTotal: null,
-          shippingTotalCents: 0,
-          buyerTotal: "$14,000",
-          buyerTotalCents: 1400000,
-          fromParticipant: "BUYER",
-        },
-      } as any)
-
-      const text = transactionSummary.text()
-
-      expect(text).toMatch("Your offer$14,000")
-      expect(text).toMatch("Shipping$0.00")
-      expect(text).toMatch("Tax$0.00")
-      expect(text).toMatch("Total$14,000")
     })
 
     it("shows empty fields when there are no myLastOffer yet", async () => {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-1102

This is follow-up from artsy/metaphysics#1696

I checked all the fields, these are the only relevant cases in reaction.

Also, this is safe to merge, the related change in MP is now in production.