### PR TITLE
[NavBar] Fix notification count for zero notifications

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -50,6 +50,7 @@ export const NavBar: React.FC = track(
   const { xs, sm } = useMedia()
   const isMobile = xs || sm
   const isLoggedIn = Boolean(user)
+  const getNotificationCount = () => cookie.get("notification-count") || 0
 
   // Close mobile menu if dragging window from small size to desktop
   useEffect(() => {
@@ -122,12 +123,20 @@ export const NavBar: React.FC = track(
                     trackEvent({
                       action_type: AnalyticsSchema.ActionType.Click,
                       subject: AnalyticsSchema.Subject.NotificationBell,
-                      new_notification_count: cookie.get("notification-count"),
+                      new_notification_count: getNotificationCount(),
                       destination_path: "/works-for-you",
                     })
                   }}
                 >
                   {({ hover }) => {
+                    if (hover) {
+                      trackEvent({
+                        action_type: AnalyticsSchema.ActionType.Hover,
+                        subject: AnalyticsSchema.Subject.NotificationBell,
+                        new_notification_count: getNotificationCount(),
+                      })
+                    }
+
                     return (
                       <BellIcon
                         top={3}

--- a/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
@@ -52,6 +52,7 @@ describe("NavBarTracking", () => {
         action_type: AnalyticsSchema.ActionType.Click,
         subject: AnalyticsSchema.Subject.NotificationBell,
         destination_path: "/works-for-you",
+        new_notification_count: 0,
       })
     })
 
@@ -155,6 +156,33 @@ describe("NavBarTracking", () => {
         action_type: AnalyticsSchema.ActionType.Click,
         subject: "Fairs",
         destination_path: "/art-fairs",
+      })
+    })
+
+    it("tracks navItem on hover", () => {
+      mount(
+        <Wrapper>
+          <NavItem href="/art-fairs" active>
+            {({ hover }) => {
+              if (hover) {
+                trackEvent({
+                  action_type: AnalyticsSchema.ActionType.Hover,
+                  subject: AnalyticsSchema.Subject.NotificationBell,
+                  destination_path: "/works-for-you",
+                  new_notification_count: 0,
+                })
+              }
+              return <div>hi</div>
+            }}
+          </NavItem>
+        </Wrapper>
+      )
+
+      expect(trackEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.Hover,
+        subject: AnalyticsSchema.Subject.NotificationBell,
+        destination_path: "/works-for-you",
+        new_notification_count: 0,
       })
     })
   })


### PR DESCRIPTION
Fixes two issues caught in analytics QA testing:

- When a user has zero notifications, the badge is hidden, with its hover event. Adds a trackable hover event to the bell icon proper
- When there are zero notifications in the cookie, it comes back undefined, which is stripped out by analytics. If undefined, assume 0. 