### PR TITLE
prevent embedded iframe from creating extra margin

### DIFF
--- a/src/Components/Publishing/Sections/Embed.tsx
+++ b/src/Components/Publishing/Sections/Embed.tsx
@@ -31,6 +31,6 @@ const IFrame = iframe`
   height: ${props => props.height + "px"};
   ${props => pMedia.sm`
     height: ${props.mobileHeight}px;
-    width: 100vw;
+    width: 100%;
   `}
 `

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Embed.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Embed.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders properly 1`] = `
 @media (max-width:720px) {
   .c0 {
     height: 1300px;
-    width: 100vw;
+    width: 100%;
   }
 }
 

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -642,7 +642,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
 @media (max-width:720px) {
   .c24 {
     height: 1300px;
-    width: 100vw;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Addresses: [GROW-1264](https://artsyproduct.atlassian.net/browse/GROW-1264)

While updating the custom editorial embedded `iFrame`, we discovered a pre-existing bug where the embedded `iFrame` was creating extra margin and causing a horizontal window scroll in mobile. This fixes that.

**Before:**
<img width="295" alt="Screen Shot 2019-05-31 at 1 06 16 PM" src="https://user-images.githubusercontent.com/5201004/58722254-fc2a0c00-83a4-11e9-8df6-e36cc88cf507.png">

**After:**
<img width="294" alt="Screen Shot 2019-05-31 at 1 06 40 PM" src="https://user-images.githubusercontent.com/5201004/58722286-11069f80-83a5-11e9-9a0c-b92c3bad0c38.png">