### PR TITLE
Collection header qa refactor

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -50,7 +50,7 @@ const getReadMoreContent = description => {
       {description && (
         <span dangerouslySetInnerHTML={{ __html: description }} />
       )}
-      <Spacer mt={3} />
+      <Spacer mt={2} />
     </>
   )
 }
@@ -63,6 +63,11 @@ const handleOpenAuth = (mediator, artist) => {
   })
 }
 
+track({
+  subject: Schema.Subject.ReadMore,
+  type: Schema.Type.Button,
+  action_type: Schema.ActionType.Click,
+})
 const trackReadMoreClick = () => {
   // noop
 }
@@ -83,18 +88,10 @@ const imageWidthSizes = {
   xl: 1112,
 }
 
+track({
+  context_module: Schema.ContextModule.CollectionDescription,
+})
 export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
-  // @track({
-  //   subject: Schema.Subject.ReadMore,
-  //   type: Schema.Type.Button,
-  //   action_type: Schema.ActionType.Click,
-  // })
-  // trackReadMoreClick() {
-  //   // noop
-  // }
-
-  // render() {
-  //   const { collection, artworks } = this.props
   const { user, mediator } = useContext(SystemContext)
 
   return (
@@ -142,7 +139,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     trackingData={{
                       modelName: Schema.OwnerType.Artist,
                       context_module: Schema.ContextModule.RecommendedArtists,
-                      // entity_id: artist._id,
+                      entity_id: artist._id,
                       entity_slug: artist.id,
                     }}
                     onOpenAuthModal={() => handleOpenAuth(mediator, artist)}
@@ -167,9 +164,6 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
             </EntityContainer>
           )
         })
