### PR TITLE
Reduce the assignees on the renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "extends": ["@artsy:lib"],
-  "assignees": ["zephraph", "damassi", "alloy"]
+  "assignees": ["zephraph"],
+  "reviewers": ["damassi"]
 }


### PR DESCRIPTION
Just stops the peril warnings about too many assignees. 