### PR TITLE
[NavBar] QA round 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "autosuggest-highlight": "^3.1.1",
     "cheerio": "^1.0.0-rc.2",
     "currency.js": "^1.2.1",
-    "deepmerge": "^3.2.0",
     "farce": "^0.2.6",
     "formik": "^0.11.11",
     "found": "^0.3.14",

--- a/src/Artsy/Analytics/useTracking.ts
+++ b/src/Artsy/Analytics/useTracking.ts
@@ -1,27 +1,5 @@
-import merge from "deepmerge"
-import { useContext } from "react"
+import { useTracking as _useTracking } from "react-tracking"
 import { Trackables } from "./Schema"
 
-import {
-  ReactTrackingContext,
-  TrackingContext,
-} from "react-tracking/build/withTrackingComponentDecorator"
-
-export function useTracking() {
-  const trackingContext = useContext(ReactTrackingContext) as TrackingContext
-
-  if (!(trackingContext && trackingContext.tracking)) {
-    throw new Error(
-      "[Artsy/Analytics/useTracking] Error: Attempting to call `useTracking` " +
-        "without a ReactTrackingContext present. Did you forget to wrap the top of " +
-        "your component tree with `track`?"
-    )
-  }
-
-  return {
-    trackEvent: (data: Partial<Trackables>): void =>
-      trackingContext.tracking.dispatch(
-        merge(trackingContext.tracking.data, data as any)
-      ),
-  }
-}
+// TODO: Update @types/react-tracking with an interface rather than aliasing
+export const useTracking = () => _useTracking<Trackables>()

