### PR TITLE
Select default time period filter selection via RadioGroup instead of Radio

### DIFF
--- a/src/Apps/Collect/Components/Filters/TimePeriodFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/TimePeriodFilter.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { FilterState } from "../../FilterState"
 
 import { Radio, RadioGroup } from "@artsy/palette"
+import { get } from "Utils/get"
 
 export const TimePeriodFilter: React.SFC<{
   filters: FilterState
@@ -10,26 +11,19 @@ export const TimePeriodFilter: React.SFC<{
   const periods = (timePeriods || allowedPeriods).filter(timePeriod =>
     allowedPeriods.includes(timePeriod)
   )
+  const defaultValue = get(filters.state, x => x.major_periods[0], "")
 
   const radioButtons = periods.map((timePeriod, index) => {
-    const isSelected = filters.state.major_periods[0] === timePeriod
-
-    return (
-      <Radio
-        my={0.3}
-        selected={isSelected}
-        value={timePeriod}
-        key={index}
-        label={timePeriod}
-      />
-    )
+    return <Radio my={0.3} value={timePeriod} key={index} label={timePeriod} />
   })
+
   return (
     <RadioGroup
       deselectable
       onSelect={selectedOption => {
         filters.setFilter("major_periods", selectedOption)
       }}
+      defaultValue={defaultValue}
     >
       {radioButtons}
     </RadioGroup>


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-1046

We were setting the `Radio`.`selected` property on the time period that matched the param in the URL, but it had no effect because our `Radio`s are inside of a `RadioGroup`. It seems that `Radio`.`selected` is overridden by `RadioGroup`.`defaultValue` when the radios are located inside a group. 

This PR specifies the default via `RadioGroup`.`defaultValue`. I'll submit a second PR to palette, making a note for users that `Radio`.`selected` is overridden by `Radio`.`defaultValue`.