-        // <Sans size="2" weight="medium" color={color("black100")}>
-        //             Follow
-        //           </Sans>
 
         return (
           <header>
@@ -202,41 +196,48 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                   <Spacer mt={1} />
                   <Serif size={["6", "10"]}>{collection.title}</Serif>
                 </MetaContainer>
-                <DescriptionContainer isColumnLayout={isColumnLayout} mb={5}>
-                  <Box>
-                    <Grid>
-                      <Row>
-                        <Col xl="8" lg="8" md="10" sm="12" xs="12">
-                          <ExtendedSerif size="3">
-                            {smallerScreen ? (
-                              <ReadMore
-                                onReadMoreClicked={this.trackReadMoreClick.bind(
-                                  this
-                                )}
-                                maxChars={chars}
-                                content={getReadMoreContent(
-                                  collection.description
-                                )}
-                              />
-                            ) : (
-                              getReadMoreContent(collection.description)
-                            )}
-                          </ExtendedSerif>
-                        </Col>
-                      </Row>
-                    </Grid>
-                  </Box>
-                  {featuredArtists.length && (
-                    <Box pt={isColumnLayout ? 20 : 0} pb={10}>
-                      <Sans size="2" weight="medium" pb={15}>
-                        {`Featured Artist${hasMultipleArtists ? "s" : ""}`}
-                      </Sans>
-                      <Flex flexWrap={isColumnLayout ? "wrap" : "nowrap"}>
-                        {featuredArtists}
+                <Grid>
+                  <Row>
+                    <Col xl="8" lg="8" md="8" sm="12" xs="12">
+                      <Flex>
+                        <ExtendedSerif size="3">
+                          {smallerScreen ? (
+                            <ReadMore
+                              onReadMoreClicked={trackReadMoreClick}
+                              maxChars={chars}
+                              content={getReadMoreContent(
+                                collection.description
+                              )}
+                            />
+                          ) : (
+                            getReadMoreContent(collection.description)
+                          )}
+                        </ExtendedSerif>
                       </Flex>
-                    </Box>
-                  )}
-                </DescriptionContainer>
+                    </Col>
+                    <Col
+                      xl={isColumnLayout ? "12" : "3"}
+                      lg={isColumnLayout ? "12" : "3"}
+                      md={isColumnLayout ? "12" : "3"}
+                      sm={12}
+                      xs={12}
+                      mdOffset={isColumnLayout ? null : 1}
+                      lgOffset={isColumnLayout ? null : 1}
+                      xlOffset={isColumnLayout ? null : 1}
+                    >
+                      {featuredArtists.length && (
+                        <Box pb={10}>
+                          <Sans size="2" weight="medium" pb={15}>
+                            {`Featured Artist${hasMultipleArtists ? "s" : ""}`}
+                          </Sans>
+                          <Flex flexWrap={isColumnLayout ? "wrap" : "nowrap"}>
+                            {featuredArtists}
+                          </Flex>
+                        </Box>
+                      )}
+                    </Col>
+                  </Row>
+                </Grid>
                 <Spacer mb={1} />
               </Box>
             </Flex>
@@ -293,12 +294,6 @@ const EntityContainer = styled(Box)<{
   isColumnLayout: boolean
 }>`
   ${props => (props.isColumnLayout ? "" : "min-width: 200px;")}
-`
-
-const DescriptionContainer = styled(Flex)<{
-  isColumnLayout: boolean
-}>`
-  flex-direction: ${props => (props.isColumnLayout ? "column" : "row")};
 `
 
 const ImageCaption = styled(Box)<{

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -100,7 +100,7 @@ export class CollectionHeader extends Component<Props> {
 
           const isColumnLayout =
             hasMultipleArtists || !collection.description || size === "xs"
-
+          const smallerScreen = size === "xs" || size === "sm"
           const featuredArtists = take(
             artworks.merchandisable_artists,
             artistsCount
@@ -161,7 +161,7 @@ export class CollectionHeader extends Component<Props> {
                       <a href={categoryTarget}>{collection.category}</a>
                     </BreadcrumbContainer>
                     <Spacer mt={1} />
-                    <Title size={["6", "10"]}>{collection.title}</Title>
+                    <Serif size={["6", "10"]}>{collection.title}</Serif>
                   </MetaContainer>
                   <DescriptionContainer isColumnLayout={isColumnLayout} mb={5}>
                     <Box>
@@ -169,15 +169,19 @@ export class CollectionHeader extends Component<Props> {
                         <Row>
                           <Col xl="8" lg="8" md="10" sm="12" xs="12">
                             <ExtendedSerif size="3">
-                              <ReadMore
-                                onReadMoreClicked={this.trackReadMoreClick.bind(
-                                  this
-                                )}
-                                maxChars={chars}
-                                content={getReadMoreContent(
-                                  collection.description
-                                )}
-                              />
+                              {smallerScreen ? (
+                                <ReadMore
+                                  onReadMoreClicked={this.trackReadMoreClick.bind(
+                                    this
+                                  )}
+                                  maxChars={chars}
+                                  content={getReadMoreContent(
+                                    collection.description
+                                  )}
+                                />
+                              ) : (
+                                getReadMoreContent(collection.description)
+                              )}
                             </ExtendedSerif>
                           </Col>
                         </Row>
@@ -257,10 +261,6 @@ const DescriptionContainer = styled(Flex)<{
   isColumnLayout: boolean
 }>`
   flex-direction: ${props => (props.isColumnLayout ? "column" : "row")};
-`
-
-const Title = styled(Serif)`
-  text-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
 `
 
 const ImageCaption = styled(Box)<{

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -198,7 +198,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                 </MetaContainer>
                 <Grid>
                   <Row>
-                    <Col xl="8" lg="8" md="8" sm="12" xs="12">
+                    <Col sm="12" md="8">
                       <Flex>
                         <ExtendedSerif size="3">
                           {smallerScreen ? (
@@ -216,11 +216,8 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                       </Flex>
                     </Col>
                     <Col
-                      xl={isColumnLayout ? "12" : "3"}
-                      lg={isColumnLayout ? "12" : "3"}
-                      md={isColumnLayout ? "12" : "3"}
                       sm={12}
-                      xs={12}
+                      md={isColumnLayout ? "12" : "3"}
                       mdOffset={isColumnLayout ? null : 1}
                       lgOffset={isColumnLayout ? null : 1}
                       xlOffset={isColumnLayout ? null : 1}

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -8,8 +8,7 @@ import { slugify } from "underscore.string"
 import { resize } from "Utils/resizer"
 import { Responsive } from "Utils/Responsive"
 
-import { track } from "Artsy/Analytics"
-import * as Schema from "Artsy/Analytics/Schema"
+import { AnalyticsSchema } from "Artsy/Analytics"
 
 import {
   Box,
@@ -58,18 +57,9 @@ const getReadMoreContent = description => {
 const handleOpenAuth = (mediator, artist) => {
   openAuthModal(mediator, {
     entity: artist,
-    contextModule: Schema.ContextModule.RecommendedArtists,
+    contextModule: AnalyticsSchema.ContextModule.CollectionDescription,
     intent: AuthModalIntent.FollowArtist,
   })
-}
-
-track({
-  subject: Schema.Subject.ReadMore,
-  type: Schema.Type.Button,
-  action_type: Schema.ActionType.Click,
-})
-const trackReadMoreClick = () => {
-  // noop
 }
 
 const maxChars = {
@@ -88,9 +78,6 @@ const imageWidthSizes = {
   xl: 1112,
 }
 
-track({
-  context_module: Schema.ContextModule.CollectionDescription,
-})
 export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
   const { user, mediator } = useContext(SystemContext)
 
@@ -137,8 +124,9 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     artist={artist}
                     user={user}
                     trackingData={{
-                      modelName: Schema.OwnerType.Artist,
-                      context_module: Schema.ContextModule.RecommendedArtists,
+                      modelName: AnalyticsSchema.OwnerType.Artist,
+                      context_module:
+                        AnalyticsSchema.ContextModule.CollectionDescription,
                       entity_id: artist._id,
                       entity_slug: artist.id,
                     }}
@@ -203,7 +191,6 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                         <ExtendedSerif size="3">
                           {smallerScreen ? (
                             <ReadMore
-                              onReadMoreClicked={trackReadMoreClick}
                               maxChars={chars}
                               content={getReadMoreContent(
                                 collection.description
@@ -223,7 +210,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                       xlOffset={isColumnLayout ? null : 1}
                     >
                       {featuredArtists.length && (
-                        <Box pb={10}>
+                        <Box pb={10} pt={smallerScreen ? 20 : null}>
                           <Sans size="2" weight="medium" pb={15}>
                             {`Featured Artist${hasMultipleArtists ? "s" : ""}`}
                           </Sans>

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -1,7 +1,7 @@
 import { EntityHeader, ReadMore } from "@artsy/palette"
 import { unica } from "Assets/Fonts"
-import { take } from "lodash"
-import React, { FC, useContext } from "react"
+import { cloneDeep, take } from "lodash"
+import React, { FC, useContext, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { slugify } from "underscore.string"
@@ -49,7 +49,6 @@ const getReadMoreContent = description => {
       {description && (
         <span dangerouslySetInnerHTML={{ __html: description }} />
       )}
-      <Spacer mt={2} />
     </>
   )
 }
@@ -80,6 +79,35 @@ const imageWidthSizes = {
 
 export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
   const { user, mediator } = useContext(SystemContext)
+  const [showMore, setShowMore] = useState(false)
+
+  const truncateForMobile = (featuredArtists, isColumnLayout) => {
+    if (featuredArtists.length < 3) {
+      return featuredArtists
+    }
+
+    const remainingArtists = featuredArtists.length - 3
+    const viewMore = (
+      <EntityContainer
+        width={["100%", "25%"]}
+        isColumnLayout={isColumnLayout}
+        pb={20}
+        key={4}
+      >
+        <Box
+          onClick={() => {
+            setShowMore(true)
+          }}
+        >
+          <EntityHeader initials={`+${remainingArtists}`} name="View more" />
+        </Box>
+      </EntityContainer>
+    )
+    const artists = cloneDeep(featuredArtists)
+    artists.splice(3, remainingArtists, viewMore)
+
+    return showMore ? featuredArtists : artists
+  }
 
   return (
     <Responsive>
@@ -199,6 +227,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                           ) : (
                             getReadMoreContent(collection.description)
                           )}
+                          {collection.description && <Spacer mt={2} />}
                         </ExtendedSerif>
                       </Flex>
                     </Col>
@@ -210,12 +239,17 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                       xlOffset={isColumnLayout ? null : 1}
                     >
                       {featuredArtists.length && (
-                        <Box pb={10} pt={smallerScreen ? 20 : null}>
+                        <Box pb={10}>
                           <Sans size="2" weight="medium" pb={15}>
                             {`Featured Artist${hasMultipleArtists ? "s" : ""}`}
                           </Sans>
                           <Flex flexWrap={isColumnLayout ? "wrap" : "nowrap"}>
-                            {featuredArtists}
+                            {smallerScreen
+                              ? truncateForMobile(
+                                  featuredArtists,
+                                  isColumnLayout
+                                )
+                              : featuredArtists}
                           </Flex>
                         </Box>
                       )}

--- a/src/__generated__/CollectionAppTestQuery.graphql.ts
+++ b/src/__generated__/CollectionAppTestQuery.graphql.ts
@@ -49,10 +49,12 @@ fragment CollectionApp_collection on MarketingCollection {
 fragment Header_artworks on FilterArtworks {
   merchandisable_artists {
     id
+    _id
     name
     imageUrl
     birthday
     nationality
+    ...FollowArtistButton_artist
     __id
   }
   __id
@@ -302,6 +304,15 @@ fragment Contact_artwork on Artwork {
   }
   __id
 }
+
+fragment FollowArtistButton_artist on Artist {
+  __id
+  id
+  is_followed
+  counts {
+    follows
+  }
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -351,18 +362,25 @@ v5 = {
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "_id",
   "args": null,
   "storageKey": null
 },
 v7 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -376,28 +394,28 @@ v8 = [
     "type": "Int"
   }
 ],
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -413,7 +431,7 @@ v12 = [
     "storageKey": "url(version:\"larger\")"
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -421,30 +439,30 @@ v13 = [
     "type": "Boolean"
   }
 ],
-v14 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v15 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v16 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v17 = [
-  v15,
+v18 = [
   v16,
+  v17,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -453,7 +471,7 @@ v17 = [
     "storageKey": null
   }
 ],
-v18 = {
+v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -465,7 +483,7 @@ return {
   "operationKind": "query",
   "name": "CollectionAppTestQuery",
   "id": null,
-  "text": "query CollectionAppTestQuery {\n  collection: marketingCollection(slug: \"kaws-companions\") {\n    ...CollectionApp_collection\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_33e20w\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  merchandisable_artists {\n    id\n    name\n    imageUrl\n    birthday\n    nationality\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_33e20w on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_33e20w\n  __id: id\n}\n\nfragment CollectionRefetch_collection_33e20w on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query CollectionAppTestQuery {\n  collection: marketingCollection(slug: \"kaws-companions\") {\n    ...CollectionApp_collection\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_33e20w\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_33e20w on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_33e20w\n  __id: id\n}\n\nfragment CollectionRefetch_collection_33e20w on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -603,6 +621,7 @@ return {
                 "selections": [
                   v3,
                   v6,
+                  v7,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -624,16 +643,41 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v7
+                  v8,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "is_followed",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistCounts",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "follows",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
                 ]
               },
-              v7,
+              v8,
               {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v8,
+                "args": v9,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -662,11 +706,11 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v7,
+                          v8,
                           v2,
-                          v9,
                           v10,
                           v11,
+                          v12,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -698,8 +742,8 @@ return {
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v6,
-                              v7
+                              v7,
+                              v8
                             ]
                           },
                           {
@@ -710,7 +754,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v12
+                            "selections": v13
                           },
                           {
                             "kind": "LinkedField",
@@ -729,12 +773,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v13,
+                            "args": v14,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v6,
-                              v14,
+                              v7,
+                              v15,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -752,9 +796,9 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v12
+                                    "selections": v13
                                   },
-                                  v7
+                                  v8
                                 ]
                               },
                               {
@@ -822,10 +866,10 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  v7
+                                  v8
                                 ]
                               },
-                              v7
+                              v8
                             ]
                           }
                         ]
@@ -860,7 +904,7 @@ return {
                     "plural": true,
                     "selections": [
                       v3,
-                      v6,
+                      v7,
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -868,7 +912,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      v7
+                      v8
                     ]
                   }
                 ]
@@ -911,13 +955,13 @@ return {
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v7,
+              v8,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v8,
+                "args": v9,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -963,7 +1007,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": true,
-                        "selections": v17
+                        "selections": v18
                       },
                       {
                         "kind": "LinkedField",
@@ -973,7 +1017,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v17
+                        "selections": v18
                       },
                       {
                         "kind": "LinkedField",
@@ -983,7 +1027,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v17
+                        "selections": v18
                       },
                       {
                         "kind": "LinkedField",
@@ -994,8 +1038,8 @@ return {
                         "concreteType": "PageCursor",
                         "plural": false,
                         "selections": [
-                          v15,
-                          v16
+                          v16,
+                          v17
                         ]
                       }
                     ]
@@ -1023,17 +1067,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v13,
+                            "args": v14,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v7,
-                              v10,
-                              v6
+                              v8,
+                              v11,
+                              v7
                             ]
                           },
-                          v7,
-                          v10,
+                          v8,
+                          v11,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1073,13 +1117,7 @@ return {
                               }
                             ]
                           },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "_id",
-                            "args": null,
-                            "storageKey": null
-                          },
+                          v6,
                           v4,
                           {
                             "kind": "ScalarField",
@@ -1088,7 +1126,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v9,
+                          v10,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1116,14 +1154,14 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v13,
+                            "args": v14,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v6,
-                              v10,
                               v7,
-                              v14
+                              v11,
+                              v8,
+                              v15
                             ]
                           },
                           {
@@ -1149,7 +1187,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v7,
+                              v8,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1216,7 +1254,7 @@ return {
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
                                 "selections": [
-                                  v18,
+                                  v19,
                                   v1
                                 ]
                               },
@@ -1229,10 +1267,10 @@ return {
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
                                 "selections": [
-                                  v18
+                                  v19
                                 ]
                               },
-                              v7
+                              v8
                             ]
                           },
                           {
@@ -1256,7 +1294,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v11,
+                          v12,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/Header_artworks.graphql.ts
+++ b/src/__generated__/Header_artworks.graphql.ts
@@ -1,15 +1,18 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
+import { FollowArtistButton_artist$ref } from "./FollowArtistButton_artist.graphql";
 declare const _Header_artworks$ref: unique symbol;
 export type Header_artworks$ref = typeof _Header_artworks$ref;
 export type Header_artworks = {
     readonly merchandisable_artists: ReadonlyArray<({
         readonly id: string;
+        readonly _id: string;
         readonly name: string | null;
         readonly imageUrl: string | null;
         readonly birthday: string | null;
         readonly nationality: string | null;
+        readonly " $fragmentRefs": FollowArtistButton_artist$ref;
     }) | null> | null;
     readonly " $refType": Header_artworks$ref;
 };
@@ -50,6 +53,13 @@ return {
         {
           "kind": "ScalarField",
           "alias": null,
+          "name": "_id",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
           "name": "name",
           "args": null,
           "storageKey": null
@@ -75,6 +85,11 @@ return {
           "args": null,
           "storageKey": null
         },
+        {
+          "kind": "FragmentSpread",
+          "name": "FollowArtistButton_artist",
+          "args": null
+        },
         v0
       ]
     },
@@ -82,5 +97,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'adcbd11100d8128dea736868aa9d975a';
+(node as any).hash = 'eb9dc53e66d792a717cada1c6fa36f93';
 export default node;

--- a/src/__generated__/routes_MarketingCollectionAppQuery.graphql.ts
+++ b/src/__generated__/routes_MarketingCollectionAppQuery.graphql.ts
@@ -79,10 +79,12 @@ fragment CollectionApp_collection_3tWJc4 on MarketingCollection {
 fragment Header_artworks on FilterArtworks {
   merchandisable_artists {
     id
+    _id
     name
     imageUrl
     birthday
     nationality
+    ...FollowArtistButton_artist
     __id
   }
   __id
@@ -332,6 +334,15 @@ fragment Contact_artwork on Artwork {
   }
   __id
 }
+
+fragment FollowArtistButton_artist on Artist {
+  __id
+  id
+  is_followed
+  counts {
+    follows
+  }
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -467,18 +478,25 @@ v6 = {
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "_id",
   "args": null,
   "storageKey": null
 },
 v8 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v9 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -492,28 +510,28 @@ v9 = [
     "type": "Int"
   }
 ],
-v10 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
-v13 = [
+v14 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -529,7 +547,7 @@ v13 = [
     "storageKey": "url(version:\"larger\")"
   }
 ],
-v14 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -537,30 +555,30 @@ v14 = [
     "type": "Boolean"
   }
 ],
-v15 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v16 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v17 = {
+v18 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v18 = [
-  v16,
+v19 = [
   v17,
+  v18,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -569,7 +587,7 @@ v18 = [
     "storageKey": null
   }
 ],
-v19 = {
+v20 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -581,7 +599,7 @@ return {
   "operationKind": "query",
   "name": "routes_MarketingCollectionAppQuery",
   "id": null,
-  "text": "query routes_MarketingCollectionAppQuery(\n  $slug: String!\n  $medium: String\n  $major_periods: [String]\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $color: String\n  $page: Int\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionApp_collection_3tWJc4\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection_3tWJc4 on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_3tWJc4\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  merchandisable_artists {\n    id\n    name\n    imageUrl\n    birthday\n    nationality\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_3tWJc4 on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_3tWJc4\n  __id: id\n}\n\nfragment CollectionRefetch_collection_3tWJc4 on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, color: $color, page: $page) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_MarketingCollectionAppQuery(\n  $slug: String!\n  $medium: String\n  $major_periods: [String]\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $color: String\n  $page: Int\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionApp_collection_3tWJc4\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection_3tWJc4 on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_3tWJc4\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_3tWJc4 on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_3tWJc4\n  __id: id\n}\n\nfragment CollectionRefetch_collection_3tWJc4 on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, color: $color, page: $page) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  _id\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -798,6 +816,7 @@ return {
                 "selections": [
                   v4,
                   v7,
+                  v8,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -819,16 +838,41 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v8
+                  v9,
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "is_followed",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistCounts",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "follows",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
                 ]
               },
-              v8,
+              v9,
               {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v9,
+                "args": v10,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -857,11 +901,11 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v8,
+                          v9,
                           v3,
-                          v10,
                           v11,
                           v12,
+                          v13,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -893,8 +937,8 @@ return {
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v7,
-                              v8
+                              v8,
+                              v9
                             ]
                           },
                           {
@@ -905,7 +949,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v13
+                            "selections": v14
                           },
                           {
                             "kind": "LinkedField",
@@ -924,12 +968,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v14,
+                            "args": v15,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v7,
-                              v15,
+                              v8,
+                              v16,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -947,9 +991,9 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v13
+                                    "selections": v14
                                   },
-                                  v8
+                                  v9
                                 ]
                               },
                               {
@@ -1017,10 +1061,10 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  v8
+                                  v9
                                 ]
                               },
-                              v8
+                              v9
                             ]
                           }
                         ]
@@ -1055,7 +1099,7 @@ return {
                     "plural": true,
                     "selections": [
                       v4,
-                      v7,
+                      v8,
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1063,7 +1107,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      v8
+                      v9
                     ]
                   }
                 ]
@@ -1172,13 +1216,13 @@ return {
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v8,
+              v9,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v9,
+                "args": v10,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -1224,7 +1268,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": true,
-                        "selections": v18
+                        "selections": v19
                       },
                       {
                         "kind": "LinkedField",
@@ -1234,7 +1278,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v18
+                        "selections": v19
                       },
                       {
                         "kind": "LinkedField",
@@ -1244,7 +1288,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v18
+                        "selections": v19
                       },
                       {
                         "kind": "LinkedField",
@@ -1255,8 +1299,8 @@ return {
                         "concreteType": "PageCursor",
                         "plural": false,
                         "selections": [
-                          v16,
-                          v17
+                          v17,
+                          v18
                         ]
                       }
                     ]
@@ -1284,17 +1328,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v14,
+                            "args": v15,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v8,
-                              v11,
-                              v7
+                              v9,
+                              v12,
+                              v8
                             ]
                           },
-                          v8,
-                          v11,
+                          v9,
+                          v12,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1334,13 +1378,7 @@ return {
                               }
                             ]
                           },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "_id",
