### PR TITLE
Clean up renovate config to remove redundant options

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,4 @@
 {
   "extends": ["@artsy:lib"],
-  "assignees": ["zephraph", "damassi", "alloy"],
-  "automerge": true,
-  "major": {
-    "automerge": false
-  }
+  "assignees": ["zephraph", "damassi", "alloy"]
 }


### PR DESCRIPTION
The automerge settings are already included in the `artsy:lib` workflow. Having them here makes it redundant. 