### PR TITLE
Signup form includes recaptcha_token on handleSubmit

### DIFF
--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -1,6 +1,3 @@
-import { Formik, FormikProps } from "formik"
-import React, { Component } from "react"
-
 import {
   Error,
   Footer,
@@ -16,6 +13,9 @@ import {
 import { SignUpValidator } from "Components/Authentication/Validators"
 import PasswordInput from "Components/PasswordInput"
 import QuickInput from "Components/QuickInput"
+import { Formik, FormikProps } from "formik"
+import { extend } from "lodash"
+import React, { Component } from "react"
 import { repcaptcha } from "Utils/repcaptcha"
 
 export interface SignUpFormState {
@@ -28,8 +28,12 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
   }
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
-    repcaptcha("signup_submit")
-    this.props.handleSubmit(values, formikBag)
+    repcaptcha("signup_submit", recaptcha_token => {
+      const valuesWithToken = extend(values, {
+        recaptcha_token,
+      })
+      this.props.handleSubmit(valuesWithToken, formikBag)
+    })
   }
 
   render() {

--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -14,7 +14,6 @@ import { SignUpValidator } from "Components/Authentication/Validators"
 import PasswordInput from "Components/PasswordInput"
 import QuickInput from "Components/QuickInput"
 import { Formik, FormikProps } from "formik"
-import { extend } from "lodash"
 import React, { Component } from "react"
 import { repcaptcha } from "Utils/repcaptcha"
 
@@ -29,9 +28,10 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
     repcaptcha("signup_submit", recaptcha_token => {
-      const valuesWithToken = extend(values, {
+      const valuesWithToken = {
+        ...values,
         recaptcha_token,
-      })
+      }
       this.props.handleSubmit(valuesWithToken, formikBag)
     })
   }

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -23,7 +23,6 @@ import { ProgressIndicator } from "Components/ProgressIndicator"
 import QuickInput from "Components/QuickInput"
 import { Step, Wizard } from "Components/Wizard"
 import { FormikProps } from "formik"
-import { extend } from "lodash"
 import React, { Component, Fragment } from "react"
 import { repcaptcha } from "Utils/repcaptcha"
 
@@ -72,9 +71,10 @@ export class MobileSignUpForm extends Component<
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
     repcaptcha("signup_submit", recaptcha_token => {
-      const valuesWithToken = extend(values, {
+      const valuesWithToken = {
+        ...values,
         recaptcha_token,
-      })
+      }
       this.props.handleSubmit(valuesWithToken, formikBag)
     })
   }

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -23,6 +23,7 @@ import { ProgressIndicator } from "Components/ProgressIndicator"
 import QuickInput from "Components/QuickInput"
 import { Step, Wizard } from "Components/Wizard"
 import { FormikProps } from "formik"
+import { extend } from "lodash"
 import React, { Component, Fragment } from "react"
 import { repcaptcha } from "Utils/repcaptcha"
 
@@ -70,8 +71,12 @@ export class MobileSignUpForm extends Component<
   }
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
-    repcaptcha("signup_submit")
-    this.props.handleSubmit(values, formikBag)
+    repcaptcha("signup_submit", recaptcha_token => {
+      const valuesWithToken = extend(values, {
+        recaptcha_token,
+      })
+      this.props.handleSubmit(valuesWithToken, formikBag)
+    })
   }
 
   render() {

--- a/src/Components/Authentication/__tests__/Desktop/SignUpForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Desktop/SignUpForm.test.tsx
@@ -37,6 +37,7 @@ describe("SignUpForm", () => {
             password: "password123",
             name: "John Doe",
             accepted_terms_of_service: true,
+            recaptcha_token: "recaptcha-token",
           },
           formik.getFormikActions()
         )

--- a/src/Components/Authentication/__tests__/Mobile/SignUpForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Mobile/SignUpForm.test.tsx
@@ -103,6 +103,7 @@ describe("MobileSignUpForm", () => {
               accepted_terms_of_service: true,
               password: "password",
               name: "User Name",
+              recaptcha_token: "recaptcha-token",
             })
             done()
           })


### PR DESCRIPTION
Signup form passes `recaptcha_token` returned from google along with other form values to `handleSubmit`.

Related to https://artsyproduct.atlassian.net/browse/PLATFORM-1389