### PR TITLE
[NavBar] Address QA items

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@types/react-tracking": "6.0.0",
     "@types/react-transition-group": "2.0.11",
     "@types/relay-runtime": "1.3.5",
-    "@types/storybook__react": "3.0.8",
+    "@types/storybook__react": "4.0.1",
     "@types/styled-components": "4.0.3",
     "@types/styled-system": "3.0.9",
     "@types/underscore.string": "0.0.32",

--- a/src/Components/NavBar/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu.tsx
@@ -37,6 +37,7 @@ export const MobileNavMenu: React.FC = () => {
       px={2}
       py={1}
       width="100%"
+      height="100vh"
       flexDirection="column"
       onClick={trackClick}
     >

--- a/src/Components/NavBar/Menus/MoreNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MoreNavMenu.tsx
@@ -19,7 +19,7 @@ export const MoreNavMenu: React.FC = () => {
   }
 
   return (
-    <Menu title="More" onClick={trackClick}>
+    <Menu onClick={trackClick}>
       {/*
         Hide nav items at md / lg as they appear in the top nav
       */}

--- a/src/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -23,6 +23,7 @@ import {
   MenuItem,
   Sans,
   Separator,
+  Serif,
 } from "@artsy/palette"
 
 export const NotificationMenuItems: React.FC<
@@ -65,20 +66,25 @@ export const NotificationMenuItems: React.FC<
       })}
 
       <Flex py={1} flexDirection="column" alignItems="center">
-        {notifications.length ? (
-          <>
+        <>
+          {notifications.length === 0 && (
+            <Flex width="100%" flexDirection="column">
+              <Box pt={1} pb={3} width="100%" textAlign="center">
+                <Serif size="3">No new works</Serif>
+              </Box>
+            </Flex>
+          )}
+
+          <Box width="100%" px={2}>
             <Separator />
-            <Box pt={2}>
-              <Sans size="2">
-                <Link href="/works-for-you">View all</Link>
-              </Sans>
-            </Box>
-          </>
-        ) : (
-          <Box>
-            <Sans size="3">No new notifications</Sans>
           </Box>
-        )}
+
+          <Box pt={2}>
+            <Sans size="2">
+              <Link href="/works-for-you">View all</Link>
+            </Sans>
+          </Box>
+        </>
       </Flex>
     </>
   )

--- a/src/Components/NavBar/Menus/__tests__/MoreNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/MoreNavMenu.test.tsx
@@ -33,10 +33,5 @@ describe("MoreNavMenu", () => {
         expect(linkLabel).toEqual(navLink.text())
       })
     })
-
-    it("menu has the correct title", () => {
-      const wrapper = getWrapper()
-      expect(wrapper.find("Menu").prop("title")).toEqual("More")
-    })
   })
 })

--- a/src/Components/NavBar/Menus/__tests__/NotificationsMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/NotificationsMenu.test.tsx
@@ -29,7 +29,7 @@ describe("NotificationsMenu", () => {
 
   it("renders proper zerostate", () => {
     const wrapper = getWrapper({} as any)
-    expect(wrapper.html()).toContain("No new notifications")
+    expect(wrapper.html()).toContain("No new works")
   })
 })
 

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -1,5 +1,5 @@
 import cookie from "cookies-js"