--- a/src/Components/NavBar/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React, { useContext, useState } from "react"
 import styled from "styled-components"
 
 import {
@@ -15,6 +15,7 @@ import {
 import { SystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import * as authentication from "Components/NavBar/Utils/authentication"
+import { useMedia } from "Utils/Hooks/useMedia"
 
 export const MobileNavMenu: React.FC = () => {
   const { trackEvent } = useTracking()
@@ -34,8 +35,7 @@ export const MobileNavMenu: React.FC = () => {
 
   return (
     <MobileNavContainer
-      px={2}
-      py={1}
+      py={[1, 4]}
       width="100%"
       height="100vh"
       flexDirection="column"
@@ -50,7 +50,7 @@ export const MobileNavMenu: React.FC = () => {
       <MobileLink href="/auctions">Auctions</MobileLink>
       <MobileLink href="/articles">Magazine</MobileLink>
 
-      <Separator my={1} />
+      <Separator my={[1, 4]} />
 
       {isLoggedIn ? (
         <>
@@ -82,15 +82,39 @@ const MobileLink: React.FC<MobileLinkProps> = ({
   children,
   ...props
 }) => {
+  const { sm: isTablet } = useMedia()
+  const [isPressed, setPressed] = useState(false)
+  const bg = isTablet && isPressed ? "black5" : "white100"
+  const getEvents = () => {
+    if (!isTablet) {
+      return {}
+    }
+    return {
+      onMouseDown: () => setPressed(true),
+      onMouseUp: () => setPressed(false),
+      onMouseLeave: () => setPressed(false),
+      onTouchStart: () => setPressed(true),
+      onTouchEnd: () => setPressed(false),
+    }
+  }
+
   return (
-    <Box my={0.5} {...props} style={{ cursor: "pointer" }}>
-      {href ? (
-        <Link href={href} underlineBehavior="none">
-          <Serif size="4">{children}</Serif>
-        </Link>
-      ) : (
-        <Serif size="4">{children}</Serif>
-      )}
+    <Box
+      py={0.5}
+      style={{ cursor: "pointer" }}
+      bg={bg}
+      {...getEvents()}
+      {...props}
+    >
+      <Box px={2} py={[0, 0.5]}>
+        {href ? (
+          <Link href={href} underlineBehavior="none">
+            <Serif size={["4", "8"]}>{children}</Serif>
+          </Link>
+        ) : (
+          <Serif size={["4", "8"]}>{children}</Serif>
+        )}
+      </Box>
     </Box>
   )
 }
@@ -103,5 +127,6 @@ const MobileNavContainer = styled(Flex)`
 `
 
 export const MobileToggleIcon: React.FC<{ open: boolean }> = ({ open }) => {
-  return open ? <CloseIcon /> : <MenuIcon />
+  const style = { transform: "scale(1.5)", top: 2 }
+  return open ? <CloseIcon style={style} /> : <MenuIcon style={style} />
 }

--- a/src/Components/NavBar/Menus/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/MobileNavMenu.test.tsx
@@ -9,6 +9,10 @@ jest.mock("Artsy/Analytics/useTracking", () => ({
   }),
 }))
 
+jest.mock("Utils/Hooks/useMedia", () => ({
+  useMedia: () => ({ sm: false }),
+}))
+
 describe("MobileNavMenu", () => {
   const getWrapper = props => {
     return mount(

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -11,8 +11,8 @@ import {
   Flex,
   Link,
   SoloIcon,
+  space,
   Spacer,
-  themeProps,
 } from "@artsy/palette"
 
 import { SystemContext } from "Artsy/SystemContext"
@@ -32,16 +32,23 @@ import * as authentication from "./Utils/authentication"
 
 import { AnalyticsSchema } from "Artsy"
 import { track, useTracking } from "Artsy/Analytics"
+import Events from "Utils/Events"
 import { useMedia } from "Utils/Hooks/useMedia"
 
-export const NavBar: React.FC = track({
-  flow: AnalyticsSchema.Flow.Header,
-  context_module: AnalyticsSchema.ContextModule.Header,
-})(_props => {
+export const NavBar: React.FC = track(
+  {
+    flow: AnalyticsSchema.Flow.Header,
+    context_module: AnalyticsSchema.ContextModule.Header,
+  },
+  {
+    dispatch: data => Events.postEvent(data),
+  }
+)(_props => {
   const { trackEvent } = useTracking()
   const { mediator, user } = useContext(SystemContext)
   const [showMobileMenu, toggleMobileNav] = useState(false)
-  const isMobile = useMedia(themeProps.mediaQueries.sm)
+  const { xs, sm } = useMedia()
+  const isMobile = xs || sm
   const isLoggedIn = Boolean(user)
 
   // Close mobile menu if dragging window from small size to desktop
@@ -102,7 +109,7 @@ export const NavBar: React.FC = track({
             </NavItem>
           </NavSection>
 
-          <Spacer mr={3} />
+          <Spacer mr={2} />
 
           <NavSection>
             {isLoggedIn && (
@@ -223,6 +230,7 @@ const NavBarContainer = styled(Flex)`
   border-bottom: 1px solid ${color("black10")};
   position: relative;
   z-index: 1;
+  height: ${space(6)}px;
 `
 
 // FIXME: This needs to be cleaned up once we get proper icons

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -1,4 +1,4 @@
-import { Box, BoxProps, Link, Sans } from "@artsy/palette"
+import { Box, BoxProps, Link, Sans, space } from "@artsy/palette"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { isFunction, isString } from "lodash"
 import React, { useState } from "react"
@@ -71,7 +71,7 @@ export const NavItem: React.FC<NavItemProps> = ({
       </Link>
 
       {showMenu && (
-        <MenuContainer>
+        <MenuContainer top={space(6)}>
           <Menu />
         </MenuContainer>
       )}
@@ -84,5 +84,4 @@ export const NavItem: React.FC<NavItemProps> = ({
 const MenuContainer = styled(Box)`
   position: absolute;
   transform: translateX(-90%);
-  top: 63px;
 `

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -14,7 +14,9 @@ jest.mock("Components/Search/SearchBar", () => {
 })
 
 jest.mock("Artsy/Analytics/useTracking")
-jest.mock("Utils/Hooks/useMedia")
+jest.mock("Utils/Hooks/useMedia", () => ({
+  useMedia: () => ({}),
+}))
 
 describe("NavBar", () => {
   const mediator = {

--- a/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
@@ -10,7 +10,9 @@ import { NavBar } from "../NavBar"
 import { NavItem } from "../NavItem"
 
 jest.mock("Artsy/Analytics/useTracking")
-jest.mock("Utils/Hooks/useMedia")
+jest.mock("Utils/Hooks/useMedia", () => ({
+  useMedia: () => ({ sm: false }),
+}))
 
 describe("NavBarTracking", () => {
   const trackEvent = jest.fn()

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -5,7 +5,6 @@ import { SystemContext, SystemContextProps } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import colors from "Assets/Colors"
-import Input from "Components/Input"
 import {
   EmptySuggestion,
   FirstSuggestionItem,
@@ -13,8 +12,8 @@ import {
   PLACEHOLDER_XS,
   SuggestionItem,
 } from "Components/Search/Suggestions/SuggestionItem"
-import { isEmpty } from "lodash"
 import { throttle } from "lodash"
+import { isEmpty } from "lodash"
 import qs from "qs"
 import React, { Component, useContext } from "react"
 import Autosuggest from "react-autosuggest"
@@ -441,14 +440,21 @@ export const SearchBarQueryRenderer: React.FC = () => {
       render={({ props }) => {
         if (props) {
           return <SearchBarRefetchContainer viewer={props.viewer} />
+          // SSR render pass. Since we don't have access to `<Boot>` context
+          // from within the NavBar (it's not a part of any app) we need to lean
+          // on styled-system for showing / hiding depending upon breakpoint.
         } else {
           return (
-            <Input
-              name="term"
-              style={{ width: "100%" }}
-              placeholder={PLACEHOLDER_XS}
-            />
+            <>
+              <Box display={["block", "none"]}>
+                <SearchInputContainer placeholder={PLACEHOLDER_XS} />
+              </Box>
+              <Box display={["none", "block"]}>
+                <SearchInputContainer placeholder={PLACEHOLDER} />
+              </Box>
+            </>
           )
+          return
         }
       }}
     />

--- a/src/Components/Search/SearchInputContainer.tsx
+++ b/src/Components/Search/SearchInputContainer.tsx
@@ -1,4 +1,4 @@
-import { Box, color } from "@artsy/palette"
+import { Box, color, MagnifyingGlassIcon } from "@artsy/palette"
 import Input from "Components/Input"
 import { isEmpty } from "lodash"
 import React from "react"
@@ -40,19 +40,7 @@ export const SearchInputContainer: React.ForwardRefExoticComponent<
           }
         }}
       >
-        <svg
-          width="18"
-          height="18"
-          xmlns="http://www.w3.org/2000/svg"
-          style={{ position: "relative", top: 3 }}
-        >
-          <title>search</title>
-          <path
-            d="M11.5 3a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7zm0-1A4.5 4.5 0 1 0 16 6.5 4.49 4.49 0 0 0 11.5 2zM9.442 9.525l-.88-.88L2.06 15.06l.88.88 6.502-6.415z"
-            fill="#000"
-            fillRule="nonzero"
-          />
-        </svg>
+        <MagnifyingGlassIcon style={{ position: "relative", top: 3 }} />
       </SearchButton>
     </Box>
   )

--- a/src/Utils/Hooks/useMedia.ts
+++ b/src/Utils/Hooks/useMedia.ts
@@ -1,11 +1,43 @@
-/**
- * Thanks! https://github.com/olistic/react-use-media/
- */
-
+import { Breakpoint, themeProps } from "@artsy/palette"
 import { useEffect, useState } from "react"
 
 /**
+ * Returns an object containing keys representing each media query as they're
+ * defined in Palette's theme file, and if they're currently matching.
+ *
+ * NOTE: useMedia is not meant to be run on the server.
+ *
+ * See: https://github.com/artsy/palette/blob/master/packages/palette/src/Theme.tsx#L84-L92
+ *
+ * @example
+
+    import { useMedia } from 'Utils/Hooks/useMedia'
+
+    const App = () => {
+      const { xs, sm, md, lg, xl } = useMedia()
+
+      return (
+        <div>Mobile view? {xs || sm}</div>
+      )
+    }
+ */
+export function useMedia(): { [k in Breakpoint]?: boolean } {
+  const matches = Object.entries(themeProps.mediaQueries).reduce(
+    (acc, [key, value]) => {
+      return {
+        ...acc,
+        [key]: useMatchMedia(value),
+      }
+    },
+    {}
+  )
+  return matches
+}
+
+/**
  * Checks to see if the browser matches a particular media query
+ *
+ * Thanks! https://github.com/olistic/react-use-media/
  *
  * @example
 
@@ -20,11 +52,17 @@ import { useEffect, useState } from "react"
       )
     }
  */
-export function useMedia(
+export function useMatchMedia(
   mediaQueryString: string,
-  { initialMatches = true } = {}
+  { initialMatches = null } = {}
 ) {
   const [matches, setMatches] = useState(initialMatches)
+
+  // Exit if we're in a server-like environment
+  const isServer = typeof window === "undefined"
+  if (isServer) {
+    return matches
+  }
 
   useEffect(() => {
     const mediaQueryList = window.matchMedia(mediaQueryString)


### PR DESCRIPTION
More NavBar feedback:

1) New "tablet" mobile menu which has larger font, different spacing, etc: 

<img width="540" alt="Screen Shot 2019-05-21 at 6 17 40 PM" src="https://user-images.githubusercontent.com/236943/58140617-bfb41e80-7bf4-11e9-9d6c-6781972142a7.png">

2) It supports tap highlights: 

![tap](https://user-images.githubusercontent.com/236943/58140621-c6db2c80-7bf4-11e9-82e2-94ee418f0d01.gif)

3) Bigger open close icons on mobile: 

<img width="118" alt="Screen Shot 2019-05-21 at 6 12 06 PM" src="https://user-images.githubusercontent.com/236943/58140649-e2dece00-7bf4-11e9-95b4-06d7f07ac86d.png">

4) Ensure top nav bar is 60px


### Misc other updates:
- Fixes weird missing icon / input text flash when SearchBar renders on the server
- Updated `react-tracking` to latest, which allows us to remove our custom `useTracking` hook code.
- Renamed `useMedia` hook to `useMatchMedia` and then created a new `useMedia` hook that's specifically tied to Palette's theme file and can be used like so: 

```tsx
import { useMedia } from "Utils/Hooks/useMedia"

const App = () => {
  const { xs, sm, md, lg, xl } = useMedia()

  return <div>Mobile view? {xs || sm}</div>
}
