### PR TITLE
DISCO-1051/DISCO-946 - Adjustments to search input styling and behavior 

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -6,7 +6,6 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import colors from "Assets/Colors"
 import {
-  EmptySuggestion,
   FirstSuggestionItem,
   PLACEHOLDER,
   PLACEHOLDER_XS,
@@ -262,8 +261,6 @@ export class SearchBar extends Component<Props, State> {
       return null
     }
 
-    const showEmptySuggestion = !xs && !query && focused
-
     const props = {
       children,
       containerProps,
@@ -271,11 +268,7 @@ export class SearchBar extends Component<Props, State> {
       query,
     }
 
-    return (
-      <SuggestionContainer {...props}>
-        {showEmptySuggestion ? <EmptySuggestion /> : children}
-      </SuggestionContainer>
-    )
+    return <SuggestionContainer {...props}>{children}</SuggestionContainer>
   }
 
   getSuggestionValue = ({ node: { displayLabel } }) => {

--- a/src/Components/Search/SearchInputContainer.tsx
+++ b/src/Components/Search/SearchInputContainer.tsx
@@ -7,7 +7,7 @@ import styled from "styled-components"
 const SearchButton = styled.button`
   position: absolute;
   right: 0;
-  top: 50%;
+  top: calc(50% + 3px);
   border: none;
   margin-top: -14px;
   width: 24px;
@@ -40,7 +40,7 @@ export const SearchInputContainer: React.ForwardRefExoticComponent<
           }
         }}
       >
-        <MagnifyingGlassIcon style={{ position: "relative", top: 3 }} />
+        <MagnifyingGlassIcon />
       </SearchButton>
     </Box>
   )

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -63,10 +63,6 @@ const InnerWrapper = styled(Flex)`
 export const PLACEHOLDER = "Search by artist, gallery, style, theme, tag, etc."
 export const PLACEHOLDER_XS = "Search Artsy"
 
-export const EmptySuggestion = () => (
-  <SuggestionWrapper>{PLACEHOLDER}</SuggestionWrapper>
-)
-
 const SuggestionWrapper = props => (
   <Flex alignItems="center" flexDirection="row" height="62px" pl={2}>
     {props.children}


### PR DESCRIPTION
## DISCO-1051 - Removes empty suggestion box from search

- https://artsyproduct.atlassian.net/browse/DISCO-1051
- The empty suggestion box is redundant with the search input placeholder, this PR removes the empty suggestion box and only displays auto suggestions once a user starts typing 

- Before

<img width="505" alt="Screen Shot 2019-05-27 at 7 00 47 AM" src="https://user-images.githubusercontent.com/21182806/58415920-fb644380-804d-11e9-9d32-c0e702a1fdc8.png">

- After

![2019-05-27 07 02 55](https://user-images.githubusercontent.com/21182806/58415934-061ed880-804e-11e9-8c39-e013a0708393.gif)


## DISCO-946 - Search icon off-center in input field

- https://artsyproduct.atlassian.net/browse/DISCO-946

- After change

<img width="485" alt="Screen Shot 2019-05-27 at 6 56 55 AM" src="https://user-images.githubusercontent.com/21182806/58415861-c7891e00-804d-11e9-8df0-260ff0cadf54.png">

<img width="494" alt="Screen Shot 2019-05-27 at 6 56 49 AM" src="https://user-images.githubusercontent.com/21182806/58415866-cc4dd200-804d-11e9-8c3e-4f7e65a88847.png">