-                            "args": null,
-                            "storageKey": null
-                          },
+                          v7,
                           v5,
                           {
                             "kind": "ScalarField",
@@ -1349,7 +1387,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v10,
+                          v11,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1377,14 +1415,14 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v14,
+                            "args": v15,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v7,
-                              v11,
                               v8,
-                              v15
+                              v12,
+                              v9,
+                              v16
                             ]
                           },
                           {
@@ -1410,7 +1448,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v8,
+                              v9,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1477,7 +1515,7 @@ return {
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
                                 "selections": [
-                                  v19,
+                                  v20,
                                   v2
                                 ]
                               },
@@ -1490,10 +1528,10 @@ return {
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
                                 "selections": [
-                                  v19
+                                  v20
                                 ]
                               },
-                              v8
+                              v9
                             ]
                           },
                           {
@@ -1517,7 +1555,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v12,
+                          v13,
                           {
                             "kind": "ScalarField",
                             "alias": null,


### PR DESCRIPTION
Addresses: [GROW-1249](https://artsyproduct.atlassian.net/browse/GROW-1249) and some of [GROW-1250](https://artsyproduct.atlassian.net/browse/GROW-1250)

This refactors the collections header component from being a class component to a functional component. It also addresses the following collection header QA items:

- Removes text shadow form page title
- Only truncates description blurb on smaller viewports
- Use 8 column grid for description blurb on XL screen
- Fixes follow button
- Fixes single artist placement

![Screen Shot 2019-05-16 at 6 19 34 PM](https://user-images.githubusercontent.com/5201004/57890843-3329ea80-7807-11e9-8213-521ae077e090.png)

Leaving out tracking for now and will address in a separate PR.
