### PR TITLE
[Collection Artist Module] fix font styles for View More truncation element

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -94,13 +94,13 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
         pb={20}
         key={4}
       >
-        <Box
+        <ViewMore
           onClick={() => {
             setShowMore(true)
           }}
         >
-          <EntityHeader initials={`+${remainingArtists}`} name="View more" />
-        </Box>
+          <EntityHeader initials={`+ ${remainingArtists}`} name="View more" />
+        </ViewMore>
       </EntityContainer>
     )
     const artists = cloneDeep(featuredArtists)
@@ -344,6 +344,18 @@ const ExtendedSerif = styled(Serif)`
     div p {
       display: inline;
       ${unica("s12")};
+    }
+  }
+`
+
+const ViewMore = styled(Box)`
+  div {
+    div {
+      text-decoration: underline;
+      ${unica("s14")};
+    }
+    div:first-child {
+      text-decoration: none;
     }
   }
 `


### PR DESCRIPTION
Addresses: [GROW-1250](https://artsyproduct.atlassian.net/browse/GROW-1250)

Ensures "View more" is Unica Medium 14px font.

<img width="373" alt="Screen Shot 2019-05-21 at 6 07 32 PM" src="https://user-images.githubusercontent.com/5201004/58133947-57b10880-7bf3-11e9-98f3-be0438514e35.png">

