### PR TITLE
[Collections] do not render featured artist module when there are not featured artists

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -238,7 +238,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                       lgOffset={isColumnLayout ? null : 1}
                       xlOffset={isColumnLayout ? null : 1}
                     >
-                      {featuredArtists.length && (
+                      {featuredArtists.length > 0 && (
                         <Box pb={10}>
                           <Sans size="2" weight="medium" pb={15}>
                             {`Featured Artist${hasMultipleArtists ? "s" : ""}`}


### PR DESCRIPTION
This addresses a featured artists module bug reported in [slack](https://artsy.slack.com/archives/C9SATFLUU/p1559758088059500). 

When there are no artworks for a collection there in turn are no featured artists. Currently we display "0" when there are no featured artists which is a bug. This PR strengthens conditional to only display when we have at least one featured articles.

**Before:**
![Screen Shot 2019-06-05 at 2 42 09 PM](https://user-images.githubusercontent.com/5201004/58981990-82799000-87a1-11e9-8557-90a68f1357f2.png)

**After:**
![Screen Shot 2019-06-05 at 2 52 37 PM](https://user-images.githubusercontent.com/5201004/58982039-98875080-87a1-11e9-93ac-b116d96ae67a.png)