-import React, { useContext, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import styled from "styled-components"
 
 import {
@@ -10,9 +10,9 @@ import {
   color,
   Flex,
   Link,
-  MoreIcon,
   SoloIcon,
   Spacer,
+  themeProps,
 } from "@artsy/palette"
 
 import { SystemContext } from "Artsy/SystemContext"
@@ -32,19 +32,28 @@ import * as authentication from "./Utils/authentication"
 
 import { AnalyticsSchema } from "Artsy"
 import { track, useTracking } from "Artsy/Analytics"
+import { useMedia } from "Utils/Hooks/useMedia"
 
 export const NavBar: React.FC = track({
   flow: AnalyticsSchema.Flow.Header,
   context_module: AnalyticsSchema.ContextModule.Header,
 })(_props => {
-  const { mediator, user } = useContext(SystemContext)
   const { trackEvent } = useTracking()
+  const { mediator, user } = useContext(SystemContext)
   const [showMobileMenu, toggleMobileNav] = useState(false)
+  const isMobile = useMedia(themeProps.mediaQueries.sm)
   const isLoggedIn = Boolean(user)
+
+  // Close mobile menu if dragging window from small size to desktop
+  useEffect(() => {
+    if (!isMobile) {
+      toggleMobileNav(false)
+    }
+  }, [isMobile])
 
   return (
     <>
-      <NavBarContainer p={1}>
+      <NavBarContainer px={1}>
         <NavSection>
           <Link href="/" style={{ display: "flex" }}>
             <ArtsyMarkIcon height={40} width={40} />
@@ -54,7 +63,7 @@ export const NavBar: React.FC = track({
         <Spacer mr={1} />
 
         <NavSection width="100%">
-          <Box width="100%" maxWidth={570}>
+          <Box width="100%">
             <SearchBar />
           </Box>
         </NavSection>
@@ -62,32 +71,40 @@ export const NavBar: React.FC = track({
         <Spacer mr={3} />
 
         {/*
-          Desktop
+          Desktop. Collapses into mobile at `sm` breakpoint.
         */}
-        <NavSection display={["none", "flex"]}>
+        <NavSection display={["none", "none", "flex"]}>
           <NavSection>
             <NavItem href="/collect">Artworks</NavItem>
             <NavItem href="/auctions">Auctions</NavItem>
+            <NavItem href="/galleries">Galleries</NavItem>
 
             {/**
-              Only show Galleries and Fairs at `lg` and `xl`
+              Only show Fairs at `xlg`
             */}
-            <NavItem href="/galleries" display={["none", "none", "block"]}>
-              Galleries
-            </NavItem>
             <NavItem
               href="/art-fairs"
-              display={["none", "none", "none", "block"]}
+              display={["none", "none", "none", "none", "block"]}
             >
               Fairs
             </NavItem>
             <NavItem href="/articles">Magazine</NavItem>
-            <NavItem Menu={MoreNavMenu}>
-              <MoreIcon top="3px" />
+            <NavItem
+              Menu={() => {
+                return (
+                  <Box mr={-2}>
+                    <MoreNavMenu />
+                  </Box>
+                )
+              }}
+            >
+              More
             </NavItem>
+          </NavSection>
 
-            <Spacer mr={3} />
+          <Spacer mr={3} />
 
+          <NavSection>
             {isLoggedIn && (
               <>
                 <NavItem
@@ -102,10 +119,24 @@ export const NavBar: React.FC = track({
                     })
                   }}
                 >
-                  <BellIcon top={3} />
+                  {({ hover }) => {
+                    return (
+                      <BellIcon
+                        top={3}
+                        fill={hover ? "purple100" : "black80"}
+                      />
+                    )
+                  }}
                 </NavItem>
                 <NavItem Menu={UserMenu}>
-                  <SoloIcon top={3} />
+                  {({ hover }) => {
+                    return (
+                      <SoloIcon
+                        top={3}
+                        fill={hover ? "purple100" : "black80"}
+                      />
+                    )
+                  }}
                 </NavItem>
               </>
             )}
@@ -142,9 +173,9 @@ export const NavBar: React.FC = track({
         </NavSection>
 
         {/*
-          Mobile
+          Mobile. Triggers at the `sm` breakpoint.
         */}
-        <NavSection display={["flex", "none"]}>
+        <NavSection display={["flex", "flex", "none"]}>
           <NavItem
             className="mobileHamburgerButton"
             onClick={() => {

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -1,12 +1,14 @@
 import { Box, BoxProps, Link, Sans } from "@artsy/palette"
 import { useTracking } from "Artsy/Analytics/useTracking"
-import { isString } from "lodash"
+import { isFunction, isString } from "lodash"
 import React, { useState } from "react"
 import styled from "styled-components"
 
 interface NavItemProps extends BoxProps {
   Menu?: React.FC
-  Overlay?: React.FC
+  Overlay?: React.FC<{
+    hover: boolean
+  }>
   active?: boolean
   className?: string
   href?: string
@@ -40,7 +42,8 @@ export const NavItem: React.FC<NavItemProps> = ({
 
   return (
     <Box
-      p={1}
+      px={1}
+      py={2}
       className={className}
       display={display}
       position="relative"
@@ -54,7 +57,16 @@ export const NavItem: React.FC<NavItemProps> = ({
     >
       <Link href={href} color={hoverColor} underlineBehavior="none">
         <Sans size="3" weight="medium" color={hoverColor}>
-          {children}
+          <Box height={25}>
+            {isFunction(children)
+              ? // NavItem children can be called as renderProps so that contents
+                // can operate on UI behaviors (such as changing the color of an
+                // icon on hover).
+                children({
+                  hover,
+                })
+              : children}
+          </Box>
         </Sans>
       </Link>
 
@@ -64,13 +76,13 @@ export const NavItem: React.FC<NavItemProps> = ({
         </MenuContainer>
       )}
 
-      {showOverlay && <Overlay />}
+      {showOverlay && <Overlay hover={hover} />}
     </Box>
   )
 }
 
 const MenuContainer = styled(Box)`
   position: absolute;
-  transform: translate(-80%);
-  padding-top: 18px;
+  transform: translateX(-90%);
+  top: 63px;
 `

--- a/src/Components/NavBar/NotificationsBadge.tsx
+++ b/src/Components/NavBar/NotificationsBadge.tsx
@@ -2,8 +2,7 @@ import { Box, color, Flex, Sans } from "@artsy/palette"
 import { AnalyticsSchema, SystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import cookie from "cookies-js"
-import { once } from "lodash"
-import React, { useContext } from "react"
+import React, { useContext, useEffect } from "react"
 import { ReadyState } from "react-relay"
 import styled from "styled-components"
 import { get } from "Utils/get"
@@ -12,9 +11,12 @@ import { NotificationsQueryRenderer } from "./Menus"
 
 const logger = createLogger("Components/NavBar")
 
-export const NotificationsBadge: React.FC = () => {
-  const { trackEvent } = useTracking()
-
+export const NotificationsBadge: React.FC<{
+  /**
+   * If hovering over the nav item, `hover` is passed into the badge (Overlay)
+   */
+  hover?: boolean
+}> = ({ hover }) => {
   return (
     <NotificationsQueryRenderer
       render={({ error, props }: ReadyState) => {
@@ -38,42 +40,35 @@ export const NotificationsBadge: React.FC = () => {
           0
         )
 
-        let notifications = totalUnread
+        let count = totalUnread
 
         // Update the notification bad with the count, and store it in a cookie
         // so that subsequent page views don't need a fetch in order to render
         // the badge.
-        if (notifications > 0) {
+        if (count > 0) {
           const cachedNotificationCount = Number(
             cookie.get("notification-count")
           )
-          if (notifications !== cachedNotificationCount) {
-            if (notifications >= 100) {
-              notifications = "99+"
+          if (count !== cachedNotificationCount) {
+            if (count >= 100) {
+              count = "99+"
             }
 
             // In force, when a request is made to `/notifications` endpoint,
             // sd.NOTIFICATIONS_COUNT is populated by this cookie.
-            cookie.set("notification-count", notifications)
+            cookie.set("notification-count", count)
           }
         }
 
         // User has no notifications; clear the cookie
-        if (notifications === 0) {
+        if (count === 0) {
           cookie.expire("notification-count")
           return null
         }
 
-        const trackOnHover = once(() => {
-          trackEvent({
-            subject: AnalyticsSchema.Subject.NotificationBell,
-            new_notification_count: totalUnread,
-          })
-        })
-
         return (
-          <Box onMouseOver={trackOnHover}>
-            <CircularCount notifications={notifications} />
+          <Box>
+            <CircularCount count={count} rawCount={totalUnread} hover={hover} />
           </Box>
         )
       }}
@@ -81,17 +76,38 @@ export const NotificationsBadge: React.FC = () => {
   )
 }
 
-const CircularCount: React.FC<{ notifications?: string }> = ({
-  notifications,
-}) => {
+const CircularCount: React.FC<{
+  /**
+   * Formatted count for display
+   */
+  count?: string
+  /**
+   * Raw unread count, used for analytics.
+   */
+  rawCount?: boolean
+  /**
+   * True if hovering over the badge
+   */
+  hover?: boolean
+}> = ({ count, rawCount, hover }) => {
   // Check to see if we've got a value from sharify, populated by a cookie on
   // the server.
   const { notificationCount } = useContext(SystemContext)
-  const notificationsLabel = notifications || notificationCount
+  const notificationsLabel = count || notificationCount
+  const { trackEvent } = useTracking()
 
   if (!notificationsLabel) {
     return null
   }
+
+  useEffect(() => {
+    if (hover) {
+      trackEvent({
+        subject: AnalyticsSchema.Subject.NotificationBell,
+        new_notification_count: rawCount,
+      })
+    }
+  }, [hover])
 
   return (
     <Container>
@@ -110,6 +126,6 @@ const Container = styled(Flex)`
   align-items: center;
   justify-content: center;
   position: absolute;
-  top: 3px;
+  top: 12px;
   right: 0;
 `

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -12,7 +12,9 @@ jest.mock("Components/Search/SearchBar", () => {
     SearchBarQueryRenderer: () => <div />,
   }
 })
+
 jest.mock("Artsy/Analytics/useTracking")
+jest.mock("Utils/Hooks/useMedia")
 
 describe("NavBar", () => {
   const mediator = {

--- a/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
@@ -10,6 +10,7 @@ import { NavBar } from "../NavBar"
 import { NavItem } from "../NavItem"
 
 jest.mock("Artsy/Analytics/useTracking")
+jest.mock("Utils/Hooks/useMedia")
 
 describe("NavBarTracking", () => {
   const trackEvent = jest.fn()

--- a/src/Components/NavBar/__tests__/NavItem.test.tsx
+++ b/src/Components/NavBar/__tests__/NavItem.test.tsx
@@ -10,6 +10,8 @@ jest.mock("Artsy/Analytics/useTracking", () => {
   }
 })
 
+jest.mock("Utils/Hooks/useMedia")
+
 describe("NavItem", () => {
   it("renders proper content", () => {
     const wrapper = mount(
@@ -35,9 +37,9 @@ describe("NavItem", () => {
       </NavItem>
     )
     expect(wrapper.html()).not.toContain("Menu Item")
-    wrapper.find("Box").simulate("mouseenter")
+    wrapper.simulate("mouseenter")
     expect(wrapper.html()).toContain("Menu Item")
-    wrapper.find("Box").simulate("mouseleave")
+    wrapper.simulate("mouseleave")
     expect(wrapper.html()).not.toContain("Menu Item")
   })
 
@@ -57,7 +59,20 @@ describe("NavItem", () => {
         hello how are you
       </NavItem>
     )
-    wrapper.find("Box").simulate("click")
+    wrapper.simulate("click")
     expect(spy).toHaveBeenCalled()
+  })
+
+  it("supports renderProps for children", () => {
+    const wrapper = mount(
+      <NavItem href="/some-link" active>
+        {({ hover }) => {
+          expect(hover).toBe(true)
+          return <div>hello renderprop</div>
+        }}
+      </NavItem>
+    )
+
+    expect(wrapper.html()).toContain("hello renderprop")
   })
 })

--- a/src/Components/__stories__/NavBar.story.tsx
+++ b/src/Components/__stories__/NavBar.story.tsx
@@ -9,7 +9,7 @@ import * as Menus from "Components/NavBar/Menus"
 storiesOf("Components/NavBar", module)
   .add("Logged out", () => {
     return (
-      <Box width="100%">
+      <Container>
         <SystemContextProvider user={null}>
           <NavBar />
         </SystemContextProvider>
@@ -17,13 +17,13 @@ storiesOf("Components/NavBar", module)
         <Box mx={1}>
           <PageCopy />
         </Box>
-      </Box>
+      </Container>
     )
   })
 
   .add("Logged in", () => {
     return (
-      <Box width="100%">
+      <Container>
         <SystemContextProvider>
           <NavBar />
         </SystemContextProvider>
@@ -31,7 +31,7 @@ storiesOf("Components/NavBar", module)
         <Box mx={1}>
           <PageCopy />
         </Box>
-      </Box>
+      </Container>
     )
   })
 
@@ -39,7 +39,7 @@ storiesOf("Components/NavBar", module)
     "Mobile",
     () => {
       return (
-        <Box width="100%">
+        <Container>
           <SystemContextProvider>
             <NavBar />
           </SystemContextProvider>
@@ -47,7 +47,7 @@ storiesOf("Components/NavBar", module)
           <Box mx={1}>
             <PageCopy />
           </Box>
-        </Box>
+        </Container>
       )
     },
     {
@@ -70,6 +70,10 @@ storiesOf("Components/NavBar/Menus", module)
   .add("MobileNavMenu", () => {
     return <Menus.MobileNavMenu />
   })
+
+const Container = ({ children }) => {
+  return <Box width="100%">{children}</Box>
+}
 
 const PageCopy = () => {
   return (

--- a/src/Utils/BreakpointVisualizer.tsx
+++ b/src/Utils/BreakpointVisualizer.tsx
@@ -12,6 +12,7 @@ const StyledBox = styled(Box)`
   border-bottom-right-radius: 5px;
   /* transition: opacity 0.3s ease-in-out; */
   opacity: 0.05;
+  z-index: 2;
 `
 
 const BreakpointText: React.SFC<{ breakpoint: string; max?: boolean }> = ({

--- a/src/Utils/Hooks/useMedia.ts
+++ b/src/Utils/Hooks/useMedia.ts
@@ -1,0 +1,41 @@
+/**
+ * Thanks! https://github.com/olistic/react-use-media/
+ */
+
+import { useEffect, useState } from "react"
+
+/**
+ * Checks to see if the browser matches a particular media query
+ *
+ * @example
+
+    import { themeProps } from '@artsy/palette'
+    import { useMedia } from 'Utils/Hooks/useMedia'
+
+    const App = () => {
+      const isMobile = useMedia(themeProps.mediaQueries.sm)
+
+      return (
+        <div>Mobile view? {isMobile}</div>
+      )
+    }
+ */
+export function useMedia(
+  mediaQueryString: string,
+  { initialMatches = true } = {}
+) {
+  const [matches, setMatches] = useState(initialMatches)
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(mediaQueryString)
+    setMatches(mediaQueryList.matches)
+    const handleChange = event => setMatches(event.matches)
+
+    mediaQueryList.addEventListener("change", handleChange)
+    return () => {
+      mediaQueryList.removeEventListener("change", handleChange)
+    }
+  }, [mediaQueryString])
+
+  return matches
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,10 +2187,10 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
   integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
 
-"@types/storybook__react@3.0.8":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@types/storybook__react/-/storybook__react-3.0.8.tgz#58deb593361b7d5e6a6eca09bc7889b613980925"
-  integrity sha512-RrIL+m84ocoYT/D2ksYAzpC+DYHTtfgTLyrzmvCdhL/zsrXc0kgKHq0VVjiS80rnvhzlQPCWFDglEP/c/H/gAg==
+"@types/storybook__react@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/storybook__react/-/storybook__react-4.0.1.tgz#b6320c9d027b8ee7ef1445fef8b4cba196d48ace"
+  integrity sha512-knkZErqv8Iy2QbebqBa5tsy2itIMKdO6bcQ7C19nmgTc+j1pnQhXCGcVyARzAQ1/NAuSYudSWQAKG+plgK7hyQ==
   dependencies:
     "@types/react" "*"
     "@types/webpack-env" "*"


### PR DESCRIPTION
As this is a lot of individual QA changes I'll comment inline where appropriate. 

**Zeplin Spec:**
https://app.zeplin.io/project/5acd19ff49a1429169c3128b/screen/5c649937a981283c0b74cc63

**JIRA:**
https://artsyproduct.atlassian.net/browse/PLATFORM-1409#add-comment?atlOrigin=eyJpIjoiOWZlY2ZhOWFlYzM4NDUzMzhjN2ZmZTEzYWZiZDFlMmMiLCJwIjoiaiJ9

#### Feedback check-list: 

- [x] Nav items sit within a flexbox that expands to a max width of 420 (Width will shrink with browser size...390 @ Large, 340 @ Medium)
- [x] Flexbox is fixed & right aligned to login/sign up buttons
- [x] 40px padding to right/left of flexbox
- [x] Search bar expands and fills space
- [x] The amount of nav items will drop at Large breakpoint
- [x] Changed the "More" nav item to text instead of "..." icon
- [x] Removed the "More" subhead within the dropdown
- [x] Visual update to the Activity dropdown zero state
- [x] At Small breakpoint, we switch to the mobile/XS view (Previously did not do this)
- [x] Mobile/XS expanded menu background should extend to bottom of browser (see spec for details)
- [x] [BUG] Mobile/XS menu stays open if you expand your browser. Expected behavior is that it would close/ reset as larger breakpoints are met
- [x] Nav is currently covering the purple banner in staging.
- [x] Some weirdness w/ the white background color not being rounded to match the border, causing a slight overlap in each of the 4 corners. Maybe something that could be addressed with different box-sizing?
- [x] Dropdown placement should align to the right edge of the icon/text it correlates with (see spec for visual) Trying to avoid the dropdown for User/Account running into the right edge of the browser.... I just noticed your comment on Zeplin about this. I'm flexible on this one, we can look at it together.

#### Todo in different PR (part of a separate, larger task) 
- It would be great if the sign-out link would work by default HTML means (eg when JS is broken)
