### PR TITLE
Add price/-price to SortFilter for collections

### DIFF
--- a/src/Apps/Collect/Components/Collection/CollectionFilterContainer.tsx
+++ b/src/Apps/Collect/Components/Collection/CollectionFilterContainer.tsx
@@ -6,6 +6,7 @@ import { CollectionRefetchContainer } from "./CollectionRefetch"
 import { CollectionFilterContainer_collection } from "__generated__/CollectionFilterContainer_collection.graphql"
 import { FilterState } from "Apps/Collect/FilterState"
 import { FilterContainer } from "../Filters"
+import { SortTypes } from "../Filters/SortFilterSortTypes"
 
 export interface CollectionFilterContainerProps {
   collection?: CollectionFilterContainer_collection
@@ -29,7 +30,7 @@ export const CollectionFilterContainer: React.FC<
       user={user}
       mediums={mediumAggregation.counts as any}
       timePeriods={timePeriodAggregation.counts as any}
-      isCollection
+      sortType={SortTypes.collection}
     >
       {(filters: FilterState) => (
         <CollectionRefetchContainer

--- a/src/Apps/Collect/Components/Collection/CollectionFilterContainer.tsx
+++ b/src/Apps/Collect/Components/Collection/CollectionFilterContainer.tsx
@@ -29,6 +29,7 @@ export const CollectionFilterContainer: React.FC<
       user={user}
       mediums={mediumAggregation.counts as any}
       timePeriods={timePeriodAggregation.counts as any}
+      isCollection
     >
       {(filters: FilterState) => (
         <CollectionRefetchContainer

--- a/src/Apps/Collect/Components/Filters/FilterContainer.tsx
+++ b/src/Apps/Collect/Components/Filters/FilterContainer.tsx
@@ -9,6 +9,7 @@ import { MediumFilter } from "./MediumFilter"
 import { PriceRangeFilter } from "./PriceRangeFilter"
 import { SizeRangeFilters } from "./SizeRangeFilters"
 import { SortFilter } from "./SortFilter"
+import { SortTypes } from "./SortFilterSortTypes"
 import { TimePeriodFilter } from "./TimePeriodFilter"
 import { WaysToBuyFilter } from "./WaysToBuyFilter"
 
@@ -20,7 +21,7 @@ export interface FilterContainerProps {
   mediums: Array<{ id: string; name: string }>
   timePeriods?: Array<{ name: string }>
   children?: (filters: FilterState) => JSX.Element
-  isCollection?: boolean
+  sortType?: SortTypes
 }
 
 export interface FilterContainerState {
@@ -105,7 +106,7 @@ export class FilterContainer extends React.Component<
                     onShow={() =>
                       this.setState({ showMobileActionSheet: true })
                     }
-                    isCollection={this.props.isCollection}
+                    sortType={this.props.sortType}
                   />
 
                   <Spacer mb={2} />
@@ -125,7 +126,7 @@ export class FilterContainer extends React.Component<
                     <span id="jump--collectArtworkGrid" />
                     <SortFilter
                       filters={filters}
-                      isCollection={this.props.isCollection}
+                      sortType={this.props.sortType}
                     />
                     <Spacer mb={2} />
                     {this.props.children(filters)}

--- a/src/Apps/Collect/Components/Filters/FilterContainer.tsx
+++ b/src/Apps/Collect/Components/Filters/FilterContainer.tsx
@@ -20,6 +20,7 @@ export interface FilterContainerProps {
   mediums: Array<{ id: string; name: string }>
   timePeriods?: Array<{ name: string }>
   children?: (filters: FilterState) => JSX.Element
+  isCollection?: boolean
 }
 
 export interface FilterContainerState {
@@ -104,6 +105,7 @@ export class FilterContainer extends React.Component<
                     onShow={() =>
                       this.setState({ showMobileActionSheet: true })
                     }
+                    isCollection={this.props.isCollection}
                   />
 
                   <Spacer mb={2} />
@@ -121,7 +123,10 @@ export class FilterContainer extends React.Component<
                   <Box width="75%">
                     <Separator mb={2} mt={-1} />
                     <span id="jump--collectArtworkGrid" />
-                    <SortFilter filters={filters} />
+                    <SortFilter
+                      filters={filters}
+                      isCollection={this.props.isCollection}
+                    />
                     <Spacer mb={2} />
                     {this.props.children(filters)}
                   </Box>

--- a/src/Apps/Collect/Components/Filters/SortFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/SortFilter.tsx
@@ -7,32 +7,55 @@ import { Button, FilterIcon, Flex, SelectSmall, Spacer } from "@artsy/palette"
 export const SortFilter: React.FC<{
   filters: FilterState
   onShow?: () => void
-}> = ({ filters, onShow }) => {
+  isCollection?: boolean
+}> = ({ filters, onShow, isCollection = false }) => {
+  let options = [
+    {
+      value: "-decayed_merch",
+      text: "Default",
+    },
+  ]
+
+  const include_for_collections = [
+    {
+      value: "-prices",
+      text: "Price (desc.)",
+    },
+    {
+      value: "prices",
+      text: "Price (asc.)",
+    },
+  ]
+
+  const always_include = [
+    {
+      value: "-partner_updated_at",
+      text: "Recently updated",
+    },
+    {
+      value: "-published_at",
+      text: "Recently added",
+    },
+    {
+      value: "-year",
+      text: "Artwork year (desc.)",
+    },
+    {
+      value: "year",
+      text: "Artwork year (asc.)",
+    },
+  ]
+
+  if (isCollection) {
+    options = options.concat(include_for_collections).concat(always_include)
+  } else {
+    options = options.concat(always_include)
+  }
+
   return (
     <Flex justifyContent={["space-between", "flex-end"]} alignItems="center">
       <SelectSmall
-        options={[
-          {
-            value: "-decayed_merch",
-            text: "Default",
-          },
-          {
-            value: "-partner_updated_at",
-            text: "Recently updated",
-          },
-          {
-            value: "-published_at",
-            text: "Recently added",
-          },
-          {
-            value: "-year",
-            text: "Artwork year (desc.)",
-          },
-          {
-            value: "year",
-            text: "Artwork year (asc.)",
-          },
-        ]}
+        options={options}
         selected={filters.state.sort}
         title="Sort"
         onSelect={sort => {

--- a/src/Apps/Collect/Components/Filters/SortFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/SortFilter.tsx
@@ -1,61 +1,19 @@
 import React from "react"
 import { Media } from "Utils/Responsive"
 import { FilterState } from "../../FilterState"
+import { getSortOptions, SortTypes } from "./SortFilterSortTypes"
 
 import { Button, FilterIcon, Flex, SelectSmall, Spacer } from "@artsy/palette"
 
 export const SortFilter: React.FC<{
   filters: FilterState
   onShow?: () => void
-  isCollection?: boolean
-}> = ({ filters, onShow, isCollection = false }) => {
-  let options = [
-    {
-      value: "-decayed_merch",
-      text: "Default",
-    },
-  ]
-
-  const include_for_collections = [
-    {
-      value: "-prices",
-      text: "Price (desc.)",
-    },
-    {
-      value: "prices",
-      text: "Price (asc.)",
-    },
-  ]
-
-  const always_include = [
-    {
-      value: "-partner_updated_at",
-      text: "Recently updated",
-    },
-    {
-      value: "-published_at",
-      text: "Recently added",
-    },
-    {
-      value: "-year",
-      text: "Artwork year (desc.)",
-    },
-    {
-      value: "year",
-      text: "Artwork year (asc.)",
-    },
-  ]
-
-  if (isCollection) {
-    options = options.concat(include_for_collections).concat(always_include)
-  } else {
-    options = options.concat(always_include)
-  }
-
+  sortType?: SortTypes
+}> = ({ filters, onShow, sortType }) => {
   return (
     <Flex justifyContent={["space-between", "flex-end"]} alignItems="center">
       <SelectSmall
-        options={options}
+        options={getSortOptions(sortType)}
         selected={filters.state.sort}
         title="Sort"
         onSelect={sort => {
@@ -74,4 +32,8 @@ export const SortFilter: React.FC<{
       </Media>
     </Flex>
   )
+}
+
+SortFilter.defaultProps = {
+  sortType: SortTypes.default,
 }

--- a/src/Apps/Collect/Components/Filters/SortFilterSortTypes.tsx
+++ b/src/Apps/Collect/Components/Filters/SortFilterSortTypes.tsx
@@ -1,0 +1,27 @@
+export enum SortTypes {
+  default = "default",
+  collection = "collection",
+}
+
+const sorts = {
+  default: [
+    { value: "-decayed_merch", text: "Default" },
+    { value: "-partner_updated_at", text: "Recently updated" },
+    { value: "-published_at", text: "Recently added" },
+    { value: "-year", text: "Artwork year (desc.)" },
+    { value: "year", text: "Artwork year (asc.)" },
+  ],
+  collection: [
+    { value: "-decayed_merch", text: "Default" },
+    { value: "price_missing,-prices", text: "Price (desc.)" },
+    { value: "price_missing,prices", text: "Price (asc.)" },
+    { value: "-partner_updated_at", text: "Recently updated" },
+    { value: "-published_at", text: "Recently added" },
+    { value: "-year", text: "Artwork year (desc.)" },
+    { value: "year", text: "Artwork year (asc.)" },
+  ],
+}
+
+export const getSortOptions = (key: SortTypes) => {
+  return sorts[key]
+}

--- a/src/Apps/Collect/Components/Filters/__tests__/FilterContainer.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/FilterContainer.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from "unstated"
 import { FilterState } from "../../../FilterState"
 import { FilterContainer } from "../FilterContainer"
 import { SortFilter } from "../SortFilter"
+import { SortTypes } from "../SortFilterSortTypes"
 
 jest.mock("sharify", () => ({
   data: {
@@ -73,15 +74,15 @@ describe("FilterContainer", () => {
     expect(wrapper.find("Desktop").length).toEqual(1)
   })
 
-  describe("passes the `isCollections` prop to SortFilter", () => {
-    const build_wrapper = ({ mobile = false, collection = false }) =>
+  describe("passes the `sortType` prop to SortFilter", () => {
+    const buildWrapper = ({ mobile = false, collection = false }) =>
       mount(
         <MockBoot breakpoint={mobile ? "xs" : "lg"}>
           <Provider inject={[filterState]}>
             <FilterContainer
               mediums={mediums}
               user={user}
-              isCollection={collection}
+              sortType={collection ? SortTypes.collection : undefined}
             >
               {filters => {
                 return <div />
@@ -91,33 +92,33 @@ describe("FilterContainer", () => {
         </MockBoot>
       )
 
-    it("defaults to false", () => {
-      const mobile_default = build_wrapper({ mobile: true })
-      const desktop_default = build_wrapper({ mobile: false })
+    it("when unspecified, SortFilter uses 'default'", () => {
+      const mobileDefault = buildWrapper({ mobile: true })
+      const desktopDefault = buildWrapper({ mobile: false })
 
-      const mobile_sort_filter = mobile_default.find(SortFilter)
-      const desktop_sort_filter = desktop_default.find(SortFilter)
+      const mobileSortFilter = mobileDefault.find(SortFilter)
+      const desktopSortFilter = desktopDefault.find(SortFilter)
 
-      expect(mobile_sort_filter.props().isCollection).toBe(false)
-      expect(desktop_sort_filter.props().isCollection).toBe(false)
+      expect(mobileSortFilter.props().sortType).toBe(SortTypes.default)
+      expect(desktopSortFilter.props().sortType).toBe(SortTypes.default)
     })
 
     it("on mobile", () => {
-      const mobile_collections = build_wrapper({
+      const mobileCollections = buildWrapper({
         mobile: true,
         collection: true,
       })
-      const mobile_sort_filter = mobile_collections.find(SortFilter)
-      expect(mobile_sort_filter.props().isCollection).toBe(true)
+      const mobileSortFilter = mobileCollections.find(SortFilter)
+      expect(mobileSortFilter.props().sortType).toBe(SortTypes.collection)
     })
 
     it("on desktop", () => {
-      const desktop_collections = build_wrapper({
+      const desktopCollections = buildWrapper({
         mobile: false,
         collection: true,
       })
-      const desktop_sort_filter = desktop_collections.find(SortFilter).at(0)
-      expect(desktop_sort_filter.props().isCollection).toBe(true)
+      const desktopSortFilter = desktopCollections.find(SortFilter).at(0)
+      expect(desktopSortFilter.props().sortType).toBe(SortTypes.collection)
     })
   })
 })

--- a/src/Apps/Collect/Components/Filters/__tests__/FilterContainer.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/FilterContainer.test.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { Provider } from "unstated"
 import { FilterState } from "../../../FilterState"
 import { FilterContainer } from "../FilterContainer"
+import { SortFilter } from "../SortFilter"
 
 jest.mock("sharify", () => ({
   data: {
@@ -70,5 +71,53 @@ describe("FilterContainer", () => {
 
     expect(wrapper.find("Mobile").length).toEqual(0)
     expect(wrapper.find("Desktop").length).toEqual(1)
+  })
+
+  describe("passes the `isCollections` prop to SortFilter", () => {
+    const build_wrapper = ({ mobile = false, collection = false }) =>
+      mount(
+        <MockBoot breakpoint={mobile ? "xs" : "lg"}>
+          <Provider inject={[filterState]}>
+            <FilterContainer
+              mediums={mediums}
+              user={user}
+              isCollection={collection}
+            >
+              {filters => {
+                return <div />
+              }}
+            </FilterContainer>
+          </Provider>
+        </MockBoot>
+      )
+
+    it("defaults to false", () => {
+      const mobile_default = build_wrapper({ mobile: true })
+      const desktop_default = build_wrapper({ mobile: false })
+
+      const mobile_sort_filter = mobile_default.find(SortFilter)
+      const desktop_sort_filter = desktop_default.find(SortFilter)
+
+      expect(mobile_sort_filter.props().isCollection).toBe(false)
+      expect(desktop_sort_filter.props().isCollection).toBe(false)
+    })
+
+    it("on mobile", () => {
+      const mobile_collections = build_wrapper({
+        mobile: true,
+        collection: true,
+      })
+      const mobile_sort_filter = mobile_collections.find(SortFilter)
+      expect(mobile_sort_filter.props().isCollection).toBe(true)
+    })
+
+    it("on desktop", () => {
+      const desktop_collections = build_wrapper({
+        mobile: false,
+        collection: true,
+      })
+      const desktop_sort_filter = desktop_collections.find(SortFilter).at(0)
+      expect(desktop_sort_filter.props().isCollection).toBe(true)
+    })
   })
 })

--- a/src/Apps/Collect/Components/Filters/__tests__/SortFilter.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/SortFilter.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme"
 import React from "react"
 import { FilterState, initialState } from "../../../FilterState"
 import { SortFilter } from "../SortFilter"
+import { getSortOptions, SortTypes } from "../SortFilterSortTypes"
 
 describe("SortFilter", () => {
   let filterState
@@ -11,7 +12,7 @@ describe("SortFilter", () => {
     filterState.setFilter = jest.fn()
   })
 
-  const expect_options = (wrapper, values) => {
+  const expectOptions = (wrapper, values) => {
     const options = wrapper.find("option")
     expect(options.length).toBe(values.length)
     values.forEach((value, index) => {
@@ -19,27 +20,19 @@ describe("SortFilter", () => {
     })
   }
 
-  it("maintains default behavior", () => {
-    const wrapper = mount(<SortFilter filters={filterState} />)
-    expect_options(wrapper, [
-      "-decayed_merch",
-      "-partner_updated_at",
-      "-published_at",
-      "-year",
-      "year",
-    ])
-  })
+  describe("props.sortType", () => {
+    it("uses default if unspecified", () => {
+      const wrapper = mount(<SortFilter filters={filterState} />)
+      const expectedOptions = getSortOptions(SortTypes.default)
+      expectOptions(wrapper, expectedOptions.map(o => o.value))
+    })
 
-  it("adds sort-by-price if and only if isCollection is ture", () => {
-    const wrapper = mount(<SortFilter filters={filterState} isCollection />)
-    expect_options(wrapper, [
-      "-decayed_merch",
-      "-prices",
-      "prices",
-      "-partner_updated_at",
-      "-published_at",
-      "-year",
-      "year",
-    ])
+    it("respects `collection` sort type", () => {
+      const wrapper = mount(
+        <SortFilter filters={filterState} sortType={SortTypes.collection} />
+      )
+      const expectedOptions = getSortOptions(SortTypes.collection)
+      expectOptions(wrapper, expectedOptions.map(o => o.value))
+    })
   })
 })

--- a/src/Apps/Collect/Components/Filters/__tests__/SortFilter.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/SortFilter.test.tsx
@@ -1,0 +1,45 @@
+import { mount } from "enzyme"
+import React from "react"
+import { FilterState, initialState } from "../../../FilterState"
+import { SortFilter } from "../SortFilter"
+
+describe("SortFilter", () => {
+  let filterState
+
+  beforeEach(() => {
+    filterState = new FilterState(initialState)
+    filterState.setFilter = jest.fn()
+  })
+
+  const expect_options = (wrapper, values) => {
+    const options = wrapper.find("option")
+    expect(options.length).toBe(values.length)
+    values.forEach((value, index) => {
+      expect(options.at(index).props().value).toBe(value)
+    })
+  }
+
+  it("maintains default behavior", () => {
+    const wrapper = mount(<SortFilter filters={filterState} />)
+    expect_options(wrapper, [
+      "-decayed_merch",
+      "-partner_updated_at",
+      "-published_at",
+      "-year",
+      "year",
+    ])
+  })
+
+  it("adds sort-by-price if and only if isCollection is ture", () => {
+    const wrapper = mount(<SortFilter filters={filterState} isCollection />)
+    expect_options(wrapper, [
+      "-decayed_merch",
+      "-prices",
+      "prices",
+      "-partner_updated_at",
+      "-published_at",
+      "-year",
+      "year",
+    ])
+  })
+})

--- a/src/Apps/Collect/Components/Filters/__tests__/SortFilterSortTypes.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/SortFilterSortTypes.test.tsx
@@ -1,0 +1,35 @@
+import { getSortOptions, SortTypes } from "../SortFilterSortTypes"
+
+describe("SortTypes", () => {
+  describe(".getSortOptions", () => {
+    it("returns default sort options", () => {
+      const options = getSortOptions(SortTypes.default)
+      expect(options.length).toBe(5)
+
+      const values = options.map(o => o.value)
+      expect(values).toEqual([
+        "-decayed_merch",
+        "-partner_updated_at",
+        "-published_at",
+        "-year",
+        "year",
+      ])
+    })
+
+    it("returns collection sort options", () => {
+      const options = getSortOptions(SortTypes.collection)
+      expect(options.length).toBe(7)
+
+      const values = options.map(o => o.value)
+      expect(values).toEqual([
+        "-decayed_merch",
+        "price_missing,-prices",
+        "price_missing,prices",
+        "-partner_updated_at",
+        "-published_at",
+        "-year",
+        "year",
+      ])
+    })
+  })
+})

--- a/src/Apps/Order/Components/__tests__/PaymentPicker.test.tsx
+++ b/src/Apps/Order/Components/__tests__/PaymentPicker.test.tsx
@@ -641,7 +641,6 @@ describe(PaymentPickerFragmentContainer, () => {
       const input = page
         .find(Input)
         .filterWhere(wrapper => wrapper.props().title === "Full name")
-      console.log()
       expect(input.props().error).toEqual("This field is required")
     })
 


### PR DESCRIPTION
This PR implements [GROW-1253](https://artsyproduct.atlassian.net/browse/GROW-1253).

This adds a flag in the props of `CollectionFilterContainer` that gets injected into `SortFilter` to let it know when it's being used in a collection page context. If that flag is present it adds two new options to the available sorts: price ascending and price descending.

There was an issue around items that had a price but whose price was hidden showing in the search results. That required a fix to gravity which you can find [here](https://github.com/artsy/gravity/pull/12373).

I've added specs everywhere it seemed appropriate, let me know if you'd like any additional coverage!

