### PR TITLE
[NavBar] Fix click-area

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu.tsx
@@ -12,7 +12,7 @@ import {
   Serif,
 } from "@artsy/palette"
 
-import { SystemContext } from "Artsy"
+import { AnalyticsSchema, SystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import * as authentication from "Components/NavBar/Utils/authentication"
 
@@ -27,6 +27,7 @@ export const MobileNavMenu: React.FC = () => {
     const href = link.parentNode.getAttribute("href")
 
     trackEvent({
+      action_type: AnalyticsSchema.ActionType.Click,
       subject: text,
       destination_path: href,
     })

--- a/src/Components/NavBar/Menus/MoreNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MoreNavMenu.tsx
@@ -12,6 +12,7 @@ export const MoreNavMenu: React.FC = () => {
     const href = link.parentNode.parentNode.getAttribute("href")
 
     trackEvent({
+      action_type: AnalyticsSchema.ActionType.Click,
       context_module: AnalyticsSchema.ContextModule.HeaderMoreDropdown,
       subject: text,
       destination_path: href,

--- a/src/Components/NavBar/Menus/UserMenu.tsx
+++ b/src/Components/NavBar/Menus/UserMenu.tsx
@@ -23,6 +23,7 @@ export const UserMenu: React.FC = () => {
     const href = link.parentNode.parentNode.getAttribute("href")
 
     trackEvent({
+      action_type: AnalyticsSchema.ActionType.Click,
       context_module: AnalyticsSchema.ContextModule.HeaderUserDropdown,
       subject: text,
       destination_path: href,

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -120,6 +120,7 @@ export const NavBar: React.FC = track(
                   Overlay={NotificationsBadge}
                   onClick={() => {
                     trackEvent({
+                      action_type: AnalyticsSchema.ActionType.Click,
                       subject: AnalyticsSchema.Subject.NotificationBell,
                       new_notification_count: cookie.get("notification-count"),
                       destination_path: "/works-for-you",
@@ -155,6 +156,7 @@ export const NavBar: React.FC = track(
                 variant="secondaryOutline"
                 onClick={() => {
                   trackEvent({
+                    action_type: AnalyticsSchema.ActionType.Click,
                     subject: AnalyticsSchema.Subject.Login,
                   })
 
@@ -167,6 +169,7 @@ export const NavBar: React.FC = track(
               <Button
                 onClick={() => {
                   trackEvent({
+                    action_type: AnalyticsSchema.ActionType.Click,
                     subject: AnalyticsSchema.Subject.Signup,
                   })
 
@@ -189,6 +192,7 @@ export const NavBar: React.FC = track(
               const showMenu = !showMobileMenu
               if (showMenu) {
                 trackEvent({
+                  action_type: AnalyticsSchema.ActionType.Click,
                   subject: AnalyticsSchema.Subject.SmallScreenMenuSandwichIcon,
                 })
               }

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps, Link, Sans, space } from "@artsy/palette"
+import { AnalyticsSchema } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { isFunction, isString } from "lodash"
 import React, { useState } from "react"
@@ -34,6 +35,7 @@ export const NavItem: React.FC<NavItemProps> = ({
   const trackClick = () => {
     if (href && isString(children)) {
       trackEvent({
+        action_type: AnalyticsSchema.ActionType.Click,
         subject: children, // Text passed into the NavItem
         destination_path: href,
       })
@@ -42,20 +44,25 @@ export const NavItem: React.FC<NavItemProps> = ({
 
   return (
     <Box
-      px={1}
-      py={2}
-      className={className}
-      display={display}
       position="relative"
-      style={{ cursor: "pointer" }}
       onMouseEnter={() => toggleHover(true)}
       onMouseLeave={() => toggleHover(false)}
-      onClick={() => {
-        trackClick()
-        onClick && onClick()
-      }}
     >
-      <Link href={href} color={hoverColor} underlineBehavior="none">
+      <Link
+        href={href}
+        color={hoverColor}
+        underlineBehavior="none"
+        px={1}
+        py={2}
+        className={className}
+        display={display}
+        position="relative"
+        style={{ cursor: "pointer" }}
+        onClick={() => {
+          trackClick()
+          onClick && onClick()
+        }}
+      >
         <Sans size="3" weight="medium" color={hoverColor}>
           <Box height={25}>
             {isFunction(children)
@@ -83,5 +90,5 @@ export const NavItem: React.FC<NavItemProps> = ({
 
 const MenuContainer = styled(Box)`
   position: absolute;
-  transform: translateX(-90%);
+  transform: translateX(-83%);
 `

--- a/src/Components/NavBar/NotificationsBadge.tsx
+++ b/src/Components/NavBar/NotificationsBadge.tsx
@@ -103,6 +103,7 @@ const CircularCount: React.FC<{
   useEffect(() => {
     if (hover) {
       trackEvent({
+        action_type: AnalyticsSchema.ActionType.Hover,
         subject: AnalyticsSchema.Subject.NotificationBell,
         new_notification_count: rawCount,
       })

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -130,6 +130,7 @@ describe("NavBar", () => {
         wrapper
           .find("NavSection")
           .find("NavItem")
+          .find("Link")
           .last()
           .simulate("click")
 

--- a/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
@@ -49,6 +49,7 @@ describe("NavBarTracking", () => {
         .simulate("click")
 
       expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Click,
         subject: AnalyticsSchema.Subject.NotificationBell,
         destination_path: "/works-for-you",
       })
@@ -66,6 +67,7 @@ describe("NavBarTracking", () => {
         .simulate("click")
 
       expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Click,
         subject: AnalyticsSchema.Subject.Login,
       })
     })
@@ -82,6 +84,7 @@ describe("NavBarTracking", () => {
         .simulate("click")
 
       expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Click,
         subject: AnalyticsSchema.Subject.Signup,
       })
     })
@@ -106,6 +109,7 @@ describe("NavBarTracking", () => {
         },
       })
       expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Click,
         context_module: AnalyticsSchema.ContextModule.HeaderMoreDropdown,
         destination_path: "/galleries",
       })
@@ -130,6 +134,7 @@ describe("NavBarTracking", () => {
         },
       })
       expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Click,
         context_module: AnalyticsSchema.ContextModule.HeaderUserDropdown,
         destination_path: "/user/saves",
       })
@@ -144,9 +149,10 @@ describe("NavBarTracking", () => {
         </Wrapper>
       )
 
-      wrapper.find("NavItem").simulate("click")
+      wrapper.find("Link").simulate("click")
 
       expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Click,
         subject: "Fairs",
         destination_path: "/art-fairs",
       })
@@ -162,10 +168,12 @@ describe("NavBarTracking", () => {
       )
       wrapper
         .find(".mobileHamburgerButton")
+        .find("Link")
         .first()
         .simulate("click")
 
       expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Click,
         subject: AnalyticsSchema.Subject.SmallScreenMenuSandwichIcon,
       })
     })
@@ -190,6 +198,7 @@ describe("NavBarTracking", () => {
         })
 
       expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Click,
         subject: "Magazine",
         destination_path: "/articles",
       })

--- a/src/Components/NavBar/__tests__/NavItem.test.tsx
+++ b/src/Components/NavBar/__tests__/NavItem.test.tsx
@@ -59,7 +59,7 @@ describe("NavItem", () => {
         hello how are you
       </NavItem>
     )
-    wrapper.simulate("click")
+    wrapper.find("Link").simulate("click")
     expect(spy).toHaveBeenCalled()
   })
 

--- a/src/Utils/Hooks/useMedia.ts
+++ b/src/Utils/Hooks/useMedia.ts
@@ -69,9 +69,10 @@ export function useMatchMedia(
     setMatches(mediaQueryList.matches)
     const handleChange = event => setMatches(event.matches)
 
-    mediaQueryList.addEventListener("change", handleChange)
+    mediaQueryList.addListener(handleChange)
+
     return () => {
-      mediaQueryList.removeEventListener("change", handleChange)
+      mediaQueryList.removeListener(handleChange)
     }
   }, [mediaQueryString])
 


### PR DESCRIPTION
Fixes an issue where the top nav bar links were only clickable on the text, and not the hover area.

Additionally, fixes
- Safari display issue
- Missing `action_type` tracking prop 