### PR TITLE
replace use of SmallSelect with SelectSmall

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -21,8 +21,8 @@ import {
   Message,
   Radio,
   Sans,
+  SelectSmall,
   Separator,
-  SmallSelect,
   Spacer,
 } from "@artsy/palette"
 import { AuthModalIntent, openAuthModal } from "Utils/openAuthModal"
@@ -246,8 +246,7 @@ class Filter extends Component<Props> {
     const { filterState } = this.props
     return (
       <Flex justifyContent={["space-between", "flex-end"]} alignItems="center">
-        <SmallSelect
-          mt="-8px"
+        <SelectSmall
           options={[
             {
               value: "-decayed_merch",
@@ -271,6 +270,7 @@ class Filter extends Component<Props> {
             },
           ]}
           selected={filterState.state.sort}
+          title="Sort"
           onSelect={sort => {
             return filterState.setSort(sort)
           }}

--- a/src/Apps/Collect/Components/Filters/SortFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/SortFilter.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { Media } from "Utils/Responsive"
 import { FilterState } from "../../FilterState"
 
-import { Button, FilterIcon, Flex, SmallSelect, Spacer } from "@artsy/palette"
+import { Button, FilterIcon, Flex, SelectSmall, Spacer } from "@artsy/palette"
 
 export const SortFilter: React.FC<{
   filters: FilterState
@@ -10,8 +10,7 @@ export const SortFilter: React.FC<{
 }> = ({ filters, onShow }) => {
   return (
     <Flex justifyContent={["space-between", "flex-end"]} alignItems="center">
-      <SmallSelect
-        mt="-8px"
+      <SelectSmall
         options={[
           {
             value: "-decayed_merch",
@@ -35,6 +34,7 @@ export const SortFilter: React.FC<{
           },
         ]}
         selected={filters.state.sort}
+        title="Sort"
         onSelect={sort => {
           return filters.setFilter("sort", sort)
         }}


### PR DESCRIPTION
New palette's SelectSmall.

Old version of artist:
<img width="1078" alt="Screen Shot 2019-05-29 at 10 27 02 AM" src="https://user-images.githubusercontent.com/437156/58565511-e24dc500-81fc-11e9-96e5-9e518dde410f.png">
and new one:
<img width="1126" alt="Screen Shot 2019-05-29 at 10 27 08 AM" src="https://user-images.githubusercontent.com/437156/58565522-e7127900-81fc-11e9-8075-5b0a41437f5b.png">


And collect:
old:
<img width="1071" alt="Screen Shot 2019-05-29 at 10 27 43 AM" src="https://user-images.githubusercontent.com/437156/58565537-eed21d80-81fc-11e9-8f91-5ff97b7fb859.png">
new:
<img width="1127" alt="Screen Shot 2019-05-29 at 10 27 37 AM" src="https://user-images.githubusercontent.com/437156/58565555-f5609500-81fc-11e9-8e40-1918a7459ff7.png">


