### PR TITLE
DISCO-1032 Apply `medium` filter in path instead of querystring on /collect

### DIFF
--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -43,7 +43,7 @@ export const initialState = {
 
 // Returns a string representing the query part of a URL.
 // It removes default values.
-export const urlFragmentFromState = (state: State, extra?: Partial<State>) => {
+export const urlFragmentFromState = (state: State) => {
   const filters = Object.entries(state).reduce((acc, [key, value]) => {
     if (isDefaultFilter(key, value)) {
       return acc
@@ -52,10 +52,7 @@ export const urlFragmentFromState = (state: State, extra?: Partial<State>) => {
     }
   }, {})
 
-  return qs.stringify({
-    ...filters,
-    ...extra,
-  })
+  return qs.stringify(filters)
 }
 
 // This is used to remove default state params that clutter up URLs.

--- a/src/Apps/Collect/AnalyticsProvider.tsx
+++ b/src/Apps/Collect/AnalyticsProvider.tsx
@@ -3,8 +3,13 @@ import { track } from "Artsy/Analytics/track"
 import React from "react"
 import { Provider } from "unstated"
 
+interface Props {
+  urlBuilder: (state: FilterState) => string
+  [key: string]: any
+}
+
 @track()
-export default class AnalyticsProvider extends React.Component<any> {
+export default class AnalyticsProvider extends React.Component<Props> {
   render() {
     const {
       __fragments,

--- a/src/Apps/Collect/AnalyticsProvider.tsx
+++ b/src/Apps/Collect/AnalyticsProvider.tsx
@@ -1,10 +1,10 @@
-import { FilterState } from "Apps/Collect/FilterState"
+import { FilterState, State } from "Apps/Collect/FilterState"
 import { track } from "Artsy/Analytics/track"
 import React from "react"
 import { Provider } from "unstated"
 
 interface Props {
-  urlBuilder: (state: FilterState) => string
+  urlBuilder: (state: State) => string
   [key: string]: any
 }
 

--- a/src/Apps/Collect/AnalyticsProvider.tsx
+++ b/src/Apps/Collect/AnalyticsProvider.tsx
@@ -11,17 +11,21 @@ export default class AnalyticsProvider extends React.Component<any> {
       __id,
       Component,
       tracking,
+      urlBuilder,
       ...remainingProps
     } = this.props
 
     return (
       <Provider
         inject={[
-          new FilterState({
-            ...this.props.params,
-            ...this.props.location.query,
-            tracking,
-          }),
+          new FilterState(
+            {
+              ...this.props.params,
+              ...this.props.location.query,
+              tracking,
+            },
+            urlBuilder
+          ),
         ]}
       >
         <Component {...remainingProps} query={{ __id, __fragments }} />

--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -101,9 +101,12 @@ export class FilterState extends Container<State> {
   static MAX_HEIGHT = 120
   static MIN_WIDTH = 1
   static MAX_WIDTH = 120
+  urlBuilder: (state: FilterState) => string
 
-  constructor(props: State) {
+  constructor(props: State, urlBuilder: (state: FilterState) => string) {
     super()
+
+    this.urlBuilder = urlBuilder
 
     if (props) {
       this.tracking = props.tracking
@@ -137,6 +140,7 @@ export class FilterState extends Container<State> {
 
   previousQueryString = ""
   pushHistory() {
+    console.log("url builder", this.urlBuilder(null))
     const currentQueryString = urlFragmentFromState(this.state)
     // PriceRangeFilter's onAfterChange event fires twice; this ensures
     //   we only push that history event once.

--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -95,18 +95,14 @@ export class FilterState extends Container<State> {
     return omitBy(this.state, isNil)
   }
 
-  previousQueryString = ""
+  previousUrl = ""
   pushHistory() {
-    const currentQueryString = this.urlBuilder(this.state)
+    const currentUrl = this.urlBuilder(this.state)
     // PriceRangeFilter's onAfterChange event fires twice; this ensures
     //   we only push that history event once.
-    if (this.previousQueryString !== currentQueryString) {
-      window.history.pushState(
-        {},
-        null,
-        `${window.location.pathname}?${currentQueryString}`
-      )
-      this.previousQueryString = currentQueryString
+    if (this.previousUrl !== currentUrl) {
+      window.history.pushState({}, null, currentUrl)
+      this.previousUrl = currentUrl
     }
   }
 

--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -1,5 +1,4 @@
 import { cloneDeep, isNil, omit, omitBy } from "lodash"
-import qs from "qs"
 import { Container } from "unstated"
 
 export interface State {
@@ -43,48 +42,6 @@ export const initialState = {
   dimension_range: null,
 }
 
-// Returns a string representing the query part of a URL.
-// It removes default values.
-export const urlFragmentFromState = (state: State, extra?: Partial<State>) => {
-  const filters = Object.entries(state).reduce((acc, [key, value]) => {
-    if (isDefaultFilter(key, value)) {
-      return acc
-    } else {
-      return { ...acc, [key]: value }
-    }
-  }, {})
-
-  return qs.stringify({
-    ...filters,
-    ...extra,
-  })
-}
-
-// This is used to remove default state params that clutter up URLs.
-const isDefaultFilter = (filter, value): boolean => {
-  if (filter === "major_periods" || filter === "attribution_class") {
-    return value.length === 0
-  }
-
-  if (filter === "sort") {
-    return value === "-decayed_merch"
-  }
-
-  if (filter === "price_range" || filter === "height" || filter === "width") {
-    return value === "*-*"
-  }
-
-  if (filter === "page") {
-    return value === 1
-  }
-
-  if (filter === "medium") {
-    return value === "*"
-  }
-
-  return !value
-}
-
 // These filters aren't tracked via the `tracking` prop passed in here.
 // Instead, they are tracked using decorators in the collect page.
 // Once all filters are switched to be tracked using decorators this can
@@ -101,9 +58,9 @@ export class FilterState extends Container<State> {
   static MAX_HEIGHT = 120
   static MIN_WIDTH = 1
   static MAX_WIDTH = 120
-  urlBuilder: (state: FilterState) => string
+  urlBuilder: (state: State) => string
 
-  constructor(props: State, urlBuilder: (state: FilterState) => string) {
+  constructor(props: State, urlBuilder: (state: State) => string) {
     super()
 
     this.urlBuilder = urlBuilder
@@ -140,8 +97,7 @@ export class FilterState extends Container<State> {
 
   previousQueryString = ""
   pushHistory() {
-    console.log("url builder", this.urlBuilder(null))
-    const currentQueryString = urlFragmentFromState(this.state)
+    const currentQueryString = this.urlBuilder(this.state)
     // PriceRangeFilter's onAfterChange event fires twice; this ensures
     //   we only push that history event once.
     if (this.previousQueryString !== currentQueryString) {

--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -1,5 +1,6 @@
 import { cloneDeep, isNil, omit, omitBy } from "lodash"
 import { Container } from "unstated"
+import { buildUrlForCollectApp } from "./urlBuilder"
 
 export interface State {
   medium?: string
@@ -60,7 +61,10 @@ export class FilterState extends Container<State> {
   static MAX_WIDTH = 120
   urlBuilder: (state: State) => string
 
-  constructor(props: State, urlBuilder: (state: State) => string) {
+  constructor(
+    props: State,
+    urlBuilder: (state: State) => string = buildUrlForCollectApp
+  ) {
     super()
 
     this.urlBuilder = urlBuilder

--- a/src/Apps/Collect/__tests__/CollectApp.test.tsx
+++ b/src/Apps/Collect/__tests__/CollectApp.test.tsx
@@ -9,6 +9,7 @@ import { CollectAppFixture } from "../../__tests__/Fixtures/Collect/CollectAppFi
 import { CollectAppFragmentContainer as CollectApp } from "../CollectApp"
 import { FilterContainer } from "../Components/Filters"
 import { FilterState } from "../FilterState"
+import { buildUrlForCollectApp } from "../urlBuilder"
 
 jest.unmock("react-relay")
 
@@ -16,11 +17,14 @@ describe("CollectApp", () => {
   let filterState: FilterState = null
 
   beforeEach(() => {
-    filterState = new FilterState({
-      tracking: {
-        trackEvent: jest.fn(),
+    filterState = new FilterState(
+      {
+        tracking: {
+          trackEvent: jest.fn(),
+        },
       },
-    })
+      buildUrlForCollectApp
+    )
   })
 
   it("renders a relay tree with SEO-friendly meta data", async () => {

--- a/src/Apps/Collect/__tests__/CollectApp.test.tsx
+++ b/src/Apps/Collect/__tests__/CollectApp.test.tsx
@@ -9,7 +9,6 @@ import { CollectAppFixture } from "../../__tests__/Fixtures/Collect/CollectAppFi
 import { CollectAppFragmentContainer as CollectApp } from "../CollectApp"
 import { FilterContainer } from "../Components/Filters"
 import { FilterState } from "../FilterState"
-import { buildUrlForCollectApp } from "../urlBuilder"
 
 jest.unmock("react-relay")
 
@@ -17,14 +16,11 @@ describe("CollectApp", () => {
   let filterState: FilterState = null
 
   beforeEach(() => {
-    filterState = new FilterState(
-      {
-        tracking: {
-          trackEvent: jest.fn(),
-        },
+    filterState = new FilterState({
+      tracking: {
+        trackEvent: jest.fn(),
       },
-      buildUrlForCollectApp
-    )
+    })
   })
 
   it("renders a relay tree with SEO-friendly meta data", async () => {

--- a/src/Apps/Collect/__tests__/urlBuilder.test.ts
+++ b/src/Apps/Collect/__tests__/urlBuilder.test.ts
@@ -1,0 +1,93 @@
+import { State } from "../FilterState"
+import { buildUrlForCollectApp, buildUrlForCollectionApp } from "../urlBuilder"
+
+describe("buildUrlForCollectApp", () => {
+  it("should not include unselected filters", () => {
+    const state: State = {}
+
+    const result = buildUrlForCollectApp(state)
+
+    expect(result).toEqual("/collect")
+  })
+
+  it("should include selected filters minus medium in querystring", () => {
+    const state: State = {
+      acquireable: true,
+      artist_id: "artistId",
+      at_auction: true,
+      attribution_class: ["attributionClass"],
+      color: "red",
+      dimension_range: "1-2",
+      for_sale: true,
+      height: "100",
+      inquireable_only: true,
+      major_periods: ["1990"],
+      offerable: true,
+      page: 3,
+      partner_id: "gegosian",
+      price_range: "10-20",
+      sort: "yes",
+      tracking: "no",
+      width: "30-40",
+    }
+
+    const result = buildUrlForCollectApp(state)
+
+    expect(result).toEqual(
+      "/collect?acquireable=true&artist_id=artistId&at_auction=true&attribution_class%5B0%5D=attributionClass&color=red&dimension_range=1-2&for_sale=true&height=100&inquireable_only=true&major_periods%5B0%5D=1990&offerable=true&page=3&partner_id=gegosian&price_range=10-20&sort=yes&tracking=no&width=30-40"
+    )
+  })
+
+  it("should include medium as part of path", () => {
+    const state: State = {
+      medium: "photography",
+    }
+
+    const result = buildUrlForCollectApp(state)
+
+    expect(result).toEqual("/collect/photography")
+  })
+})
+
+describe("buildUrlForCollectionApp", () => {
+  beforeAll(() => {
+    window.history.pushState({}, null, "/collection/kitties")
+  })
+
+  it("should not include unselected filters", () => {
+    const state: State = {}
+
+    const result = buildUrlForCollectionApp(state)
+
+    expect(result).toEqual("/collection/kitties")
+  })
+
+  it("should include all selected filters, including medium, in querystring", () => {
+    const state: State = {
+      acquireable: true,
+      artist_id: "artistId",
+      at_auction: true,
+      attribution_class: ["attributionClass"],
+      color: "red",
+      dimension_range: "1-2",
+      for_sale: true,
+      height: "100",
+      inquireable_only: true,
+      major_periods: ["1990"],
+      medium: "photography",
+      offerable: true,
+      page: 3,
+      partner_id: "gegosian",
+      price_range: "10-20",
+      sort: "yes",
+      tracking: "no",
+      width: "30-40",
+    }
+
+    const result = buildUrlForCollectionApp(state)
+
+    expect(result).toEqual(
+      "/collection/kitties?acquireable=true&artist_id=artistId&at_auction=true&attribution_class%5B0%5D=attributionClass&color=red&dimension_range=1-2&for_sale=true&height=100&inquireable_only=true&major_periods%5B0%5D=1990&medium=photography&offerable=true&page=3&partner_id=gegosian&price_range=10-20&sort=yes&tracking=no&width=30-40"
+    )
+  })
+})

--- a/src/Apps/Collect/__tests__/urlBuilder.test.ts
+++ b/src/Apps/Collect/__tests__/urlBuilder.test.ts
@@ -10,6 +10,32 @@ describe("buildUrlForCollectApp", () => {
     expect(result).toEqual("/collect")
   })
 
+  it("should not include defaulted filters", () => {
+    const state: State = {
+      acquireable: false,
+      artist_id: "",
+      at_auction: false,
+      attribution_class: [],
+      color: "",
+      dimension_range: "",
+      for_sale: false,
+      height: "*-*",
+      inquireable_only: false,
+      major_periods: [],
+      offerable: false,
+      page: 1,
+      partner_id: "",
+      price_range: "*-*",
+      sort: "-decayed_merch",
+      tracking: "",
+      width: "*-*",
+    }
+
+    const result = buildUrlForCollectApp(state)
+
+    expect(result).toEqual("/collect")
+  })
+
   it("should include selected filters minus medium in querystring", () => {
     const state: State = {
       acquireable: true,
@@ -56,6 +82,32 @@ describe("buildUrlForCollectionApp", () => {
 
   it("should not include unselected filters", () => {
     const state: State = {}
+
+    const result = buildUrlForCollectionApp(state)
+
+    expect(result).toEqual("/collection/kitties")
+  })
+
+  it("should not include defaulted filters", () => {
+    const state: State = {
+      acquireable: false,
+      artist_id: "",
+      at_auction: false,
+      attribution_class: [],
+      color: "",
+      dimension_range: "",
+      for_sale: false,
+      height: "*-*",
+      inquireable_only: false,
+      major_periods: [],
+      offerable: false,
+      page: 1,
+      partner_id: "",
+      price_range: "*-*",
+      sort: "-decayed_merch",
+      tracking: "",
+      width: "*-*",
+    }
 
     const result = buildUrlForCollectionApp(state)
 

--- a/src/Apps/Collect/routes.tsx
+++ b/src/Apps/Collect/routes.tsx
@@ -4,7 +4,7 @@ import { graphql } from "react-relay"
 import AnalyticsProvider from "./AnalyticsProvider"
 import { CollectAppFragmentContainer as CollectApp } from "./CollectApp"
 import { CollectionAppFragmentContainer as CollectionApp } from "./CollectionApp"
-import { CollectionUrlBuilder, CollectUrlBuilder } from "./urlBuilder"
+import { buildUrlForCollectApp, buildUrlForCollectionApp } from "./urlBuilder"
 
 const initializeVariablesWithFilterState = (params, props) => {
   const initialFilterState = props.location ? props.location.query : {}
@@ -75,7 +75,7 @@ export const routes: RouteConfig[] = [
         <AnalyticsProvider
           {...props}
           Component={Component}
-          urlBuilder={CollectUrlBuilder}
+          urlBuilder={buildUrlForCollectApp}
         />
       )
     },
@@ -130,7 +130,7 @@ export const routes: RouteConfig[] = [
         <AnalyticsProvider
           {...props}
           Component={Component}
-          urlBuilder={CollectionUrlBuilder}
+          urlBuilder={buildUrlForCollectionApp}
         />
       )
     },

--- a/src/Apps/Collect/routes.tsx
+++ b/src/Apps/Collect/routes.tsx
@@ -4,6 +4,7 @@ import { graphql } from "react-relay"
 import AnalyticsProvider from "./AnalyticsProvider"
 import { CollectAppFragmentContainer as CollectApp } from "./CollectApp"
 import { CollectionAppFragmentContainer as CollectionApp } from "./CollectionApp"
+import { CollectionUrlBuilder, CollectUrlBuilder } from "./urlBuilder"
 
 const initializeVariablesWithFilterState = (params, props) => {
   const initialFilterState = props.location ? props.location.query : {}
@@ -70,7 +71,13 @@ export const routes: RouteConfig[] = [
         return null
       }
 
-      return <AnalyticsProvider {...props} Component={Component} />
+      return (
+        <AnalyticsProvider
+          {...props}
+          Component={Component}
+          urlBuilder={CollectUrlBuilder}
+        />
+      )
     },
     prepareVariables: initializeVariablesWithFilterState,
   },
@@ -119,7 +126,13 @@ export const routes: RouteConfig[] = [
         return null
       }
 
-      return <AnalyticsProvider {...props} Component={Component} />
+      return (
+        <AnalyticsProvider
+          {...props}
+          Component={Component}
+          urlBuilder={CollectionUrlBuilder}
+        />
+      )
     },
     prepareVariables: initializeVariablesWithFilterState,
   },

--- a/src/Apps/Collect/urlBuilder.ts
+++ b/src/Apps/Collect/urlBuilder.ts
@@ -1,0 +1,9 @@
+import { FilterState } from "./FilterState"
+
+export const CollectUrlBuilder: (state: FilterState) => string = state => {
+  return "collect"
+}
+
+export const CollectionUrlBuilder: (state: FilterState) => string = state => {
+  return "collection"
+}

--- a/src/Apps/Collect/urlBuilder.ts
+++ b/src/Apps/Collect/urlBuilder.ts
@@ -1,26 +1,41 @@
 import qs from "qs"
 import { State } from "./FilterState"
 
-export const CollectUrlBuilder: (state: State) => string = state => {
-  return urlFragmentFromState(state)
+export const buildUrlForCollectionApp = (state: State): string => {
+  const params = removeDefaultValues(state)
+  const queryString = qs.stringify(params)
+
+  return queryString
+    ? `${window.location.pathname}?${queryString}`
+    : window.location.pathname
 }
 
-export const CollectionUrlBuilder: (state: State) => string = state => {
-  return urlFragmentFromState(state)
+export const buildUrlForCollectApp = (state: State): string => {
+  const fragment = buildCollectUrlFragmentFromState(state)
+
+  return fragment ? `/collect${fragment}` : "/collect"
 }
 
-// Returns a string representing the query part of a URL.
-// It removes default values.
-export const urlFragmentFromState = (state: State) => {
-  const filters = Object.entries(state).reduce((acc, [key, value]) => {
+const buildCollectUrlFragmentFromState = (state: State): string => {
+  const { medium, ...params } = removeDefaultValues(state)
+
+  const emptyOrSpecificMedium = medium ? `/${medium}` : ""
+
+  if (Object.keys(params).length === 0) {
+    return emptyOrSpecificMedium
+  }
+
+  return `${emptyOrSpecificMedium}?${qs.stringify(params)}`
+}
+
+const removeDefaultValues = (state: State): State => {
+  return Object.entries(state).reduce((acc, [key, value]) => {
     if (isDefaultFilter(key, value)) {
       return acc
     } else {
       return { ...acc, [key]: value }
     }
   }, {})
-
-  return qs.stringify(filters)
 }
 
 // This is used to remove default state params that clutter up URLs.

--- a/src/Apps/Collect/urlBuilder.ts
+++ b/src/Apps/Collect/urlBuilder.ts
@@ -5,15 +5,19 @@ export const buildUrlForCollectionApp = (state: State): string => {
   const params = removeDefaultValues(state)
   const queryString = qs.stringify(params)
 
-  return queryString
+  const url = queryString
     ? `${window.location.pathname}?${queryString}`
     : window.location.pathname
+
+  return url
 }
 
 export const buildUrlForCollectApp = (state: State): string => {
   const fragment = buildCollectUrlFragmentFromState(state)
 
-  return fragment ? `/collect${fragment}` : "/collect"
+  const url = fragment ? `/collect${fragment}` : "/collect"
+
+  return url
 }
 
 const buildCollectUrlFragmentFromState = (state: State): string => {

--- a/src/Apps/Collect/urlBuilder.ts
+++ b/src/Apps/Collect/urlBuilder.ts
@@ -1,9 +1,49 @@
-import { FilterState } from "./FilterState"
+import qs from "qs"
+import { State } from "./FilterState"
 
-export const CollectUrlBuilder: (state: FilterState) => string = state => {
-  return "collect"
+export const CollectUrlBuilder: (state: State) => string = state => {
+  return urlFragmentFromState(state)
 }
 
-export const CollectionUrlBuilder: (state: FilterState) => string = state => {
-  return "collection"
+export const CollectionUrlBuilder: (state: State) => string = state => {
+  return urlFragmentFromState(state)
+}
+
+// Returns a string representing the query part of a URL.
+// It removes default values.
+export const urlFragmentFromState = (state: State) => {
+  const filters = Object.entries(state).reduce((acc, [key, value]) => {
+    if (isDefaultFilter(key, value)) {
+      return acc
+    } else {
+      return { ...acc, [key]: value }
+    }
+  }, {})
+
+  return qs.stringify(filters)
+}
+
+// This is used to remove default state params that clutter up URLs.
+const isDefaultFilter = (filter, value): boolean => {
+  if (filter === "major_periods" || filter === "attribution_class") {
+    return value.length === 0
+  }
+
+  if (filter === "sort") {
+    return value === "-decayed_merch"
+  }
+
+  if (filter === "price_range" || filter === "height" || filter === "width") {
+    return value === "*-*"
+  }
+
+  if (filter === "page") {
+    return value === 1
+  }
+
+  if (filter === "medium") {
+    return value === "*"
+  }
+
+  return !value
 }

--- a/src/Apps/Collect/urlBuilder.ts
+++ b/src/Apps/Collect/urlBuilder.ts
@@ -44,25 +44,21 @@ const removeDefaultValues = (state: State): State => {
 
 // This is used to remove default state params that clutter up URLs.
 const isDefaultFilter = (filter, value): boolean => {
-  if (filter === "major_periods" || filter === "attribution_class") {
-    return value.length === 0
+  switch (filter) {
+    case "major_periods":
+    case "attribution_class":
+      return value.length === 0
+    case "sort":
+      return value === "-decayed_merch"
+    case "price_range":
+    case "height":
+    case "width":
+      return value === "*-*"
+    case "page":
+      return value === 1
+    case "medium":
+      return value === "*"
+    default:
+      return !value
   }
-
-  if (filter === "sort") {
-    return value === "-decayed_merch"
-  }
-
-  if (filter === "price_range" || filter === "height" || filter === "width") {
-    return value === "*-*"
-  }
-
-  if (filter === "page") {
-    return value === 1
-  }
-
-  if (filter === "medium") {
-    return value === "*"
-  }
-
-  return !value
 }

--- a/src/Apps/Search/FilterState.tsx
+++ b/src/Apps/Search/FilterState.tsx
@@ -44,7 +44,7 @@ export const initialState = {
 
 // Returns a string representing the query part of a URL.
 // It removes default values, and rewrites keyword -> term.
-export const urlFragmentFromState = (state: State, extra?: Partial<State>) => {
+export const urlFragmentFromState = (state: State) => {
   const { keyword: term } = state
   const filters = Object.entries(state).reduce((acc, [key, value]) => {
     if (isDefaultFilter(key, value) || key === "keyword") {
@@ -57,7 +57,6 @@ export const urlFragmentFromState = (state: State, extra?: Partial<State>) => {
   return qs.stringify({
     ...filters,
     term,
-    ...extra,
   })
 }
 


### PR DESCRIPTION
~This is an incomplete PR. I wanted to put it out for people to look at while I am out tomorrow.~ This PR is green & ready for review/merge!

Addresses https://artsyproduct.atlassian.net/browse/DISCO-1032

## The Problem

In our `urlFragmentFromState` helpers in the Collect app's `FilterState`, we are tracking all state properties in the querystring. This is correct for all params *except* `medium`. 

We have special routes for the /collect page when filtered by `medium`: `/collect/:medium`. These URLs are indexed by bots, and we like them and want to use them. 

We have special logic to get the medium from the path instead of querystring, so going directly to the url `/collect?medium=photography` does _not_ filter by `medium=photography`. Going to `/collect/photography` _does_ filter by `medium=photography`, and we should direct our users there when they are interacting with our filters.

## A Wrench

To make the solution more difficult for this problem, the `FilterState` in the Collect app is shared by both `/collect` and `/collection/:id` routes. We need to apply these special `medium` rules to only the `/collect` route.

## This Solution

It's probably easiest to follow the PR one commit at a time; it's easier that way to see how I found a seam to allow different URL construction rules for the different routes. 

The idea is to inject a URL construction function into `FilterState`, so we can build the correct URL when we push history to the window. 