### PR TITLE
DISCO-1053 - Remove major_periods filter properly from FilterState in /collect & /collection/:id apps

### DIFF
--- a/src/Apps/Collect/FilterState.tsx
+++ b/src/Apps/Collect/FilterState.tsx
@@ -162,7 +162,7 @@ export class FilterState extends Container<State> {
 
     switch (filter) {
       case "major_periods":
-        newPartialState = { major_periods: [value] }
+        newPartialState = { major_periods: value ? [value] : [] }
         break
       case "attribution_class":
         newPartialState = {


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-1053.

This is a very small change that unsets the "time period" filter properly when you remove it. 

Without this change, if you remove a time period from your filters, you end up with "no results", because it's filtering by `major_periods[0]=null`.

After this change, if you remove a time period from your filters, you end up with the correct results. 

* I couldn't find a good place to add a test for this. I did think about adding a test to [FilterState.test.ts](https://github.com/artsy/reaction/blob/29336af3928e1f20aa885e815ea53ab9fe941acf/src/Apps/Collect/__tests__/FilterState.test.tsx#L3), but it felt very much like a test of an implementation detail that would eventually just get deleted. It feels more like a UI test would be appropriate for this...but we don't have those (yet).
* My initial instinct was that this would also be broken for the /artist/:id and /search apps. But it's not. I haven't figure out why (yet). 