### PR TITLE
[Lib] Ensure tests run against linked packages and upgrade jest@24.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           requires:
             - yarn/workflow-queue
       - yarn/jest:
-          args: --runInBand
+          args: --runInBand --no-cache -u
           requires:
             - yarn/workflow-queue
       - yarn/auto-release:

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@types/styled-system": "3.0.9",
     "@types/underscore.string": "0.0.32",
     "babel-core": "7.0.0-bridge.0",
-    "babel-jest": "23.6.0",
+    "babel-jest": "24.8.0",
     "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "1.2.0",
     "babel-plugin-lodash": "3.3.3",
@@ -125,7 +125,7 @@
     "graphql-fetch-schema": "0.8.0",
     "husky": "1.3.1",
     "immer": "1.12.1",
-    "jest": "23.6.0",
+    "jest": "24.8.0",
     "jest-junit": "6.3.0",
     "jest-raw-loader": "1.0.1",
     "jest-styled-components": "7.0.0-2",
@@ -252,7 +252,7 @@
     "setupFiles": [
       "raf/polyfill"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/src/setup_jest.ts",
+    "setupFilesAfterEnv": ["<rootDir>/src/setup_jest.ts"],
     "testURL": "http://localhost/",
     "moduleNameMapper": {
       "Assets(.*)$": "<rootDir>/src/Assets/$1",

--- a/package.json
+++ b/package.json
@@ -255,6 +255,7 @@
     "setupFilesAfterEnv": ["<rootDir>/src/setup_jest.ts"],
     "testURL": "http://localhost/",
     "moduleNameMapper": {
+      "^react$": "<rootDir>/node_modules/react",
       "Assets(.*)$": "<rootDir>/src/Assets/$1",
       "^Components(.*)$": "<rootDir>/src/Components/$1"
     }

--- a/src/Components/Artist/MarketInsights/__tests__/__snapshots__/MarketInsights.test.tsx.snap
+++ b/src/Components/Artist/MarketInsights/__tests__/__snapshots__/MarketInsights.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MarketInsights snapshots renders correctly 1`] = `
-.c6 {
+.c5 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 15px;
   line-height: 1.25em;
@@ -76,10 +76,6 @@ exports[`MarketInsights snapshots renders correctly 1`] = `
   content: "Blue chip galleries have multiple locations internationally and participate in major art fairs.";
 }
 
-.c4 {
-  position: relative;
-}
-
 .c0 {
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -99,7 +95,7 @@ exports[`MarketInsights snapshots renders correctly 1`] = `
   padding: 10px 30px;
 }
 
-.c5 {
+.c4 {
   color: #666666;
   padding: 8px 0;
   font-family: Unica77LLWebRegular,Arial,serif;
@@ -108,7 +104,7 @@ exports[`MarketInsights snapshots renders correctly 1`] = `
   line-height: 1.4em;
 }
 
-.c5 a {
+.c4 a {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 10px;
@@ -147,7 +143,7 @@ exports[`MarketInsights snapshots renders correctly 1`] = `
               }
             >
               <svg
-                className="c4"
+                className="Icon-sc-1eovgys-0 lmJieb"
                 fill="black100"
                 height="18px"
                 viewBox="0 0 18 18"
@@ -168,11 +164,11 @@ exports[`MarketInsights snapshots renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="c5"
+    className="c4"
   >
     Generated using partial data. 
     <a
-      className="c6"
+      className="c5"
       href="mailto:productfeedback@artsy.net?subject=Feedback on \\"About the Artist\\" information"
       target="_self"
     >

--- a/src/Components/Publishing/Byline/__tests__/__snapshots__/Byline.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__tests__/__snapshots__/Byline.test.tsx.snap
@@ -2,17 +2,10 @@
 
 exports[`Byline renders a byline 1`] = `
 .c1 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c2 {
   margin: 10px 20px 0 0;
 }
 
-.c2::before {
+.c1::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -22,12 +15,12 @@ exports[`Byline renders a byline 1`] = `
   background-color: black;
 }
 
-.c3 {
+.c2 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -41,18 +34,18 @@ exports[`Byline renders a byline 1`] = `
   margin-top: 5px;
 }
 
-.c5 {
+.c4 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c5:hover {
+.c4:hover {
   opacity: 0.6;
 }
 
-.c5:first-child {
+.c4:first-child {
   padding-left: 0;
 }
 
@@ -76,7 +69,7 @@ exports[`Byline renders a byline 1`] = `
   color="black"
 >
   <div
-    className="c1"
+    className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
     fontFamily={
       Object {
         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -86,17 +79,17 @@ exports[`Byline renders a byline 1`] = `
     fontSize="14px"
   >
     <div
-      className="c2"
+      className="c1"
       color="black"
     >
       Casey Lesser
     </div>
   </div>
   <div
-    className="c3"
+    className="c2"
   >
     <div
-      className="c1"
+      className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -109,10 +102,10 @@ exports[`Byline renders a byline 1`] = `
     </div>
   </div>
   <div
-    className="c4"
+    className="c3"
   >
     <a
-      className="c5"
+      className="c4"
       href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
       onClick={[Function]}
       target="_blank"
@@ -138,7 +131,7 @@ exports[`Byline renders a byline 1`] = `
       </svg>
     </a>
     <a
-      className="c5"
+      className="c4"
       href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
       onClick={[Function]}
       target="_blank"
@@ -164,7 +157,7 @@ exports[`Byline renders a byline 1`] = `
       </svg>
     </a>
     <a
-      className="c5"
+      className="c4"
       href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
       onClick={[Function]}
       target="_blank"

--- a/src/Components/Publishing/Byline/__tests__/__snapshots__/Date.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__tests__/__snapshots__/Date.test.tsx.snap
@@ -1,13 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Date Snapshots renders a condensed date 1`] = `
-.c1 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-}
-
 .c0 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
@@ -17,7 +10,7 @@ exports[`Date Snapshots renders a condensed date 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
     fontFamily={
       Object {
         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -32,13 +25,6 @@ exports[`Date Snapshots renders a condensed date 1`] = `
 `;
 
 exports[`Date Snapshots renders a date 1`] = `
-.c1 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
 .c0 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
@@ -48,7 +34,7 @@ exports[`Date Snapshots renders a date 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
     fontFamily={
       Object {
         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",

--- a/src/Components/Publishing/Byline/__tests__/__snapshots__/NewsByline.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__tests__/__snapshots__/NewsByline.test.tsx.snap
@@ -1,18 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`News Byline renders on mobile 1`] = `
-.c2 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c4 {
+.c3 {
   margin: 10px 20px 0 0;
 }
 
-.c4::before {
+.c3::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -22,7 +15,7 @@ exports[`News Byline renders on mobile 1`] = `
   background-color: black;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -34,11 +27,11 @@ exports[`News Byline renders on mobile 1`] = `
   color: #999999;
 }
 
-.c5 a {
+.c4 a {
   color: #999999;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -52,18 +45,18 @@ exports[`News Byline renders on mobile 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c7:hover {
+.c6:hover {
   opacity: 0.6;
 }
 
-.c7:first-child {
+.c6:first-child {
   padding-left: 0;
 }
 
@@ -85,7 +78,7 @@ exports[`News Byline renders on mobile 1`] = `
   align-items: flex-start;
 }
 
-.c0 .c3 {
+.c0 .c2 {
   margin-top: 0;
   margin-bottom: 5px;
 }
@@ -101,7 +94,7 @@ exports[`News Byline renders on mobile 1`] = `
 }
 
 @media (max-width:720px) {
-  .c5 {
+  .c4 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
@@ -110,7 +103,7 @@ exports[`News Byline renders on mobile 1`] = `
 }
 
 @media (max-width:600px) {
-  .c6 {
+  .c5 {
     margin-top: 15px;
   }
 }
@@ -122,7 +115,7 @@ exports[`News Byline renders on mobile 1`] = `
     className="c1"
   >
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -132,23 +125,23 @@ exports[`News Byline renders on mobile 1`] = `
       fontSize="14px"
     >
       <div
-        className="c3 c4"
+        className="c2 c3"
         color="black"
       >
         Casey Lesser
       </div>
     </div>
     <div
-      className="c5"
+      className="c4"
     >
       Jul 19, 2018 at 1:19 pm
     </div>
   </div>
   <div
-    className="c6"
+    className="c5"
   >
     <a
-      className="c7"
+      className="c6"
       href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
       onClick={[Function]}
       target="_blank"
@@ -174,7 +167,7 @@ exports[`News Byline renders on mobile 1`] = `
       </svg>
     </a>
     <a
-      className="c7"
+      className="c6"
       href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
       onClick={[Function]}
       target="_blank"
@@ -200,7 +193,7 @@ exports[`News Byline renders on mobile 1`] = `
       </svg>
     </a>
     <a
-      className="c7"
+      className="c6"
       href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
       onClick={[Function]}
       target="_blank"
@@ -304,18 +297,11 @@ exports[`News Byline renders on mobile truncated 1`] = `
 `;
 
 exports[`News Byline renders properly 1`] = `
-.c2 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c4 {
+.c3 {
   margin: 10px 20px 0 0;
 }
 
-.c4::before {
+.c3::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -325,7 +311,7 @@ exports[`News Byline renders properly 1`] = `
   background-color: black;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -337,11 +323,11 @@ exports[`News Byline renders properly 1`] = `
   color: #999999;
 }
 
-.c5 a {
+.c4 a {
   color: #999999;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -355,18 +341,18 @@ exports[`News Byline renders properly 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c7:hover {
+.c6:hover {
   opacity: 0.6;
 }
 
-.c7:first-child {
+.c6:first-child {
   padding-left: 0;
 }
 
@@ -388,7 +374,7 @@ exports[`News Byline renders properly 1`] = `
   align-items: flex-start;
 }
 
-.c0 .c3 {
+.c0 .c2 {
   margin-top: 0;
   margin-bottom: 5px;
 }
@@ -404,7 +390,7 @@ exports[`News Byline renders properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c5 {
+  .c4 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
@@ -419,7 +405,7 @@ exports[`News Byline renders properly 1`] = `
     className="c1"
   >
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -429,14 +415,14 @@ exports[`News Byline renders properly 1`] = `
       fontSize="14px"
     >
       <div
-        className="c3 c4"
+        className="c2 c3"
         color="black"
       >
         Casey Lesser
       </div>
     </div>
     <div
-      className="c5"
+      className="c4"
     >
       Jul 19, 2018 at 1:19 pm
       , via
@@ -451,10 +437,10 @@ exports[`News Byline renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c6"
+    className="c5"
   >
     <a
-      className="c7"
+      className="c6"
       href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
       onClick={[Function]}
       target="_blank"
@@ -480,7 +466,7 @@ exports[`News Byline renders properly 1`] = `
       </svg>
     </a>
     <a
-      className="c7"
+      className="c6"
       href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
       onClick={[Function]}
       target="_blank"
@@ -506,7 +492,7 @@ exports[`News Byline renders properly 1`] = `
       </svg>
     </a>
     <a
-      className="c7"
+      className="c6"
       href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
       onClick={[Function]}
       target="_blank"
@@ -610,18 +596,11 @@ exports[`News Byline renders properly when truncated 1`] = `
 `;
 
 exports[`News Byline renders without a news source 1`] = `
-.c2 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c4 {
+.c3 {
   margin: 10px 20px 0 0;
 }
 
-.c4::before {
+.c3::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -631,7 +610,7 @@ exports[`News Byline renders without a news source 1`] = `
   background-color: black;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -643,11 +622,11 @@ exports[`News Byline renders without a news source 1`] = `
   color: #999999;
 }
 
-.c5 a {
+.c4 a {
   color: #999999;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -661,18 +640,18 @@ exports[`News Byline renders without a news source 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c7:hover {
+.c6:hover {
   opacity: 0.6;
 }
 
-.c7:first-child {
+.c6:first-child {
   padding-left: 0;
 }
 
@@ -694,7 +673,7 @@ exports[`News Byline renders without a news source 1`] = `
   align-items: flex-start;
 }
 
-.c0 .c3 {
+.c0 .c2 {
   margin-top: 0;
   margin-bottom: 5px;
 }
@@ -710,7 +689,7 @@ exports[`News Byline renders without a news source 1`] = `
 }
 
 @media (max-width:720px) {
-  .c5 {
+  .c4 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
@@ -725,7 +704,7 @@ exports[`News Byline renders without a news source 1`] = `
     className="c1"
   >
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -735,23 +714,23 @@ exports[`News Byline renders without a news source 1`] = `
       fontSize="14px"
     >
       <div
-        className="c3 c4"
+        className="c2 c3"
         color="black"
       >
         Casey Lesser
       </div>
     </div>
     <div
-      className="c5"
+      className="c4"
     >
       Jul 19, 2018 at 1:19 pm
     </div>
   </div>
   <div
-    className="c6"
+    className="c5"
   >
     <a
-      className="c7"
+      className="c6"
       href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
       onClick={[Function]}
       target="_blank"
@@ -777,7 +756,7 @@ exports[`News Byline renders without a news source 1`] = `
       </svg>
     </a>
     <a
-      className="c7"
+      className="c6"
       href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
       onClick={[Function]}
       target="_blank"
@@ -803,7 +782,7 @@ exports[`News Byline renders without a news source 1`] = `
       </svg>
     </a>
     <a
-      className="c7"
+      className="c6"
       href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
       onClick={[Function]}
       target="_blank"

--- a/src/Components/Publishing/Byline/__tests__/__snapshots__/ShareDate.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__tests__/__snapshots__/ShareDate.test.tsx.snap
@@ -1,19 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders ShareDate properly 1`] = `
-.c2 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
 .c1 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -27,22 +20,22 @@ exports[`renders ShareDate properly 1`] = `
   margin-top: 5px;
 }
 
-.c6 {
+.c5 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c6:hover {
+.c5:hover {
   opacity: 0.6;
 }
 
-.c6:first-child {
+.c5:first-child {
   padding-left: 0;
 }
 
-.c5 {
+.c4 {
   margin: 5px 10px 5px 0;
 }
 
@@ -51,7 +44,7 @@ exports[`renders ShareDate properly 1`] = `
 }
 
 @media (max-width:768px) {
-  .c0 .c3 {
+  .c0 .c2 {
     margin-top: 0px;
   }
 }
@@ -63,7 +56,7 @@ exports[`renders ShareDate properly 1`] = `
     className="c1"
   >
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -76,10 +69,10 @@ exports[`renders ShareDate properly 1`] = `
     </div>
   </div>
   <div
-    className="c3 c4"
+    className="c2 c3"
   >
     <div
-      className="c5 c2"
+      className="c4 sc-htpNat dOrNHt"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -91,7 +84,7 @@ exports[`renders ShareDate properly 1`] = `
       Share
     </div>
     <a
-      className="c6"
+      className="c5"
       href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
       onClick={[Function]}
       target="_blank"
@@ -117,7 +110,7 @@ exports[`renders ShareDate properly 1`] = `
       </svg>
     </a>
     <a
-      className="c6"
+      className="c5"
       href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
       onClick={[Function]}
       target="_blank"
@@ -143,7 +136,7 @@ exports[`renders ShareDate properly 1`] = `
       </svg>
     </a>
     <a
-      className="c6"
+      className="c5"
       href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
       onClick={[Function]}
       target="_blank"

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders the new canvas in standard layout 1`] = `
-.c1 {
-  margin: auto;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 10px;
-  line-height: 14px;
-  color: black30;
-  margin: 4px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -33,7 +21,7 @@ exports[`renders the new canvas in standard layout 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="sc-bdVaJa fdqRED"
   >
     <div
       style={
@@ -44,7 +32,7 @@ exports[`renders the new canvas in standard layout 1`] = `
       }
     />
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat jritVp"
       color="black30"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="10px"

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayCanvas.test.tsx.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshot renders the new canvas in standard layout 1`] = `
-.c1 {
-  margin: auto;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 10px;
-  line-height: 14px;
-  color: black30;
-  margin: 4px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -33,7 +21,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="sc-bdVaJa fdqRED"
   >
     <div
       style={
@@ -44,7 +32,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
       }
     />
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat jritVp"
       color="black30"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="10px"

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayPanel.test.tsx.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshot renders the new canvas in standard layout 1`] = `
-.c1 {
-  margin: auto;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 10px;
-  line-height: 14px;
-  color: black30;
-  margin: 4px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -33,7 +21,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="sc-bdVaJa fdqRED"
   >
     <div
       style={
@@ -44,7 +32,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
       }
     />
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat jritVp"
       color="black30"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="10px"

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -1,151 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
-.c9 {
-  max-width: 1600px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c24 {
-  max-width: 100%;
-  margin-left: auto;
-  padding-left: 20px;
-  padding-right: 20px;
-}
-
-.c73 {
-  margin-bottom: 40px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c41 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c79 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
-.c80 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
-.c7 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: #000;
-  text-align: center;
-}
-
-.c19 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c26 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 22px;
-  line-height: 32px;
-  padding-bottom: 40px;
-}
-
-.c32 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 10px;
-  line-height: 14px;
-  color: white;
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-top: 64px;
-  padding-bottom: 64px;
-}
-
-.c43 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 16px;
-  line-height: 26px;
-  padding-bottom: 8px;
-}
-
-.c46 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-}
-
-.c47 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 12px;
-  line-height: 16px;
-  padding-left: 20px;
-}
-
-.c50 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c81 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c82 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c20 {
+.c17 {
   margin: 10px 20px 0 0;
 }
 
-.c20::before {
+.c17::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -155,11 +15,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   background-color: black;
 }
 
-.c84 {
+.c68 {
   margin: 10px 20px 0 0;
 }
 
-.c84::before {
+.c68::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -169,12 +29,12 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   background-color: #000;
 }
 
-.c21 {
+.c18 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c22 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -188,22 +48,22 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c23 {
+.c20 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c23:hover {
+.c20:hover {
   opacity: 0.6;
 }
 
-.c23:first-child {
+.c20:first-child {
   padding-left: 0;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -218,7 +78,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   color: black;
 }
 
-.c83 {
+.c67 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -265,7 +125,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-interpolation-mode: bicubic;
 }
 
-.c3 .c88 {
+.c3 .c72 {
   margin: 0 20px;
 }
 
@@ -316,13 +176,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   z-index: 10;
 }
 
-.c28 {
+.c23 {
   position: relative;
   width: 100%;
   color: black;
 }
 
-.c28 a {
+.c23 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -332,22 +192,22 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   background-position: bottom;
 }
 
-.c28 a:hover {
+.c23 a:hover {
   color: #C2C2C2;
   opacity: 1;
 }
 
-.c28 div[class*='ToolTip'] a {
+.c23 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c28 p,
-.c28 ul,
-.c28 ol,
-.c28 .paragraph,
-.c28 div[data-block=true] .public-DraftStyleDefault-block {
+.c23 p,
+.c23 ul,
+.c23 ol,
+.c23 .paragraph,
+.c23 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -358,32 +218,32 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   font-style: inherit;
 }
 
-.c28 p:first-child,
-.c28 .paragraph:first-child,
-.c28 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c23 p:first-child,
+.c23 .paragraph:first-child,
+.c23 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c28 p:last-child,
-.c28 .paragraph:last-child,
-.c28 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c23 p:last-child,
+.c23 .paragraph:last-child,
+.c23 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c28 ul,
-.c28 ol {
+.c23 ul,
+.c23 ol {
   padding-left: 1em;
 }
 
-.c28 ul {
+.c23 ul {
   list-style: disc;
 }
 
-.c28 ol {
+.c23 ol {
   list-style: decimal;
 }
 
-.c28 li {
+.c23 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -392,7 +252,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   padding-bottom: .5em;
 }
 
-.c28 h1 {
+.c23 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -405,7 +265,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   text-align: center;
 }
 
-.c28 h1::before {
+.c23 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -416,7 +276,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   right: calc(50% - 4px);
 }
 
-.c28 h2 {
+.c23 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -425,15 +285,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   margin: 0;
 }
 
-.c28 h2 a {
+.c23 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c28 h2 .c89 {
+.c23 h2 .c73 {
   background-position: bottom !important;
 }
 
-.c28 h3 {
+.c23 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -443,7 +303,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   margin: 0;
 }
 
-.c28 h3 strong {
+.c23 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -451,11 +311,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   line-height: 1.5em;
 }
 
-.c28 h3 a {
+.c23 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c28 blockquote {
+.c23 blockquote {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -468,11 +328,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   word-break: break-word;
 }
 
-.c28 .preventLineBreak {
+.c23 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c28 .content-end {
+.c23 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -483,14 +343,14 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   margin-bottom: 1px;
 }
 
-.c28 .artist-follow {
+.c23 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c28 .artist-follow::before {
+.c23 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -498,7 +358,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   font-size: 32px;
 }
 
-.c28 .artist-follow::after {
+.c23 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -507,7 +367,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   text-transform: none;
 }
 
-.c87 {
+.c71 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -517,7 +377,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   display: block;
 }
 
-.c85 {
+.c69 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -526,7 +386,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   background: white;
 }
 
-.c78 {
+.c66 {
   border: 1px solid;
   border-radius: 2px;
   color: #000;
@@ -536,30 +396,30 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   display: block;
 }
 
-.c78 .c86 {
+.c66 .c70 {
   opacity: 1;
 }
 
-.c78:hover .c86 {
+.c66:hover .c70 {
   opacity: 0.7;
 }
 
-.c76 {
+.c64 {
   margin-bottom: 40px;
 }
 
-.c48 {
+.c38 {
   height: 45px;
   position: relative;
   margin-left: 40px;
   text-align: right;
 }
 
-.c48 > svg {
+.c38 > svg {
   height: 98%;
 }
 
-.c40 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -576,19 +436,19 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   width: 100%;
 }
 
-.c45 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c36 {
+.c30 {
   position: relative;
   width: 100%;
 }
 
-.c38 {
+.c32 {
   position: absolute;
   bottom: 20px;
   left: 20px;
@@ -601,22 +461,22 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   cursor: pointer;
 }
 
-.c38:hover {
+.c32:hover {
   background: rgba(0,0,0,0.6);
   color: white;
 }
 
-.c38:hover path,
-.c38:hover polygon {
+.c32:hover path,
+.c32:hover polygon {
   fill: white;
 }
 
-.c53 {
+.c42 {
   height: auto;
   width: 100%;
 }
 
-.c11 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -631,7 +491,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   bottom: 0;
 }
 
-.c10 {
+.c8 {
   height: 90vh;
   max-height: 1000px;
   border: 3px solid #6E1EFF;
@@ -647,7 +507,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   overflow: hidden;
 }
 
-.c12 {
+.c10 {
   min-height: 100%;
   min-width: 100%;
   padding: 20px;
@@ -670,13 +530,13 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   font-weight: inherit;
 }
 
-.c13 {
+.c11 {
   display: block;
   font-size: calc(80px + (200 - 80) * ((100vw - 300px) / (1600 - 300)));
   line-height: initial;
 }
 
-.c14 {
+.c12 {
   display: block;
   font-size: calc(80px + (200 - 80) * ((100vw - 300px) / (1600 - 300)));
   line-height: initial;
@@ -687,7 +547,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   border-bottom: none;
 }
 
-.c8 {
+.c7 {
   border-bottom: 6px solid #6E1EFF;
   position: absolute;
   top: 100%;
@@ -697,14 +557,14 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   margin: 0 auto;
 }
 
-.c15 {
+.c13 {
   padding-top: 40px;
   padding-bottom: 40px;
   border-left: 6px solid #6E1EFF;
   border-bottom: 6px solid #6E1EFF;
 }
 
-.c15 blockquote {
+.c13 blockquote {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 34px;
@@ -714,7 +574,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   font-weight: inherit;
 }
 
-.c29 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -729,7 +589,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   border-left-width: 0;
 }
 
-.c30 {
+.c25 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -740,7 +600,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   min-height: min-content;
 }
 
-.c30 h1 {
+.c25 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 65px;
@@ -756,7 +616,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   font-weight: inherit;
 }
 
-.c30 h2 {
+.c25 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 25px;
@@ -775,11 +635,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   font-weight: inherit;
 }
 
-.c30 h2:last-child {
+.c25 h2:last-child {
   border-left: 6px solid #6E1EFF;
 }
 
-.c31 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -797,7 +657,260 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   background-position: center;
 }
 
-.c31 p {
+.c26 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c43 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FnlMY9VcLmWae2o0fwpvUWw%252FAdrian2.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c43 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c44 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBBJ7xDcd8JV2HoI_7iC2bw%252Fcattelan_crop.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c44 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c45 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F5Ww0vmM4m54-yy8duulLGw%252FJudy_crop2.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c45 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c46 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-zxcH5MJpHFsGT6YmmVjlA%252FAlex-Da-Corte-1.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c46 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c47 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FejQfY6k6HaEYq77uFwLSDg%252FBruce-crop-2.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c47 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c48 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F2vk2gnhoUzhrEQWaCQjKyw%252FCao-fei-2.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c48 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c49 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FhEOTF5m2OkHPxocchkntXg%252FSimone_crop.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c49 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F1kPiAY_ExpQb0iTnRiYf1A%252Fhockney_crop_pulledback.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c50 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c51 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fc29PdWzeGmZ2FnfpzBExKQ%252Fwu_crop.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c51 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c52 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FWoWfgpwz1R6hYXowTMtQbg%252FTomas_crop.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c52 p {
+  text-shadow: 0 0 5px black;
+  opacity: 0.6;
+}
+
+.c53 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background: #6E1EFF;
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F3oOK_ctPDJV9hBSiUURaBA%252Ftakashi_crop_otheroption.jpg&width=700&quality=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.c53 p {
   text-shadow: 0 0 5px black;
   opacity: 0.6;
 }
@@ -815,7 +928,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex: 1;
   flex: 1;
   background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FnlMY9VcLmWae2o0fwpvUWw%252FAdrian2.jpg&width=700&quality=80);
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F5IpvVQ9JhQ-YFYSrFF450Q%252FJoan_crop.jpg&width=700&quality=80);
   background-size: cover;
   background-position: center;
 }
@@ -838,7 +951,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex: 1;
   flex: 1;
   background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBBJ7xDcd8JV2HoI_7iC2bw%252Fcattelan_crop.jpg&width=700&quality=80);
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fl-eI1OtsSoanJ_x3YlnEWg%252FFA.jpg&width=700&quality=80);
   background-size: cover;
   background-position: center;
 }
@@ -861,7 +974,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex: 1;
   flex: 1;
   background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F5Ww0vmM4m54-yy8duulLGw%252FJudy_crop2.jpg&width=700&quality=80);
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FgaTpzI49OUOFP1Ks1-bTNg%252Fwolfgang_crop.jpg&width=700&quality=80);
   background-size: cover;
   background-position: center;
 }
@@ -884,7 +997,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex: 1;
   flex: 1;
   background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-zxcH5MJpHFsGT6YmmVjlA%252FAlex-Da-Corte-1.jpg&width=700&quality=80);
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FY96402AXIKWZiX1iACXVLg%252Fcharline2.jpg&width=700&quality=80);
   background-size: cover;
   background-position: center;
 }
@@ -907,7 +1020,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex: 1;
   flex: 1;
   background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FejQfY6k6HaEYq77uFwLSDg%252FBruce-crop-2.jpg&width=700&quality=80);
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FRgD2WhDMmriNWjQaiVAtYA%252FCharles_crop2.jpg&width=700&quality=80);
   background-size: cover;
   background-position: center;
 }
@@ -930,7 +1043,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex: 1;
   flex: 1;
   background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F2vk2gnhoUzhrEQWaCQjKyw%252FCao-fei-2.jpg&width=700&quality=80);
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F2We6jcCx0JXM7EmjoJKc3g%252FAndrea_crop.jpg&width=700&quality=80);
   background-size: cover;
   background-position: center;
 }
@@ -953,7 +1066,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex: 1;
   flex: 1;
   background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FhEOTF5m2OkHPxocchkntXg%252FSimone_crop.jpg&width=700&quality=80);
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F69-YSOLh8LC9E2BmQQcAqw%252Fjohn-bock.jpg&width=700&quality=80);
   background-size: cover;
   background-position: center;
 }
@@ -976,7 +1089,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   -ms-flex: 1;
   flex: 1;
   background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F1kPiAY_ExpQb0iTnRiYf1A%252Fhockney_crop_pulledback.jpg&width=700&quality=80);
+  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGDx8y_WfzrowtQpmaMcQRw%252Fkehinde_crop.jpg&width=700&quality=80);
   background-size: cover;
   background-position: center;
 }
@@ -986,260 +1099,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   opacity: 0.6;
 }
 
-.c62 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fc29PdWzeGmZ2FnfpzBExKQ%252Fwu_crop.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c62 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c63 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FWoWfgpwz1R6hYXowTMtQbg%252FTomas_crop.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c63 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c64 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F3oOK_ctPDJV9hBSiUURaBA%252Ftakashi_crop_otheroption.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c64 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c65 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F5IpvVQ9JhQ-YFYSrFF450Q%252FJoan_crop.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c65 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c66 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fl-eI1OtsSoanJ_x3YlnEWg%252FFA.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c66 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c67 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FgaTpzI49OUOFP1Ks1-bTNg%252Fwolfgang_crop.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c67 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c68 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FY96402AXIKWZiX1iACXVLg%252Fcharline2.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c68 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c69 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FRgD2WhDMmriNWjQaiVAtYA%252FCharles_crop2.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c69 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c70 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F2We6jcCx0JXM7EmjoJKc3g%252FAndrea_crop.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c70 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c71 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F69-YSOLh8LC9E2BmQQcAqw%252Fjohn-bock.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c71 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c72 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  background: #6E1EFF;
-  background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGDx8y_WfzrowtQpmaMcQRw%252Fkehinde_crop.jpg&width=700&quality=80);
-  background-size: cover;
-  background-position: center;
-}
-
-.c72 p {
-  text-shadow: 0 0 5px black;
-  opacity: 0.6;
-}
-
-.c16 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1254,7 +1114,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   padding-left: 0px;
 }
 
-.c16 .c17 {
+.c14 .c15 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -1264,40 +1124,40 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   align-items: flex-start;
 }
 
-.c25 .c27 blockquote {
+.c21 .c22 blockquote {
   padding: 0;
 }
 
-.c25 .c27 p,
-.c25 .c27 .paragraph {
+.c21 .c22 p,
+.c21 .c22 .paragraph {
   font-size: 24px;
   text-indent: 2em;
   padding: 0;
 }
 
-.c33 .c27 blockquote {
+.c27 .c22 blockquote {
   padding: 0;
 }
 
-.c33 .c27 p,
-.c33 .c27 .paragraph {
+.c27 .c22 p,
+.c27 .c22 .paragraph {
   font-size: 24px;
   text-indent: 2em;
   padding: 0;
 }
 
-.c33 .c27 p:first-child,
-.c33 .c27 .paragraph:first-child {
+.c27 .c22 p:first-child,
+.c27 .c22 .paragraph:first-child {
   text-indent: 0;
 }
 
-.c49 {
+.c39 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c51 {
+.c40 {
   height: 100%;
   padding: 20px;
   background: white;
@@ -1305,14 +1165,14 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   border-bottom: 6px solid #6E1EFF;
 }
 
-.c34 {
+.c28 {
   max-width: 100%;
   margin-bottom: 60px;
   border: 6px solid #6E1EFF;
   border-left: none;
 }
 
-.c34 .c35 {
+.c28 .c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1322,7 +1182,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   flex-direction: row-reverse;
 }
 
-.c34 .c37 {
+.c28 .c31 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1341,300 +1201,49 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   box-shadow: none;
 }
 
-.c34 .c37:hover {
+.c28 .c31:hover {
   background-color: #6E1EFF;
 }
 
-.c34 .c42 {
+.c28 .c35 {
   display: none;
 }
 
-.c34 .c44 {
+.c28 .c36 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
 }
 
-.c34 .c44 > div {
+.c28 .c36 > div {
   padding: 0;
 }
 
-.c34 .c52 {
+.c28 .c41 {
   -webkit-flex: 3;
   -ms-flex: 3;
   flex: 3;
   border-right: 6px solid #6E1EFF;
 }
 
-.c34 .c52 img {
+.c28 .c41 img {
   object-fit: cover;
   object-position: center;
   height: 100%;
 }
 
-.c74 {
+.c62 {
   border-right: 6px solid #6E1EFF;
   border-bottom: 6px solid #6E1EFF;
 }
 
-.c74 .c75 {
+.c62 .c63 {
   margin-bottom: 0;
   margin-top: 0;
 }
 
-.c74 .c77 {
+.c62 .c65 {
   border: none;
-}
-
-@media screen and (min-width:40em) {
-  .c9 {
-    padding-left: 10px;
-    padding-right: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c9 {
-    padding-left: 55px;
-    padding-right: 55px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c24 {
-    max-width: 75%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c24 {
-    max-width: 75%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c24 {
-    padding-left: 0px;
-    padding-right: 0px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c73 {
-    padding-left: 10px;
-    padding-right: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c73 {
-    padding-left: 55px;
-    padding-right: 55px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c79 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c79 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c79 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c79 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c79 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c79 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c80 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c80 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c80 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c80 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c80 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c80 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c26 {
-    padding-bottom: 60px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c43 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c43 {
-    line-height: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c46 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c46 {
-    line-height: 24px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c47 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c47 {
-    line-height: 24px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c50 {
-    font-size: 16px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c50 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c81 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c81 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c81 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c81 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c81 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c81 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c82 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c82 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c82 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c82 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c82 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c82 {
-    line-height: 32px;
-  }
 }
 
 @media (max-width:720px) {
@@ -1646,44 +1255,44 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
     font-size: 24px;
   }
 
-  .c3 .c88 {
+  .c3 .c72 {
     margin: 0 10px;
   }
 }
 
 @media (max-width:600px) {
-  .c28 p,
-  .c28 ul,
-  .c28 ol,
-  .c28 div[data-block=true] .public-DraftStyleDefault-block {
+  .c23 p,
+  .c23 ul,
+  .c23 ol,
+  .c23 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c28 li {
+  .c23 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c28 h1 {
+  .c23 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c28 h2 {
+  .c23 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c28 h3 {
+  .c23 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1691,14 +1300,14 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
     line-height: 1.5em;
   }
 
-  .c28 h3 strong {
+  .c23 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c28 blockquote {
+  .c23 blockquote {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
@@ -1706,65 +1315,65 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
     margin: 0;
   }
 
-  .c28 .content-start {
+  .c23 .content-start {
     font-size: 55px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c85 {
+  .c69 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c85 {
+  .c69 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c85 {
+  .c69 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c85 {
+  .c69 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c85 {
+  .c69 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c85 {
+  .c69 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c76 {
+  .c64 {
     margin-bottom: 60px;
   }
 }
 
 @media (max-width:900px) {
-  .c8 {
+  .c7 {
     left: 10px;
     right: 10px;
   }
 }
 
 @media (max-width:768px) {
-  .c15 blockquote {
+  .c13 blockquote {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 25px;
@@ -1774,7 +1383,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c29 {
+  .c24 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -1782,7 +1391,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c29 {
+  .c24 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1790,7 +1399,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media screen and (min-width:64em) {
-  .c29 {
+  .c24 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1798,7 +1407,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media (max-width:900px) {
-  .c29 {
+  .c24 {
     height: -webkit-fit-content;
     height: -moz-fit-content;
     height: fit-content;
@@ -1806,7 +1415,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media (max-width:900px) {
-  .c30 h1 {
+  .c25 h1 {
     width: 60%;
     float: right;
     height: 100%;
@@ -1816,7 +1425,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media (max-width:767px) {
-  .c30 h1 {
+  .c25 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 45px;
@@ -1830,19 +1439,19 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media (max-width:900px) {
-  .c30 h2 {
+  .c25 h2 {
     width: 40%;
     float: left;
   }
 
-  .c30 h2:last-child {
+  .c25 h2:last-child {
     border-left: none;
     border-top: 6px solid #6E1EFF;
   }
 }
 
 @media (max-width:767px) {
-  .c30 h2 {
+  .c25 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 19px;
@@ -1851,14 +1460,14 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
     float: none;
   }
 
-  .c30 h2:last-child {
+  .c25 h2:last-child {
     border-left: 6px solid #6E1EFF;
     border-top: none;
   }
 }
 
 @media (max-width:900px) {
-  .c30 {
+  .c25 {
     height: 65vh;
     border-right: none;
     border-bottom: 6px solid #6E1EFF;
@@ -1866,7 +1475,73 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media (max-width:900px) {
-  .c31 {
+  .c26 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c43 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c44 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c45 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c46 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c47 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c48 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c49 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c50 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c51 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c52 {
+    min-height: 70vw;
+  }
+}
+
+@media (max-width:900px) {
+  .c53 {
     min-height: 70vw;
   }
 }
@@ -1919,74 +1594,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   }
 }
 
-@media (max-width:900px) {
-  .c62 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c63 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c64 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c65 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c66 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c67 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c68 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c69 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c70 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c71 {
-    min-height: 70vw;
-  }
-}
-
-@media (max-width:900px) {
-  .c72 {
-    min-height: 70vw;
-  }
-}
-
 @media screen and (min-width:40em) {
-  .c16 {
+  .c14 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1994,50 +1603,50 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c16 {
+  .c14 {
     padding-left: 20px;
   }
 }
 
 @media (max-width:900px) {
-  .c16 .c17 {
+  .c14 .c15 {
     padding: 0 20px 20px;
   }
 }
 
 @media (max-width:768px) {
-  .c49 {
+  .c39 {
     min-width: 50%;
   }
 }
 
 @media (max-width:768px) {
-  .c51 {
+  .c40 {
     border-bottom: none;
     border-right: 6px solid #6E1EFF;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c34 {
+  .c28 {
     max-width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c34 {
+  .c28 {
     max-width: 100%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c34 {
+  .c28 {
     max-width: 75%;
   }
 }
 
 @media (max-width:768px) {
-  .c34 .c35 {
+  .c28 .c29 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
@@ -2045,19 +1654,19 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 }
 
 @media (max-width:768px) {
-  .c34 .c37 {
+  .c28 .c31 {
     -webkit-flex-direction: row-reverse;
     -ms-flex-direction: row-reverse;
     flex-direction: row-reverse;
   }
 
-  .c34 .c37 .c39 {
+  .c28 .c31 .c33 {
     max-width: 50%;
   }
 }
 
 @media (max-width:768px) {
-  .c34 .c52 {
+  .c28 .c41 {
     border-right: none;
     border-bottom: 6px solid #6E1EFF;
   }
@@ -2089,7 +1698,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         className="rrm-container rrm-greaterThan-xs"
       >
         <div
-          className="c6 c7"
+          className="c6 bqFMSs"
           color="#000"
           fontFamily={
             Object {
@@ -2107,7 +1716,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c8"
+        className="c7"
       />
     </div>
     <span
@@ -2119,35 +1728,35 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c9"
+    className="cvAPcm"
   >
     <div
-      className="c10"
+      className="c8"
     >
       <div
         className="rrm-container rrm-at-xs"
       >
         <div
-          className="c11"
+          className="c9"
         />
       </div>
       <div
         className="rrm-container rrm-greaterThan-xs"
       >
         <div
-          className="c11"
+          className="c9"
         />
       </div>
       <h1
-        className="c12"
+        className="c10"
       >
         <span
-          className="c13"
+          className="c11"
         >
           The Most 
         </span>
         <span
-          className="c14"
+          className="c12"
         >
           Influential 
         </span>
@@ -2155,7 +1764,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           className="rrm-container rrm-lessThan-md"
         >
           <span
-            className="c13"
+            className="c11"
           >
             Artists
           </span>
@@ -2164,7 +1773,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           className="rrm-container rrm-lessThan-md"
         >
           <span
-            className="c14"
+            className="c12"
           >
              of 2018
           </span>
@@ -2173,7 +1782,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           className="rrm-container rrm-greaterThan-sm"
         >
           <span
-            className="c13"
+            className="c11"
           >
             Artists of 2018
           </span>
@@ -2181,17 +1790,17 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
       </h1>
     </div>
     <div
-      className="c15"
+      className="c13"
     >
       <div
-        className="c16"
+        className="c14"
       >
         <div
-          className="Byline c17 c18"
+          className="Byline c15 c16"
           color="black"
         >
           <div
-            className="c19"
+            className="bUZGRr dOrNHt"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2201,17 +1810,17 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             fontSize="14px"
           >
             <div
-              className="c20"
+              className="c17"
               color="black"
             >
               Artsy Editors
             </div>
           </div>
           <div
-            className="c21"
+            className="c18"
           >
             <div
-              className="c19"
+              className="bUZGRr dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2224,10 +1833,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c22"
+            className="c19"
           >
             <a
-              className="c23"
+              className="c20"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018"
               onClick={[Function]}
               target="_blank"
@@ -2253,7 +1862,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="c23"
+              className="c20"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018&text=The Most Influential Artists of 2018&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-influential-artists-2018&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -2279,7 +1888,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="c23"
+              className="c20"
               href="mailto:?subject=The Most Influential Artists of 2018&body=Check out The Most Influential Artists of 2018 on Artsy: https://www.artsy.net/article/artsy-editorial-influential-artists-2018"
               onClick={[Function]}
               target="_blank"
@@ -2307,15 +1916,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c24"
+          className="dsPMOy"
         >
           <div
-            className="c25 c26"
+            className="c21 eqQmss"
             fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
             fontSize="22px"
           >
             <div
-              className="article__text-section c27 c28"
+              className="article__text-section c22 c23"
               color="black"
             >
               <div
@@ -2330,10 +1939,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Kerry James Marshall</h1><h2>B. 1955, Birmingham, Alabama</h2><h2>Lives and works in Chicago</h2>",
@@ -2341,11 +1950,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c31"
+          className="c26"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FoT1vtmuowAQU9SG2M-gmnw%252FKerry_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -2361,15 +1970,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -2383,23 +1992,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2416,10 +2025,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Kerry James Marshall
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2436,7 +2045,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -2453,7 +2062,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -2478,7 +2087,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -2488,7 +2097,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Kerry James Marshall, <i>Past Times, </i>1997. Courtesy of Sotheby’s. </p>",
@@ -2498,26 +2107,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Kerry James Marshall"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FX8Ew_Hp2QurfxBx4A_hOJQ%252Fd7hftxdivxxvm.cloudfront-4.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -2531,10 +2140,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Adrian Piper</h1><h2>B. 1948, New York, New York </h2><h2>Lives and works in Berlin</h2>",
@@ -2542,11 +2151,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c54"
+          className="c43"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FnlMY9VcLmWae2o0fwpvUWw%252FAdrian2.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -2562,15 +2171,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -2584,23 +2193,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2617,10 +2226,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Adrian Piper
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2637,7 +2246,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -2654,7 +2263,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -2679,7 +2288,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -2689,7 +2298,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Adrian Piper, <i>Safe #1, </i>1990. Courtesy of the Museum of Modern Art.</p>",
@@ -2699,26 +2308,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Adrian Piper"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F8CIBxY3JyP8Cw4g1piRRTQ%252Fadrian2.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -2732,10 +2341,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Maurizio Cattelan</h1><h2>B. 1960, Padua, Italy </h2><h2>Lives and works in New York</h2>",
@@ -2743,11 +2352,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c55"
+          className="c44"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBBJ7xDcd8JV2HoI_7iC2bw%252Fcattelan_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -2763,15 +2372,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -2785,23 +2394,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2818,10 +2427,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Maurizio Cattelan
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2838,7 +2447,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -2855,7 +2464,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -2880,7 +2489,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -2890,7 +2499,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Maurizio Cattelan, <i>Untitled</i>, 2018, in “The Artist is Present” at the Yuz Museum, Shanghai. Courtesy of the artist.</p>",
@@ -2900,26 +2509,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Maurizio Cattelan"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FrFQMyKzr0rr2J2dyE8Z_CQ%252FMaurizio-Cattelan%252C-Untitled%252C-2018.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -2933,10 +2542,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Judy Chicago</h1><h2>B. 1939, Chicago, Illinois</h2><h2>Lives and works in Belen, New Mexico</h2>",
@@ -2944,11 +2553,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c56"
+          className="c45"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F5Ww0vmM4m54-yy8duulLGw%252FJudy_crop2.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -2964,15 +2573,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -2986,23 +2595,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3019,10 +2628,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Judy Chicago
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3039,7 +2648,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -3056,7 +2665,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -3081,7 +2690,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -3091,7 +2700,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Judy Chicago, <i>Purple Atmosphere</i>, 1969. © Judy Chicago/Artists Rights Society (ARS), NY. Photo courtesy of Through the Flower Archives. </p>",
@@ -3101,26 +2710,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Judy Chicago"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FokvgJtWoMGOcqu8jQPM-rg%252F04-Judy-Chicago---Purple-Atmosphere-%25281%2529.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3134,10 +2743,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Alex Da Corte</h1><h2>B. 1980, Camden, New Jersey</h2><h2>Lives and works in Philadelphia</h2>",
@@ -3145,11 +2754,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c57"
+          className="c46"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-zxcH5MJpHFsGT6YmmVjlA%252FAlex-Da-Corte-1.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -3165,15 +2774,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3187,23 +2796,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3220,10 +2829,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Alex Da Corte
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3240,7 +2849,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -3257,7 +2866,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -3282,7 +2891,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -3292,7 +2901,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Alex Da Corte, <i>Rubber Pencil Devil</i>, 2018. Courtesy of Gió Marconi. Photo by Tom Little.</p>",
@@ -3302,26 +2911,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Alex Da Corte"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fm2oi5n0W8HGvQX6E7nqC0w%252Fadc4.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3335,10 +2944,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Bruce Nauman</h1><h2>B. 1941, Fort Wayne, Indiana </h2><h2>Lives and works in Galisteo, New Mexico</h2>",
@@ -3346,11 +2955,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c58"
+          className="c47"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FejQfY6k6HaEYq77uFwLSDg%252FBruce-crop-2.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -3366,15 +2975,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3388,23 +2997,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3421,10 +3030,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Bruce Nauman
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3441,7 +3050,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -3458,7 +3067,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -3483,7 +3092,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -3493,7 +3102,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Still from Bruce Nauman, <i>Green Horses</i>, 1988. © 2018 Bruce Nauman/Artists Rights Society (ARS), NY. Photo by Ron Amstutz.</p>",
@@ -3503,26 +3112,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Bruce Nauman"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FrUujNsJxqofZl_aUDfqFRw%252Fl_nauman_greenhorses_1988_02.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3536,10 +3145,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Cao Fei</h1><h2>B. 1978, Guangzhou, China</h2><h2>Lives and works in Beijing</h2>",
@@ -3547,11 +3156,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c59"
+          className="c48"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F2vk2gnhoUzhrEQWaCQjKyw%252FCao-fei-2.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -3567,15 +3176,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3589,23 +3198,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3622,10 +3231,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Cao Fei
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3642,7 +3251,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -3659,7 +3268,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -3684,7 +3293,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -3694,7 +3303,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Still from Cao Fei, <i>Prison Architect, </i>2018. Cinematography by Kwan Pun Leung. Courtesy of Tai Kwun.</p>",
@@ -3704,26 +3313,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Cao Fei"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FkYwGX2zgLX0azm8Nw1D5XQ%252FCao-fei.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3737,10 +3346,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Simone Leigh</h1><h2>B. 1967, Chicago, Illinois</h2><h2>Lives and works in Brooklyn</h2>",
@@ -3748,11 +3357,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c60"
+          className="c49"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FhEOTF5m2OkHPxocchkntXg%252FSimone_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -3768,15 +3377,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3790,23 +3399,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3823,10 +3432,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Simone Leigh
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -3843,7 +3452,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -3860,7 +3469,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -3885,7 +3494,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -3895,7 +3504,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Simone Leigh, <i>Brick House</i>, 2018 (in progress). Photo by Timothy Schenck. Courtesy of Friends of the High Line.</p>",
@@ -3905,26 +3514,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Simone Leigh"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fj88zDN6TeQRfRIEoxRkQrg%252FHLA_Plinth_Leigh_Schenck_horizontal.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3938,10 +3547,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>David Hockney</h1><h2>B. 1937, Bradford, United Kingdom</h2><h2>Lives and works in Los Angeles</h2>",
@@ -3949,11 +3558,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c61"
+          className="c50"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F1kPiAY_ExpQb0iTnRiYf1A%252Fhockney_crop_pulledback.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -3969,15 +3578,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -3991,23 +3600,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4024,10 +3633,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   David Hockney
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4044,7 +3653,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -4061,7 +3670,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -4086,7 +3695,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -4096,7 +3705,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>David Hockney, <i>Portrait of an Artist (Pool with Two Figures), </i>1972. Courtesy of Christie&#x27;s.</p>",
@@ -4106,26 +3715,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="David Hockney"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FN6Ppl6hCbWSi4sSlg8JTWw%252Fhockney.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4139,10 +3748,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Wu Tsang</h1><h2>B. 1982, Worcester, Massachusetts</h2><h2>Lives and works in Los Angeles</h2>",
@@ -4150,11 +3759,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c62"
+          className="c51"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fc29PdWzeGmZ2FnfpzBExKQ%252Fwu_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -4170,15 +3779,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4192,23 +3801,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4225,10 +3834,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Wu Tsang
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4245,7 +3854,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -4262,7 +3871,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -4287,7 +3896,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -4297,7 +3906,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Wu Tsang, <i>We Hold Where Study, </i>2017, at “Devotional Document (Part 2),” Kunsthalle Münster, Münster, 2017. Courtesy of the artist and Galerie Isabella Bortolozzi, Berlin.</p>",
@@ -4307,26 +3916,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Wu Tsang"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBR-Vvj7daJkMh130NjyJng%252Fwu1.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4340,10 +3949,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Tomás Saraceno</h1><h2>B. 1973, San Miguel de Tucumán, Argentina</h2><h2>Lives and works in Berlin</h2>",
@@ -4351,11 +3960,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c63"
+          className="c52"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FWoWfgpwz1R6hYXowTMtQbg%252FTomas_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -4371,15 +3980,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4393,23 +4002,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4426,10 +4035,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Tomás Saraceno
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4446,7 +4055,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -4463,7 +4072,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -4488,7 +4097,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -4498,7 +4107,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Tomás Saraceno, <i>Algo-r(h)i(y)thms</i>, 2018, at “ON AIR,” Palais de Tokyo, Paris. Photo © Andrea Rossetti. Courtesy of the artist; Esther Schipper; and Pinksummer Contemporary Art.</p>",
@@ -4508,26 +4117,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Tomás Saraceno"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FuZs7UwgzctSiTGbBaiubaA%252F56_18FRA_PdT_Press_36_AR.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4541,10 +4150,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Takashi Murakami</h1><h2>B. 1962, Tokyo, Japan</h2><h2>Lives and works in Tokyo</h2>",
@@ -4552,11 +4161,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c64"
+          className="c53"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F3oOK_ctPDJV9hBSiUURaBA%252Ftakashi_crop_otheroption.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -4572,15 +4181,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4594,23 +4203,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4627,10 +4236,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Takashi Murakami
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4647,7 +4256,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -4664,7 +4273,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -4689,7 +4298,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -4699,7 +4308,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Takashi Murakami, <i>DOB’s March, </i>1995. © Takashi Murakami/Kaikai Kiki Co., Ltd. All rights reserved. Courtesy of Gagosian.</p>",
@@ -4709,26 +4318,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Takashi Murakami"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4vfQ9iy4VgbAQa_8IY_Lqw%252FMurakami-10-web.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4742,10 +4351,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Joan Mitchell</h1><h2>B. 1925, Chicago, Illinois</h2><h2>D. 1992, Paris</h2>",
@@ -4753,11 +4362,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c65"
+          className="c54"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F5IpvVQ9JhQ-YFYSrFF450Q%252FJoan_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -4773,15 +4382,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4795,23 +4404,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4828,10 +4437,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Joan Mitchell
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -4848,7 +4457,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -4865,7 +4474,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -4890,7 +4499,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -4900,7 +4509,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Joan Mitchell, <i>Ici, </i>1992. © Estate of Joan Mitchell.</p>",
@@ -4910,26 +4519,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Joan Mitchell"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FxRgeOh2cJK2HzWbUVpa4-A%252Fjm1.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4943,10 +4552,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Forensic Architecture</h1><h2>Founded in 2010</h2><h2>Based in London</h2>",
@@ -4954,11 +4563,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c66"
+          className="c55"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fl-eI1OtsSoanJ_x3YlnEWg%252FFA.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -4974,15 +4583,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -4996,23 +4605,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5029,10 +4638,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Forensic Architecture
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5049,7 +4658,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -5066,7 +4675,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -5091,7 +4700,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -5101,7 +4710,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p> Forensic Architecture, <i>Counter Investigations, </i> 2018, at The Institute of Contemporary Art, Boston. Photo by Mark Blower.</p>",
@@ -5111,26 +4720,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Forensic Architecture"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FTm1l55s5WWabhlGEEN7sYg%252Ffm6.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5144,10 +4753,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Wolfgang Tillmans</h1><h2>B. 1968, Remscheid, Germany</h2><h2>Lives and works in Berlin and London</h2>",
@@ -5155,11 +4764,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c67"
+          className="c56"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FgaTpzI49OUOFP1Ks1-bTNg%252Fwolfgang_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -5175,15 +4784,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5197,23 +4806,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5230,10 +4839,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Wolfgang Tillmans
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5250,7 +4859,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -5267,7 +4876,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -5292,7 +4901,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -5302,7 +4911,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>English National Opera, <i>War Requiem, </i>2018. Set design by Wolfgang Tillmans. Photo © Richard Hubert Smith. Courtesy of the English National Opera.</p>",
@@ -5312,26 +4921,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Wolfgang Tillmans"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FHSAs4GGSc-K_1ZiXvuv-kA%252FTillmans5.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5345,10 +4954,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Charline von Heyl</h1><h2>B. 1960, Mainz, Germany</h2><h2>Lives and works in New York and Marfa, Texas</h2>",
@@ -5356,11 +4965,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c68"
+          className="c57"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FY96402AXIKWZiX1iACXVLg%252Fcharline2.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -5376,15 +4985,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5398,23 +5007,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5431,10 +5040,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Charline von Heyl
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5451,7 +5060,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -5468,7 +5077,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -5493,7 +5102,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -5503,7 +5112,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Charline von Heyl, <i>Vandals without Sandals, </i> 2018. Courtesy of Petzel.</p>",
@@ -5513,26 +5122,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Charline von Heyl"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fm6lI89fEesw43gExCb1HeA%252Fc3.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5546,10 +5155,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Charles White</h1><h2>B. 1918, Chicago, Illinois</h2><h2>D. 1979, Los Angeles, California</h2>",
@@ -5557,11 +5166,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c69"
+          className="c58"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FRgD2WhDMmriNWjQaiVAtYA%252FCharles_crop2.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -5577,15 +5186,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5599,23 +5208,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5632,10 +5241,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Charles White
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5652,7 +5261,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -5669,7 +5278,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -5694,7 +5303,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -5704,7 +5313,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Charles White, <i>Sound of Silence, </i>1978. © 1978 The Charles White Archives. Courtesy of the Museum of Modern Art.</p>",
@@ -5714,26 +5323,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Charles White"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FV9ah8w3raEYKYCoVweBjLQ%252Fz6.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5747,10 +5356,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Andrea Fraser</h1><h2>B. 1965, Billings, Montana</h2><h2>Lives and works in Los Angeles</h2>",
@@ -5758,11 +5367,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c70"
+          className="c59"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F2We6jcCx0JXM7EmjoJKc3g%252FAndrea_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -5778,15 +5387,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5800,23 +5409,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5833,10 +5442,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Andrea Fraser
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -5853,7 +5462,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -5870,7 +5479,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -5895,7 +5504,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -5905,7 +5514,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Andrea Fraser, <i>2016 in Museums, Money, and Politics, </i>a SITE Santa Fe Commission, 2018. Photo by Brandon Soder. Courtesy of SITE Santa Fe.</p>",
@@ -5915,26 +5524,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Andrea Fraser"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco209l53g3nK9mfoMO3cpQ%252Fandrea2.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -5948,10 +5557,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>John Bock</h1><h2>B. 1965, Schenefeld, Germany</h2><h2>Lives and works in Berlin</h2>",
@@ -5959,11 +5568,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c71"
+          className="c60"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F69-YSOLh8LC9E2BmQQcAqw%252Fjohn-bock.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -5979,15 +5588,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -6001,23 +5610,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -6034,10 +5643,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   John Bock
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -6054,7 +5663,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -6071,7 +5680,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -6096,7 +5705,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -6106,7 +5715,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>John Bock, “Dead + Juicy,” 2018. Courtesy of Anton Kern Gallery.  </p>",
@@ -6116,26 +5725,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="John Bock"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGNsez6zKrcmqu-HvUGDxbw%252Fb1.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -6149,10 +5758,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c24"
       >
         <div
-          className="c30"
+          className="c25"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<h1>Kehinde Wiley</h1><h2>B. 1977, Los Angeles, California</h2><h2>Lives and works in New York</h2>",
@@ -6160,11 +5769,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           }
         />
         <div
-          className="c72"
+          className="c61"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FGDx8y_WfzrowtQpmaMcQRw%252Fkehinde_crop.jpg&width=700&quality=80"
         >
           <div
-            className="c32"
+            className="bUZGRr jHhIjZ"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="10px"
@@ -6180,15 +5789,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c33 c26"
+          className="c27 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -6202,23 +5811,23 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c34"
+        className="c28"
       >
         <div
-          className="c35 c36"
+          className="c29 c30"
         >
           <div
-            className="c37 c38"
+            className="c31 c32"
             onClick={[Function]}
           >
             <div
-              className="c39 c40"
+              className="c33 c34"
             >
               <div
-                className="c41"
+                className="jXywsm"
               >
                 <div
-                  className="c42 c43"
+                  className="c35 hTdRdk"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -6235,10 +5844,10 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   Kehinde Wiley
                 </div>
                 <div
-                  className="c44 c45"
+                  className="c36 c37"
                 >
                   <div
-                    className="c46"
+                    className="bUZGRr iPLCTR"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -6255,7 +5864,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     View Slideshow
                   </div>
                   <div
-                    className="c47"
+                    className="bUZGRr gMzPqM"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -6272,7 +5881,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 className="rrm-container rrm-greaterThanOrEqual-sm"
               >
                 <div
-                  className="c48"
+                  className="c38"
                 >
                   <svg
                     className="image-set"
@@ -6297,7 +5906,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c49 c50"
+              className="c39 jdwHwA"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -6307,7 +5916,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               }
             >
               <div
-                className="c51"
+                className="c40"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Kehinde Wiley, <i>Three Girls in a Wood, </i> 2018. © Kehinde Wiley. Courtesy of the artist and Roberts Projects.</p>",
@@ -6317,26 +5926,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c52 "
+            className="c41 "
           >
             <img
               alt="Kehinde Wiley"
-              className="c53"
+              className="c42"
               src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FzyXvajTSQIlmSwD5vitxGQ%252FKehinde3.jpg&width=800&quality=80"
             />
           </div>
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -6350,15 +5959,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="dsPMOy"
       >
         <div
-          className="c25 c26"
+          className="c21 eqQmss"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c27 c28"
+            className="article__text-section c22 c23"
             color="black"
           >
             <div
@@ -6374,28 +5983,28 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c73"
+    className="dgPWzK"
   >
     <div
-      className="c74"
+      className="c62"
     >
       <div
-        className=""
+        className="dVZOZN"
       >
         <div
-          className="c75 c76"
+          className="c63 c64"
         >
           <a
-            className="ArticleCard c77 c78"
+            className="ArticleCard c65 c66"
             color="#000"
             href="artsy-editorial-people-defined-visual-culture-2018"
             onClick={[Function]}
           >
             <div
-              className="c79"
+              className="drjzXt"
             >
               <div
-                className="c80"
+                className="jUYeYa"
                 width={
                   Array [
                     "100%",
@@ -6407,7 +6016,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               >
                 <div>
                   <div
-                    className="c81"
+                    className="bUZGRr cwRRLl"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize={
                       Array [
@@ -6421,7 +6030,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     The People Who Defined Visual Culture in 2018
                   </div>
                   <div
-                    className="c82"
+                    className="cFlEyZ hAOaLg"
                     fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                     fontSize={
                       Array [
@@ -6436,11 +6045,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  className="Byline c17 c83"
+                  className="Byline c15 c67"
                   color="#000"
                 >
                   <div
-                    className="c19"
+                    className="bUZGRr dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -6450,17 +6059,17 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                     fontSize="14px"
                   >
                     <div
-                      className="c84"
+                      className="c68"
                       color="#000"
                     >
                       Artsy Editors
                     </div>
                   </div>
                   <div
-                    className="c21"
+                    className="c18"
                   >
                     <div
-                      className="c19"
+                      className="bUZGRr dOrNHt"
                       fontFamily={
                         Object {
                           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -6475,7 +6084,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="c85"
+                className="c69"
                 width={
                   Array [
                     "100%",
@@ -6486,7 +6095,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 }
               >
                 <img
-                  className="c86 c87"
+                  className="c70 c71"
                   src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fr3TUoJ9u8QhxGeWdjR4ccQ%252FVC-email-final.jpg&width=680&height=450&quality=95"
                 />
               </div>
@@ -6500,121 +6109,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 `;
 
 exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
-.c13 {
-  max-width: 1400px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c15 {
-  width: 100%;
-}
-
-.c24 {
-  max-width: 1000px;
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
-}
-
-.c49 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
 .c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-  padding-bottom: 20px;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  max-width: 1000px;
-  width: 100%;
-}
-
-.c19 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c51 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 16px;
-  line-height: 26px;
-  padding-bottom: 8px;
-}
-
-.c54 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-}
-
-.c55 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 12px;
-  line-height: 16px;
-  padding-left: 20px;
-}
-
-.c7 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: black;
-  text-align: center;
-}
-
-.c10 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 100px;
-  line-height: 104px;
-  padding-bottom: 10px;
-  padding-top: 20px;
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c39 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 22px;
-  line-height: 32px;
-}
-
-.c21 {
   margin: 10px 20px 0 0;
 }
 
-.c21::before {
+.c14::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -6624,12 +6123,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   background-color: black;
 }
 
-.c23 {
+.c16 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c16 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6643,22 +6142,22 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c17 {
+.c12 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c17:hover {
+.c12:hover {
   opacity: 0.6;
 }
 
-.c17:first-child {
+.c12:first-child {
   padding-left: 0;
 }
 
-.c37 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6670,16 +6169,16 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c38 {
+.c30 {
   padding: 0 10px;
   width: 100%;
   word-break: break-word;
 }
 
-.c38 > p,
-.c38 p,
-.c38 .public-DraftEditorPlaceholder-root,
-.c38 .public-DraftStyleDefault-block {
+.c30 > p,
+.c30 p,
+.c30 .public-DraftEditorPlaceholder-root,
+.c30 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -6688,13 +6187,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin: 0;
 }
 
-.c38 > a,
-.c38 a {
+.c30 > a,
+.c30 a {
   color: #999;
 }
 
-.c38 > a:hover,
-.c38 a:hover {
+.c30 > a:hover,
+.c30 a:hover {
   color: black;
 }
 
@@ -6730,7 +6229,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   -ms-interpolation-mode: bicubic;
 }
 
-.c3 .c66 {
+.c3 .c53 {
   margin: 0 20px;
 }
 
@@ -6781,13 +6280,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   z-index: 10;
 }
 
-.c41 {
+.c32 {
   position: relative;
   width: 100%;
   color: white;
 }
 
-.c41 a {
+.c32 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6797,22 +6296,22 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   background-position: bottom;
 }
 
-.c41 a:hover {
+.c32 a:hover {
   color: white;
   opacity: .65;
 }
 
-.c41 div[class*='ToolTip'] a {
+.c32 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c41 p,
-.c41 ul,
-.c41 ol,
-.c41 .paragraph,
-.c41 div[data-block=true] .public-DraftStyleDefault-block {
+.c32 p,
+.c32 ul,
+.c32 ol,
+.c32 .paragraph,
+.c32 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -6823,32 +6322,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   font-style: inherit;
 }
 
-.c41 p:first-child,
-.c41 .paragraph:first-child,
-.c41 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c32 p:first-child,
+.c32 .paragraph:first-child,
+.c32 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c41 p:last-child,
-.c41 .paragraph:last-child,
-.c41 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c32 p:last-child,
+.c32 .paragraph:last-child,
+.c32 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c41 ul,
-.c41 ol {
+.c32 ul,
+.c32 ol {
   padding-left: 1em;
 }
 
-.c41 ul {
+.c32 ul {
   list-style: disc;
 }
 
-.c41 ol {
+.c32 ol {
   list-style: decimal;
 }
 
-.c41 li {
+.c32 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -6857,7 +6356,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   padding-bottom: .5em;
 }
 
-.c41 h1 {
+.c32 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -6870,7 +6369,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   text-align: center;
 }
 
-.c41 h1::before {
+.c32 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -6881,7 +6380,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   right: calc(50% - 4px);
 }
 
-.c41 h2 {
+.c32 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -6890,15 +6389,15 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin: 0;
 }
 
-.c41 h2 a {
+.c32 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c41 h2 .c68 {
+.c32 h2 .c55 {
   background-position: bottom !important;
 }
 
-.c41 h3 {
+.c32 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -6908,7 +6407,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin: 0;
 }
 
-.c41 h3 strong {
+.c32 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -6916,11 +6415,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   line-height: 1.5em;
 }
 
-.c41 h3 a {
+.c32 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c41 blockquote {
+.c32 blockquote {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -6933,11 +6432,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   word-break: break-word;
 }
 
-.c41 .preventLineBreak {
+.c32 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c41 .content-end {
+.c32 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -6948,14 +6447,14 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin-bottom: 1px;
 }
 
-.c41 .artist-follow {
+.c32 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c41 .artist-follow::before {
+.c32 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -6963,7 +6462,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   font-size: 32px;
 }
 
-.c41 .artist-follow::after {
+.c32 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -6972,13 +6471,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   text-transform: none;
 }
 
-.c60 {
+.c47 {
   position: relative;
   width: 100%;
   color: #000;
 }
 
-.c60 a {
+.c47 a {
   color: #000;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6988,22 +6487,22 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   background-position: bottom;
 }
 
-.c60 a:hover {
+.c47 a:hover {
   color: #000;
   opacity: .65;
 }
 
-.c60 div[class*='ToolTip'] a {
+.c47 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c60 p,
-.c60 ul,
-.c60 ol,
-.c60 .paragraph,
-.c60 div[data-block=true] .public-DraftStyleDefault-block {
+.c47 p,
+.c47 ul,
+.c47 ol,
+.c47 .paragraph,
+.c47 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -7014,32 +6513,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   font-style: inherit;
 }
 
-.c60 p:first-child,
-.c60 .paragraph:first-child,
-.c60 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c47 p:first-child,
+.c47 .paragraph:first-child,
+.c47 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c60 p:last-child,
-.c60 .paragraph:last-child,
-.c60 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c47 p:last-child,
+.c47 .paragraph:last-child,
+.c47 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c60 ul,
-.c60 ol {
+.c47 ul,
+.c47 ol {
   padding-left: 1em;
 }
 
-.c60 ul {
+.c47 ul {
   list-style: disc;
 }
 
-.c60 ol {
+.c47 ol {
   list-style: decimal;
 }
 
-.c60 li {
+.c47 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -7048,7 +6547,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   padding-bottom: .5em;
 }
 
-.c60 h1 {
+.c47 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -7061,7 +6560,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   text-align: center;
 }
 
-.c60 h1::before {
+.c47 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -7072,7 +6571,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   right: calc(50% - 4px);
 }
 
-.c60 h2 {
+.c47 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -7081,15 +6580,15 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin: 0;
 }
 
-.c60 h2 a {
+.c47 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c60 h2 .c68 {
+.c47 h2 .c55 {
   background-position: bottom !important;
 }
 
-.c60 h3 {
+.c47 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -7099,7 +6598,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin: 0;
 }
 
-.c60 h3 strong {
+.c47 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -7107,11 +6606,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   line-height: 1.5em;
 }
 
-.c60 h3 a {
+.c47 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c60 blockquote {
+.c47 blockquote {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -7124,11 +6623,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   word-break: break-word;
 }
 
-.c60 .preventLineBreak {
+.c47 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c60 .content-end {
+.c47 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -7139,14 +6638,14 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   margin-bottom: 1px;
 }
 
-.c60 .artist-follow {
+.c47 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c60 .artist-follow::before {
+.c47 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -7154,7 +6653,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   font-size: 32px;
 }
 
-.c60 .artist-follow::after {
+.c47 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -7163,7 +6662,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   text-transform: none;
 }
 
-.c35 {
+.c27 {
   position: absolute;
   bottom: 0;
   right: 0;
@@ -7176,39 +6675,39 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   transition: opacity 0.3s;
 }
 
-.c35:hover {
+.c27:hover {
   opacity: 1;
 }
 
-.c34 {
+.c26 {
   opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
 }
 
-.c31 {
+.c23 {
   position: relative;
 }
 
-.c31:hover .c33 {
+.c23:hover .c25 {
   opacity: 1;
 }
 
-.c31 .BlockImage__container {
+.c23 .BlockImage__container {
   opacity: 0;
   -webkit-transition: opacity 1s;
   transition: opacity 1s;
 }
 
-.c31 .image-loaded {
+.c23 .image-loaded {
   opacity: 1;
 }
 
-.c32 {
+.c24 {
   display: block;
 }
 
-.c28 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7220,23 +6719,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c30 {
+.c22 {
   margin-right: 0px;
   width: 100%;
 }
 
-.c56 {
+.c43 {
   height: 45px;
   position: relative;
   margin-left: 40px;
   text-align: right;
 }
 
-.c56 > svg {
+.c43 > svg {
   height: 98%;
 }
 
-.c48 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7253,19 +6752,19 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   width: 100%;
 }
 
-.c53 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c44 {
+.c35 {
   position: relative;
   width: 100%;
 }
 
-.c46 {
+.c37 {
   position: absolute;
   bottom: 20px;
   left: 20px;
@@ -7278,53 +6777,53 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   cursor: pointer;
 }
 
-.c46:hover {
+.c37:hover {
   background: rgba(0,0,0,0.6);
   color: white;
 }
 
-.c46:hover path,
-.c46:hover polygon {
+.c37:hover path,
+.c37:hover polygon {
   fill: white;
 }
 
-.c58 {
+.c45 {
   height: auto;
   width: 100%;
 }
 
-.c62 .c1 {
+.c49 .c1 {
   border-bottom: none;
 }
 
-.c63 .c40 blockquote {
+.c50 .c31 blockquote {
   padding: 0;
 }
 
-.c63 .c40 p,
-.c63 .c40 .paragraph {
+.c50 .c31 p,
+.c50 .c31 .paragraph {
   font-size: 24px;
   text-indent: 2em;
   padding: 0;
 }
 
-.c64 .c40 blockquote {
+.c51 .c31 blockquote {
   padding: 0;
 }
 
-.c64 .c40 p,
-.c64 .c40 .paragraph {
+.c51 .c31 p,
+.c51 .c31 .paragraph {
   font-size: 24px;
   text-indent: 2em;
   padding: 0;
 }
 
-.c64 .c40 p:first-child,
-.c64 .c40 .paragraph:first-child {
+.c51 .c31 p:first-child,
+.c51 .c31 .paragraph:first-child {
   text-indent: 0;
 }
 
-.c65 .c43 {
+.c52 .c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7334,7 +6833,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   flex-direction: row-reverse;
 }
 
-.c65 .c45 {
+.c52 .c36 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7353,32 +6852,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   box-shadow: none;
 }
 
-.c65 .c45:hover {
+.c52 .c36:hover {
   background-color: #6E1EFF;
 }
 
-.c65 .c50 {
+.c52 .c40 {
   display: none;
 }
 
-.c65 .c52 {
+.c52 .c41 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
 }
 
-.c65 .c52 > div {
+.c52 .c41 > div {
   padding: 0;
 }
 
-.c65 .c57 {
+.c52 .c44 {
   -webkit-flex: 3;
   -ms-flex: 3;
   flex: 3;
   border-right: 6px solid #6E1EFF;
 }
 
-.c65 .c57 img {
+.c52 .c44 img {
   object-fit: cover;
   object-position: center;
   height: 100%;
@@ -7389,33 +6888,33 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   border-top: 6px solid black;
 }
 
-.c0 .c22 {
+.c0 .c15 {
   margin-top: 0;
 }
 
-.c0 .c20 {
+.c0 .c13 {
   margin-top: 0;
 }
 
-.c25 {
+.c17 {
   color: white;
   background-color: #000;
 }
 
-.c25 .c67 {
+.c17 .c54 {
   color: #000;
 }
 
-.c59 .c67 {
+.c46 .c54 {
   color: #000;
 }
 
-.c8 {
+.c7 {
   border-bottom: 6px solid;
   position: relative;
 }
 
-.c61 {
+.c48 {
   padding-left: 10px;
   padding-right: 10px;
   padding-top: 40px;
@@ -7424,7 +6923,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   position: relative;
 }
 
-.c12 {
+.c10 {
   margin-left: auto;
   margin-right: auto;
   padding-left: 10px;
@@ -7435,7 +6934,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   position: relative;
 }
 
-.c12 blockquote {
+.c10 blockquote {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 34px;
@@ -7446,26 +6945,26 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   font-weight: inherit;
 }
 
-.c12 .c40 p,
-.c12 .c40 .paragraph {
+.c10 .c31 p,
+.c10 .c31 .paragraph {
   font-size: 24px;
   text-indent: 2em;
   padding: 0;
 }
 
-.c12 .c40 p:first-child,
-.c12 .c40 .paragraph:first-child {
+.c10 .c31 p:first-child,
+.c10 .c31 .paragraph:first-child {
   text-indent: 0;
 }
 
-.c9 {
+.c8 {
   text-transform: uppercase;
   border-bottom: 6px solid;
   font-size: 7.5vw;
   line-height: 1em;
 }
 
-.c26 {
+.c18 {
   padding-bottom: 10px;
   padding-top: 10px;
   padding-left: 10px;
@@ -7473,7 +6972,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   border-bottom: 6px solid;
 }
 
-.c26 > div {
+.c18 > div {
   max-width: 1600px;
   margin: 0 auto;
   width: 100%;
@@ -7487,7 +6986,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   align-items: flex-end;
 }
 
-.c26 h1 {
+.c18 h1 {
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 65px;
@@ -7500,7 +6999,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   font-weight: inherit;
 }
 
-.c26 h2 {
+.c18 h2 {
   font-size: 50px;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -7511,7 +7010,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   font-weight: inherit;
 }
 
-.c11 {
+.c9 {
   height: calc(100vh - 50px);
   min-height: 400px;
   object-fit: cover;
@@ -7519,165 +7018,71 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   width: 100%;
 }
 
-.c27 {
+.c19 {
   border-bottom: 6px solid;
   position: relative;
 }
 
-.c27 img {
+.c19 img {
   max-height: calc(100vh - 50px);
   min-height: 400px;
   object-fit: cover;
   object-position: center;
 }
 
-.c27 .c36 {
+.c19 .c28 {
   position: absolute;
   bottom: 0;
   left: 5px;
 }
 
-.c27 .c36 p {
+.c19 .c28 p {
   font-size: 10px;
   color: white;
   opacity: 0.6;
   text-shadow: 0 0 5px black;
 }
 
-.c42 {
+.c33 {
   padding-left: 0px;
   padding-right: 0px;
   border-bottom: 6px solid;
   position: relative;
 }
 
-.c42 .c43 {
+.c33 .c34 {
   width: 70%;
   max-width: 1000px;
   margin: 0 auto;
   color: black;
 }
 
-.c42 .c43 img {
+.c33 .c34 img {
   width: 100%;
 }
 
-.c42 .c43 .c50 {
+.c33 .c34 .c40 {
   display: none;
 }
 
-.c42 .c43 .c52 {
+.c33 .c34 .c41 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
 }
 
-.c42 .c43 .c52 > div {
+.c33 .c34 .c41 > div {
   padding: 0;
 }
 
-@media screen and (min-width:40em) {
-  .c15 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c15 {
-    width: 15%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c24 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c24 {
-    width: 70%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c14 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c18 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c18 {
-    width: 70%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c51 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c51 {
-    line-height: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c54 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c54 {
-    line-height: 24px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c55 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c55 {
-    line-height: 24px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c10 {
-    padding-left: 10px;
-    padding-right: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c10 {
-    padding-left: 55px;
-    padding-right: 55px;
-  }
-}
-
 @media (max-width:600px) {
-  .c37 {
+  .c29 {
     padding: 0px 10px;
   }
 }
 
 @media (max-width:600px) {
-  .c38 {
+  .c30 {
     padding: 0px;
   }
 }
@@ -7691,44 +7096,44 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     font-size: 24px;
   }
 
-  .c3 .c66 {
+  .c3 .c53 {
     margin: 0 10px;
   }
 }
 
 @media (max-width:600px) {
-  .c41 p,
-  .c41 ul,
-  .c41 ol,
-  .c41 div[data-block=true] .public-DraftStyleDefault-block {
+  .c32 p,
+  .c32 ul,
+  .c32 ol,
+  .c32 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c41 li {
+  .c32 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c41 h1 {
+  .c32 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c41 h2 {
+  .c32 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c41 h3 {
+  .c32 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -7736,14 +7141,14 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     line-height: 1.5em;
   }
 
-  .c41 h3 strong {
+  .c32 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c41 blockquote {
+  .c32 blockquote {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
@@ -7751,44 +7156,44 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     margin: 0;
   }
 
-  .c41 .content-start {
+  .c32 .content-start {
     font-size: 55px;
   }
 }
 
 @media (max-width:600px) {
-  .c60 p,
-  .c60 ul,
-  .c60 ol,
-  .c60 div[data-block=true] .public-DraftStyleDefault-block {
+  .c47 p,
+  .c47 ul,
+  .c47 ol,
+  .c47 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c60 li {
+  .c47 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c60 h1 {
+  .c47 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c60 h2 {
+  .c47 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c60 h3 {
+  .c47 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -7796,14 +7201,14 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     line-height: 1.5em;
   }
 
-  .c60 h3 strong {
+  .c47 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c60 blockquote {
+  .c47 blockquote {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
@@ -7811,19 +7216,19 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     margin: 0;
   }
 
-  .c60 .content-start {
+  .c47 .content-start {
     font-size: 55px;
   }
 }
 
 @media (max-width:720px) {
-  .c31 .c33 {
+  .c23 .c25 {
     opacity: 1;
   }
 }
 
 @media (max-width:600px) {
-  .c28 {
+  .c20 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -7831,13 +7236,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 }
 
 @media (max-width:600px) {
-  .c30 {
+  .c22 {
     margin-bottom: 10px;
   }
 }
 
 @media (max-width:768px) {
-  .c65 .c43 {
+  .c52 .c34 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
@@ -7845,26 +7250,26 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 }
 
 @media (max-width:768px) {
-  .c65 .c45 {
+  .c52 .c36 {
     -webkit-flex-direction: row-reverse;
     -ms-flex-direction: row-reverse;
     flex-direction: row-reverse;
   }
 
-  .c65 .c45 .c47 {
+  .c52 .c36 .c38 {
     max-width: 50%;
   }
 }
 
 @media (max-width:768px) {
-  .c65 .c57 {
+  .c52 .c44 {
     border-right: none;
     border-bottom: 6px solid #6E1EFF;
   }
 }
 
 @media (max-width:767px) {
-  .c0 .c20 {
+  .c0 .c13 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -7872,41 +7277,41 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c61 {
+  .c48 {
     padding-left: 10px;
     padding-right: 10px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c61 {
+  .c48 {
     padding-left: 55px;
     padding-right: 55px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c12 {
+  .c10 {
     padding-left: 10px;
     padding-right: 10px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c12 {
+  .c10 {
     padding-left: 55px;
     padding-right: 55px;
   }
 }
 
 @media (max-width:768px) {
-  .c12 blockquote {
+  .c10 blockquote {
     font-size: 24px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c26 {
+  .c18 {
     padding-bottom: 10px;
     padding-left: 10px;
     padding-right: 10px;
@@ -7914,7 +7319,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c26 {
+  .c18 {
     padding-bottom: 20px;
     padding-left: 55px;
     padding-right: 55px;
@@ -7922,54 +7327,54 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 }
 
 @media (max-width:900px) {
-  .c26 h1 {
+  .c18 h1 {
     font-size: 45px;
   }
 
-  .c26 h2 {
+  .c18 h2 {
     font-size: 30px;
   }
 }
 
 @media (max-width:767px) {
-  .c26 h1 {
+  .c18 h1 {
     font-size: 30px;
   }
 
-  .c26 h2 {
+  .c18 h2 {
     font-size: 20px;
   }
 }
 
 @media (max-width:900px) {
-  .c27 img {
+  .c19 img {
     min-height: unset;
   }
 }
 
 @media (max-width:600px) {
-  .c27 .c29 {
+  .c19 .c21 {
     margin-bottom: 0;
     min-height: unset;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c42 {
+  .c33 {
     padding-left: 0px;
     padding-right: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c42 {
+  .c33 {
     padding-left: 55px;
     padding-right: 55px;
   }
 }
 
 @media (max-width:900px) {
-  .c42 .c43 {
+  .c33 .c34 {
     width: 100%;
   }
 }
@@ -8000,7 +7405,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         className="rrm-container rrm-greaterThan-xs"
       >
         <div
-          className="c6 c7"
+          className="c6 gcRkdF"
           color="black"
           fontFamily={
             Object {
@@ -8027,10 +7432,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c8"
+    className="c7"
   >
     <div
-      className="c9 c10"
+      className="c8 iTOBJS"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -8047,21 +7452,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <img
-      className="c11"
+      className="c9"
       src="https://artsy-media-uploads.s3.amazonaws.com/-XyBoU_ZEbnlyKfjNyu1zA%2Fblack-panther-header.jpg"
     />
   </div>
   <div
-    className="c12"
+    className="c10"
   >
     <div
-      className="c13"
+      className="eIGhhO"
     >
       <div
-        className="c14"
+        className="bDBxFO"
       >
         <div
-          className="c15"
+          className="azUib"
           width={
             Array [
               "100%",
@@ -8071,10 +7476,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           }
         >
           <div
-            className="c16"
+            className="c11"
           >
             <a
-              className="c17"
+              className="c12"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018"
               onClick={[Function]}
               target="_blank"
@@ -8100,7 +7505,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="c17"
+              className="c12"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018&text=The Year In Culture 2018&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-editorial-year-culture-2018&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -8126,7 +7531,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="c17"
+              className="c12"
               href="mailto:?subject=The Year In Culture 2018&body=Check out The Year In Culture 2018 on Artsy: https://www.artsy.net/article/artsy-editorial-year-culture-2018"
               onClick={[Function]}
               target="_blank"
@@ -8154,7 +7559,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c18"
+          className="flPVot"
           width={
             Array [
               "100%",
@@ -8164,7 +7569,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           }
         >
           <div
-            className="c19"
+            className="bUZGRr dOrNHt"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -8174,17 +7579,17 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             fontSize="14px"
           >
             <div
-              className="c20 c21"
+              className="c13 c14"
               color="black"
             >
               Artsy Editors
             </div>
           </div>
           <div
-            className="c22 c23"
+            className="c15 c16"
           >
             <div
-              className="c19"
+              className="bUZGRr dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -8199,7 +7604,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -8226,7 +7631,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -8236,7 +7641,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8247,32 +7652,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="A still from Donald Glover’s “This Is America” video. Courtesy of the artist."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FcFYhEkcOH68HfFsRha83yA%252Fthis-is-america.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -8324,10 +7729,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8343,10 +7748,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -8356,12 +7761,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -8376,23 +7781,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -8409,10 +7814,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Donald Glover and Hiro Murai
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -8429,7 +7834,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -8446,7 +7851,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -8472,21 +7877,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Donald Glover and Hiro Murai"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FKLtrAvpKSBrd3eeop2N_tw%252FATL_EP209_0048.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -8496,12 +7901,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -8524,7 +7929,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -8534,7 +7939,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8545,32 +7950,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Detail of Amy Sherald, Michelle LaVaughn Robinson Obama, 2018. Courtesy of the National Portrait Gallery, Smithsonian Institution."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FPs8YXbW8eqEo1pn9tWmtUw%252FMichelle-Obama-2-3.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -8622,10 +8027,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8641,10 +8046,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -8654,12 +8059,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -8674,23 +8079,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -8707,10 +8112,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Amy Sherald
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -8727,7 +8132,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -8744,7 +8149,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -8770,21 +8175,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Amy Sherald"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FhTe5F1xOYgvc49JSF86xHQ%252FAmy-Sherald.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -8794,12 +8199,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -8822,7 +8227,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -8832,7 +8237,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -8843,32 +8248,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Installation view of teamLab, “Borderless,” 2018, at Mori Building Digital Art Museum, Odaiba, Tokyo. © teamLab. Courtesy of Pace Gallery."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FMSmO8KUrvWXG89xkuYTXcQ%252FTeam-Lab-1.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -8920,10 +8325,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -8939,10 +8344,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -8952,12 +8357,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -8972,23 +8377,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -9005,10 +8410,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 teamLab
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -9025,7 +8430,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -9042,7 +8447,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -9068,21 +8473,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="teamLab"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9Uurw-CkPYfKMpbXOFOaVQ%252F01_Universe-of-Water-Particles-on-a-Rock-where-People-Gather_02.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -9092,12 +8497,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -9120,7 +8525,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -9130,7 +8535,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9141,32 +8546,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Photo of Nan Goldin during a protest at the Harvard Art Museums. Photo by TW Collins. Courtesy of P.A.I.N. Sackler. "
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FVGqbgOtSAwLIh4b1i6qUjg%252FNan-Goldin.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -9218,10 +8623,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9237,10 +8642,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -9250,12 +8655,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -9270,23 +8675,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -9303,10 +8708,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Nan Goldin
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -9323,7 +8728,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -9340,7 +8745,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -9366,21 +8771,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Nan Goldin"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fg8dtyJ6h_73di_mnbQNDcA%252FPAIN-Met-Thom-Pavia.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -9390,12 +8795,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -9418,7 +8823,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -9428,7 +8833,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9439,32 +8844,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Illustrations by Tim O’Brien for Time. Courtesy of Time."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FyswckDIxtxpMOJVUn0buTA%252Ftrump-cover.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -9516,10 +8921,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9535,10 +8940,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -9548,12 +8953,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -9568,23 +8973,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -9601,10 +9006,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 D.W. Pine
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -9621,7 +9026,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -9638,7 +9043,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -9664,21 +9069,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="D.W. Pine"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FE0kxF5gFOcTHmZ7eJkV6qw%252Fdwnewsroom2bw.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -9688,12 +9093,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -9716,7 +9121,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -9726,7 +9131,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -9737,32 +9142,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Portrait of Virgil Abloh at the Louis Vuitton headquarters © Alex Majoli/Magnum Photos. Courtesy of Magnum Photos."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FB5TJX7T9KhipmIMQNa89UQ%252FVirgilAbloh1.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -9814,10 +9219,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -9833,10 +9238,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -9846,12 +9251,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -9866,23 +9271,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -9899,10 +9304,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Virgil Abloh
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -9919,7 +9324,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -9936,7 +9341,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -9962,21 +9367,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Virgil Abloh"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FLmo6qr-T4qcliTd5Da00cg%252FVA6.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -9986,12 +9391,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -10014,7 +9419,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -10024,7 +9429,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10035,32 +9440,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Photo by Nicolas McComber via Getty Images."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FqhospIkboXNNaKstMepR8Q%252Fgettyimages-497948239-1024x1024.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -10112,10 +9517,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10131,10 +9536,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -10144,12 +9549,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -10164,23 +9569,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -10197,10 +9602,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 James Monsees and Adam Bowen 
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -10217,7 +9622,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -10234,7 +9639,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -10260,21 +9665,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="James Monsees and Adam Bowen "
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Flsmscwlt8G99eYm_2ClTDg%252Fcustom-Custom_Size___custom-Custom_Size____Q4A0076.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -10284,12 +9689,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -10312,7 +9717,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -10322,7 +9727,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10333,32 +9738,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="A demonstration of SenseTime surveillance software identifying details about people and vehicles. Image by REUTERS/Thomas Peter."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9x64dDN-rzDGvP1I_2_LIA%252FRTS1JOE1.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -10410,10 +9815,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10429,10 +9834,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -10442,12 +9847,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -10462,10 +9867,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -10475,12 +9880,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -10503,7 +9908,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -10513,7 +9918,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10524,32 +9929,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Chromat’s “Pool Rules” campaign, 2018. Courtesy of Chromat."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FP60eLGMR2gw-28uv0_HqHg%252FAll-Body-Hair_SQUARE.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -10601,10 +10006,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10620,10 +10025,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -10633,12 +10038,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -10653,23 +10058,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -10686,10 +10091,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Becca McCharen-Tran
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -10706,7 +10111,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -10723,7 +10128,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -10749,21 +10154,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Becca McCharen-Tran"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAVsEZBxGBlrimU7CjHLFjA%252Fgiphy%2B%25283%2529.gif&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -10773,12 +10178,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -10801,7 +10206,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -10811,7 +10216,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -10822,32 +10227,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Detail of Artemisia Gentileschi, Judith and Holofernes, ca. 1620. Courtesy of Uffizi Gallery, Florence."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fi2CYazJvF5wLXzyNKYvieg%252FAG.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -10899,10 +10304,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -10918,10 +10323,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -10931,12 +10336,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -10951,10 +10356,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -10964,12 +10369,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -10992,7 +10397,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -11002,7 +10407,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -11013,32 +10418,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Tyler Mitchell’s portraits of Beyoncé on the September cover of Vogue, 2018. Courtesy of the artist. "
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FLuFZ75Fw5Y3o3ykPG4GlHA%252FTyler-Mitchell.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -11090,10 +10495,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -11109,10 +10514,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -11122,12 +10527,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -11142,23 +10547,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -11175,10 +10580,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Tyler Mitchell
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -11195,7 +10600,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -11212,7 +10617,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -11238,21 +10643,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Tyler Mitchell"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9T0iJeeEigiyxNReF0QfwA%252FTyler-Mitchell-2.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -11262,12 +10667,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -11290,7 +10695,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -11300,7 +10705,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -11311,32 +10716,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Courtesy of Nike."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fz_OfNx3FevCzKtM5mpladg%252FKaep_Twitter_original.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -11388,10 +10793,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -11407,10 +10812,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -11420,12 +10825,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -11440,13 +10845,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c61"
+      className="c48"
     />
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -11456,12 +10861,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -11484,7 +10889,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -11494,7 +10899,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -11505,32 +10910,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Frida Escobedo in the Serpentine Pavilion 2018. Photo by Yui Mok/PA Images via Getty Images."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FZOqOihulahiEyNTAUIC-KQ%252FFrida.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -11582,10 +10987,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -11601,10 +11006,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -11614,12 +11019,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -11634,23 +11039,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -11667,10 +11072,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Frida Escobedo
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -11687,7 +11092,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -11704,7 +11109,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -11730,21 +11135,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Frida Escobedo"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FFjRmnOVSStJA1gKZTGPFhg%252Fserpentine.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -11754,12 +11159,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -11782,7 +11187,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -11792,7 +11197,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -11803,32 +11208,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="The Peoples Vote March For The Future, October 20, 2018 in London, United Kingdom. Photo by Richard Baker/In Pictures via Getty Images."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FHFx9YigVAntD6nEK2RsKUA%252FEU-flag.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -11880,10 +11285,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -11899,10 +11304,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -11912,12 +11317,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -11932,13 +11337,13 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c61"
+      className="c48"
     />
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -11948,12 +11353,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -11976,7 +11381,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -11986,7 +11391,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -11997,32 +11402,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Banksy, Love is in the Bin, 2018. Photo by Ben Stansall/AFP/Getty Images."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-befF7qZAmHJkDWB2xJkgg%252Fbanksy.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -12074,10 +11479,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -12093,10 +11498,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -12106,12 +11511,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -12126,26 +11531,26 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c61"
+      className="c48"
     />
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -12162,10 +11567,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Banksy
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -12182,7 +11587,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -12199,7 +11604,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -12225,21 +11630,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Banksy"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FnKLf0gK4wyZqXVRABztjMg%252FScreen%2BShot%2B2018-12-18%2Bat%2B5.51.43%2BPM%2Bcopy.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -12249,12 +11654,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -12277,7 +11682,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -12287,7 +11692,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -12298,32 +11703,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Robin Hammond’s photo for the cover of National Geographic’sRace Issue, 2018. Courtesy of the artist."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FTv5WK-OU5YcfcC91v4vMmg%252FRH2.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -12375,10 +11780,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -12394,10 +11799,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -12407,12 +11812,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -12427,23 +11832,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -12460,10 +11865,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Robin Hammond
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -12480,7 +11885,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -12497,7 +11902,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -12523,21 +11928,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Robin Hammond"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FsrC1j1nSPLkPjq5AnJ_wCw%252FMM8590_170730_005205-2.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -12547,12 +11952,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -12575,7 +11980,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -12585,7 +11990,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -12596,32 +12001,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Meryl Streep, Ai-jen Poo, Natalie Portman, Tarana Burke, Michelle Williams, America Ferrera, Jessica Chastain, Amy Poehler, and activist Saru Jayaraman attend 19th Annual Post-Golden Globes Party, 2018. Photo by Frazer Harrison/Getty Images."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FbkvGvE6tp2EP19kqnFcpZg%252FTimes-Up.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -12673,10 +12078,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -12692,10 +12097,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -12705,12 +12110,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -12725,23 +12130,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -12758,10 +12163,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 The Women of Time’s Up
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -12778,7 +12183,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -12795,7 +12200,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -12821,21 +12226,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="The Women of Time’s Up"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FBe0Sn_Sw53_E6MQoMLGHiQ%252Fwwwb.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -12845,12 +12250,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -12873,7 +12278,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -12883,7 +12288,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -12894,32 +12299,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Icon&#x27;s 3-D Home and Vulcan Printer. Courtesy of New Story."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FonTeTCjr_e83ByifcMtXbw%252F3d.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -12971,10 +12376,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -12990,10 +12395,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -13003,12 +12408,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -13023,10 +12428,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -13036,12 +12441,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -13064,7 +12469,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -13074,7 +12479,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -13085,32 +12490,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Still from Marvel Studios’ Black Panther, featuring M’Baku (Winston Duke). Photo by Film Frame. Courtesy of and ©Marvel Studios 2018."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F_l1KjIyqKDM91G16jKyaXw%252FRET0780_v130_1081.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -13162,10 +12567,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -13181,10 +12586,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -13194,12 +12599,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -13214,23 +12619,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -13247,10 +12652,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Ruth E. Carter
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -13267,7 +12672,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -13284,7 +12689,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -13310,21 +12715,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Ruth E. Carter"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FdaecYc_R6lkMny_y75k0gg%252FMBB7040_v044.1008-%25281%2529.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -13334,12 +12739,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -13362,7 +12767,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -13372,7 +12777,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -13383,32 +12788,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Photo by John Moore/Getty Images."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4shupex2D9w9PWXdTmAMzA%252FJohn-Moore.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -13460,10 +12865,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -13479,10 +12884,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -13492,12 +12897,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -13512,23 +12917,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -13545,10 +12950,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 John Moore
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -13565,7 +12970,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -13582,7 +12987,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -13608,21 +13013,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="John Moore"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F-abSduBjHqXS9GUQF3d77g%252FGettyImages-1052458070-%25281%2529.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -13632,12 +13037,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -13660,7 +13065,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -13670,7 +13075,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -13681,32 +13086,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Film still from Crazy Rich Asians. © 2018 Warner Bros. Entertainment Inc. and Kimmel Distribution, LLC. Photo courtesy of Warner Bros. Pictures. "
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FkpnNQ1PlOLDm36GE6hs-cg%252FCRA3.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -13758,10 +13163,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -13777,10 +13182,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -13790,12 +13195,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -13810,23 +13215,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -13843,10 +13248,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Jon M. Chu
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -13863,7 +13268,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -13880,7 +13285,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -13906,21 +13311,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Jon M. Chu"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FfgsmCOJQ0x-CHwAUG9d-GQ%252FCra30.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -13930,12 +13335,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -13958,7 +13363,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -13968,7 +13373,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -13979,32 +13384,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Millicent Fawcett, 2018. Photo by Garry Knight, via Flickr. "
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FXhJSikVVXBGXnzCgeCM1aQ%252FMF.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -14056,10 +13461,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -14075,10 +13480,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -14088,12 +13493,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -14108,10 +13513,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -14121,12 +13526,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -14149,7 +13554,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -14159,7 +13564,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -14170,32 +13575,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Portrait of Sean Combs by Kevin Mazur/WireImage."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FQuNflQwi_NT0JbQT5tdnUg%252FSean-Combs.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -14247,10 +13652,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -14266,10 +13671,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -14279,12 +13684,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -14299,23 +13704,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -14332,10 +13737,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Sean Combs
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -14352,7 +13757,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -14369,7 +13774,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -14395,21 +13800,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Sean Combs"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FAtL5eJG3iSkwG3Kqx3u3wg%252FSean-Combs.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -14419,12 +13824,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -14447,7 +13852,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c59"
+    className="c46"
   >
     <span
       style={
@@ -14457,7 +13862,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -14468,32 +13873,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Red Antler&#x27;s branding designs for Burrow on the New York subway. Courtesy of Red Antler."
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FfUmNBMo9PJ2XTbLGd0bunw%252FBurrow4.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -14545,10 +13950,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -14564,10 +13969,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -14577,12 +13982,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -14597,23 +14002,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -14630,10 +14035,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Emily Heyward, JB Osborne, and Simon Endres
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -14650,7 +14055,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -14667,7 +14072,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -14693,21 +14098,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Emily Heyward, JB Osborne, and Simon Endres"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FQBYknGwt3MpId7Omep3oSQ%252Fcasper.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -14717,12 +14122,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c60"
+            className="article__text-section c31 c47"
             color="#000"
           >
             <div
@@ -14745,7 +14150,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
     />
   </div>
   <div
-    className="c25"
+    className="c17"
   >
     <span
       style={
@@ -14755,7 +14160,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       }
     />
     <div
-      className="c26"
+      className="c18"
     >
       <div
         dangerouslySetInnerHTML={
@@ -14766,32 +14171,32 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       />
     </div>
     <div
-      className="c27"
+      className="c19"
     >
       <div
-        className="c28"
+        className="c20"
       >
         <div
-          className="c29 c30"
+          className="c21 c22"
         >
           <div
             className="article-image"
           >
             <div
-              className="c31"
+              className="c23"
             >
               <img
                 alt="Make America Great Again with Spider Martin in Pearl, MS, 2016. Courtesy of Wyatt Gallery/For Freedoms. "
-                className="BlockImage__container c32"
+                className="BlockImage__container c24"
                 height="auto"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FG7L_BaQLUPAo6Er5_SqQjw%252Ffor-freedoms.jpg&width=2000&quality=80"
                 width="100%"
               />
               <div
-                className="c33 c34"
+                className="c25 c26"
               >
                 <div
-                  className="c35"
+                  className="c27"
                   onClick={[Function]}
                 >
                   <svg
@@ -14843,10 +14248,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c36 c37"
+              className="c28 c29"
             >
               <div
-                className="c38"
+                className="c30"
               >
                 <div
                   dangerouslySetInnerHTML={
@@ -14862,10 +14267,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -14875,12 +14280,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -14895,23 +14300,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c42"
+      className="c33"
     >
       <div
-        className="c43 c44"
+        className="c34 c35"
       >
         <div
-          className="c45 c46"
+          className="c36 c37"
           onClick={[Function]}
         >
           <div
-            className="c47 c48"
+            className="c38 c39"
           >
             <div
-              className="c49"
+              className="jXywsm"
             >
               <div
-                className="c50 c51"
+                className="c40 hTdRdk"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -14928,10 +14333,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                 Hank Willis Thomas and Eric Gottesman
               </div>
               <div
-                className="c52 c53"
+                className="c41 c42"
               >
                 <div
-                  className="c54"
+                  className="bUZGRr iPLCTR"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -14948,7 +14353,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
                   View Slideshow
                 </div>
                 <div
-                  className="c55"
+                  className="bUZGRr gMzPqM"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -14965,7 +14370,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               className="rrm-container rrm-greaterThanOrEqual-sm"
             >
               <div
-                className="c56"
+                className="c43"
               >
                 <svg
                   className="image-set"
@@ -14991,21 +14396,21 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c57 "
+          className="c44 "
         >
           <img
             alt="Hank Willis Thomas and Eric Gottesman"
-            className="c58"
+            className="c45"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F51DvSBZIfkbuWp8rkvHNtQ%252FUNC_Greensboro_LawnSignActivation.jpg&width=800&quality=80"
           />
         </div>
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -15015,12 +14420,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div
@@ -15035,10 +14440,10 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c12"
+      className="c10"
     >
       <div
-        className="c24"
+        className="gyqQCU"
         width={
           Array [
             "100%",
@@ -15048,12 +14453,12 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         }
       >
         <div
-          className="c39"
+          className="cFlEyZ jcCgJD"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="22px"
         >
           <div
-            className="article__text-section c40 c41"
+            className="article__text-section c31 c32"
             color="white"
           >
             <div

--- a/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/StandardHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/StandardHeader.test.tsx.snap
@@ -1,26 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Standard Header Snapshots renders editable props properly 1`] = `
-.c7 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c4 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-  color: #C2C2C2;
-}
-
-.c8 {
+.c6 {
   margin: 10px 20px 0 0;
 }
 
-.c8::before {
+.c6::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -30,12 +15,12 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
   background-color: black;
 }
 
-.c9 {
+.c7 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c10 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,22 +34,22 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
   margin-top: 5px;
 }
 
-.c11 {
+.c9 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c11:hover {
+.c9:hover {
   opacity: 0.6;
 }
 
-.c11:first-child {
+.c9:first-child {
   padding-left: 0;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -103,7 +88,7 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c4 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 50px;
   line-height: 1.1em;
@@ -128,7 +113,7 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c5 {
+  .c4 {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -146,7 +131,7 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
       className="c2"
     >
       <div
-        className="c3 c4"
+        className="c3 sc-htpNat gUqKVf"
         color="#C2C2C2"
         fontFamily={
           Object {
@@ -165,7 +150,7 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
       </div>
     </div>
     <div
-      className="c5"
+      className="c4"
     >
       <div>
         Child 
@@ -173,11 +158,11 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
       </div>
     </div>
     <div
-      className="Byline c6"
+      className="Byline c5"
       color="black"
     >
       <div
-        className="c7"
+        className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
         fontFamily={
           Object {
             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -187,17 +172,17 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
         fontSize="14px"
       >
         <div
-          className="c8"
+          className="c6"
           color="black"
         >
           Casey Lesser
         </div>
       </div>
       <div
-        className="c9"
+        className="c7"
       >
         <div
-          className="c7"
+          className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -210,10 +195,10 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
         </div>
       </div>
       <div
-        className="c10"
+        className="c8"
       >
         <a
-          className="c11"
+          className="c9"
           href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
           onClick={[Function]}
           target="_blank"
@@ -239,7 +224,7 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
           </svg>
         </a>
         <a
-          className="c11"
+          className="c9"
           href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
           onClick={[Function]}
           target="_blank"
@@ -265,7 +250,7 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
           </svg>
         </a>
         <a
-          className="c11"
+          className="c9"
           href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
           onClick={[Function]}
           target="_blank"
@@ -297,26 +282,11 @@ exports[`Standard Header Snapshots renders editable props properly 1`] = `
 `;
 
 exports[`Standard Header Snapshots renders properly 1`] = `
-.c4 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-  color: #000;
-}
-
-.c7 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c8 {
+.c6 {
   margin: 10px 20px 0 0;
 }
 
-.c8::before {
+.c6::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -326,12 +296,12 @@ exports[`Standard Header Snapshots renders properly 1`] = `
   background-color: black;
 }
 
-.c9 {
+.c7 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c10 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -345,22 +315,22 @@ exports[`Standard Header Snapshots renders properly 1`] = `
   margin-top: 5px;
 }
 
-.c11 {
+.c9 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c11:hover {
+.c9:hover {
   opacity: 0.6;
 }
 
-.c11:first-child {
+.c9:first-child {
   padding-left: 0;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -399,7 +369,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c4 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 50px;
   line-height: 1.1em;
@@ -424,7 +394,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c5 {
+  .c4 {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -442,7 +412,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
       className="c2"
     >
       <div
-        className="c3 c4"
+        className="c3 sc-htpNat gTPxXw"
         color="#000"
         fontFamily={
           Object {
@@ -458,18 +428,18 @@ exports[`Standard Header Snapshots renders properly 1`] = `
       </div>
     </div>
     <div
-      className="c5"
+      className="c4"
     >
       <h1>
         New York's Next Art District
       </h1>
     </div>
     <div
-      className="Byline c6"
+      className="Byline c5"
       color="black"
     >
       <div
-        className="c7"
+        className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
         fontFamily={
           Object {
             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -479,17 +449,17 @@ exports[`Standard Header Snapshots renders properly 1`] = `
         fontSize="14px"
       >
         <div
-          className="c8"
+          className="c6"
           color="black"
         >
           Casey Lesser
         </div>
       </div>
       <div
-        className="c9"
+        className="c7"
       >
         <div
-          className="c7"
+          className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -502,10 +472,10 @@ exports[`Standard Header Snapshots renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c10"
+        className="c8"
       >
         <a
-          className="c11"
+          className="c9"
           href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
           onClick={[Function]}
           target="_blank"
@@ -531,7 +501,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
           </svg>
         </a>
         <a
-          className="c11"
+          className="c9"
           href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&text=New York's Next Art District&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district&via=artsy"
           onClick={[Function]}
           target="_blank"
@@ -557,7 +527,7 @@ exports[`Standard Header Snapshots renders properly 1`] = `
           </svg>
         </a>
         <a
-          className="c11"
+          className="c9"
           href="mailto:?subject=New York's Next Art District&body=Check out New York's Next Art District on Artsy: https://www.artsy.net/article/new-yorks-next-art-district"
           onClick={[Function]}
           target="_blank"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
@@ -1,18 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`News Layout renders the news layout on mobile 1`] = `
-.c17 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c19 {
+.c18 {
   margin: 10px 20px 0 0;
 }
 
-.c19::before {
+.c18::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -22,7 +15,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   background-color: black;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -34,11 +27,11 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   color: #999999;
 }
 
-.c20 a {
+.c19 a {
   color: #999999;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -52,18 +45,18 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   margin-top: 5px;
 }
 
-.c22 {
+.c21 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c22:hover {
+.c21:hover {
   opacity: 0.6;
 }
 
-.c22:first-child {
+.c21:first-child {
   padding-left: 0;
 }
 
@@ -85,7 +78,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   align-items: flex-start;
 }
 
-.c15 .c18 {
+.c15 .c17 {
   margin-top: 0;
   margin-bottom: 5px;
 }
@@ -104,7 +97,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   position: relative;
 }
 
-.c8:hover .c24 {
+.c8:hover .c23 {
   opacity: 1;
 }
 
@@ -292,7 +285,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   background-size: 1.25px 1px;
 }
 
-.c13 h2 .c25 {
+.c13 h2 .c24 {
   background-position: bottom !important;
 }
 
@@ -419,11 +412,11 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   font-weight: 600;
 }
 
-.c0 .c26 {
+.c0 .c25 {
   border-bottom: 1px solid #E5E5E5;
 }
 
-.c23 {
+.c22 {
   width: 80px;
   height: 30px;
   background-color: black;
@@ -446,11 +439,11 @@ exports[`News Layout renders the news layout on mobile 1`] = `
   line-height: 1em;
 }
 
-.c23:focus {
+.c22:focus {
   outline: 0;
 }
 
-.c23:hover {
+.c22:hover {
   color: #E5E5E5;
 }
 
@@ -465,7 +458,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
 }
 
 @media (max-width:720px) {
-  .c20 {
+  .c19 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
@@ -474,13 +467,13 @@ exports[`News Layout renders the news layout on mobile 1`] = `
 }
 
 @media (max-width:600px) {
-  .c21 {
+  .c20 {
     margin-top: 15px;
   }
 }
 
 @media (max-width:720px) {
-  .c8 .c24 {
+  .c8 .c23 {
     opacity: 1;
   }
 }
@@ -603,7 +596,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
 }
 
 @media (max-width:720px) {
-  .c23 {
+  .c22 {
     bottom: 15px;
     right: 15px;
   }
@@ -802,7 +795,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
             className="c16"
           >
             <div
-              className="c17"
+              className="bUZGRr dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -812,14 +805,14 @@ exports[`News Layout renders the news layout on mobile 1`] = `
               fontSize="14px"
             >
               <div
-                className="c18 c19"
+                className="c17 c18"
                 color="black"
               >
                 Casey Lesser
               </div>
             </div>
             <div
-              className="c20"
+              className="c19"
             >
               Jul 19, 2018 at 1:19 pm
               , via
@@ -834,10 +827,10 @@ exports[`News Layout renders the news layout on mobile 1`] = `
             </div>
           </div>
           <div
-            className="c21"
+            className="c20"
           >
             <a
-              className="c22"
+              className="c21"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
               onClick={[Function]}
               target="_blank"
@@ -863,7 +856,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
               </svg>
             </a>
             <a
-              className="c22"
+              className="c21"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -889,7 +882,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
               </svg>
             </a>
             <a
-              className="c22"
+              className="c21"
               href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
               onClick={[Function]}
               target="_blank"
@@ -919,7 +912,7 @@ exports[`News Layout renders the news layout on mobile 1`] = `
       </div>
     </div>
     <button
-      className="c23"
+      className="c22"
       onClick={[Function]}
     >
       Expand
@@ -929,18 +922,11 @@ exports[`News Layout renders the news layout on mobile 1`] = `
 `;
 
 exports[`News Layout renders the news layout properly 1`] = `
-.c17 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c19 {
+.c18 {
   margin: 10px 20px 0 0;
 }
 
-.c19::before {
+.c18::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -950,7 +936,7 @@ exports[`News Layout renders the news layout properly 1`] = `
   background-color: black;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -962,11 +948,11 @@ exports[`News Layout renders the news layout properly 1`] = `
   color: #999999;
 }
 
-.c20 a {
+.c19 a {
   color: #999999;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -980,18 +966,18 @@ exports[`News Layout renders the news layout properly 1`] = `
   margin-top: 5px;
 }
 
-.c22 {
+.c21 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c22:hover {
+.c21:hover {
   opacity: 0.6;
 }
 
-.c22:first-child {
+.c21:first-child {
   padding-left: 0;
 }
 
@@ -1013,7 +999,7 @@ exports[`News Layout renders the news layout properly 1`] = `
   align-items: flex-start;
 }
 
-.c15 .c18 {
+.c15 .c17 {
   margin-top: 0;
   margin-bottom: 5px;
 }
@@ -1032,7 +1018,7 @@ exports[`News Layout renders the news layout properly 1`] = `
   position: relative;
 }
 
-.c8:hover .c24 {
+.c8:hover .c23 {
   opacity: 1;
 }
 
@@ -1220,7 +1206,7 @@ exports[`News Layout renders the news layout properly 1`] = `
   background-size: 1.25px 1px;
 }
 
-.c13 h2 .c25 {
+.c13 h2 .c24 {
   background-position: bottom !important;
 }
 
@@ -1347,11 +1333,11 @@ exports[`News Layout renders the news layout properly 1`] = `
   font-weight: 600;
 }
 
-.c0 .c26 {
+.c0 .c25 {
   border-bottom: 1px solid #E5E5E5;
 }
 
-.c23 {
+.c22 {
   width: 80px;
   height: 30px;
   background-color: black;
@@ -1374,11 +1360,11 @@ exports[`News Layout renders the news layout properly 1`] = `
   line-height: 1em;
 }
 
-.c23:focus {
+.c22:focus {
   outline: 0;
 }
 
-.c23:hover {
+.c22:hover {
   color: #E5E5E5;
 }
 
@@ -1393,7 +1379,7 @@ exports[`News Layout renders the news layout properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c20 {
+  .c19 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
@@ -1402,7 +1388,7 @@ exports[`News Layout renders the news layout properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c8 .c24 {
+  .c8 .c23 {
     opacity: 1;
   }
 }
@@ -1525,7 +1511,7 @@ exports[`News Layout renders the news layout properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c23 {
+  .c22 {
     bottom: 15px;
     right: 15px;
   }
@@ -1724,7 +1710,7 @@ exports[`News Layout renders the news layout properly 1`] = `
             className="c16"
           >
             <div
-              className="c17"
+              className="bUZGRr dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1734,14 +1720,14 @@ exports[`News Layout renders the news layout properly 1`] = `
               fontSize="14px"
             >
               <div
-                className="c18 c19"
+                className="c17 c18"
                 color="black"
               >
                 Casey Lesser
               </div>
             </div>
             <div
-              className="c20"
+              className="c19"
             >
               Jul 19, 2018 at 1:19 pm
               , via
@@ -1756,10 +1742,10 @@ exports[`News Layout renders the news layout properly 1`] = `
             </div>
           </div>
           <div
-            className="c21"
+            className="c20"
           >
             <a
-              className="c22"
+              className="c21"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
               onClick={[Function]}
               target="_blank"
@@ -1785,7 +1771,7 @@ exports[`News Layout renders the news layout properly 1`] = `
               </svg>
             </a>
             <a
-              className="c22"
+              className="c21"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -1811,7 +1797,7 @@ exports[`News Layout renders the news layout properly 1`] = `
               </svg>
             </a>
             <a
-              className="c22"
+              className="c21"
               href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
               onClick={[Function]}
               target="_blank"
@@ -1841,7 +1827,7 @@ exports[`News Layout renders the news layout properly 1`] = `
       </div>
     </div>
     <button
-      className="c23"
+      className="c22"
       onClick={[Function]}
     >
       Expand

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayoutAdsEnabled.test.tsx.snap
@@ -1,26 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`News Layout with new ads enabled renders the news layout properly when new ads are enabled 1`] = `
-.c25 {
-  margin: auto;
-}
-
-.c17 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c26 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 10px;
-  line-height: 14px;
-  color: black30;
-  margin: 4px;
-}
-
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -63,11 +44,11 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   font-weight: 600;
 }
 
-.c19 {
+.c18 {
   margin: 10px 20px 0 0;
 }
 
-.c19::before {
+.c18::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -77,7 +58,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   background-color: black;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,11 +70,11 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   color: #999999;
 }
 
-.c20 a {
+.c19 a {
   color: #999999;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -107,18 +88,18 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   margin-top: 5px;
 }
 
-.c22 {
+.c21 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c22:hover {
+.c21:hover {
   opacity: 0.6;
 }
 
-.c22:first-child {
+.c21:first-child {
   padding-left: 0;
 }
 
@@ -140,7 +121,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   align-items: flex-start;
 }
 
-.c15 .c18 {
+.c15 .c17 {
   margin-top: 0;
   margin-bottom: 5px;
 }
@@ -159,7 +140,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   position: relative;
 }
 
-.c8:hover .c27 {
+.c8:hover .c24 {
   opacity: 1;
 }
 
@@ -347,7 +328,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   background-size: 1.25px 1px;
 }
 
-.c13 h2 .c28 {
+.c13 h2 .c25 {
   background-position: bottom !important;
 }
 
@@ -447,11 +428,11 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   margin-top: 30px;
 }
 
-.c0 .c29 {
+.c0 .c26 {
   border-bottom: 1px solid #E5E5E5;
 }
 
-.c23 {
+.c22 {
   width: 80px;
   height: 30px;
   background-color: black;
@@ -474,11 +455,11 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   line-height: 1em;
 }
 
-.c23:focus {
+.c22:focus {
   outline: 0;
 }
 
-.c23:hover {
+.c22:hover {
   color: #E5E5E5;
 }
 
@@ -503,7 +484,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
 }
 
 @media (max-width:720px) {
-  .c20 {
+  .c19 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 12px;
@@ -512,7 +493,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
 }
 
 @media (max-width:720px) {
-  .c8 .c27 {
+  .c8 .c24 {
     opacity: 1;
   }
 }
@@ -625,7 +606,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
 }
 
 @media (max-width:720px) {
-  .c23 {
+  .c22 {
     bottom: 15px;
     right: 15px;
   }
@@ -824,7 +805,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
             className="c16"
           >
             <div
-              className="c17"
+              className="bUZGRr dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -834,14 +815,14 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
               fontSize="14px"
             >
               <div
-                className="c18 c19"
+                className="c17 c18"
                 color="black"
               >
                 Casey Lesser
               </div>
             </div>
             <div
-              className="c20"
+              className="c19"
             >
               Jul 19, 2018 at 1:19 pm
               , via
@@ -856,10 +837,10 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
             </div>
           </div>
           <div
-            className="c21"
+            className="c20"
           >
             <a
-              className="c22"
+              className="c21"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article"
               onClick={[Function]}
               target="_blank"
@@ -885,7 +866,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
               </svg>
             </a>
             <a
-              className="c22"
+              className="c21"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&text=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnews-article&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -911,7 +892,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
               </svg>
             </a>
             <a
-              className="c22"
+              className="c21"
               href="mailto:?subject=The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe.&body=Check out The oldest known depiction of a supernova was found in a work of 5,000 year old rock art, scientists believe. on Artsy: https://www.artsy.net/article/news-article"
               onClick={[Function]}
               target="_blank"
@@ -941,17 +922,17 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
       </div>
     </div>
     <button
-      className="c23"
+      className="c22"
       onClick={[Function]}
     >
       Expand
     </button>
   </div>
   <div
-    className="c24"
+    className="c23"
   >
     <div
-      className="c25"
+      className="fdqRED"
     >
       <div
         style={
@@ -962,7 +943,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
         }
       />
       <div
-        className="c26"
+        className="bUZGRr jritVp"
         color="black30"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="10px"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1,130 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a series properly 1`] = `
-.c15 {
-  color: white;
-}
-
-.c33 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-top: 40px;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
-.c35 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.c40 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-}
-
-.c6 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: white;
-  text-align: center;
-}
-
-.c20 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 4px;
-}
-
-.c21 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c22 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c24 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c30 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1em;
-}
-
-.c36 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: white;
-  margin-bottom: 10px;
-}
-
-.c37 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 18px;
-  line-height: 30px;
-  margin-bottom: 20px;
-}
-
 .c4 {
   font-family: artsy-icons;
   color: white;
@@ -157,7 +33,7 @@ exports[`renders a series properly 1`] = `
   -ms-interpolation-mode: bicubic;
 }
 
-.c2 .c42 {
+.c2 .c28 {
   margin: 0 20px;
 }
 
@@ -210,11 +86,11 @@ exports[`renders a series properly 1`] = `
   z-index: 10;
 }
 
-.c32 {
+.c23 {
   margin: 10px 20px 0 0;
 }
 
-.c32::before {
+.c23::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -224,12 +100,12 @@ exports[`renders a series properly 1`] = `
   background-color: white;
 }
 
-.c23 {
+.c16 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c38 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -243,22 +119,22 @@ exports[`renders a series properly 1`] = `
   margin-top: 5px;
 }
 
-.c39 {
+.c26 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c39:hover {
+.c26:hover {
   opacity: 0.6;
 }
 
-.c39:first-child {
+.c26:first-child {
   padding-left: 0;
 }
 
-.c31 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -273,12 +149,12 @@ exports[`renders a series properly 1`] = `
   color: white;
 }
 
-.c29 {
+.c21 {
   width: 32px;
   height: 32px;
 }
 
-.c27 {
+.c19 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -288,7 +164,7 @@ exports[`renders a series properly 1`] = `
   display: block;
 }
 
-.c25 {
+.c17 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -297,7 +173,7 @@ exports[`renders a series properly 1`] = `
   background: white;
 }
 
-.c17 {
+.c15 {
   border: 1px solid;
   border-radius: 2px;
   color: white;
@@ -307,15 +183,15 @@ exports[`renders a series properly 1`] = `
   display: block;
 }
 
-.c17 .c26 {
+.c15 .c18 {
   opacity: 1;
 }
 
-.c17:hover .c26 {
+.c15:hover .c18 {
   opacity: 0.7;
 }
 
-.c28 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -334,15 +210,15 @@ exports[`renders a series properly 1`] = `
   bottom: 20px;
 }
 
-.c28 svg {
+.c20 svg {
   height: 40px;
 }
 
-.c16 {
+.c14 {
   margin-bottom: 40px;
 }
 
-.c7 {
+.c6 {
   background-color: #000;
   position: fixed;
   top: 0;
@@ -352,7 +228,7 @@ exports[`renders a series properly 1`] = `
   z-index: -1;
 }
 
-.c8 {
+.c7 {
   background-image: url(https://artsy-media-uploads.s3.amazonaws.com/GXvnaBYBdP2z6LKIBQF7XA%2FArtboard.jpg);
   background-size: cover;
   background-position: 50%;
@@ -364,7 +240,7 @@ exports[`renders a series properly 1`] = `
   z-index: -2;
 }
 
-.c9 {
+.c8 {
   background: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.6));
   position: fixed;
   top: 0;
@@ -374,13 +250,13 @@ exports[`renders a series properly 1`] = `
   z-index: -1;
 }
 
-.c41 {
+.c27 {
   position: relative;
   width: 100%;
   color: white;
 }
 
-.c41 a {
+.c27 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -390,22 +266,22 @@ exports[`renders a series properly 1`] = `
   background-position: bottom;
 }
 
-.c41 a:hover {
+.c27 a:hover {
   color: white;
   opacity: .65;
 }
 
-.c41 div[class*='ToolTip'] a {
+.c27 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c41 p,
-.c41 ul,
-.c41 ol,
-.c41 .paragraph,
-.c41 div[data-block=true] .public-DraftStyleDefault-block {
+.c27 p,
+.c27 ul,
+.c27 ol,
+.c27 .paragraph,
+.c27 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -416,32 +292,32 @@ exports[`renders a series properly 1`] = `
   font-style: inherit;
 }
 
-.c41 p:first-child,
-.c41 .paragraph:first-child,
-.c41 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c27 p:first-child,
+.c27 .paragraph:first-child,
+.c27 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c41 p:last-child,
-.c41 .paragraph:last-child,
-.c41 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c27 p:last-child,
+.c27 .paragraph:last-child,
+.c27 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c41 ul,
-.c41 ol {
+.c27 ul,
+.c27 ol {
   padding-left: 1em;
 }
 
-.c41 ul {
+.c27 ul {
   list-style: disc;
 }
 
-.c41 ol {
+.c27 ol {
   list-style: decimal;
 }
 
-.c41 li {
+.c27 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -450,7 +326,7 @@ exports[`renders a series properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c41 h1 {
+.c27 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -463,7 +339,7 @@ exports[`renders a series properly 1`] = `
   text-align: center;
 }
 
-.c41 h1::before {
+.c27 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -474,7 +350,7 @@ exports[`renders a series properly 1`] = `
   right: calc(50% - 4px);
 }
 
-.c41 h2 {
+.c27 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -483,15 +359,15 @@ exports[`renders a series properly 1`] = `
   margin: 0;
 }
 
-.c41 h2 a {
+.c27 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c41 h2 .c44 {
+.c27 h2 .c30 {
   background-position: bottom !important;
 }
 
-.c41 h3 {
+.c27 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -501,7 +377,7 @@ exports[`renders a series properly 1`] = `
   margin: 0;
 }
 
-.c41 h3 strong {
+.c27 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -509,11 +385,11 @@ exports[`renders a series properly 1`] = `
   line-height: 1.5em;
 }
 
-.c41 h3 a {
+.c27 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c41 blockquote {
+.c27 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -526,11 +402,11 @@ exports[`renders a series properly 1`] = `
   word-break: break-word;
 }
 
-.c41 .preventLineBreak {
+.c27 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c41 .content-end {
+.c27 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -541,14 +417,14 @@ exports[`renders a series properly 1`] = `
   margin-bottom: 1px;
 }
 
-.c41 .artist-follow {
+.c27 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c41 .artist-follow::before {
+.c27 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -556,7 +432,7 @@ exports[`renders a series properly 1`] = `
   font-size: 32px;
 }
 
-.c41 .artist-follow::after {
+.c27 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -565,7 +441,7 @@ exports[`renders a series properly 1`] = `
   text-transform: none;
 }
 
-.c34 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -579,22 +455,22 @@ exports[`renders a series properly 1`] = `
   width: 100%;
 }
 
-.c13 {
+.c12 {
   color: white;
   text-align: center;
 }
 
-.c13 .c43 {
+.c12 .c29 {
   padding-top: 5px;
   padding-bottom: 40px;
 }
 
-.c13 .c43 img {
+.c12 .c29 img {
   margin-left: auto;
   margin-right: auto;
 }
 
-.c14 {
+.c13 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 120px;
@@ -602,13 +478,13 @@ exports[`renders a series properly 1`] = `
   margin-bottom: 30px;
 }
 
-.c11 {
+.c10 {
   max-width: 1200px;
   min-height: 100vh;
   margin: 0 auto;
 }
 
-.c11 .c12 {
+.c10 .c11 {
   margin-bottom: 90px;
 }
 
@@ -616,242 +492,8 @@ exports[`renders a series properly 1`] = `
   color: white;
 }
 
-.c0 .c10 {
+.c0 .c9 {
   padding: 90px 20px 150px;
-}
-
-@media screen and (min-width:40em) {
-  .c33 {
-    padding-top: 40px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c33 {
-    padding-top: 60px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c18 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c18 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c18 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c18 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c18 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c18 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c19 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c19 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c19 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c19 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c19 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c19 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c35 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c35 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c35 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c40 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c40 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c40 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c21 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c21 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c21 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c21 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c21 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c21 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c22 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c22 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c22 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c22 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c22 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c22 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c36 {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c36 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c36 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c37 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c37 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c37 {
-    margin-bottom: 0px;
-  }
 }
 
 @media (max-width:720px) {
@@ -863,95 +505,95 @@ exports[`renders a series properly 1`] = `
     font-size: 24px;
   }
 
-  .c2 .c42 {
+  .c2 .c28 {
     margin: 0 10px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c25 {
+  .c17 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c25 {
+  .c17 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c25 {
+  .c17 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c25 {
+  .c17 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c25 {
+  .c17 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c25 {
+  .c17 {
     width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c28 svg {
+  .c20 svg {
     height: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c16 {
+  .c14 {
     margin-bottom: 60px;
   }
 }
 
 @media (max-width:600px) {
-  .c41 p,
-  .c41 ul,
-  .c41 ol,
-  .c41 div[data-block=true] .public-DraftStyleDefault-block {
+  .c27 p,
+  .c27 ul,
+  .c27 ol,
+  .c27 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c41 li {
+  .c27 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c41 h1 {
+  .c27 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c41 h2 {
+  .c27 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c41 h3 {
+  .c27 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -959,14 +601,14 @@ exports[`renders a series properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c41 h3 strong {
+  .c27 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c41 blockquote {
+  .c27 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -974,13 +616,13 @@ exports[`renders a series properly 1`] = `
     margin: 0;
   }
 
-  .c41 .content-start {
+  .c27 .content-start {
     font-size: 55px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c34 {
+  .c24 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -988,7 +630,7 @@ exports[`renders a series properly 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c34 {
+  .c24 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -996,7 +638,7 @@ exports[`renders a series properly 1`] = `
 }
 
 @media screen and (min-width:64em) {
-  .c34 {
+  .c24 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1004,13 +646,13 @@ exports[`renders a series properly 1`] = `
 }
 
 @media (max-width:900px) {
-  .c13 .c43 {
+  .c12 .c29 {
     padding-bottom: 0;
   }
 }
 
 @media (max-width:900px) {
-  .c14 {
+  .c13 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 65px;
@@ -1046,7 +688,7 @@ exports[`renders a series properly 1`] = `
         className="rrm-container rrm-greaterThan-xs"
       >
         <div
-          className="c5 c6"
+          className="c5 joTwtA"
           color="white"
           fontFamily={
             Object {
@@ -1073,46 +715,46 @@ exports[`renders a series properly 1`] = `
     />
   </div>
   <div
-    className="c7"
+    className="c6"
   >
+    <div
+      className="c7"
+    />
     <div
       className="c8"
     />
-    <div
-      className="c9"
-    />
   </div>
   <div
-    className="c10 c11"
+    className="c9 c10"
   >
     <div
-      className="c12 c13"
+      className="c11 c12"
       color="white"
     >
       <div
-        className="c14"
+        className="c13"
       >
         The Future of Art
       </div>
     </div>
     <div
-      className="c15"
+      className="dYptke"
       color="white"
     >
       <div
-        className="c16"
+        className="c14"
       >
         <a
-          className="ArticleCard c17"
+          className="ArticleCard c15"
           color="white"
           href="joanne-artman-gallery-poetry-naturerefinement-form"
           onClick={[Function]}
         >
           <div
-            className="c18"
+            className="drjzXt"
           >
             <div
-              className="c19"
+              className="jUYeYa"
               width={
                 Array [
                   "100%",
@@ -1124,7 +766,7 @@ exports[`renders a series properly 1`] = `
             >
               <div>
                 <div
-                  className="c20"
+                  className="bUZGRr frfaAc"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1136,7 +778,7 @@ exports[`renders a series properly 1`] = `
                   The Future of Art
                 </div>
                 <div
-                  className="c21"
+                  className="bUZGRr cwRRLl"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -1150,7 +792,7 @@ exports[`renders a series properly 1`] = `
                   New Study Shows the Gender Pay Gap for Artists Is Not So Simple
                 </div>
                 <div
-                  className="c22"
+                  className="sc-ifAKCX cFlEyZ hAOaLg"
                   fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                   fontSize={
                     Array [
@@ -1165,10 +807,10 @@ exports[`renders a series properly 1`] = `
                 </div>
               </div>
               <div
-                className="c23"
+                className="c16"
               >
                 <div
-                  className="c24"
+                  className="bUZGRr dOrNHt"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1182,7 +824,7 @@ exports[`renders a series properly 1`] = `
               </div>
             </div>
             <div
-              className="c25"
+              className="c17"
               width={
                 Array [
                   "100%",
@@ -1193,14 +835,14 @@ exports[`renders a series properly 1`] = `
               }
             >
               <img
-                className="c26 c27"
+                className="c18 c19"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
               />
               <div
-                className="c28"
+                className="c20"
               >
                 <svg
-                  className="c29"
+                  className="c21"
                   version="1.1"
                   viewBox="0 0 40 56"
                   x="0px"
@@ -1220,7 +862,7 @@ exports[`renders a series properly 1`] = `
                   </g>
                 </svg>
                 <div
-                  className="c30"
+                  className="bUZGRr jwuwyh"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1237,19 +879,19 @@ exports[`renders a series properly 1`] = `
         </a>
       </div>
       <div
-        className="c16"
+        className="c14"
       >
         <a
-          className="ArticleCard c17"
+          className="ArticleCard c15"
           color="white"
           href="new-yorks-next-art-district"
           onClick={[Function]}
         >
           <div
-            className="c18"
+            className="drjzXt"
           >
             <div
-              className="c19"
+              className="jUYeYa"
               width={
                 Array [
                   "100%",
@@ -1261,7 +903,7 @@ exports[`renders a series properly 1`] = `
             >
               <div>
                 <div
-                  className="c20"
+                  className="bUZGRr frfaAc"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1273,7 +915,7 @@ exports[`renders a series properly 1`] = `
                   The Future of Art
                 </div>
                 <div
-                  className="c21"
+                  className="bUZGRr cwRRLl"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -1287,7 +929,7 @@ exports[`renders a series properly 1`] = `
                   New York's Next Art District
                 </div>
                 <div
-                  className="c22"
+                  className="sc-ifAKCX cFlEyZ hAOaLg"
                   fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                   fontSize={
                     Array [
@@ -1302,11 +944,11 @@ exports[`renders a series properly 1`] = `
                 </div>
               </div>
               <div
-                className="Byline c31"
+                className="Byline c22"
                 color="white"
               >
                 <div
-                  className="c24"
+                  className="bUZGRr dOrNHt"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1316,17 +958,17 @@ exports[`renders a series properly 1`] = `
                   fontSize="14px"
                 >
                   <div
-                    className="c32"
+                    className="c23"
                     color="white"
                   >
                     Casey Lesser
                   </div>
                 </div>
                 <div
-                  className="c23"
+                  className="c16"
                 >
                   <div
-                    className="c24"
+                    className="bUZGRr dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1341,7 +983,7 @@ exports[`renders a series properly 1`] = `
               </div>
             </div>
             <div
-              className="c25"
+              className="c17"
               width={
                 Array [
                   "100%",
@@ -1352,7 +994,7 @@ exports[`renders a series properly 1`] = `
               }
             >
               <img
-                className="c26 c27"
+                className="c18 c19"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
               />
             </div>
@@ -1361,15 +1003,15 @@ exports[`renders a series properly 1`] = `
       </div>
     </div>
     <div
-      className="c33"
+      className="fiAwVF"
     >
       <div
-        className="c34"
+        className="c24"
         color="white"
         width="100%"
       >
         <div
-          className="c35"
+          className="ckfosv"
           width={
             Array [
               1,
@@ -1381,7 +1023,7 @@ exports[`renders a series properly 1`] = `
         >
           <div>
             <div
-              className="c36"
+              className="bUZGRr eMhSvP"
               color="white"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="28px"
@@ -1389,15 +1031,15 @@ exports[`renders a series properly 1`] = `
               About the Series
             </div>
             <div
-              className="c37"
+              className="bUZGRr fRcQPt"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="18px"
             >
               <div
-                className="c38"
+                className="c25"
               >
                 <a
-                  className="c39"
+                  className="c26"
                   href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art"
                   onClick={[Function]}
                   target="_blank"
@@ -1423,7 +1065,7 @@ exports[`renders a series properly 1`] = `
                   </svg>
                 </a>
                 <a
-                  className="c39"
+                  className="c26"
                   href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&text=undefined&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&via=artsy"
                   onClick={[Function]}
                   target="_blank"
@@ -1449,7 +1091,7 @@ exports[`renders a series properly 1`] = `
                   </svg>
                 </a>
                 <a
-                  className="c39"
+                  className="c26"
                   href="mailto:?subject=undefined&body=Check out undefined on Artsy: https://www.artsy.net/article/future-of-art"
                   onClick={[Function]}
                   target="_blank"
@@ -1482,7 +1124,7 @@ exports[`renders a series properly 1`] = `
           />
         </div>
         <div
-          className="c40"
+          className="bQqYVB"
           width={
             Array [
               1,
@@ -1496,7 +1138,7 @@ exports[`renders a series properly 1`] = `
             className="SeriesAbout__description"
           >
             <div
-              className="article__text-section c41"
+              className="article__text-section c27"
               color="white"
             >
               <div
@@ -1519,138 +1161,6 @@ exports[`renders a series properly 1`] = `
 `;
 
 exports[`renders a sponsored series properly 1`] = `
-.c21 {
-  color: white;
-}
-
-.c39 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-top: 40px;
-}
-
-.c46 {
-  margin-bottom: 4px;
-}
-
-.c49 {
-  margin-top: 60px;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
-.c41 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.c47 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-}
-
-.c8 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: white;
-  text-align: center;
-}
-
-.c26 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 4px;
-}
-
-.c27 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c28 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c30 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c36 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1em;
-}
-
-.c42 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: white;
-  margin-bottom: 10px;
-}
-
-.c43 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 18px;
-  line-height: 30px;
-  margin-bottom: 20px;
-}
-
 .c4 {
   font-family: artsy-icons;
   color: white;
@@ -1741,11 +1251,11 @@ exports[`renders a sponsored series properly 1`] = `
   z-index: 10;
 }
 
-.c38 {
+.c29 {
   margin: 10px 20px 0 0;
 }
 
-.c38::before {
+.c29::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -1755,12 +1265,12 @@ exports[`renders a sponsored series properly 1`] = `
   background-color: white;
 }
 
-.c29 {
+.c22 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c44 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1774,22 +1284,22 @@ exports[`renders a sponsored series properly 1`] = `
   margin-top: 5px;
 }
 
-.c45 {
+.c32 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c45:hover {
+.c32:hover {
   opacity: 0.6;
 }
 
-.c45:first-child {
+.c32:first-child {
   padding-left: 0;
 }
 
-.c37 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1804,12 +1314,12 @@ exports[`renders a sponsored series properly 1`] = `
   color: white;
 }
 
-.c35 {
+.c27 {
   width: 32px;
   height: 32px;
 }
 
-.c33 {
+.c25 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -1819,7 +1329,7 @@ exports[`renders a sponsored series properly 1`] = `
   display: block;
 }
 
-.c31 {
+.c23 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -1828,7 +1338,7 @@ exports[`renders a sponsored series properly 1`] = `
   background: white;
 }
 
-.c23 {
+.c21 {
   border: 1px solid;
   border-radius: 2px;
   color: white;
@@ -1838,15 +1348,15 @@ exports[`renders a sponsored series properly 1`] = `
   display: block;
 }
 
-.c23 .c32 {
+.c21 .c24 {
   opacity: 1;
 }
 
-.c23:hover .c32 {
+.c21:hover .c24 {
   opacity: 0.7;
 }
 
-.c34 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1865,15 +1375,15 @@ exports[`renders a sponsored series properly 1`] = `
   bottom: 20px;
 }
 
-.c34 svg {
+.c26 svg {
   height: 40px;
 }
 
-.c22 {
+.c20 {
   margin-bottom: 40px;
 }
 
-.c9 {
+.c8 {
   background-color: #000;
   position: fixed;
   top: 0;
@@ -1883,7 +1393,7 @@ exports[`renders a sponsored series properly 1`] = `
   z-index: -1;
 }
 
-.c10 {
+.c9 {
   background-image: url(https://artsy-media-uploads.s3.amazonaws.com/GXvnaBYBdP2z6LKIBQF7XA%2FArtboard.jpg);
   background-size: cover;
   background-position: 50%;
@@ -1895,7 +1405,7 @@ exports[`renders a sponsored series properly 1`] = `
   z-index: -2;
 }
 
-.c11 {
+.c10 {
   background: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.6));
   position: fixed;
   top: 0;
@@ -1905,18 +1415,18 @@ exports[`renders a sponsored series properly 1`] = `
   z-index: -1;
 }
 
-.c17 {
+.c16 {
   display: block;
 }
 
-.c20 img {
+.c19 img {
   max-width: 240px;
   max-height: 40px;
   object-fit: contain;
   object-position: left;
 }
 
-.c18 {
+.c17 {
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
@@ -1924,13 +1434,13 @@ exports[`renders a sponsored series properly 1`] = `
   margin-bottom: 20px;
 }
 
-.c48 {
+.c33 {
   position: relative;
   width: 100%;
   color: white;
 }
 
-.c48 a {
+.c33 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1940,22 +1450,22 @@ exports[`renders a sponsored series properly 1`] = `
   background-position: bottom;
 }
 
-.c48 a:hover {
+.c33 a:hover {
   color: white;
   opacity: .65;
 }
 
-.c48 div[class*='ToolTip'] a {
+.c33 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c48 p,
-.c48 ul,
-.c48 ol,
-.c48 .paragraph,
-.c48 div[data-block=true] .public-DraftStyleDefault-block {
+.c33 p,
+.c33 ul,
+.c33 ol,
+.c33 .paragraph,
+.c33 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -1966,32 +1476,32 @@ exports[`renders a sponsored series properly 1`] = `
   font-style: inherit;
 }
 
-.c48 p:first-child,
-.c48 .paragraph:first-child,
-.c48 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c33 p:first-child,
+.c33 .paragraph:first-child,
+.c33 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c48 p:last-child,
-.c48 .paragraph:last-child,
-.c48 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c33 p:last-child,
+.c33 .paragraph:last-child,
+.c33 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c48 ul,
-.c48 ol {
+.c33 ul,
+.c33 ol {
   padding-left: 1em;
 }
 
-.c48 ul {
+.c33 ul {
   list-style: disc;
 }
 
-.c48 ol {
+.c33 ol {
   list-style: decimal;
 }
 
-.c48 li {
+.c33 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -2000,7 +1510,7 @@ exports[`renders a sponsored series properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c48 h1 {
+.c33 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -2013,7 +1523,7 @@ exports[`renders a sponsored series properly 1`] = `
   text-align: center;
 }
 
-.c48 h1::before {
+.c33 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -2024,7 +1534,7 @@ exports[`renders a sponsored series properly 1`] = `
   right: calc(50% - 4px);
 }
 
-.c48 h2 {
+.c33 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -2033,15 +1543,15 @@ exports[`renders a sponsored series properly 1`] = `
   margin: 0;
 }
 
-.c48 h2 a {
+.c33 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c48 h2 .c51 {
+.c33 h2 .c35 {
   background-position: bottom !important;
 }
 
-.c48 h3 {
+.c33 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -2051,7 +1561,7 @@ exports[`renders a sponsored series properly 1`] = `
   margin: 0;
 }
 
-.c48 h3 strong {
+.c33 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -2059,11 +1569,11 @@ exports[`renders a sponsored series properly 1`] = `
   line-height: 1.5em;
 }
 
-.c48 h3 a {
+.c33 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c48 blockquote {
+.c33 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -2076,11 +1586,11 @@ exports[`renders a sponsored series properly 1`] = `
   word-break: break-word;
 }
 
-.c48 .preventLineBreak {
+.c33 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c48 .content-end {
+.c33 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -2091,14 +1601,14 @@ exports[`renders a sponsored series properly 1`] = `
   margin-bottom: 1px;
 }
 
-.c48 .artist-follow {
+.c33 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c48 .artist-follow::before {
+.c33 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -2106,7 +1616,7 @@ exports[`renders a sponsored series properly 1`] = `
   font-size: 32px;
 }
 
-.c48 .artist-follow::after {
+.c33 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -2115,7 +1625,7 @@ exports[`renders a sponsored series properly 1`] = `
   text-transform: none;
 }
 
-.c40 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2129,22 +1639,22 @@ exports[`renders a sponsored series properly 1`] = `
   width: 100%;
 }
 
-.c15 {
+.c14 {
   color: white;
   text-align: center;
 }
 
-.c15 .c19 {
+.c14 .c18 {
   padding-top: 5px;
   padding-bottom: 40px;
 }
 
-.c15 .c19 img {
+.c14 .c18 img {
   margin-left: auto;
   margin-right: auto;
 }
 
-.c16 {
+.c15 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 120px;
@@ -2152,17 +1662,17 @@ exports[`renders a sponsored series properly 1`] = `
   margin-bottom: 30px;
 }
 
-.c50 .c14 {
+.c34 .c13 {
   margin-bottom: 90px;
 }
 
-.c13 {
+.c12 {
   max-width: 1200px;
   min-height: 100vh;
   margin: 0 auto;
 }
 
-.c13 .c14 {
+.c12 .c13 {
   margin-bottom: 60px;
 }
 
@@ -2170,242 +1680,8 @@ exports[`renders a sponsored series properly 1`] = `
   color: white;
 }
 
-.c0 .c12 {
+.c0 .c11 {
   padding: 90px 20px 150px;
-}
-
-@media screen and (min-width:40em) {
-  .c39 {
-    padding-top: 40px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c39 {
-    padding-top: 60px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c24 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c24 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c24 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c24 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c24 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c24 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c25 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c25 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c25 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c25 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c25 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c25 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c41 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c41 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c41 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c47 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c47 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c47 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c27 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c27 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c27 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c27 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c27 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c27 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c28 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c28 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c28 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c28 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c28 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c28 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c42 {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c42 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c42 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c43 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c43 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c43 {
-    margin-bottom: 0px;
-  }
 }
 
 @media (max-width:900px) {
@@ -2430,58 +1706,58 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c31 {
+  .c23 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c31 {
+  .c23 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c31 {
+  .c23 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c31 {
+  .c23 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c31 {
+  .c23 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c31 {
+  .c23 {
     width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c34 svg {
+  .c26 svg {
     height: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c22 {
+  .c20 {
     margin-bottom: 60px;
   }
 }
 
 @media (max-width:720px) {
-  .c18 {
+  .c17 {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -2490,38 +1766,38 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media (max-width:600px) {
-  .c48 p,
-  .c48 ul,
-  .c48 ol,
-  .c48 div[data-block=true] .public-DraftStyleDefault-block {
+  .c33 p,
+  .c33 ul,
+  .c33 ol,
+  .c33 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c48 li {
+  .c33 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c48 h1 {
+  .c33 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c48 h2 {
+  .c33 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c48 h3 {
+  .c33 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -2529,14 +1805,14 @@ exports[`renders a sponsored series properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c48 h3 strong {
+  .c33 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c48 blockquote {
+  .c33 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -2544,13 +1820,13 @@ exports[`renders a sponsored series properly 1`] = `
     margin: 0;
   }
 
-  .c48 .content-start {
+  .c33 .content-start {
     font-size: 55px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c40 {
+  .c30 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -2558,7 +1834,7 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c40 {
+  .c30 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2566,7 +1842,7 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media screen and (min-width:64em) {
-  .c40 {
+  .c30 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2574,13 +1850,13 @@ exports[`renders a sponsored series properly 1`] = `
 }
 
 @media (max-width:900px) {
-  .c15 .c19 {
+  .c14 .c18 {
     padding-bottom: 0;
   }
 }
 
 @media (max-width:900px) {
-  .c16 {
+  .c15 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 65px;
@@ -2660,7 +1936,7 @@ exports[`renders a sponsored series properly 1`] = `
         className="rrm-container rrm-greaterThan-xs"
       >
         <div
-          className="c7 c8"
+          className="c7 joTwtA"
           color="white"
           fontFamily={
             Object {
@@ -2687,37 +1963,37 @@ exports[`renders a sponsored series properly 1`] = `
     />
   </div>
   <div
-    className="c9"
+    className="c8"
   >
+    <div
+      className="c9"
+    />
     <div
       className="c10"
     />
-    <div
-      className="c11"
-    />
   </div>
   <div
-    className="c12 c13"
+    className="c11 c12"
   >
     <div
-      className="c14 c15"
+      className="c13 c14"
       color="white"
     >
       <div
-        className="c16"
+        className="c15"
       >
         The Future of Art
       </div>
       <div
-        className="PartnerBlock c17"
+        className="PartnerBlock c16"
       >
         <div
-          className="c18"
+          className="c17"
         >
           Presented in Partnership with
         </div>
         <div
-          className="c19 c20"
+          className="c18 c19"
         >
           <a
             href="http://artsy.net"
@@ -2732,23 +2008,23 @@ exports[`renders a sponsored series properly 1`] = `
       </div>
     </div>
     <div
-      className="c21"
+      className="dYptke"
       color="white"
     >
       <div
-        className="c22"
+        className="c20"
       >
         <a
-          className="ArticleCard c23"
+          className="ArticleCard c21"
           color="white"
           href="joanne-artman-gallery-poetry-naturerefinement-form"
           onClick={[Function]}
         >
           <div
-            className="c24"
+            className="drjzXt"
           >
             <div
-              className="c25"
+              className="jUYeYa"
               width={
                 Array [
                   "100%",
@@ -2760,7 +2036,7 @@ exports[`renders a sponsored series properly 1`] = `
             >
               <div>
                 <div
-                  className="c26"
+                  className="bUZGRr frfaAc"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2772,7 +2048,7 @@ exports[`renders a sponsored series properly 1`] = `
                   The Future of Art
                 </div>
                 <div
-                  className="c27"
+                  className="bUZGRr cwRRLl"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -2786,7 +2062,7 @@ exports[`renders a sponsored series properly 1`] = `
                   New Study Shows the Gender Pay Gap for Artists Is Not So Simple
                 </div>
                 <div
-                  className="c28"
+                  className="sc-ifAKCX cFlEyZ hAOaLg"
                   fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                   fontSize={
                     Array [
@@ -2801,10 +2077,10 @@ exports[`renders a sponsored series properly 1`] = `
                 </div>
               </div>
               <div
-                className="c29"
+                className="c22"
               >
                 <div
-                  className="c30"
+                  className="bUZGRr dOrNHt"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2818,7 +2094,7 @@ exports[`renders a sponsored series properly 1`] = `
               </div>
             </div>
             <div
-              className="c31"
+              className="c23"
               width={
                 Array [
                   "100%",
@@ -2829,14 +2105,14 @@ exports[`renders a sponsored series properly 1`] = `
               }
             >
               <img
-                className="c32 c33"
+                className="c24 c25"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
               />
               <div
-                className="c34"
+                className="c26"
               >
                 <svg
-                  className="c35"
+                  className="c27"
                   version="1.1"
                   viewBox="0 0 40 56"
                   x="0px"
@@ -2856,7 +2132,7 @@ exports[`renders a sponsored series properly 1`] = `
                   </g>
                 </svg>
                 <div
-                  className="c36"
+                  className="bUZGRr jwuwyh"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2873,19 +2149,19 @@ exports[`renders a sponsored series properly 1`] = `
         </a>
       </div>
       <div
-        className="c22"
+        className="c20"
       >
         <a
-          className="ArticleCard c23"
+          className="ArticleCard c21"
           color="white"
           href="new-yorks-next-art-district"
           onClick={[Function]}
         >
           <div
-            className="c24"
+            className="drjzXt"
           >
             <div
-              className="c25"
+              className="jUYeYa"
               width={
                 Array [
                   "100%",
@@ -2897,7 +2173,7 @@ exports[`renders a sponsored series properly 1`] = `
             >
               <div>
                 <div
-                  className="c26"
+                  className="bUZGRr frfaAc"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2909,7 +2185,7 @@ exports[`renders a sponsored series properly 1`] = `
                   The Future of Art
                 </div>
                 <div
-                  className="c27"
+                  className="bUZGRr cwRRLl"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -2923,7 +2199,7 @@ exports[`renders a sponsored series properly 1`] = `
                   New York's Next Art District
                 </div>
                 <div
-                  className="c28"
+                  className="sc-ifAKCX cFlEyZ hAOaLg"
                   fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                   fontSize={
                     Array [
@@ -2938,11 +2214,11 @@ exports[`renders a sponsored series properly 1`] = `
                 </div>
               </div>
               <div
-                className="Byline c37"
+                className="Byline c28"
                 color="white"
               >
                 <div
-                  className="c30"
+                  className="bUZGRr dOrNHt"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2952,17 +2228,17 @@ exports[`renders a sponsored series properly 1`] = `
                   fontSize="14px"
                 >
                   <div
-                    className="c38"
+                    className="c29"
                     color="white"
                   >
                     Casey Lesser
                   </div>
                 </div>
                 <div
-                  className="c29"
+                  className="c22"
                 >
                   <div
-                    className="c30"
+                    className="bUZGRr dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2977,7 +2253,7 @@ exports[`renders a sponsored series properly 1`] = `
               </div>
             </div>
             <div
-              className="c31"
+              className="c23"
               width={
                 Array [
                   "100%",
@@ -2988,7 +2264,7 @@ exports[`renders a sponsored series properly 1`] = `
               }
             >
               <img
-                className="c32 c33"
+                className="c24 c25"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
               />
             </div>
@@ -2997,15 +2273,15 @@ exports[`renders a sponsored series properly 1`] = `
       </div>
     </div>
     <div
-      className="c39"
+      className="fiAwVF"
     >
       <div
-        className="c40"
+        className="c30"
         color="white"
         width="100%"
       >
         <div
-          className="c41"
+          className="ckfosv"
           width={
             Array [
               1,
@@ -3017,7 +2293,7 @@ exports[`renders a sponsored series properly 1`] = `
         >
           <div>
             <div
-              className="c42"
+              className="bUZGRr eMhSvP"
               color="white"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="28px"
@@ -3025,15 +2301,15 @@ exports[`renders a sponsored series properly 1`] = `
               About the Series
             </div>
             <div
-              className="c43"
+              className="bUZGRr fRcQPt"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="18px"
             >
               <div
-                className="c44"
+                className="c31"
               >
                 <a
-                  className="c45"
+                  className="c32"
                   href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art"
                   onClick={[Function]}
                   target="_blank"
@@ -3059,7 +2335,7 @@ exports[`renders a sponsored series properly 1`] = `
                   </svg>
                 </a>
                 <a
-                  className="c45"
+                  className="c32"
                   href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&text=undefined&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&via=artsy"
                   onClick={[Function]}
                   target="_blank"
@@ -3085,7 +2361,7 @@ exports[`renders a sponsored series properly 1`] = `
                   </svg>
                 </a>
                 <a
-                  className="c45"
+                  className="c32"
                   href="mailto:?subject=undefined&body=Check out undefined on Artsy: https://www.artsy.net/article/future-of-art"
                   onClick={[Function]}
                   target="_blank"
@@ -3117,18 +2393,18 @@ exports[`renders a sponsored series properly 1`] = `
             className="rrm-container rrm-greaterThanOrEqual-md"
           >
             <div
-              className="c46"
+              className="hirWLY"
             >
               <div
-                className="PartnerBlock c17"
+                className="PartnerBlock c16"
               >
                 <div
-                  className="c18"
+                  className="c17"
                 >
                   Presented in Partnership with
                 </div>
                 <div
-                  className="c19 c20"
+                  className="c18 c19"
                 >
                   <a
                     href="http://artsy.net"
@@ -3145,7 +2421,7 @@ exports[`renders a sponsored series properly 1`] = `
           </div>
         </div>
         <div
-          className="c47"
+          className="bQqYVB"
           width={
             Array [
               1,
@@ -3159,7 +2435,7 @@ exports[`renders a sponsored series properly 1`] = `
             className="SeriesAbout__description"
           >
             <div
-              className="article__text-section c48"
+              className="article__text-section c33"
               color="white"
             >
               <div
@@ -3175,18 +2451,18 @@ exports[`renders a sponsored series properly 1`] = `
             className="rrm-container rrm-lessThan-md"
           >
             <div
-              className="c49"
+              className="hhOARf"
             >
               <div
-                className="PartnerBlock c17"
+                className="PartnerBlock c16"
               >
                 <div
-                  className="c18"
+                  className="c17"
                 >
                   Presented in Partnership with
                 </div>
                 <div
-                  className="c19 c20"
+                  className="c18 c19"
                 >
                   <a
                     href="http://artsy.net"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayoutAdsEnabled.test.tsx.snap
@@ -1,75 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`News Layout with new ads enabled renders the news layout properly when new ads are enabled 1`] = `
-.c15 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-top: 40px;
-}
-
-.c25 {
-  margin: auto;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-}
-
-.c6 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: white;
-  text-align: center;
-}
-
-.c18 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: white;
-  margin-bottom: 10px;
-}
-
-.c19 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 18px;
-  line-height: 30px;
-  margin-bottom: 20px;
-}
-
-.c26 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 10px;
-  line-height: 14px;
-  color: black30;
-  margin: 4px;
-}
-
 .c4 {
   font-family: artsy-icons;
   color: white;
@@ -84,7 +15,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   color: white;
 }
 
-.c24 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,7 +49,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   -ms-interpolation-mode: bicubic;
 }
 
-.c2 .c27 {
+.c2 .c19 {
   margin: 0 20px;
 }
 
@@ -171,7 +102,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   z-index: 10;
 }
 
-.c20 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -185,22 +116,22 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   margin-top: 5px;
 }
 
-.c21 {
+.c16 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c21:hover {
+.c16:hover {
   opacity: 0.6;
 }
 
-.c21:first-child {
+.c16:first-child {
   padding-left: 0;
 }
 
-.c7 {
+.c6 {
   background-color: #000;
   position: fixed;
   top: 0;
@@ -210,7 +141,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   z-index: -1;
 }
 
-.c8 {
+.c7 {
   background-image: url(https://artsy-media-uploads.s3.amazonaws.com/GXvnaBYBdP2z6LKIBQF7XA%2FArtboard.jpg);
   background-size: cover;
   background-position: 50%;
@@ -222,7 +153,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   z-index: -2;
 }
 
-.c9 {
+.c8 {
   background: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.6));
   position: fixed;
   top: 0;
@@ -232,13 +163,13 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   z-index: -1;
 }
 
-.c23 {
+.c17 {
   position: relative;
   width: 100%;
   color: white;
 }
 
-.c23 a {
+.c17 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -248,22 +179,22 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   background-position: bottom;
 }
 
-.c23 a:hover {
+.c17 a:hover {
   color: white;
   opacity: .65;
 }
 
-.c23 div[class*='ToolTip'] a {
+.c17 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c23 p,
-.c23 ul,
-.c23 ol,
-.c23 .paragraph,
-.c23 div[data-block=true] .public-DraftStyleDefault-block {
+.c17 p,
+.c17 ul,
+.c17 ol,
+.c17 .paragraph,
+.c17 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -274,32 +205,32 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   font-style: inherit;
 }
 
-.c23 p:first-child,
-.c23 .paragraph:first-child,
-.c23 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c17 p:first-child,
+.c17 .paragraph:first-child,
+.c17 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c23 p:last-child,
-.c23 .paragraph:last-child,
-.c23 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c17 p:last-child,
+.c17 .paragraph:last-child,
+.c17 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c23 ul,
-.c23 ol {
+.c17 ul,
+.c17 ol {
   padding-left: 1em;
 }
 
-.c23 ul {
+.c17 ul {
   list-style: disc;
 }
 
-.c23 ol {
+.c17 ol {
   list-style: decimal;
 }
 
-.c23 li {
+.c17 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -308,7 +239,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   padding-bottom: .5em;
 }
 
-.c23 h1 {
+.c17 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -321,7 +252,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   text-align: center;
 }
 
-.c23 h1::before {
+.c17 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -332,7 +263,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   right: calc(50% - 4px);
 }
 
-.c23 h2 {
+.c17 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -341,15 +272,15 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   margin: 0;
 }
 
-.c23 h2 a {
+.c17 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c23 h2 .c29 {
+.c17 h2 .c21 {
   background-position: bottom !important;
 }
 
-.c23 h3 {
+.c17 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -359,7 +290,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   margin: 0;
 }
 
-.c23 h3 strong {
+.c17 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -367,11 +298,11 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   line-height: 1.5em;
 }
 
-.c23 h3 a {
+.c17 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c23 blockquote {
+.c17 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -384,11 +315,11 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   word-break: break-word;
 }
 
-.c23 .preventLineBreak {
+.c17 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c23 .content-end {
+.c17 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -399,14 +330,14 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   margin-bottom: 1px;
 }
 
-.c23 .artist-follow {
+.c17 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c23 .artist-follow::before {
+.c17 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -414,7 +345,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   font-size: 32px;
 }
 
-.c23 .artist-follow::after {
+.c17 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -423,7 +354,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   text-transform: none;
 }
 
-.c16 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -437,22 +368,22 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   width: 100%;
 }
 
-.c13 {
+.c12 {
   color: white;
   text-align: center;
 }
 
-.c13 .c28 {
+.c12 .c20 {
   padding-top: 5px;
   padding-bottom: 40px;
 }
 
-.c13 .c28 img {
+.c12 .c20 img {
   margin-left: auto;
   margin-right: auto;
 }
 
-.c14 {
+.c13 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 120px;
@@ -460,13 +391,13 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   margin-bottom: 30px;
 }
 
-.c11 {
+.c10 {
   max-width: 1200px;
   min-height: 100vh;
   margin: 0 auto;
 }
 
-.c11 .c12 {
+.c10 .c11 {
   margin-bottom: 90px;
 }
 
@@ -474,92 +405,8 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   color: white;
 }
 
-.c0 .c10 {
+.c0 .c9 {
   padding: 90px 20px 150px;
-}
-
-@media screen and (min-width:40em) {
-  .c15 {
-    padding-top: 40px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c15 {
-    padding-top: 60px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c17 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c17 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c17 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c22 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c22 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c22 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c18 {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c18 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c18 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c19 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c19 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c19 {
-    margin-bottom: 0px;
-  }
 }
 
 @media (max-width:720px) {
@@ -571,44 +418,44 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
     font-size: 24px;
   }
 
-  .c2 .c27 {
+  .c2 .c19 {
     margin: 0 10px;
   }
 }
 
 @media (max-width:600px) {
-  .c23 p,
-  .c23 ul,
-  .c23 ol,
-  .c23 div[data-block=true] .public-DraftStyleDefault-block {
+  .c17 p,
+  .c17 ul,
+  .c17 ol,
+  .c17 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c23 li {
+  .c17 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c23 h1 {
+  .c17 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c23 h2 {
+  .c17 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c23 h3 {
+  .c17 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -616,14 +463,14 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
     line-height: 1.5em;
   }
 
-  .c23 h3 strong {
+  .c17 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c23 blockquote {
+  .c17 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -631,13 +478,13 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
     margin: 0;
   }
 
-  .c23 .content-start {
+  .c17 .content-start {
     font-size: 55px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c16 {
+  .c14 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -645,7 +492,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
 }
 
 @media screen and (min-width:52em) {
-  .c16 {
+  .c14 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -653,7 +500,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
 }
 
 @media screen and (min-width:64em) {
-  .c16 {
+  .c14 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -661,13 +508,13 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
 }
 
 @media (max-width:900px) {
-  .c13 .c28 {
+  .c12 .c20 {
     padding-bottom: 0;
   }
 }
 
 @media (max-width:900px) {
-  .c14 {
+  .c13 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 65px;
@@ -703,7 +550,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
         className="rrm-container rrm-greaterThan-xs"
       >
         <div
-          className="c5 c6"
+          className="c5 joTwtA"
           color="white"
           fontFamily={
             Object {
@@ -730,38 +577,38 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
     />
   </div>
   <div
-    className="c7"
+    className="c6"
   >
+    <div
+      className="c7"
+    />
     <div
       className="c8"
     />
-    <div
-      className="c9"
-    />
   </div>
   <div
-    className="c10 c11"
+    className="c9 c10"
   >
     <div
-      className="c12 c13"
+      className="c11 c12"
       color="white"
     >
       <div
-        className="c14"
+        className="c13"
       >
         The Future of Art
       </div>
     </div>
     <div
-      className="c15"
+      className="fiAwVF"
     >
       <div
-        className="c16"
+        className="c14"
         color="white"
         width="100%"
       >
         <div
-          className="c17"
+          className="ckfosv"
           width={
             Array [
               1,
@@ -773,7 +620,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
         >
           <div>
             <div
-              className="c18"
+              className="bUZGRr eMhSvP"
               color="white"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="28px"
@@ -781,15 +628,15 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
               About the Series
             </div>
             <div
-              className="c19"
+              className="bUZGRr fRcQPt"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="18px"
             >
               <div
-                className="c20"
+                className="c15"
               >
                 <a
-                  className="c21"
+                  className="c16"
                   href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art"
                   onClick={[Function]}
                   target="_blank"
@@ -815,7 +662,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
                   </svg>
                 </a>
                 <a
-                  className="c21"
+                  className="c16"
                   href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&text=undefined&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&via=artsy"
                   onClick={[Function]}
                   target="_blank"
@@ -841,7 +688,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
                   </svg>
                 </a>
                 <a
-                  className="c21"
+                  className="c16"
                   href="mailto:?subject=undefined&body=Check out undefined on Artsy: https://www.artsy.net/article/future-of-art"
                   onClick={[Function]}
                   target="_blank"
@@ -874,7 +721,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
           />
         </div>
         <div
-          className="c22"
+          className="bQqYVB"
           width={
             Array [
               1,
@@ -888,7 +735,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
             className="SeriesAbout__description"
           >
             <div
-              className="article__text-section c23"
+              className="article__text-section c17"
               color="white"
             >
               <div
@@ -908,10 +755,10 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
     </div>
   </div>
   <div
-    className="c24"
+    className="c18"
   >
     <div
-      className="c25"
+      className="fdqRED"
     >
       <div
         style={
@@ -922,7 +769,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
         }
       />
       <div
-        className="c26"
+        className="bUZGRr jritVp"
         color="black30"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="10px"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -1,226 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video Layout matches the snapshot 1`] = `
-.c31 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-bottom: 12px;
-}
-
-.c33 {
-  padding-right: 20px;
-  width: 60px;
-}
-
-.c38 {
-  max-width: 100%;
-}
-
-.c40 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 20px;
-  padding-right: 20px;
-}
-
-.c41 {
-  padding-top: 40px;
-}
-
-.c47 {
-  margin-top: 40px;
-}
-
-.c55 {
-  width: 100%;
-}
-
-.c56 {
-  padding-top: 60px;
-}
-
-.c58 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c62 {
-  color: white;
-}
-
-.c77 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-bottom: 100px;
-  padding-top: 40px;
-}
-
-.c32 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c65 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
-.c66 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
-.c79 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.c82 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-}
-
-.c7 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: white;
-  text-align: center;
-}
-
-.c35 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  margin-right: 20px;
-}
-
-.c36 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c37 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 42px;
-  line-height: 50px;
-}
-
-.c39 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  padding-top: 30px;
-}
-
-.c44 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: white;
-  padding-bottom: 10px;
-}
-
-.c50 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c61 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-  color: white;
-}
-
-.c67 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 4px;
-}
-
-.c68 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c69 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c74 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1em;
-}
-
-.c80 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: white;
-  margin-bottom: 10px;
-}
-
-.c81 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 18px;
-  line-height: 30px;
-  margin-bottom: 20px;
-}
-
 .c5 {
   font-family: artsy-icons;
   color: white;
@@ -253,7 +33,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   -ms-interpolation-mode: bicubic;
 }
 
-.c3 .c83 {
+.c3 .c53 {
   margin: 0 20px;
 }
 
@@ -306,11 +86,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   z-index: 10;
 }
 
-.c76 {
+.c51 {
   margin: 10px 20px 0 0;
 }
 
-.c76::before {
+.c51::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -320,12 +100,12 @@ exports[`Video Layout matches the snapshot 1`] = `
   background-color: white;
 }
 
-.c49 {
+.c36 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c52 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -339,26 +119,26 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c54 {
+.c40 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c54:hover {
+.c40:hover {
   opacity: 0.6;
 }
 
-.c54:first-child {
+.c40:first-child {
   padding-left: 0;
 }
 
-.c53 {
+.c39 {
   margin: 5px 10px 5px 0;
 }
 
-.c75 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -373,12 +153,12 @@ exports[`Video Layout matches the snapshot 1`] = `
   color: white;
 }
 
-.c18 {
+.c17 {
   width: 32px;
   height: 32px;
 }
 
-.c72 {
+.c48 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -388,7 +168,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   display: block;
 }
 
-.c70 {
+.c46 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -397,7 +177,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   background: white;
 }
 
-.c64 {
+.c45 {
   border: 1px solid;
   border-radius: 2px;
   color: white;
@@ -407,15 +187,15 @@ exports[`Video Layout matches the snapshot 1`] = `
   display: block;
 }
 
-.c64 .c71 {
+.c45 .c47 {
   opacity: 1;
 }
 
-.c64:hover .c71 {
+.c45:hover .c47 {
   opacity: 0.7;
 }
 
-.c73 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -434,17 +214,17 @@ exports[`Video Layout matches the snapshot 1`] = `
   bottom: 20px;
 }
 
-.c73 svg {
+.c49 svg {
   height: 40px;
 }
 
-.c46 {
+.c34 {
   position: relative;
   width: 100%;
   color: white;
 }
 
-.c46 a {
+.c34 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -454,22 +234,22 @@ exports[`Video Layout matches the snapshot 1`] = `
   background-position: bottom;
 }
 
-.c46 a:hover {
+.c34 a:hover {
   color: white;
   opacity: .65;
 }
 
-.c46 div[class*='ToolTip'] a {
+.c34 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c46 p,
-.c46 ul,
-.c46 ol,
-.c46 .paragraph,
-.c46 div[data-block=true] .public-DraftStyleDefault-block {
+.c34 p,
+.c34 ul,
+.c34 ol,
+.c34 .paragraph,
+.c34 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -480,32 +260,32 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-style: inherit;
 }
 
-.c46 p:first-child,
-.c46 .paragraph:first-child,
-.c46 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c34 p:first-child,
+.c34 .paragraph:first-child,
+.c34 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c46 p:last-child,
-.c46 .paragraph:last-child,
-.c46 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c34 p:last-child,
+.c34 .paragraph:last-child,
+.c34 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c46 ul,
-.c46 ol {
+.c34 ul,
+.c34 ol {
   padding-left: 1em;
 }
 
-.c46 ul {
+.c34 ul {
   list-style: disc;
 }
 
-.c46 ol {
+.c34 ol {
   list-style: decimal;
 }
 
-.c46 li {
+.c34 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -514,7 +294,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   padding-bottom: .5em;
 }
 
-.c46 h1 {
+.c34 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -527,7 +307,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   text-align: center;
 }
 
-.c46 h1::before {
+.c34 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -538,7 +318,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   right: calc(50% - 4px);
 }
 
-.c46 h2 {
+.c34 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -547,15 +327,15 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c46 h2 a {
+.c34 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c46 h2 .c84 {
+.c34 h2 .c54 {
   background-position: bottom !important;
 }
 
-.c46 h3 {
+.c34 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -565,7 +345,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c46 h3 strong {
+.c34 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -573,11 +353,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   line-height: 1.5em;
 }
 
-.c46 h3 a {
+.c34 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c46 blockquote {
+.c34 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -590,11 +370,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   word-break: break-word;
 }
 
-.c46 .preventLineBreak {
+.c34 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c46 .content-end {
+.c34 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -605,14 +385,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-bottom: 1px;
 }
 
-.c46 .artist-follow {
+.c34 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c46 .artist-follow::before {
+.c34 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -620,7 +400,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   font-size: 32px;
 }
 
-.c46 .artist-follow::after {
+.c34 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -629,7 +409,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   text-transform: none;
 }
 
-.c78 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -643,23 +423,23 @@ exports[`Video Layout matches the snapshot 1`] = `
   width: 100%;
 }
 
+.c24 {
+  width: 28px;
+  height: 28px;
+}
+
+.c22 {
+  height: 28px;
+  cursor: pointer;
+}
+
+.c15 {
+  height: 28px;
+  width: 28px;
+  cursor: pointer;
+}
+
 .c25 {
-  width: 28px;
-  height: 28px;
-}
-
-.c23 {
-  height: 28px;
-  cursor: pointer;
-}
-
-.c16 {
-  height: 28px;
-  width: 28px;
-  cursor: pointer;
-}
-
-.c26 {
   width: 100%;
   background-size: NaN% 100%;
   height: 18px;
@@ -670,13 +450,13 @@ exports[`Video Layout matches the snapshot 1`] = `
   background: transparent;
 }
 
-.c26::-webkit-slider-thumb {
+.c25::-webkit-slider-thumb {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c26::-ms-track {
+.c25::-ms-track {
   width: 100%;
   height: 2px;
   cursor: pointer;
@@ -685,7 +465,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   color: transparent;
 }
 
-.c26::-webkit-slider-runnable-track {
+.c25::-webkit-slider-runnable-track {
   height: 2px;
   cursor: pointer;
   -webkit-animate: 0.2s;
@@ -694,7 +474,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   border: 0px;
 }
 
-.c26::-moz-range-track {
+.c25::-moz-range-track {
   height: 2px;
   cursor: pointer;
   -webkit-animate: 0.2s;
@@ -703,7 +483,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   border: 0px;
 }
 
-.c26::-webkit-slider-thumb {
+.c25::-webkit-slider-thumb {
   color: white;
   border: 0px;
   height: 12px;
@@ -717,7 +497,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   appearance: none;
 }
 
-.c26::-moz-range-thumb {
+.c25::-moz-range-thumb {
   color: white;
   box-shadow: 0px 0px 0px white;
   border: 0px;
@@ -732,17 +512,17 @@ exports[`Video Layout matches the snapshot 1`] = `
   appearance: none;
 }
 
-.c26::-ms-fill-lower {
+.c25::-ms-fill-lower {
   background: white;
   border: 0px;
 }
 
-.c26::-ms-fill-upper {
+.c25::-ms-fill-upper {
   background: white;
   border: 0px;
 }
 
-.c26::-ms-thumb {
+.c25::-ms-thumb {
   color: white;
   box-shadow: 0px 0px 0px white;
   border: 0px;
@@ -757,22 +537,22 @@ exports[`Video Layout matches the snapshot 1`] = `
   appearance: none;
 }
 
-.c26:focus::-webkit-slider-runnable-track {
+.c25:focus::-webkit-slider-runnable-track {
   background: white;
 }
 
-.c26:focus {
+.c25:focus {
   outline: none;
 }
 
-.c21 {
+.c20 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
   -webkit-font-smoothing: antialiased;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -784,7 +564,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   width: 100%;
 }
 
-.c13 {
+.c12 {
   color: white;
   display: -webkit-box;
   display: -webkit-flex;
@@ -807,19 +587,19 @@ exports[`Video Layout matches the snapshot 1`] = `
   transition: opacity 0.25s ease;
 }
 
-.c13 .c20 {
+.c12 .c19 {
   margin-right: 30px;
 }
 
-.c13 .c22 {
+.c12 .c21 {
   margin-right: 20px;
 }
 
-.c13 .c24 {
+.c12 .c23 {
   cursor: pointer;
 }
 
-.c19 {
+.c18 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -827,14 +607,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-left: 20px;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -844,28 +624,28 @@ exports[`Video Layout matches the snapshot 1`] = `
   width: 100%;
 }
 
-.c10 {
+.c9 {
   width: 100%;
   height: 100%;
   position: relative;
   background-color: black;
 }
 
-.c10 video {
+.c9 video {
   object-fit: contain;
   width: 100%;
   height: 100%;
 }
 
-.c10 .c12 {
+.c9 .c11 {
   opacity: 1;
 }
 
-.c48 {
+.c35 {
   color: white;
 }
 
-.c43 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -877,11 +657,11 @@ exports[`Video Layout matches the snapshot 1`] = `
   width: 100%;
 }
 
-.c43 .c45 p {
+.c32 .c33 p {
   padding: 0;
 }
 
-.c42 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -894,21 +674,21 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-right: auto;
 }
 
-.c60 a {
+.c43 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c63 {
+.c44 {
   margin-bottom: 40px;
 }
 
-.c57 {
+.c41 {
   color: white;
 }
 
-.c57 .c59 {
+.c41 .c42 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -917,17 +697,17 @@ exports[`Video Layout matches the snapshot 1`] = `
   margin-bottom: 40px;
 }
 
-.c57 .c59 a {
+.c41 .c42 a {
   border-bottom: 2px solid;
 }
 
-.c34 a {
+.c30 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c28 {
+.c27 {
   background: url(https://artsy-vanity-files-production.s3.amazonaws.com/images/galerie-ceysson-benetiere_abmb.jpg) no-repeat center center;
   background-size: cover;
   background-color: black;
@@ -936,14 +716,14 @@ exports[`Video Layout matches the snapshot 1`] = `
   height: 100%;
 }
 
-.c29 {
+.c28 {
   background: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.6));
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-.c30 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -963,13 +743,13 @@ exports[`Video Layout matches the snapshot 1`] = `
   height: 100%;
 }
 
-.c30 .c17 {
+.c29 .c16 {
   height: 60px;
   width: 44px;
   cursor: pointer;
 }
 
-.c27 {
+.c26 {
   position: absolute;
   top: 0;
   left: 0;
@@ -999,327 +779,9 @@ exports[`Video Layout matches the snapshot 1`] = `
   height: 100vh;
 }
 
-.c8 .c9 {
+.c8 .c7 {
   position: absolute;
   top: 0;
-}
-
-@media screen and (min-width:40em) {
-  .c38 {
-    max-width: 60%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c41 {
-    padding-top: 40px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c41 {
-    padding-top: 60px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c55 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c55 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c55 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c56 {
-    padding-top: 60px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c56 {
-    padding-top: 100px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c77 {
-    padding-top: 40px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c77 {
-    padding-top: 60px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c65 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c65 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c65 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c65 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c65 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c65 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c66 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c66 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c66 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c66 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c66 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c66 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c79 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c79 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c79 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c82 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c82 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c82 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c39 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c39 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c39 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c39 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c39 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c39 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c68 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c68 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c68 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c68 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c68 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c68 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c69 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c69 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c69 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c69 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c69 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c69 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c80 {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c80 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c80 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c81 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c81 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c81 {
-    margin-bottom: 0px;
-  }
 }
 
 @media (max-width:720px) {
@@ -1331,89 +793,89 @@ exports[`Video Layout matches the snapshot 1`] = `
     font-size: 24px;
   }
 
-  .c3 .c83 {
+  .c3 .c53 {
     margin: 0 10px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c70 {
+  .c46 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c70 {
+  .c46 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c70 {
+  .c46 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c70 {
+  .c46 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c70 {
+  .c46 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c70 {
+  .c46 {
     width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c73 svg {
+  .c49 svg {
     height: 30px;
   }
 }
 
 @media (max-width:600px) {
-  .c46 p,
-  .c46 ul,
-  .c46 ol,
-  .c46 div[data-block=true] .public-DraftStyleDefault-block {
+  .c34 p,
+  .c34 ul,
+  .c34 ol,
+  .c34 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c46 li {
+  .c34 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c46 h1 {
+  .c34 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c46 h2 {
+  .c34 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c46 h3 {
+  .c34 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1421,14 +883,14 @@ exports[`Video Layout matches the snapshot 1`] = `
     line-height: 1.5em;
   }
 
-  .c46 h3 strong {
+  .c34 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c46 blockquote {
+  .c34 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -1436,13 +898,13 @@ exports[`Video Layout matches the snapshot 1`] = `
     margin: 0;
   }
 
-  .c46 .content-start {
+  .c34 .content-start {
     font-size: 55px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c78 {
+  .c52 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -1450,7 +912,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c78 {
+  .c52 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1458,7 +920,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:64em) {
-  .c78 {
+  .c52 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1466,49 +928,49 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media (max-width:768px) {
-  .c48 .c51 {
+  .c35 .c37 {
     margin-top: 0px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c43 {
+  .c32 {
     padding-top: 80px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c43 {
+  .c32 {
     padding-top: 0px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c43 {
+  .c32 {
     padding-top: 0px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c43 {
+  .c32 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c43 {
+  .c32 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c43 {
+  .c32 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c42 {
+  .c31 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
@@ -1516,7 +978,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c42 {
+  .c31 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1524,7 +986,7 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:64em) {
-  .c42 {
+  .c31 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1532,13 +994,13 @@ exports[`Video Layout matches the snapshot 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c63 {
+  .c44 {
     margin-bottom: 60px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c30 {
+  .c29 {
     padding-bottom: 60px;
   }
 }
@@ -1569,7 +1031,7 @@ exports[`Video Layout matches the snapshot 1`] = `
         className="rrm-container rrm-greaterThan-xs"
       >
         <div
-          className="c6 c7"
+          className="c6 c7 joTwtA"
           color="white"
           fontFamily={
             Object {
@@ -1599,7 +1061,7 @@ exports[`Video Layout matches the snapshot 1`] = `
     className="c8"
   >
     <div
-      className="c9 c10"
+      className="c7 c9"
     >
       <video
         muted={false}
@@ -1607,23 +1069,23 @@ exports[`Video Layout matches the snapshot 1`] = `
         src="https://artsy-vanity-files-production.s3.amazonaws.com/videos/scenic_mono_3.mp4"
       />
       <div
-        className="c11"
+        className="c10"
       >
         <div
-          className="c12 c13"
+          className="c11 c12"
         >
           <div
-            className="c14"
+            className="c13"
           >
             <div
-              className="c15"
+              className="c14"
             >
               <div
-                className="c16"
+                className="c15"
                 onClick={[Function]}
               >
                 <svg
-                  className="c17 c18"
+                  className="c16 c17"
                   version="1.1"
                   viewBox="0 0 40 56"
                   x="0px"
@@ -1644,21 +1106,21 @@ exports[`Video Layout matches the snapshot 1`] = `
                 </svg>
               </div>
               <div
-                className="c19"
+                className="c18"
               />
             </div>
             <div
-              className="c15"
+              className="c14"
             >
               <div
-                className="c20 c21"
+                className="c19 c20"
               >
                 00:00
                  / 
                 00:00
               </div>
               <div
-                className="c22 c23"
+                className="c21 c22"
                 onClick={[Function]}
               >
                 <svg
@@ -1676,7 +1138,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                 </svg>
               </div>
               <svg
-                className="c24 c25"
+                className="c23 c24"
                 height="32px"
                 onClick={[Function]}
                 viewBox="0 0 28 28"
@@ -1735,7 +1197,7 @@ exports[`Video Layout matches the snapshot 1`] = `
             </div>
           </div>
           <input
-            className="c26"
+            className="c25"
             max={0}
             onChange={[Function]}
             onMouseDown={[Function]}
@@ -1748,32 +1210,32 @@ exports[`Video Layout matches the snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c27"
+      className="c26"
     >
       <div
-        className="c28"
+        className="c27"
         src="https://artsy-vanity-files-production.s3.amazonaws.com/images/galerie-ceysson-benetiere_abmb.jpg"
       />
       <div
-        className="c29"
+        className="c28"
       />
       <div
-        className="c30"
+        className="c29"
         width="100%"
       >
         <div
-          className="c31"
+          className="bBcFLq"
         >
           <div
-            className="c32"
+            className="eNmxcA"
           >
             <div
-              className="c33"
+              className="eydErb"
               onClick={[Function]}
               width="60px"
             >
               <svg
-                className="c17 c18"
+                className="c16 c17"
                 version="1.1"
                 viewBox="0 0 40 56"
                 x="0px"
@@ -1794,14 +1256,14 @@ exports[`Video Layout matches the snapshot 1`] = `
               </svg>
             </div>
             <div
-              className=""
+              className="dVZOZN"
             >
               <div>
                 <div
-                  className="c32"
+                  className="eNmxcA"
                 >
                   <div
-                    className="c34 c35"
+                    className="c30 c7 dszOpy"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize="14px"
                   >
@@ -1812,7 +1274,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     </a>
                   </div>
                   <div
-                    className="c36"
+                    className="sc-bxivhb bUZGRr c7 deJBsu"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize="14px"
                   >
@@ -1820,7 +1282,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  className="c37"
+                  className="sc-bxivhb bUZGRr c7 kUuHSn"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize="42px"
                 >
@@ -1830,10 +1292,10 @@ exports[`Video Layout matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c38"
+            className="gdqIDJ"
           >
             <div
-              className="c39"
+              className="sc-ifAKCX cFlEyZ c7 iwZBau"
               fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
               fontSize={
                 Array [
@@ -1852,16 +1314,16 @@ exports[`Video Layout matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c40"
+    className="iHcxGD"
   >
     <div
-      className="c41"
+      className="iyAljF"
     >
       <div
-        className="c42"
+        className="c31"
       >
         <div
-          className="c43"
+          className="c32"
           width={
             Array [
               1,
@@ -1872,7 +1334,7 @@ exports[`Video Layout matches the snapshot 1`] = `
           }
         >
           <div
-            className="c44"
+            className="sc-bxivhb bUZGRr c7 cExSie"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="28px"
@@ -1880,7 +1342,7 @@ exports[`Video Layout matches the snapshot 1`] = `
             Credits
           </div>
           <div
-            className="article__text-section c45 c46"
+            className="article__text-section c33 c34"
             color="white"
           >
             <div
@@ -1895,16 +1357,16 @@ exports[`Video Layout matches the snapshot 1`] = `
             className="rrm-container rrm-greaterThanOrEqual-md"
           >
             <div
-              className="c47"
+              className="jObTem"
             >
               <div
-                className="c48"
+                className="c35"
               >
                 <div
-                  className="c49"
+                  className="c36"
                 >
                   <div
-                    className="c50"
+                    className="sc-bxivhb bUZGRr c7 dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1917,10 +1379,10 @@ exports[`Video Layout matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  className="c51 c52"
+                  className="c37 c38"
                 >
                   <div
-                    className="c53 c50"
+                    className="c39 c7 dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1932,7 +1394,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     Share
                   </div>
                   <a
-                    className="c54"
+                    className="c40"
                     href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
                     onClick={[Function]}
                     target="_blank"
@@ -1958,7 +1420,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     </svg>
                   </a>
                   <a
-                    className="c54"
+                    className="c40"
                     href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
                     onClick={[Function]}
                     target="_blank"
@@ -1984,7 +1446,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     </svg>
                   </a>
                   <a
-                    className="c54"
+                    className="c40"
                     href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
                     onClick={[Function]}
                     target="_blank"
@@ -2015,7 +1477,7 @@ exports[`Video Layout matches the snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c55"
+          className="ffckeT"
           width={
             Array [
               1,
@@ -2026,7 +1488,7 @@ exports[`Video Layout matches the snapshot 1`] = `
           }
         >
           <div
-            className="c44"
+            className="sc-bxivhb bUZGRr c7 cExSie"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="28px"
@@ -2034,7 +1496,7 @@ exports[`Video Layout matches the snapshot 1`] = `
             About the Film
           </div>
           <div
-            className="article__text-section c45 c46"
+            className="article__text-section c33 c34"
             color="white"
           >
             <div
@@ -2049,16 +1511,16 @@ exports[`Video Layout matches the snapshot 1`] = `
             className="rrm-container rrm-lessThan-md"
           >
             <div
-              className="c47"
+              className="jObTem"
             >
               <div
-                className="c48"
+                className="c35"
               >
                 <div
-                  className="c49"
+                  className="c36"
                 >
                   <div
-                    className="c50"
+                    className="sc-bxivhb bUZGRr c7 dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2071,10 +1533,10 @@ exports[`Video Layout matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  className="c51 c52"
+                  className="c37 c38"
                 >
                   <div
-                    className="c53 c50"
+                    className="c39 c7 dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2086,7 +1548,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     Share
                   </div>
                   <a
-                    className="c54"
+                    className="c40"
                     href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
                     onClick={[Function]}
                     target="_blank"
@@ -2112,7 +1574,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     </svg>
                   </a>
                   <a
-                    className="c54"
+                    className="c40"
                     href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
                     onClick={[Function]}
                     target="_blank"
@@ -2138,7 +1600,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     </svg>
                   </a>
                   <a
-                    className="c54"
+                    className="c40"
                     href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
                     onClick={[Function]}
                     target="_blank"
@@ -2171,17 +1633,17 @@ exports[`Video Layout matches the snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c56"
+      className="jyOXKm"
     >
       <div
-        className="c57"
+        className="c41"
         color="white"
       >
         <div
-          className="c58"
+          className="dVmQNL"
         >
           <div
-            className="c59 c60 c61"
+            className="c42 c43 c7 buxuNk"
             color="white"
             fontFamily={
               Object {
@@ -2199,23 +1661,23 @@ exports[`Video Layout matches the snapshot 1`] = `
             </a>
           </div>
           <div
-            className="c62"
+            className="dYptke"
             color="white"
           >
             <div
-              className="c63"
+              className="c44"
             >
               <a
-                className="ArticleCard c64"
+                className="ArticleCard c45"
                 color="white"
                 href="joanne-artman-gallery-poetry-naturerefinement-form"
                 onClick={[Function]}
               >
                 <div
-                  className="c65"
+                  className="drjzXt"
                 >
                   <div
-                    className="c66"
+                    className="jUYeYa"
                     width={
                       Array [
                         "100%",
@@ -2227,7 +1689,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                   >
                     <div>
                       <div
-                        className="c67"
+                        className="sc-bxivhb bUZGRr c7 frfaAc"
                         fontFamily={
                           Object {
                             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2239,7 +1701,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                         The Future of Art
                       </div>
                       <div
-                        className="c68"
+                        className="sc-bxivhb bUZGRr c7 cwRRLl"
                         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                         fontSize={
                           Array [
@@ -2253,7 +1715,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                         New Study Shows the Gender Pay Gap for Artists Is Not So Simple
                       </div>
                       <div
-                        className="c69"
+                        className="sc-ifAKCX cFlEyZ c7 hAOaLg"
                         fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                         fontSize={
                           Array [
@@ -2268,10 +1730,10 @@ exports[`Video Layout matches the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      className="c49"
+                      className="c36"
                     >
                       <div
-                        className="c50"
+                        className="sc-bxivhb bUZGRr c7 dOrNHt"
                         fontFamily={
                           Object {
                             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2285,7 +1747,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    className="c70"
+                    className="c46"
                     width={
                       Array [
                         "100%",
@@ -2296,14 +1758,14 @@ exports[`Video Layout matches the snapshot 1`] = `
                     }
                   >
                     <img
-                      className="c71 c72"
+                      className="c47 c48"
                       src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
                     />
                     <div
-                      className="c73"
+                      className="c49"
                     >
                       <svg
-                        className="c17 c18"
+                        className="c16 c17"
                         version="1.1"
                         viewBox="0 0 40 56"
                         x="0px"
@@ -2323,7 +1785,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                         </g>
                       </svg>
                       <div
-                        className="c74"
+                        className="sc-bxivhb bUZGRr c7 jwuwyh"
                         fontFamily={
                           Object {
                             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2340,19 +1802,19 @@ exports[`Video Layout matches the snapshot 1`] = `
               </a>
             </div>
             <div
-              className="c63"
+              className="c44"
             >
               <a
-                className="ArticleCard c64"
+                className="ArticleCard c45"
                 color="white"
                 href="new-yorks-next-art-district"
                 onClick={[Function]}
               >
                 <div
-                  className="c65"
+                  className="drjzXt"
                 >
                   <div
-                    className="c66"
+                    className="jUYeYa"
                     width={
                       Array [
                         "100%",
@@ -2364,7 +1826,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                   >
                     <div>
                       <div
-                        className="c67"
+                        className="sc-bxivhb bUZGRr c7 frfaAc"
                         fontFamily={
                           Object {
                             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2376,7 +1838,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                         The Future of Art
                       </div>
                       <div
-                        className="c68"
+                        className="sc-bxivhb bUZGRr c7 cwRRLl"
                         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                         fontSize={
                           Array [
@@ -2390,7 +1852,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                         New York's Next Art District
                       </div>
                       <div
-                        className="c69"
+                        className="sc-ifAKCX cFlEyZ c7 hAOaLg"
                         fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                         fontSize={
                           Array [
@@ -2405,11 +1867,11 @@ exports[`Video Layout matches the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      className="Byline c75"
+                      className="Byline c50"
                       color="white"
                     >
                       <div
-                        className="c50"
+                        className="sc-bxivhb bUZGRr c7 dOrNHt"
                         fontFamily={
                           Object {
                             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2419,17 +1881,17 @@ exports[`Video Layout matches the snapshot 1`] = `
                         fontSize="14px"
                       >
                         <div
-                          className="c76"
+                          className="c51"
                           color="white"
                         >
                           Casey Lesser
                         </div>
                       </div>
                       <div
-                        className="c49"
+                        className="c36"
                       >
                         <div
-                          className="c50"
+                          className="sc-bxivhb bUZGRr c7 dOrNHt"
                           fontFamily={
                             Object {
                               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2444,7 +1906,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    className="c70"
+                    className="c46"
                     width={
                       Array [
                         "100%",
@@ -2455,7 +1917,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                     }
                   >
                     <img
-                      className="c71 c72"
+                      className="c47 c48"
                       src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
                     />
                   </div>
@@ -2465,15 +1927,15 @@ exports[`Video Layout matches the snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c77"
+          className="gIQdNo"
         >
           <div
-            className="c78"
+            className="c52"
             color="white"
             width="100%"
           >
             <div
-              className="c79"
+              className="ckfosv"
               width={
                 Array [
                   1,
@@ -2485,7 +1947,7 @@ exports[`Video Layout matches the snapshot 1`] = `
             >
               <div>
                 <div
-                  className="c80"
+                  className="sc-bxivhb bUZGRr c7 eMhSvP"
                   color="white"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize="28px"
@@ -2493,15 +1955,15 @@ exports[`Video Layout matches the snapshot 1`] = `
                   About the Series
                 </div>
                 <div
-                  className="c81"
+                  className="sc-bxivhb bUZGRr c7 fRcQPt"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize="18px"
                 >
                   <div
-                    className="c51 c52"
+                    className="c37 c38"
                   >
                     <a
-                      className="c54"
+                      className="c40"
                       href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art"
                       onClick={[Function]}
                       target="_blank"
@@ -2527,7 +1989,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                       </svg>
                     </a>
                     <a
-                      className="c54"
+                      className="c40"
                       href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&text=undefined&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&via=artsy"
                       onClick={[Function]}
                       target="_blank"
@@ -2553,7 +2015,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                       </svg>
                     </a>
                     <a
-                      className="c54"
+                      className="c40"
                       href="mailto:?subject=undefined&body=Check out undefined on Artsy: https://www.artsy.net/article/future-of-art"
                       onClick={[Function]}
                       target="_blank"
@@ -2586,7 +2048,7 @@ exports[`Video Layout matches the snapshot 1`] = `
               />
             </div>
             <div
-              className="c82"
+              className="bQqYVB"
               width={
                 Array [
                   1,
@@ -2600,7 +2062,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                 className="SeriesAbout__description"
               >
                 <div
-                  className="article__text-section c45 c46"
+                  className="article__text-section c33 c34"
                   color="white"
                 >
                   <div

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayoutAdsEnabled.test.tsx.snap
@@ -1,111 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video Layout with new ads enabled renders the video layout properly when new ads are enabled 1`] = `
-.c31 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-bottom: 12px;
-}
-
-.c33 {
-  padding-right: 20px;
-  width: 60px;
-}
-
-.c38 {
-  max-width: 100%;
-}
-
-.c40 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 20px;
-  padding-right: 20px;
-}
-
-.c41 {
-  padding-top: 40px;
-}
-
-.c47 {
-  margin-top: 40px;
-}
-
-.c55 {
-  width: 100%;
-}
-
-.c57 {
-  margin: auto;
-}
-
-.c32 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c7 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: white;
-  text-align: center;
-}
-
-.c35 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  margin-right: 20px;
-}
-
-.c36 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c37 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 42px;
-  line-height: 50px;
-}
-
-.c39 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  padding-top: 30px;
-}
-
-.c44 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: white;
-  padding-bottom: 10px;
-}
-
-.c50 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c58 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 10px;
-  line-height: 14px;
-  color: black30;
-  margin: 4px;
-}
-
 .c5 {
   font-family: artsy-icons;
   color: white;
@@ -120,7 +15,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   color: white;
 }
 
-.c56 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -154,7 +49,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   -ms-interpolation-mode: bicubic;
 }
 
-.c3 .c59 {
+.c3 .c42 {
   margin: 0 20px;
 }
 
@@ -207,7 +102,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   z-index: 10;
 }
 
-.c52 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -221,32 +116,32 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   margin-top: 5px;
 }
 
-.c54 {
+.c40 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c54:hover {
+.c40:hover {
   opacity: 0.6;
 }
 
-.c54:first-child {
+.c40:first-child {
   padding-left: 0;
 }
 
-.c53 {
+.c39 {
   margin: 5px 10px 5px 0;
 }
 
-.c46 {
+.c34 {
   position: relative;
   width: 100%;
   color: white;
 }
 
-.c46 a {
+.c34 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -256,22 +151,22 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   background-position: bottom;
 }
 
-.c46 a:hover {
+.c34 a:hover {
   color: white;
   opacity: .65;
 }
 
-.c46 div[class*='ToolTip'] a {
+.c34 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c46 p,
-.c46 ul,
-.c46 ol,
-.c46 .paragraph,
-.c46 div[data-block=true] .public-DraftStyleDefault-block {
+.c34 p,
+.c34 ul,
+.c34 ol,
+.c34 .paragraph,
+.c34 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -282,32 +177,32 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   font-style: inherit;
 }
 
-.c46 p:first-child,
-.c46 .paragraph:first-child,
-.c46 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c34 p:first-child,
+.c34 .paragraph:first-child,
+.c34 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c46 p:last-child,
-.c46 .paragraph:last-child,
-.c46 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c34 p:last-child,
+.c34 .paragraph:last-child,
+.c34 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c46 ul,
-.c46 ol {
+.c34 ul,
+.c34 ol {
   padding-left: 1em;
 }
 
-.c46 ul {
+.c34 ul {
   list-style: disc;
 }
 
-.c46 ol {
+.c34 ol {
   list-style: decimal;
 }
 
-.c46 li {
+.c34 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -316,7 +211,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   padding-bottom: .5em;
 }
 
-.c46 h1 {
+.c34 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -329,7 +224,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   text-align: center;
 }
 
-.c46 h1::before {
+.c34 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -340,7 +235,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   right: calc(50% - 4px);
 }
 
-.c46 h2 {
+.c34 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -349,15 +244,15 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   margin: 0;
 }
 
-.c46 h2 a {
+.c34 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c46 h2 .c60 {
+.c34 h2 .c43 {
   background-position: bottom !important;
 }
 
-.c46 h3 {
+.c34 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -367,7 +262,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   margin: 0;
 }
 
-.c46 h3 strong {
+.c34 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -375,11 +270,11 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   line-height: 1.5em;
 }
 
-.c46 h3 a {
+.c34 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c46 blockquote {
+.c34 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -392,11 +287,11 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   word-break: break-word;
 }
 
-.c46 .preventLineBreak {
+.c34 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c46 .content-end {
+.c34 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -407,14 +302,14 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   margin-bottom: 1px;
 }
 
-.c46 .artist-follow {
+.c34 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c46 .artist-follow::before {
+.c34 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -422,7 +317,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   font-size: 32px;
 }
 
-.c46 .artist-follow::after {
+.c34 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -431,33 +326,33 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   text-transform: none;
 }
 
-.c49 {
+.c36 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c18 {
+.c17 {
   width: 32px;
   height: 32px;
 }
 
+.c24 {
+  width: 28px;
+  height: 28px;
+}
+
+.c22 {
+  height: 28px;
+  cursor: pointer;
+}
+
+.c15 {
+  height: 28px;
+  width: 28px;
+  cursor: pointer;
+}
+
 .c25 {
-  width: 28px;
-  height: 28px;
-}
-
-.c23 {
-  height: 28px;
-  cursor: pointer;
-}
-
-.c16 {
-  height: 28px;
-  width: 28px;
-  cursor: pointer;
-}
-
-.c26 {
   width: 100%;
   background-size: NaN% 100%;
   height: 18px;
@@ -468,13 +363,13 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   background: transparent;
 }
 
-.c26::-webkit-slider-thumb {
+.c25::-webkit-slider-thumb {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c26::-ms-track {
+.c25::-ms-track {
   width: 100%;
   height: 2px;
   cursor: pointer;
@@ -483,7 +378,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   color: transparent;
 }
 
-.c26::-webkit-slider-runnable-track {
+.c25::-webkit-slider-runnable-track {
   height: 2px;
   cursor: pointer;
   -webkit-animate: 0.2s;
@@ -492,7 +387,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   border: 0px;
 }
 
-.c26::-moz-range-track {
+.c25::-moz-range-track {
   height: 2px;
   cursor: pointer;
   -webkit-animate: 0.2s;
@@ -501,7 +396,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   border: 0px;
 }
 
-.c26::-webkit-slider-thumb {
+.c25::-webkit-slider-thumb {
   color: white;
   border: 0px;
   height: 12px;
@@ -515,7 +410,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   appearance: none;
 }
 
-.c26::-moz-range-thumb {
+.c25::-moz-range-thumb {
   color: white;
   box-shadow: 0px 0px 0px white;
   border: 0px;
@@ -530,17 +425,17 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   appearance: none;
 }
 
-.c26::-ms-fill-lower {
+.c25::-ms-fill-lower {
   background: white;
   border: 0px;
 }
 
-.c26::-ms-fill-upper {
+.c25::-ms-fill-upper {
   background: white;
   border: 0px;
 }
 
-.c26::-ms-thumb {
+.c25::-ms-thumb {
   color: white;
   box-shadow: 0px 0px 0px white;
   border: 0px;
@@ -555,22 +450,22 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   appearance: none;
 }
 
-.c26:focus::-webkit-slider-runnable-track {
+.c25:focus::-webkit-slider-runnable-track {
   background: white;
 }
 
-.c26:focus {
+.c25:focus {
   outline: none;
 }
 
-.c21 {
+.c20 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
   -webkit-font-smoothing: antialiased;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -582,7 +477,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   width: 100%;
 }
 
-.c13 {
+.c12 {
   color: white;
   display: -webkit-box;
   display: -webkit-flex;
@@ -605,19 +500,19 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   transition: opacity 0.25s ease;
 }
 
-.c13 .c20 {
+.c12 .c19 {
   margin-right: 30px;
 }
 
-.c13 .c22 {
+.c12 .c21 {
   margin-right: 20px;
 }
 
-.c13 .c24 {
+.c12 .c23 {
   cursor: pointer;
 }
 
-.c19 {
+.c18 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -625,14 +520,14 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   margin-left: 20px;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -642,28 +537,28 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   width: 100%;
 }
 
-.c10 {
+.c9 {
   width: 100%;
   height: 100%;
   position: relative;
   background-color: black;
 }
 
-.c10 video {
+.c9 video {
   object-fit: contain;
   width: 100%;
   height: 100%;
 }
 
-.c10 .c12 {
+.c9 .c11 {
   opacity: 1;
 }
 
-.c48 {
+.c35 {
   color: white;
 }
 
-.c43 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -675,11 +570,11 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   width: 100%;
 }
 
-.c43 .c45 p {
+.c32 .c33 p {
   padding: 0;
 }
 
-.c42 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -692,13 +587,13 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   margin-right: auto;
 }
 
-.c34 a {
+.c30 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c28 {
+.c27 {
   background: url(https://artsy-vanity-files-production.s3.amazonaws.com/images/galerie-ceysson-benetiere_abmb.jpg) no-repeat center center;
   background-size: cover;
   background-color: black;
@@ -707,14 +602,14 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   height: 100%;
 }
 
-.c29 {
+.c28 {
   background: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.6));
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-.c30 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -734,13 +629,13 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   height: 100%;
 }
 
-.c30 .c17 {
+.c29 .c16 {
   height: 60px;
   width: 44px;
   cursor: pointer;
 }
 
-.c27 {
+.c26 {
   position: absolute;
   top: 0;
   left: 0;
@@ -764,87 +659,15 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   top: 0;
 }
 
-.c8 {
+.c7 {
   position: relative;
   width: 100vw;
   height: 100vh;
 }
 
-.c8 .c9 {
+.c7 .c8 {
   position: absolute;
   top: 0;
-}
-
-@media screen and (min-width:40em) {
-  .c38 {
-    max-width: 60%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c41 {
-    padding-top: 40px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c41 {
-    padding-top: 60px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c55 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c55 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c55 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c39 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c39 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c39 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c39 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c39 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c39 {
-    line-height: 32px;
-  }
 }
 
 @media (max-width:720px) {
@@ -856,44 +679,44 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
     font-size: 24px;
   }
 
-  .c3 .c59 {
+  .c3 .c42 {
     margin: 0 10px;
   }
 }
 
 @media (max-width:600px) {
-  .c46 p,
-  .c46 ul,
-  .c46 ol,
-  .c46 div[data-block=true] .public-DraftStyleDefault-block {
+  .c34 p,
+  .c34 ul,
+  .c34 ol,
+  .c34 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c46 li {
+  .c34 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c46 h1 {
+  .c34 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c46 h2 {
+  .c34 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c46 h3 {
+  .c34 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -901,14 +724,14 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
     line-height: 1.5em;
   }
 
-  .c46 h3 strong {
+  .c34 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c46 blockquote {
+  .c34 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -916,55 +739,55 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
     margin: 0;
   }
 
-  .c46 .content-start {
+  .c34 .content-start {
     font-size: 55px;
   }
 }
 
 @media (max-width:768px) {
-  .c48 .c51 {
+  .c35 .c37 {
     margin-top: 0px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c43 {
+  .c32 {
     padding-top: 80px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c43 {
+  .c32 {
     padding-top: 0px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c43 {
+  .c32 {
     padding-top: 0px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c43 {
+  .c32 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c43 {
+  .c32 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c43 {
+  .c32 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c42 {
+  .c31 {
     -webkit-flex-direction: column-reverse;
     -ms-flex-direction: column-reverse;
     flex-direction: column-reverse;
@@ -972,7 +795,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
 }
 
 @media screen and (min-width:52em) {
-  .c42 {
+  .c31 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -980,7 +803,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
 }
 
 @media screen and (min-width:64em) {
-  .c42 {
+  .c31 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -988,7 +811,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
 }
 
 @media screen and (min-width:40em) {
-  .c30 {
+  .c29 {
     padding-bottom: 60px;
   }
 }
@@ -1019,7 +842,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
         className="rrm-container rrm-greaterThan-xs"
       >
         <div
-          className="c6 c7"
+          className="c6 joTwtA"
           color="white"
           fontFamily={
             Object {
@@ -1046,10 +869,10 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
     />
   </div>
   <div
-    className="c8"
+    className="c7"
   >
     <div
-      className="c9 c10"
+      className="c8 c9"
     >
       <video
         muted={false}
@@ -1057,23 +880,23 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
         src="https://artsy-vanity-files-production.s3.amazonaws.com/videos/scenic_mono_3.mp4"
       />
       <div
-        className="c11"
+        className="c10"
       >
         <div
-          className="c12 c13"
+          className="c11 c12"
         >
           <div
-            className="c14"
+            className="c13"
           >
             <div
-              className="c15"
+              className="c14"
             >
               <div
-                className="c16"
+                className="c15"
                 onClick={[Function]}
               >
                 <svg
-                  className="c17 c18"
+                  className="c16 c17"
                   version="1.1"
                   viewBox="0 0 40 56"
                   x="0px"
@@ -1094,21 +917,21 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                 </svg>
               </div>
               <div
-                className="c19"
+                className="c18"
               />
             </div>
             <div
-              className="c15"
+              className="c14"
             >
               <div
-                className="c20 c21"
+                className="c19 c20"
               >
                 00:00
                  / 
                 00:00
               </div>
               <div
-                className="c22 c23"
+                className="c21 c22"
                 onClick={[Function]}
               >
                 <svg
@@ -1126,7 +949,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                 </svg>
               </div>
               <svg
-                className="c24 c25"
+                className="c23 c24"
                 height="32px"
                 onClick={[Function]}
                 viewBox="0 0 28 28"
@@ -1185,7 +1008,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
             </div>
           </div>
           <input
-            className="c26"
+            className="c25"
             max={0}
             onChange={[Function]}
             onMouseDown={[Function]}
@@ -1198,32 +1021,32 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
       </div>
     </div>
     <div
-      className="c27"
+      className="c26"
     >
       <div
-        className="c28"
+        className="c27"
         src="https://artsy-vanity-files-production.s3.amazonaws.com/images/galerie-ceysson-benetiere_abmb.jpg"
       />
       <div
-        className="c29"
+        className="c28"
       />
       <div
-        className="c30"
+        className="c29"
         width="100%"
       >
         <div
-          className="c31"
+          className="bBcFLq"
         >
           <div
-            className="c32"
+            className="eNmxcA"
           >
             <div
-              className="c33"
+              className="eydErb"
               onClick={[Function]}
               width="60px"
             >
               <svg
-                className="c17 c18"
+                className="c16 c17"
                 version="1.1"
                 viewBox="0 0 40 56"
                 x="0px"
@@ -1244,21 +1067,21 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
               </svg>
             </div>
             <div
-              className=""
+              className="dVZOZN"
             >
               <div>
                 <div
-                  className="c32"
+                  className="eNmxcA"
                 >
                   <div
-                    className="c34 c35"
+                    className="c30 dszOpy"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize="14px"
                   >
                     Art Market
                   </div>
                   <div
-                    className="c36"
+                    className="bUZGRr deJBsu"
                     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                     fontSize="14px"
                   >
@@ -1266,7 +1089,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                   </div>
                 </div>
                 <div
-                  className="c37"
+                  className="bUZGRr kUuHSn"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize="42px"
                 >
@@ -1276,10 +1099,10 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
             </div>
           </div>
           <div
-            className="c38"
+            className="gdqIDJ"
           >
             <div
-              className="c39"
+              className="cFlEyZ iwZBau"
               fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
               fontSize={
                 Array [
@@ -1298,16 +1121,16 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
     </div>
   </div>
   <div
-    className="c40"
+    className="iHcxGD"
   >
     <div
-      className="c41"
+      className="iyAljF"
     >
       <div
-        className="c42"
+        className="c31"
       >
         <div
-          className="c43"
+          className="c32"
           width={
             Array [
               1,
@@ -1318,7 +1141,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
           }
         >
           <div
-            className="c44"
+            className="bUZGRr cExSie"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="28px"
@@ -1326,7 +1149,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
             Credits
           </div>
           <div
-            className="article__text-section c45 c46"
+            className="article__text-section c33 c34"
             color="white"
           >
             <div
@@ -1341,16 +1164,16 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
             className="rrm-container rrm-greaterThanOrEqual-md"
           >
             <div
-              className="c47"
+              className="jObTem"
             >
               <div
-                className="c48"
+                className="c35"
               >
                 <div
-                  className="c49"
+                  className="c36"
                 >
                   <div
-                    className="c50"
+                    className="bUZGRr dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1363,10 +1186,10 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                   </div>
                 </div>
                 <div
-                  className="c51 c52"
+                  className="c37 c38"
                 >
                   <div
-                    className="c53 c50"
+                    className="c39 dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1378,7 +1201,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                     Share
                   </div>
                   <a
-                    className="c54"
+                    className="c40"
                     href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
                     onClick={[Function]}
                     target="_blank"
@@ -1404,7 +1227,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                     </svg>
                   </a>
                   <a
-                    className="c54"
+                    className="c40"
                     href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
                     onClick={[Function]}
                     target="_blank"
@@ -1430,7 +1253,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                     </svg>
                   </a>
                   <a
-                    className="c54"
+                    className="c40"
                     href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
                     onClick={[Function]}
                     target="_blank"
@@ -1461,7 +1284,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
           </div>
         </div>
         <div
-          className="c55"
+          className="ffckeT"
           width={
             Array [
               1,
@@ -1472,7 +1295,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
           }
         >
           <div
-            className="c44"
+            className="bUZGRr cExSie"
             color="white"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize="28px"
@@ -1480,7 +1303,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
             About the Film
           </div>
           <div
-            className="article__text-section c45 c46"
+            className="article__text-section c33 c34"
             color="white"
           >
             <div
@@ -1495,16 +1318,16 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
             className="rrm-container rrm-lessThan-md"
           >
             <div
-              className="c47"
+              className="jObTem"
             >
               <div
-                className="c48"
+                className="c35"
               >
                 <div
-                  className="c49"
+                  className="c36"
                 >
                   <div
-                    className="c50"
+                    className="bUZGRr dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1517,10 +1340,10 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                   </div>
                 </div>
                 <div
-                  className="c51 c52"
+                  className="c37 c38"
                 >
                   <div
-                    className="c53 c50"
+                    className="c39 dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1532,7 +1355,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                     Share
                   </div>
                   <a
-                    className="c54"
+                    className="c40"
                     href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
                     onClick={[Function]}
                     target="_blank"
@@ -1558,7 +1381,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                     </svg>
                   </a>
                   <a
-                    className="c54"
+                    className="c40"
                     href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
                     onClick={[Function]}
                     target="_blank"
@@ -1584,7 +1407,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
                     </svg>
                   </a>
                   <a
-                    className="c54"
+                    className="c40"
                     href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
                     onClick={[Function]}
                     target="_blank"
@@ -1618,10 +1441,10 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
     </div>
   </div>
   <div
-    className="c56"
+    className="c41"
   >
     <div
-      className="c57"
+      className="fdqRED"
     >
       <div
         style={
@@ -1632,7 +1455,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
         }
       />
       <div
-        className="c58"
+        className="bUZGRr jritVp"
         color="black30"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="10px"

--- a/src/Components/Publishing/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/src/Components/Publishing/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -1,15 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Nav renders a Nav 1`] = `
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: white;
-  text-align: center;
-}
-
 .c3 {
   font-family: artsy-icons;
   color: white;
@@ -42,7 +33,7 @@ exports[`Nav renders a Nav 1`] = `
   -ms-interpolation-mode: bicubic;
 }
 
-.c1 .c6 {
+.c1 .c5 {
   margin: 0 20px;
 }
 
@@ -102,7 +93,7 @@ exports[`Nav renders a Nav 1`] = `
     font-size: 24px;
   }
 
-  .c1 .c6 {
+  .c1 .c5 {
     margin: 0 10px;
   }
 }
@@ -130,7 +121,7 @@ exports[`Nav renders a Nav 1`] = `
       className="rrm-container rrm-greaterThan-xs"
     >
       <div
-        className="c4 c5"
+        className="c4 sc-htpNat joTwtA"
         color="white"
         fontFamily={
           Object {
@@ -159,15 +150,6 @@ exports[`Nav renders a Nav 1`] = `
 `;
 
 exports[`Nav renders a sponsored nav 1`] = `
-.c7 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: white;
-  text-align: center;
-}
-
 .c3 {
   font-family: artsy-icons;
   color: white;
@@ -344,7 +326,7 @@ exports[`Nav renders a sponsored nav 1`] = `
       className="rrm-container rrm-greaterThan-xs"
     >
       <div
-        className="c6 c7"
+        className="c6 sc-htpNat joTwtA"
         color="white"
         fontFamily={
           Object {
@@ -373,15 +355,6 @@ exports[`Nav renders a sponsored nav 1`] = `
 `;
 
 exports[`Nav renders a transparent nav 1`] = `
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-weight: 600;
-  font-size: 22px;
-  line-height: 32px;
-  color: white;
-  text-align: center;
-}
-
 .c3 {
   font-family: artsy-icons;
   color: white;
@@ -414,7 +387,7 @@ exports[`Nav renders a transparent nav 1`] = `
   -ms-interpolation-mode: bicubic;
 }
 
-.c1 .c6 {
+.c1 .c5 {
   margin: 0 20px;
 }
 
@@ -476,7 +449,7 @@ exports[`Nav renders a transparent nav 1`] = `
     font-size: 24px;
   }
 
-  .c1 .c6 {
+  .c1 .c5 {
     margin: 0 10px;
   }
 }
@@ -504,7 +477,7 @@ exports[`Nav renders a transparent nav 1`] = `
       className="rrm-container rrm-greaterThan-xs"
     >
       <div
-        className="c4 c5"
+        className="c4 sc-htpNat joTwtA"
         color="white"
         fontFamily={
           Object {

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCard.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCard.test.tsx.snap
@@ -1,72 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArticleCard renders an article properly 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
 .c3 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 4px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c7 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c9 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c8 {
+.c2 {
   margin: 10px 20px 0 0;
 }
 
-.c8::before {
+.c2::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -76,7 +20,7 @@ exports[`ArticleCard renders an article properly 1`] = `
   background-color: #000;
 }
 
-.c6 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -91,7 +35,7 @@ exports[`ArticleCard renders an article properly 1`] = `
   color: #000;
 }
 
-.c12 {
+.c6 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -101,7 +45,7 @@ exports[`ArticleCard renders an article properly 1`] = `
   display: block;
 }
 
-.c10 {
+.c4 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -120,199 +64,49 @@ exports[`ArticleCard renders an article properly 1`] = `
   display: block;
 }
 
-.c0 .c11 {
+.c0 .c5 {
   opacity: 1;
 }
 
-.c0:hover .c11 {
+.c0:hover .c5 {
   opacity: 0.7;
 }
 
 @media screen and (min-width:40em) {
-  .c1 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c1 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
   .c4 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c4 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c4 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c4 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c4 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c5 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c5 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c5 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c5 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c5 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c5 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c10 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c10 {
+  .c4 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c10 {
+  .c4 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c10 {
+  .c4 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c10 {
+  .c4 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c10 {
+  .c4 {
     width: 50%;
   }
 }
@@ -324,10 +118,10 @@ exports[`ArticleCard renders an article properly 1`] = `
   onClick={[Function]}
 >
   <div
-    className="c1"
+    className="sc-bwzfXH drjzXt"
   >
     <div
-      className="c2"
+      className="sc-bwzfXH jUYeYa"
       width={
         Array [
           "100%",
@@ -339,7 +133,7 @@ exports[`ArticleCard renders an article properly 1`] = `
     >
       <div>
         <div
-          className="c3"
+          className="sc-bxivhb bUZGRr sc-htpNat frfaAc"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -351,7 +145,7 @@ exports[`ArticleCard renders an article properly 1`] = `
           The Future of Art
         </div>
         <div
-          className="c4"
+          className="sc-bxivhb bUZGRr sc-htpNat cwRRLl"
           fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
           fontSize={
             Array [
@@ -365,7 +159,7 @@ exports[`ArticleCard renders an article properly 1`] = `
           New York's Next Art District
         </div>
         <div
-          className="c5"
+          className="sc-ifAKCX cFlEyZ sc-htpNat hAOaLg"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize={
             Array [
@@ -380,11 +174,11 @@ exports[`ArticleCard renders an article properly 1`] = `
         </div>
       </div>
       <div
-        className="Byline c6"
+        className="Byline c1"
         color="#000"
       >
         <div
-          className="c7"
+          className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -394,17 +188,17 @@ exports[`ArticleCard renders an article properly 1`] = `
           fontSize="14px"
         >
           <div
-            className="c8"
+            className="c2"
             color="#000"
           >
             Casey Lesser
           </div>
         </div>
         <div
-          className="c9"
+          className="c3"
         >
           <div
-            className="c7"
+            className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -419,7 +213,7 @@ exports[`ArticleCard renders an article properly 1`] = `
       </div>
     </div>
     <div
-      className="c10"
+      className="c4"
       width={
         Array [
           "100%",
@@ -430,7 +224,7 @@ exports[`ArticleCard renders an article properly 1`] = `
       }
     >
       <img
-        className="c11 c12"
+        className="c5 c6"
         src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
       />
     </div>
@@ -439,75 +233,12 @@ exports[`ArticleCard renders an article properly 1`] = `
 `;
 
 exports[`ArticleCard renders an article with children properly 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
 .c3 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 4px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c6 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c10 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1em;
-}
-
-.c9 {
   width: 32px;
   height: 32px;
 }
 
-.c7 {
+.c1 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -526,15 +257,15 @@ exports[`ArticleCard renders an article with children properly 1`] = `
   display: block;
 }
 
-.c0 .c11 {
+.c0 .c4 {
   opacity: 1;
 }
 
-.c0:hover .c11 {
+.c0:hover .c4 {
   opacity: 0.7;
 }
 
-.c8 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -553,201 +284,51 @@ exports[`ArticleCard renders an article with children properly 1`] = `
   bottom: 20px;
 }
 
-.c8 svg {
+.c2 svg {
   height: 40px;
 }
 
 @media screen and (min-width:40em) {
   .c1 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c1 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c4 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c4 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c4 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c4 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c5 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c5 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c5 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c5 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c5 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c5 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c7 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c1 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c7 {
+  .c1 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c7 {
+  .c1 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c1 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c7 {
+  .c1 {
     width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c8 svg {
+  .c2 svg {
     height: 30px;
   }
 }
@@ -759,10 +340,10 @@ exports[`ArticleCard renders an article with children properly 1`] = `
   onClick={[Function]}
 >
   <div
-    className="c1"
+    className="sc-bwzfXH drjzXt"
   >
     <div
-      className="c2"
+      className="sc-bwzfXH jUYeYa"
       width={
         Array [
           "100%",
@@ -774,7 +355,7 @@ exports[`ArticleCard renders an article with children properly 1`] = `
     >
       <div>
         <div
-          className="c3"
+          className="sc-bxivhb bUZGRr sc-htpNat frfaAc"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -786,7 +367,7 @@ exports[`ArticleCard renders an article with children properly 1`] = `
           The Future of Art
         </div>
         <div
-          className="c4"
+          className="sc-bxivhb bUZGRr sc-htpNat cwRRLl"
           fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
           fontSize={
             Array [
@@ -803,7 +384,7 @@ exports[`ArticleCard renders an article with children properly 1`] = `
           </div>
         </div>
         <div
-          className="c5"
+          className="sc-ifAKCX cFlEyZ sc-htpNat hAOaLg"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize={
             Array [
@@ -821,7 +402,7 @@ exports[`ArticleCard renders an article with children properly 1`] = `
         </div>
       </div>
       <div
-        className="c6"
+        className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
         fontFamily={
           Object {
             "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -837,7 +418,7 @@ exports[`ArticleCard renders an article with children properly 1`] = `
       </div>
     </div>
     <div
-      className="c7"
+      className="c1"
       width={
         Array [
           "100%",
@@ -852,10 +433,10 @@ exports[`ArticleCard renders an article with children properly 1`] = `
         image
       </div>
       <div
-        className="c8"
+        className="c2"
       >
         <svg
-          className="c9"
+          className="c3"
           version="1.1"
           viewBox="0 0 40 56"
           x="0px"
@@ -875,7 +456,7 @@ exports[`ArticleCard renders an article with children properly 1`] = `
           </g>
         </svg>
         <div
-          className="c10"
+          className="sc-bxivhb bUZGRr sc-htpNat jwuwyh"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -894,79 +475,16 @@ exports[`ArticleCard renders an article with children properly 1`] = `
 
 exports[`ArticleCard renders an article with unpublished media properly 1`] = `
 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
-.c3 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 4px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c7 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c13 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1em;
-}
-
-.c6 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c12 {
+.c6 {
   width: 32px;
   height: 32px;
 }
 
-.c10 {
+.c4 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -976,7 +494,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
   display: block;
 }
 
-.c8 {
+.c2 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -995,15 +513,15 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
   display: block;
 }
 
-.c0 .c9 {
+.c0 .c3 {
   opacity: 1;
 }
 
-.c0:hover .c9 {
+.c0:hover .c3 {
   opacity: 0.7;
 }
 
-.c11 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1022,201 +540,51 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
   bottom: 20px;
 }
 
-.c11 svg {
+.c5 svg {
   height: 40px;
 }
 
 @media screen and (min-width:40em) {
-  .c1 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c1 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
   .c2 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c4 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c4 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c4 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c4 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c5 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c5 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c5 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c5 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c5 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c5 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c8 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c8 {
+  .c2 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c8 {
+  .c2 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c8 {
+  .c2 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c8 {
+  .c2 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c8 {
+  .c2 {
     width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c11 svg {
+  .c5 svg {
     height: 30px;
   }
 }
@@ -1228,10 +596,10 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
   onClick={[Function]}
 >
   <div
-    className="c1"
+    className="sc-bwzfXH drjzXt"
   >
     <div
-      className="c2"
+      className="sc-bwzfXH jUYeYa"
       width={
         Array [
           "100%",
@@ -1243,7 +611,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
     >
       <div>
         <div
-          className="c3"
+          className="sc-bxivhb bUZGRr sc-htpNat frfaAc"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1255,7 +623,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
           The Future of Art
         </div>
         <div
-          className="c4"
+          className="sc-bxivhb bUZGRr sc-htpNat cwRRLl"
           fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
           fontSize={
             Array [
@@ -1269,7 +637,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
           New Study Shows the Gender Pay Gap for Artists Is Not So Simple
         </div>
         <div
-          className="c5"
+          className="sc-ifAKCX cFlEyZ sc-htpNat hAOaLg"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize={
             Array [
@@ -1284,10 +652,10 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
         </div>
       </div>
       <div
-        className="c6"
+        className="c1"
       >
         <div
-          className="c7"
+          className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1301,7 +669,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
       </div>
     </div>
     <div
-      className="c8"
+      className="c2"
       width={
         Array [
           "100%",
@@ -1312,14 +680,14 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
       }
     >
       <img
-        className="c9 c10"
+        className="c3 c4"
         src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
       />
       <div
-        className="c11"
+        className="c5"
       >
         <svg
-          className="c12"
+          className="c6"
           version="1.1"
           viewBox="0 0 40 56"
           x="0px"
@@ -1339,7 +707,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
           </g>
         </svg>
         <div
-          className="c13"
+          className="sc-bxivhb bUZGRr sc-htpNat jwuwyh"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCards.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCards.test.tsx.snap
@@ -1,66 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArticleCard renders properly 1`] = `
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c5 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c7 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c15 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1em;
-}
-
-.c8 {
   margin: 10px 20px 0 0;
 }
 
-.c8::before {
+.c3::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -70,12 +15,12 @@ exports[`ArticleCard renders properly 1`] = `
   background-color: #000;
 }
 
-.c9 {
+.c4 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c6 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,12 +35,12 @@ exports[`ArticleCard renders properly 1`] = `
   color: #000;
 }
 
-.c14 {
+.c9 {
   width: 32px;
   height: 32px;
 }
 
-.c12 {
+.c7 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -105,7 +50,7 @@ exports[`ArticleCard renders properly 1`] = `
   display: block;
 }
 
-.c10 {
+.c5 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -124,15 +69,15 @@ exports[`ArticleCard renders properly 1`] = `
   display: block;
 }
 
-.c1 .c11 {
+.c1 .c6 {
   opacity: 1;
 }
 
-.c1:hover .c11 {
+.c1:hover .c6 {
   opacity: 0.7;
 }
 
-.c13 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -151,7 +96,7 @@ exports[`ArticleCard renders properly 1`] = `
   bottom: 20px;
 }
 
-.c13 svg {
+.c8 svg {
   height: 40px;
 }
 
@@ -160,196 +105,46 @@ exports[`ArticleCard renders properly 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c2 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c3 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c3 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c3 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c3 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c3 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c4 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c4 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c4 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c4 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
   .c5 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c5 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c5 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c5 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c5 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c5 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c10 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c10 {
+  .c5 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c10 {
+  .c5 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c10 {
+  .c5 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c10 {
+  .c5 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c10 {
+  .c5 {
     width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c13 svg {
+  .c8 svg {
     height: 30px;
   }
 }
@@ -361,7 +156,7 @@ exports[`ArticleCard renders properly 1`] = `
 }
 
 <div
-  className=""
+  className="sc-bdVaJa dVZOZN"
 >
   <div
     className="c0"
@@ -373,10 +168,10 @@ exports[`ArticleCard renders properly 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c2"
+        className="sc-bwzfXH drjzXt"
       >
         <div
-          className="c3"
+          className="sc-bwzfXH jUYeYa"
           width={
             Array [
               "100%",
@@ -388,7 +183,7 @@ exports[`ArticleCard renders properly 1`] = `
         >
           <div>
             <div
-              className="c4"
+              className="sc-bxivhb bUZGRr sc-htpNat cwRRLl"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -402,7 +197,7 @@ exports[`ArticleCard renders properly 1`] = `
               New York's Next Art District
             </div>
             <div
-              className="c5"
+              className="sc-ifAKCX cFlEyZ sc-htpNat hAOaLg"
               fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
               fontSize={
                 Array [
@@ -417,11 +212,11 @@ exports[`ArticleCard renders properly 1`] = `
             </div>
           </div>
           <div
-            className="Byline c6"
+            className="Byline c2"
             color="#000"
           >
             <div
-              className="c7"
+              className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -431,17 +226,17 @@ exports[`ArticleCard renders properly 1`] = `
               fontSize="14px"
             >
               <div
-                className="c8"
+                className="c3"
                 color="#000"
               >
                 Casey Lesser
               </div>
             </div>
             <div
-              className="c9"
+              className="c4"
             >
               <div
-                className="c7"
+                className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -456,7 +251,7 @@ exports[`ArticleCard renders properly 1`] = `
           </div>
         </div>
         <div
-          className="c10"
+          className="c5"
           width={
             Array [
               "100%",
@@ -467,7 +262,7 @@ exports[`ArticleCard renders properly 1`] = `
           }
         >
           <img
-            className="c11 c12"
+            className="c6 c7"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
           />
         </div>
@@ -484,10 +279,10 @@ exports[`ArticleCard renders properly 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c2"
+        className="sc-bwzfXH drjzXt"
       >
         <div
-          className="c3"
+          className="sc-bwzfXH jUYeYa"
           width={
             Array [
               "100%",
@@ -499,7 +294,7 @@ exports[`ArticleCard renders properly 1`] = `
         >
           <div>
             <div
-              className="c4"
+              className="sc-bxivhb bUZGRr sc-htpNat cwRRLl"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize={
                 Array [
@@ -513,7 +308,7 @@ exports[`ArticleCard renders properly 1`] = `
               New Study Shows the Gender Pay Gap for Artists Is Not So Simple
             </div>
             <div
-              className="c5"
+              className="sc-ifAKCX cFlEyZ sc-htpNat hAOaLg"
               fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
               fontSize={
                 Array [
@@ -528,10 +323,10 @@ exports[`ArticleCard renders properly 1`] = `
             </div>
           </div>
           <div
-            className="c9"
+            className="c4"
           >
             <div
-              className="c7"
+              className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -545,7 +340,7 @@ exports[`ArticleCard renders properly 1`] = `
           </div>
         </div>
         <div
-          className="c10"
+          className="c5"
           width={
             Array [
               "100%",
@@ -556,14 +351,14 @@ exports[`ArticleCard renders properly 1`] = `
           }
         >
           <img
-            className="c11 c12"
+            className="c6 c7"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
           />
           <div
-            className="c13"
+            className="c8"
           >
             <svg
-              className="c14"
+              className="c9"
               version="1.1"
               viewBox="0 0 40 56"
               x="0px"
@@ -583,7 +378,7 @@ exports[`ArticleCard renders properly 1`] = `
               </g>
             </svg>
             <div
-              className="c15"
+              className="sc-bxivhb bUZGRr sc-htpNat jwuwyh"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/Block.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/Block.test.tsx.snap
@@ -1,90 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArticleCard renders properly 1`] = `
-.c1 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c5 {
-  color: #000;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
-  flex-direction: column-reverse;
-  padding: 20px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
-.c4 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-  color: #000;
-}
-
-.c10 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  margin-bottom: 20px;
-}
-
-.c11 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  margin-bottom: 20px;
-}
-
-.c13 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c21 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1em;
-}
-
-.c3 a {
+.c2 a {
   color: #000;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c14 {
+.c6 {
   margin: 10px 20px 0 0;
 }
 
-.c14::before {
+.c6::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -94,12 +21,12 @@ exports[`ArticleCard renders properly 1`] = `
   background-color: #000;
 }
 
-.c15 {
+.c7 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c12 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -114,12 +41,12 @@ exports[`ArticleCard renders properly 1`] = `
   color: #000;
 }
 
-.c20 {
+.c12 {
   width: 32px;
   height: 32px;
 }
 
-.c18 {
+.c10 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -129,7 +56,7 @@ exports[`ArticleCard renders properly 1`] = `
   display: block;
 }
 
-.c16 {
+.c8 {
   margin-bottom: 10px;
   margin-left: 0px;
   width: 100%;
@@ -138,7 +65,7 @@ exports[`ArticleCard renders properly 1`] = `
   background: white;
 }
 
-.c7 {
+.c4 {
   border: 1px solid;
   border-radius: 2px;
   color: #000;
@@ -148,15 +75,15 @@ exports[`ArticleCard renders properly 1`] = `
   display: block;
 }
 
-.c7 .c17 {
+.c4 .c9 {
   opacity: 1;
 }
 
-.c7:hover .c17 {
+.c4:hover .c9 {
   opacity: 0.7;
 }
 
-.c19 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -175,11 +102,11 @@ exports[`ArticleCard renders properly 1`] = `
   bottom: 20px;
 }
 
-.c19 svg {
+.c11 svg {
   height: 40px;
 }
 
-.c6 {
+.c3 {
   margin-bottom: 40px;
 }
 
@@ -187,7 +114,7 @@ exports[`ArticleCard renders properly 1`] = `
   color: #000;
 }
 
-.c0 .c2 {
+.c0 .c1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -196,207 +123,57 @@ exports[`ArticleCard renders properly 1`] = `
   margin-bottom: 40px;
 }
 
-.c0 .c2 a {
+.c0 .c1 a {
   border-bottom: 2px solid;
 }
 
 @media screen and (min-width:40em) {
   .c8 {
-    -webkit-flex-direction: column-reverse;
-    -ms-flex-direction: column-reverse;
-    flex-direction: column-reverse;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c8 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c8 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c8 {
-    padding: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c8 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c8 {
-    padding: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c9 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c9 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c9 {
-    margin-bottom: 5px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c9 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c9 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c9 {
-    width: 50%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c10 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c10 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c10 {
-    font-size: 42px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c10 {
-    line-height: 36px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c10 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c10 {
-    line-height: 50px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c11 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c11 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c11 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c11 {
-    line-height: 26px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c11 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c11 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c16 {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c16 {
+  .c8 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c16 {
+  .c8 {
     margin-bottom: 0px;
     margin-left: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c16 {
+  .c8 {
     width: 100%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c16 {
+  .c8 {
     width: 50%;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c16 {
+  .c8 {
     width: 50%;
   }
 }
 
 @media (max-width:900px) {
-  .c19 svg {
+  .c11 svg {
     height: 30px;
   }
 }
 
 @media screen and (min-width:40em) {
-  .c6 {
+  .c3 {
     margin-bottom: 60px;
   }
 }
@@ -406,10 +183,10 @@ exports[`ArticleCard renders properly 1`] = `
   color="#000"
 >
   <div
-    className="c1"
+    className="dVmQNL"
   >
     <div
-      className="c2 c3 c4"
+      className="c1 c2 sc-htpNat gTPxXw"
       color="#000"
       fontFamily={
         Object {
@@ -425,23 +202,23 @@ exports[`ArticleCard renders properly 1`] = `
       </span>
     </div>
     <div
-      className="c5"
+      className="jihjqW"
       color="#000"
     >
       <div
-        className="c6"
+        className="c3"
       >
         <a
-          className="ArticleCard c7"
+          className="ArticleCard c4"
           color="#000"
           href="new-yorks-next-art-district"
           onClick={[Function]}
         >
           <div
-            className="c8"
+            className="sc-bwzfXH drjzXt"
           >
             <div
-              className="c9"
+              className="sc-bwzfXH jUYeYa"
               width={
                 Array [
                   "100%",
@@ -453,7 +230,7 @@ exports[`ArticleCard renders properly 1`] = `
             >
               <div>
                 <div
-                  className="c10"
+                  className="sc-bxivhb bUZGRr sc-htpNat cwRRLl"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -467,7 +244,7 @@ exports[`ArticleCard renders properly 1`] = `
                   New York's Next Art District
                 </div>
                 <div
-                  className="c11"
+                  className="sc-ifAKCX cFlEyZ sc-htpNat hAOaLg"
                   fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                   fontSize={
                     Array [
@@ -482,11 +259,11 @@ exports[`ArticleCard renders properly 1`] = `
                 </div>
               </div>
               <div
-                className="Byline c12"
+                className="Byline c5"
                 color="#000"
               >
                 <div
-                  className="c13"
+                  className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -496,17 +273,17 @@ exports[`ArticleCard renders properly 1`] = `
                   fontSize="14px"
                 >
                   <div
-                    className="c14"
+                    className="c6"
                     color="#000"
                   >
                     Casey Lesser
                   </div>
                 </div>
                 <div
-                  className="c15"
+                  className="c7"
                 >
                   <div
-                    className="c13"
+                    className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -521,7 +298,7 @@ exports[`ArticleCard renders properly 1`] = `
               </div>
             </div>
             <div
-              className="c16"
+              className="c8"
               width={
                 Array [
                   "100%",
@@ -532,7 +309,7 @@ exports[`ArticleCard renders properly 1`] = `
               }
             >
               <img
-                className="c17 c18"
+                className="c9 c10"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
               />
             </div>
@@ -540,19 +317,19 @@ exports[`ArticleCard renders properly 1`] = `
         </a>
       </div>
       <div
-        className="c6"
+        className="c3"
       >
         <a
-          className="ArticleCard c7"
+          className="ArticleCard c4"
           color="#000"
           href="joanne-artman-gallery-poetry-naturerefinement-form"
           onClick={[Function]}
         >
           <div
-            className="c8"
+            className="sc-bwzfXH drjzXt"
           >
             <div
-              className="c9"
+              className="sc-bwzfXH jUYeYa"
               width={
                 Array [
                   "100%",
@@ -564,7 +341,7 @@ exports[`ArticleCard renders properly 1`] = `
             >
               <div>
                 <div
-                  className="c10"
+                  className="sc-bxivhb bUZGRr sc-htpNat cwRRLl"
                   fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                   fontSize={
                     Array [
@@ -578,7 +355,7 @@ exports[`ArticleCard renders properly 1`] = `
                   New Study Shows the Gender Pay Gap for Artists Is Not So Simple
                 </div>
                 <div
-                  className="c11"
+                  className="sc-ifAKCX cFlEyZ sc-htpNat hAOaLg"
                   fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
                   fontSize={
                     Array [
@@ -593,10 +370,10 @@ exports[`ArticleCard renders properly 1`] = `
                 </div>
               </div>
               <div
-                className="c15"
+                className="c7"
               >
                 <div
-                  className="c13"
+                  className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -610,7 +387,7 @@ exports[`ArticleCard renders properly 1`] = `
               </div>
             </div>
             <div
-              className="c16"
+              className="c8"
               width={
                 Array [
                   "100%",
@@ -621,14 +398,14 @@ exports[`ArticleCard renders properly 1`] = `
               }
             >
               <img
-                className="c17 c18"
+                className="c9 c10"
                 src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
               />
               <div
-                className="c19"
+                className="c11"
               >
                 <svg
-                  className="c20"
+                  className="c12"
                   version="1.1"
                   viewBox="0 0 40 56"
                   x="0px"
@@ -648,7 +425,7 @@ exports[`ArticleCard renders properly 1`] = `
                   </g>
                 </svg>
                 <div
-                  className="c21"
+                  className="sc-bxivhb bUZGRr sc-htpNat jwuwyh"
                   fontFamily={
                     Object {
                       "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
@@ -1,45 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  max-width: 1250px;
-  margin-bottom: 128px;
-  margin-top: 32px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 22px;
-  line-height: 30px;
-}
-
-.c8 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 16px;
-  line-height: 20px;
-}
-
-.c10 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-}
-
-.c11 {
+.c7 {
   margin: 10px 20px 0 0;
 }
 
-.c11::before {
+.c7::before {
   content: "";
   display: inline-block;
   width: 8px;
@@ -49,12 +15,12 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   background-color: black;
 }
 
-.c12 {
+.c8 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c9 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -69,7 +35,7 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   color: black;
 }
 
-.c6 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -82,7 +48,7 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   text-decoration: none;
 }
 
-.c5 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -96,7 +62,7 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   color: black;
 }
 
-.c7 {
+.c5 {
   display: block;
   width: 278px;
   height: 185px;
@@ -104,11 +70,11 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   object-fit: cover;
 }
 
-.c1 {
+.c0 {
   margin-bottom: 20px;
 }
 
-.c4 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -120,86 +86,74 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   overflow-x: scroll;
 }
 
-.c4::-webkit-scrollbar {
+.c2::-webkit-scrollbar {
   display: none;
 }
 
-.c4 a {
+.c2 a {
   margin-right: 30px;
 }
 
-.c4 a:last-child {
+.c2 a:last-child {
   margin-right: 0;
 }
 
-@media screen and (min-width:40em) {
-  .c2 {
-    font-size: 28px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    line-height: 36px;
+@media (max-width:720px) {
+  .c3 {
+    width: 225px;
   }
 }
 
 @media (max-width:720px) {
   .c5 {
     width: 225px;
-  }
-}
-
-@media (max-width:720px) {
-  .c7 {
-    width: 225px;
     height: 150px;
   }
 }
 
 @media (max-width:1280px) {
-  .c1 {
+  .c0 {
     margin: 0 20px 30px 40px;
   }
 }
 
 @media (max-width:720px) {
-  .c1 {
+  .c0 {
     margin-left: 20px;
   }
 }
 
 @media (max-width:720px) {
-  .c3 {
+  .c1 {
     display: block;
   }
 }
 
 @media (max-width:1280px) {
-  .c4 a {
+  .c2 a {
     margin: 0 10px;
   }
 
-  .c4 a:first-child {
+  .c2 a:first-child {
     margin-left: 40px;
   }
 
-  .c4 a:last-child {
+  .c2 a:last-child {
     border-right: 20px solid white;
   }
 }
 
 @media (max-width:720px) {
-  .c4 a:first-child {
+  .c2 a:first-child {
     margin-left: 20px;
   }
 }
 
 <div
-  className="c0"
+  className="sc-bwzfXH iwozgG"
 >
   <div
-    className="c1 c2"
+    className="c0 sc-htpNat eAWabs"
     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
     fontSize={
       Array [
@@ -210,7 +164,7 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
   >
     Further reading in 
     <span
-      className="c3"
+      className="c1"
     >
       Art Market
     </span>
@@ -223,23 +177,23 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
     }
   />
   <div
-    className="c4"
+    className="c2"
   >
     <a
-      className="c5"
+      className="c3"
       href="/article/artsy-editorial-15-top-art-schools-united-states"
       onClick={[Function]}
     >
       <div
-        className="c6"
+        className="c4"
       >
         <img
           alt="The 15 Top Art Schools in the United States"
-          className="c7"
+          className="c5"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4Tq-iYkN8dOpshFoKRXyYw%252Fcustom-Custom_Size___PoetterHall_Exterior%2Bcopy.jpg&width=510&height=340&quality=95"
         />
         <div
-          className="c8"
+          className="sc-ifAKCX cFlEyZ sc-htpNat dejqeb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="16px"
         >
@@ -247,11 +201,11 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
         </div>
       </div>
       <div
-        className="Byline c9"
+        className="Byline c6"
         color="black"
       >
         <div
-          className="c10"
+          className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -261,17 +215,17 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
           fontSize="12px"
         >
           <div
-            className="c11"
+            className="c7"
             color="black"
           >
             Anna Louis-Sussman and Kana Abe
           </div>
         </div>
         <div
-          className="c12"
+          className="c8"
         >
           <div
-            className="c10"
+            className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -286,20 +240,20 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
       </div>
     </a>
     <a
-      className="c5"
+      className="c3"
       href="/article/artsy-editorial-four-years-walter-de-marias-death-final-work-complete"
       onClick={[Function]}
     >
       <div
-        className="c6"
+        className="c4"
       >
         <img
           alt="Four Years after Walter De Maria’s Death, His Final Work Is Complete"
-          className="c7"
+          className="c5"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F6IqxBTQCkExip2auQ7ZWCA%252FDEMAR-2011.0006-B.jpg&width=510&height=340&quality=95"
         />
         <div
-          className="c8"
+          className="sc-ifAKCX cFlEyZ sc-htpNat dejqeb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="16px"
         >
@@ -307,11 +261,11 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
         </div>
       </div>
       <div
-        className="Byline c9"
+        className="Byline c6"
         color="black"
       >
         <div
-          className="c10"
+          className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -321,17 +275,17 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
           fontSize="12px"
         >
           <div
-            className="c11"
+            className="c7"
             color="black"
           >
             Halley Johnson
           </div>
         </div>
         <div
-          className="c12"
+          className="c8"
         >
           <div
-            className="c10"
+            className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -346,20 +300,20 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
       </div>
     </a>
     <a
-      className="c5"
+      className="c3"
       href="/series/artsy-editorial-french-art-history-in-a-nutshell"
       onClick={[Function]}
     >
       <div
-        className="c6"
+        className="c4"
       >
         <img
           alt="French Art History in a Nutshell"
-          className="c7"
+          className="c5"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlEcCm2XbfZ7bPAVgLlM21w%252Flarger-21.jpg&width=510&height=340&quality=95"
         />
         <div
-          className="c8"
+          className="sc-ifAKCX cFlEyZ sc-htpNat dejqeb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="16px"
         >
@@ -367,11 +321,11 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
         </div>
       </div>
       <div
-        className="Byline c9"
+        className="Byline c6"
         color="black"
       >
         <div
-          className="c10"
+          className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -381,17 +335,17 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
           fontSize="12px"
         >
           <div
-            className="c11"
+            className="c7"
             color="black"
           >
             Casey Lesser
           </div>
         </div>
         <div
-          className="c12"
+          className="c8"
         >
           <div
-            className="c10"
+            className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -406,20 +360,20 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
       </div>
     </a>
     <a
-      className="c5"
+      className="c3"
       href="/news/artsy-editorial-miami-artists-museums-brace-hurricane-irma"
       onClick={[Function]}
     >
       <div
-        className="c6"
+        className="c4"
       >
         <img
           alt="Miami Artists and Museums Brace for Hurricane Irma"
-          className="c7"
+          className="c5"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FjAu4NaKnr_m53OnnMaDe_w%252Fmag.jpg&width=510&height=340&quality=95"
         />
         <div
-          className="c8"
+          className="sc-ifAKCX cFlEyZ sc-htpNat dejqeb"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize="16px"
         >
@@ -427,11 +381,11 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
         </div>
       </div>
       <div
-        className="Byline c9"
+        className="Byline c6"
         color="black"
       >
         <div
-          className="c10"
+          className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -441,17 +395,17 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
           fontSize="12px"
         >
           <div
-            className="c11"
+            className="c7"
             color="black"
           >
             Owen Dodd
           </div>
         </div>
         <div
-          className="c12"
+          className="c8"
         >
           <div
-            className="c10"
+            className="sc-bxivhb bUZGRr sc-htpNat AaDvB"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",

--- a/src/Components/Publishing/RelatedArticles/Panel/__tests__/__snapshots__/RelatedArticlesPanel.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/Panel/__tests__/__snapshots__/RelatedArticlesPanel.test.tsx.snap
@@ -1,21 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
-.c2 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c6 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 22px;
-  color: #000;
-}
-
-.c4 {
+.c3 {
   -webkit-text-decoration: none;
   text-decoration: none;
   display: -webkit-box;
@@ -29,7 +15,7 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
   margin-bottom: 20px;
 }
 
-.c5 {
+.c4 {
   min-width: 80px;
   height: 55px;
   margin-right: 10px;
@@ -39,7 +25,7 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
   max-width: 360px;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -57,7 +43,7 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
   className="c0"
 >
   <div
-    className="c1 c2"
+    className="c1 sc-htpNat dOrNHt"
     fontFamily={
       Object {
         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -76,19 +62,19 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
     }
   />
   <div
-    className="c3"
+    className="c2"
   >
     <a
-      className="c4"
+      className="c3"
       href="/article/artsy-editorial-15-top-art-schools-united-states"
       onClick={[Function]}
     >
       <img
-        className="c5"
+        className="c4"
         src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4Tq-iYkN8dOpshFoKRXyYw%252Fcustom-Custom_Size___PoetterHall_Exterior%2Bcopy.jpg&width=160&height=110&quality=95"
       />
       <div
-        className="c6"
+        className="sc-ifAKCX cFlEyZ sc-htpNat kZRUpp"
         color="#000"
         fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
         fontSize="18px"
@@ -97,16 +83,16 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
       </div>
     </a>
     <a
-      className="c4"
+      className="c3"
       href="/article/artsy-editorial-four-years-walter-de-marias-death-final-work-complete"
       onClick={[Function]}
     >
       <img
-        className="c5"
+        className="c4"
         src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F6IqxBTQCkExip2auQ7ZWCA%252FDEMAR-2011.0006-B.jpg&width=160&height=110&quality=95"
       />
       <div
-        className="c6"
+        className="sc-ifAKCX cFlEyZ sc-htpNat kZRUpp"
         color="#000"
         fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
         fontSize="18px"
@@ -115,16 +101,16 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
       </div>
     </a>
     <a
-      className="c4"
+      className="c3"
       href="/news/artsy-editorial-french-art-history-in-a-nutshell"
       onClick={[Function]}
     >
       <img
-        className="c5"
+        className="c4"
         src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlEcCm2XbfZ7bPAVgLlM21w%252Flarger-21.jpg&width=160&height=110&quality=95"
       />
       <div
-        className="c6"
+        className="sc-ifAKCX cFlEyZ sc-htpNat kZRUpp"
         color="#000"
         fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
         fontSize="18px"

--- a/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Caption.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Caption.test.tsx.snap
@@ -1,18 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders an artwork caption properly 1`] = `
-.c5 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c7 {
+.c6 {
   margin-right: 30px;
 }
 
-.c8 {
+.c7 {
   white-space: nowrap;
 }
 
@@ -49,7 +42,7 @@ exports[`renders an artwork caption properly 1`] = `
   color: black;
 }
 
-.c9 {
+.c8 {
   margin-left: 20px;
   white-space: nowrap;
   font-family: Unica77LLWebRegular,Arial,serif;
@@ -85,18 +78,6 @@ exports[`renders an artwork caption properly 1`] = `
   flex-direction: column;
 }
 
-@media screen and (min-width:40em) {
-  .c5 {
-    font-size: 16px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c5 {
-    line-height: 26px;
-  }
-}
-
 @media (max-width:720px) {
   .c4 {
     -webkit-flex-direction: column;
@@ -106,7 +87,7 @@ exports[`renders an artwork caption properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c6.artist-name {
+  .c5.artist-name {
     margin-bottom: 5px;
   }
 }
@@ -138,7 +119,7 @@ exports[`renders an artwork caption properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c9 {
+  .c8 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -175,7 +156,7 @@ exports[`renders an artwork caption properly 1`] = `
     >
       <div>
         <div
-          className="c4 c5"
+          className="c4 sc-htpNat kQLpuM"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -190,13 +171,13 @@ exports[`renders an artwork caption properly 1`] = `
           }
         >
           <div
-            className="c6"
+            className="c5"
           >
             <span
-              className="c7"
+              className="c6"
             >
               <span
-                className="c8"
+                className="c7"
               >
                 <a
                   href="/artist/fernando-botero"
@@ -208,7 +189,7 @@ exports[`renders an artwork caption properly 1`] = `
           </div>
           <div>
             <div
-              className="c6"
+              className="c5"
             >
               <span
                 className="title"
@@ -229,7 +210,7 @@ exports[`renders an artwork caption properly 1`] = `
               </span>
             </div>
             <div
-              className="c6"
+              className="c5"
             >
               <a
                 href="/gary-nader"
@@ -251,7 +232,7 @@ exports[`renders an artwork caption properly 1`] = `
     </div>
   </div>
   <div
-    className="c9"
+    className="c8"
   >
     2 of 10
   </div>

--- a/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/FullscreenViewer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/FullscreenViewer.test.tsx.snap
@@ -1,14 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders properly 1`] = `
-.c9 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c17 {
+.c16 {
   font-family: artsy-icons;
   color: gray;
   font-size: 24px;
@@ -22,11 +15,11 @@ exports[`renders properly 1`] = `
   color: gray;
 }
 
-.c11 {
+.c10 {
   margin-right: 30px;
 }
 
-.c12 {
+.c11 {
   white-space: nowrap;
 }
 
@@ -63,7 +56,7 @@ exports[`renders properly 1`] = `
   color: black;
 }
 
-.c13 {
+.c12 {
   margin-left: 20px;
   white-space: nowrap;
   font-family: Unica77LLWebRegular,Arial,serif;
@@ -122,7 +115,7 @@ exports[`renders properly 1`] = `
   margin: 50px 60px;
 }
 
-.c14 {
+.c13 {
   display: block;
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco8j2xq40ROMyBrJQm_4eQ%252FDafenOilPaintingVillage_AK03.jpg&width=1200&quality=80) no-repeat center;
   background-size: contain;
@@ -132,7 +125,7 @@ exports[`renders properly 1`] = `
   margin: 50px 60px;
 }
 
-.c15 {
+.c14 {
   display: block;
   background: url(https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCpHY-DRr7KW0HGXLslCXHw%2Flarger.jpg&width=1200&quality=80) no-repeat center;
   background-size: contain;
@@ -162,24 +155,12 @@ exports[`renders properly 1`] = `
   background-color: white;
 }
 
-.c16 {
+.c15 {
   position: absolute;
   right: 0;
   top: 0;
   margin: 20px;
   cursor: pointer;
-}
-
-@media screen and (min-width:40em) {
-  .c9 {
-    font-size: 16px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c9 {
-    line-height: 26px;
-  }
 }
 
 @media (max-width:720px) {
@@ -191,7 +172,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c10.artist-name {
+  .c9.artist-name {
     margin-bottom: 5px;
   }
 }
@@ -223,7 +204,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c13 {
+  .c12 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -248,13 +229,13 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c14 {
+  .c13 {
     margin: 20px 0 80px 0;
   }
 }
 
 @media (max-width:720px) {
-  .c15 {
+  .c14 {
     margin: 20px 0 80px 0;
   }
 }
@@ -308,7 +289,7 @@ exports[`renders properly 1`] = `
               >
                 <div>
                   <div
-                    className="c8 c9"
+                    className="c8 kQLpuM"
                     fontFamily={
                       Object {
                         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -323,13 +304,13 @@ exports[`renders properly 1`] = `
                     }
                   >
                     <div
-                      className="c10"
+                      className="c9"
                     >
                       <span
-                        className="c11"
+                        className="c10"
                       >
                         <span
-                          className="c12"
+                          className="c11"
                         >
                           <a
                             href="/artist/fernando-botero"
@@ -341,7 +322,7 @@ exports[`renders properly 1`] = `
                     </div>
                     <div>
                       <div
-                        className="c10"
+                        className="c9"
                       >
                         <span
                           className="title"
@@ -362,7 +343,7 @@ exports[`renders properly 1`] = `
                         </span>
                       </div>
                       <div
-                        className="c10"
+                        className="c9"
                       >
                         <a
                           href="/gary-nader"
@@ -384,7 +365,7 @@ exports[`renders properly 1`] = `
               </div>
             </div>
             <div
-              className="c13"
+              className="c12"
             >
               1 of 3
             </div>
@@ -401,7 +382,7 @@ exports[`renders properly 1`] = `
             New York City
           </div>
           <div
-            className="c14"
+            className="c13"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fco8j2xq40ROMyBrJQm_4eQ%252FDafenOilPaintingVillage_AK03.jpg&width=1200&quality=80"
           />
           <div
@@ -432,7 +413,7 @@ exports[`renders properly 1`] = `
               </div>
             </div>
             <div
-              className="c13"
+              className="c12"
             >
               2 of 3
             </div>
@@ -449,7 +430,7 @@ exports[`renders properly 1`] = `
             New York City
           </div>
           <div
-            className="c15"
+            className="c14"
             src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCpHY-DRr7KW0HGXLslCXHw%2Flarger.jpg&width=1200&quality=80"
           />
           <div
@@ -480,7 +461,7 @@ exports[`renders properly 1`] = `
               </div>
             </div>
             <div
-              className="c13"
+              className="c12"
             >
               3 of 3
             </div>
@@ -489,11 +470,11 @@ exports[`renders properly 1`] = `
       </div>
     </div>
     <div
-      className="c16"
+      className="c15"
       onClick={[Function]}
     >
       <div
-        className="c17"
+        className="c16"
       >
         
       </div>

--- a/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Slide.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Slide.test.tsx.snap
@@ -1,18 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders properly 1`] = `
-.c8 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c10 {
+.c9 {
   margin-right: 30px;
 }
 
-.c11 {
+.c10 {
   white-space: nowrap;
 }
 
@@ -49,7 +42,7 @@ exports[`renders properly 1`] = `
   color: black;
 }
 
-.c12 {
+.c11 {
   margin-left: 20px;
   white-space: nowrap;
   font-family: Unica77LLWebRegular,Arial,serif;
@@ -117,18 +110,6 @@ exports[`renders properly 1`] = `
   line-height: 1.1em;
 }
 
-@media screen and (min-width:40em) {
-  .c8 {
-    font-size: 16px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c8 {
-    line-height: 26px;
-  }
-}
-
 @media (max-width:720px) {
   .c7 {
     -webkit-flex-direction: column;
@@ -138,7 +119,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c9.artist-name {
+  .c8.artist-name {
     margin-bottom: 5px;
   }
 }
@@ -170,7 +151,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c12 {
+  .c11 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -238,7 +219,7 @@ exports[`renders properly 1`] = `
         >
           <div>
             <div
-              className="c7 c8"
+              className="c7 sc-htpNat kQLpuM"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -253,13 +234,13 @@ exports[`renders properly 1`] = `
               }
             >
               <div
-                className="c9"
+                className="c8"
               >
                 <span
-                  className="c10"
+                  className="c9"
                 >
                   <span
-                    className="c11"
+                    className="c10"
                   >
                     <a
                       href="/artist/fernando-botero"
@@ -271,7 +252,7 @@ exports[`renders properly 1`] = `
               </div>
               <div>
                 <div
-                  className="c9"
+                  className="c8"
                 >
                   <span
                     className="title"
@@ -292,7 +273,7 @@ exports[`renders properly 1`] = `
                   </span>
                 </div>
                 <div
-                  className="c9"
+                  className="c8"
                 >
                   <a
                     href="/gary-nader"
@@ -314,7 +295,7 @@ exports[`renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c12"
+        className="c11"
       >
         undefined of undefined
       </div>

--- a/src/Components/Publishing/Sections/ImageSetPreview/__tests__/__snapshots__/ImageSetPreview.test.tsx.snap
+++ b/src/Components/Publishing/Sections/ImageSetPreview/__tests__/__snapshots__/ImageSetPreview.test.tsx.snap
@@ -1,50 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a full image set properly 1`] = `
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
 .c4 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 16px;
-  line-height: 26px;
-  padding-bottom: 8px;
-}
-
-.c6 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-}
-
-.c7 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 12px;
-  line-height: 16px;
-  padding-left: 20px;
-}
-
-.c8 {
   height: 45px;
   position: relative;
   margin-left: 40px;
   text-align: right;
 }
 
-.c8 > svg {
+.c4 > svg {
   height: 98%;
 }
 
@@ -65,7 +29,7 @@ exports[`renders a full image set properly 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,45 +64,9 @@ exports[`renders a full image set properly 1`] = `
   fill: white;
 }
 
-.c9 {
+.c5 {
   height: auto;
   width: 100%;
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c4 {
-    line-height: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c6 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c6 {
-    line-height: 24px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c7 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c7 {
-    line-height: 24px;
-  }
 }
 
 <div
@@ -152,10 +80,10 @@ exports[`renders a full image set properly 1`] = `
       className="c2"
     >
       <div
-        className="c3"
+        className="sc-bwzfXH jXywsm"
       >
         <div
-          className="c4"
+          className="sc-htpNat hTdRdk"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -172,10 +100,10 @@ exports[`renders a full image set properly 1`] = `
           The Work of Bruce M. Sherman
         </div>
         <div
-          className="c5"
+          className="c3"
         >
           <div
-            className="c6"
+            className="sc-bxivhb bUZGRr sc-htpNat iPLCTR"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -192,7 +120,7 @@ exports[`renders a full image set properly 1`] = `
             View Slideshow
           </div>
           <div
-            className="c7"
+            className="sc-bxivhb bUZGRr sc-htpNat gMzPqM"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize={
               Array [
@@ -209,7 +137,7 @@ exports[`renders a full image set properly 1`] = `
         className="rrm-container rrm-greaterThanOrEqual-sm"
       >
         <div
-          className="c8"
+          className="c4"
         >
           <svg
             className="image-set"
@@ -239,7 +167,7 @@ exports[`renders a full image set properly 1`] = `
   >
     <img
       alt="The Work of Bruce M. Sherman"
-      className="c9"
+      className="c5"
       src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0aRUvnVgQKbQk5dj8xcCAg%2Flarger.jpg&width=800&quality=80"
     />
   </div>
@@ -247,50 +175,14 @@ exports[`renders a full image set properly 1`] = `
 `;
 
 exports[`renders a mini image set properly 1`] = `
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
 .c6 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 16px;
-  line-height: 26px;
-  padding-bottom: 8px;
-}
-
-.c8 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-}
-
-.c9 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 12px;
-  line-height: 16px;
-  padding-left: 20px;
-}
-
-.c10 {
   height: 45px;
   position: relative;
   margin-left: 40px;
   text-align: right;
 }
 
-.c10 > svg {
+.c6 > svg {
   height: 98%;
 }
 
@@ -311,7 +203,7 @@ exports[`renders a mini image set properly 1`] = `
   width: 100%;
 }
 
-.c7 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -348,42 +240,6 @@ exports[`renders a mini image set properly 1`] = `
   width: auto;
 }
 
-@media screen and (min-width:40em) {
-  .c6 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c6 {
-    line-height: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c8 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c8 {
-    line-height: 24px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c9 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c9 {
-    line-height: 24px;
-  }
-}
-
 <div
   className="c0"
 >
@@ -400,10 +256,10 @@ exports[`renders a mini image set properly 1`] = `
       className="c4"
     >
       <div
-        className="c5"
+        className="sc-bwzfXH jXywsm"
       >
         <div
-          className="c6"
+          className="sc-htpNat hTdRdk"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -420,10 +276,10 @@ exports[`renders a mini image set properly 1`] = `
           The Work of Bruce M. Sherman
         </div>
         <div
-          className="c7"
+          className="c5"
         >
           <div
-            className="c8"
+            className="sc-bxivhb bUZGRr sc-htpNat iPLCTR"
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -440,7 +296,7 @@ exports[`renders a mini image set properly 1`] = `
             View Slideshow
           </div>
           <div
-            className="c9"
+            className="sc-bxivhb bUZGRr sc-htpNat gMzPqM"
             fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
             fontSize={
               Array [
@@ -457,7 +313,7 @@ exports[`renders a mini image set properly 1`] = `
         className="rrm-container rrm-greaterThanOrEqual-sm"
       >
         <div
-          className="c10"
+          className="c6"
         >
           <svg
             className="image-set"

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Artwork.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Artwork.test.tsx.snap
@@ -2,17 +2,10 @@
 
 exports[`Artwork snapshots renders properly 1`] = `
 .c8 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  color: #C2C2C2;
-}
-
-.c9 {
   margin-right: 30px;
 }
 
-.c10 {
+.c9 {
   white-space: nowrap;
 }
 
@@ -183,16 +176,16 @@ exports[`Artwork snapshots renders properly 1`] = `
   </a>
   <div>
     <div
-      className="c7 c8"
+      className="c7 sc-htpNat hoYAXX"
       color="#C2C2C2"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="14px"
     >
       <span
-        className="c9"
+        className="c8"
       >
         <span
-          className="c10"
+          className="c9"
         >
           <a
             href="/artist/fernando-botero"

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/ArtworkCaption.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/ArtworkCaption.test.tsx.snap
@@ -1,13 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArtworkCaption snapshot renders a classic caption properly 1`] = `
-.c1 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 14px;
-  line-height: 18px;
-  color: #666;
-}
-
 .c0 {
   margin-top: 10px;
   display: block;
@@ -19,12 +12,12 @@ exports[`ArtworkCaption snapshot renders a classic caption properly 1`] = `
   text-decoration: none;
 }
 
-.c0 .c2 {
+.c0 .c1 {
   margin-right: 0;
   font-weight: bold;
 }
 
-.c0 .c2::after {
+.c0 .c1::after {
   content: ", ";
 }
 
@@ -34,7 +27,7 @@ exports[`ArtworkCaption snapshot renders a classic caption properly 1`] = `
 
 <div>
   <div
-    className="display-artwork__caption c0 c1"
+    className="display-artwork__caption c0 sc-htpNat eAqBPJ"
     color="#666"
     fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
     fontSize="14px"
@@ -42,7 +35,7 @@ exports[`ArtworkCaption snapshot renders a classic caption properly 1`] = `
     <div
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<span><span class=\\"c2 ciyMlo\\"><span class=\\"name\\">Fernando Botero</span></span><span class=\\"title\\">Nude on the Beach</span><span>, </span><span class=\\"date\\">2000</span>. Gary Nader</span>",
+          "__html": "<span><span class=\\"c1 ciyMlo\\"><span class=\\"name\\">Fernando Botero</span></span><span class=\\"title\\">Nude on the Beach</span><span>, </span><span class=\\"date\\">2000</span>. Gary Nader</span>",
         }
       }
     />
@@ -51,14 +44,7 @@ exports[`ArtworkCaption snapshot renders a classic caption properly 1`] = `
 `;
 
 exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
-.c1 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c3 {
+.c2 {
   margin-right: 30px;
 }
 
@@ -80,18 +66,6 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
   font-style: italic;
 }
 
-@media screen and (min-width:40em) {
-  .c1 {
-    font-size: 16px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c1 {
-    line-height: 26px;
-  }
-}
-
 @media (max-width:720px) {
   .c0 {
     -webkit-flex-direction: column;
@@ -101,14 +75,14 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
 }
 
 @media (max-width:720px) {
-  .c2.artist-name {
+  .c1.artist-name {
     margin-bottom: 5px;
   }
 }
 
 <div>
   <div
-    className="c0 c1"
+    className="c0 sc-htpNat kQLpuM"
     fontFamily={
       Object {
         "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -123,10 +97,10 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
     }
   >
     <div
-      className="c2"
+      className="c1"
     >
       <span
-        className="c3"
+        className="c2"
       >
         <span
           className="name"
@@ -137,7 +111,7 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
     </div>
     <div>
       <div
-        className="c2"
+        className="c1"
       >
         <span
           className="title"
@@ -154,7 +128,7 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
         </span>
       </div>
       <div
-        className="c2"
+        className="c1"
       >
         Gary Nader
         <span>
@@ -172,14 +146,7 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
 `;
 
 exports[`ArtworkCaption snapshot renders a standard caption properly 1`] = `
-.c1 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  color: #C2C2C2;
-}
-
-.c3 {
+.c2 {
   margin-right: 30px;
 }
 
@@ -203,12 +170,12 @@ exports[`ArtworkCaption snapshot renders a standard caption properly 1`] = `
   font-style: italic;
 }
 
-.c4 .c2 {
+.c3 .c1 {
   margin-right: 0;
   font-weight: bold;
 }
 
-.c4 .c2::after {
+.c3 .c1::after {
   content: ", ";
 }
 
@@ -220,13 +187,13 @@ exports[`ArtworkCaption snapshot renders a standard caption properly 1`] = `
 
 <div>
   <div
-    className="c0 c1"
+    className="c0 sc-htpNat hoYAXX"
     color="#C2C2C2"
     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
     fontSize="14px"
   >
     <span
-      className="c2 c3"
+      className="c1 c2"
     >
       <span
         className="name"

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Authors.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Authors.test.tsx.snap
@@ -1,14 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders properly 1`] = `
-.c3 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 16px;
-  line-height: 26px;
-}
-
-.c7 {
+.c6 {
   font-family: artsy-icons;
   color: black;
   font-size: 24px;
@@ -31,7 +24,7 @@ exports[`renders properly 1`] = `
   background-size: cover;
 }
 
-.c8 {
+.c7 {
   margin-right: 20px;
   min-width: 60px;
   min-height: 60px;
@@ -57,17 +50,17 @@ exports[`renders properly 1`] = `
   color: black;
 }
 
-.c4 {
+.c3 {
   margin-right: 20px;
 }
 
-.c5 {
+.c4 {
   -webkit-text-decoration: none;
   text-decoration: none;
   white-space: nowrap;
 }
 
-.c5 .c6 {
+.c4 .c5 {
   vertical-align: middle;
   margin: 0;
 }
@@ -90,7 +83,7 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width:600px) {
-  .c8 {
+  .c7 {
     min-width: 40px;
     min-height: 40px;
   }
@@ -108,7 +101,7 @@ exports[`renders properly 1`] = `
       src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F9vcX6FR21rKHatmvJ8K0sg%252FAbigail.jpg&width=200&quality=80"
     />
     <div
-      className="c3"
+      className="sc-bxivhb bUZGRr sc-htpNat htJRPl"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -118,7 +111,7 @@ exports[`renders properly 1`] = `
       fontSize="16px"
     >
       <span
-        className="c4"
+        className="c3"
       >
         <span>
           <a
@@ -131,11 +124,11 @@ exports[`renders properly 1`] = `
       </span>
       <span>
         <a
-          className="c5"
+          className="c4"
           href="http://twitter.com/abigailcain"
         >
           <div
-            className="c6 c7"
+            className="c5 c6"
           >
             
           </div>
@@ -149,11 +142,11 @@ exports[`renders properly 1`] = `
     color="black"
   >
     <div
-      className="c8"
+      className="c7"
       src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=http%3A%2F%2Ffiles.artsy.net%2Fimages%2Fmolly_01.jpg&width=200&quality=80"
     />
     <div
-      className="c3"
+      className="sc-bxivhb bUZGRr sc-htpNat htJRPl"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -163,7 +156,7 @@ exports[`renders properly 1`] = `
       fontSize="16px"
     >
       <span
-        className="c4"
+        className="c3"
       >
         <span>
           <a
@@ -176,11 +169,11 @@ exports[`renders properly 1`] = `
       </span>
       <span>
         <a
-          className="c5"
+          className="c4"
           href="http://twitter.com/mollygottschalk"
         >
           <div
-            className="c6 c7"
+            className="c5 c6"
           >
             
           </div>
@@ -194,7 +187,7 @@ exports[`renders properly 1`] = `
     color="black"
   >
     <div
-      className="c3"
+      className="sc-bxivhb bUZGRr sc-htpNat htJRPl"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -204,7 +197,7 @@ exports[`renders properly 1`] = `
       fontSize="16px"
     >
       <span
-        className="c4"
+        className="c3"
       >
         <span>
           <a
@@ -217,11 +210,11 @@ exports[`renders properly 1`] = `
       </span>
       <span>
         <a
-          className="c5"
+          className="c4"
           href="http://twitter.com/halleyjohnson"
         >
           <div
-            className="c6 c7"
+            className="c5 c6"
           >
             
           </div>
@@ -235,7 +228,7 @@ exports[`renders properly 1`] = `
     color="black"
   >
     <div
-      className="c3"
+      className="sc-bxivhb bUZGRr sc-htpNat htJRPl"
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -245,7 +238,7 @@ exports[`renders properly 1`] = `
       fontSize="16px"
     >
       <span
-        className="c4"
+        className="c3"
       >
         <div>
           Kana Abe

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/ImageCollection.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/ImageCollection.test.tsx.snap
@@ -2,17 +2,10 @@
 
 exports[`renders a single image properly 1`] = `
 .c10 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  color: #C2C2C2;
-}
-
-.c11 {
   margin-right: 30px;
 }
 
-.c12 {
+.c11 {
   white-space: nowrap;
 }
 
@@ -220,16 +213,16 @@ exports[`renders a single image properly 1`] = `
       </a>
       <div>
         <div
-          className="c9 c10"
+          className="c9 sc-htpNat hoYAXX"
           color="#C2C2C2"
           fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
           fontSize="14px"
         >
           <span
-            className="c11"
+            className="c10"
           >
             <span
-              className="c12"
+              className="c11"
             >
               <a
                 href="/artist/fernando-botero"
@@ -295,17 +288,10 @@ exports[`renders a single image properly 1`] = `
 
 exports[`renders properly 1`] = `
 .c10 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  color: #C2C2C2;
-}
-
-.c11 {
   margin-right: 30px;
 }
 
-.c12 {
+.c11 {
   white-space: nowrap;
 }
 
@@ -389,7 +375,7 @@ exports[`renders properly 1`] = `
   flex-direction: column;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -401,16 +387,16 @@ exports[`renders properly 1`] = `
   margin: 10px 0 10px 0;
 }
 
-.c15 {
+.c14 {
   padding: 0;
   width: 100%;
   word-break: break-word;
 }
 
-.c15 > p,
-.c15 p,
-.c15 .public-DraftEditorPlaceholder-root,
-.c15 .public-DraftStyleDefault-block {
+.c14 > p,
+.c14 p,
+.c14 .public-DraftEditorPlaceholder-root,
+.c14 .public-DraftStyleDefault-block {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
@@ -419,13 +405,13 @@ exports[`renders properly 1`] = `
   margin: 0;
 }
 
-.c15 > a,
-.c15 a {
+.c14 > a,
+.c14 a {
   color: #999;
 }
 
-.c15 > a:hover,
-.c15 a:hover {
+.c14 > a:hover,
+.c14 a:hover {
   color: black;
 }
 
@@ -446,12 +432,12 @@ exports[`renders properly 1`] = `
   width: 312px;
 }
 
-.c13 {
+.c12 {
   margin-right: 10px;
   width: 168px;
 }
 
-.c16 {
+.c15 {
   margin-right: 0px;
   width: 178px;
 }
@@ -469,13 +455,13 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width:600px) {
-  .c14 {
+  .c13 {
     padding: 0px 10px;
   }
 }
 
 @media (max-width:600px) {
-  .c15 {
+  .c14 {
     padding: 0px;
   }
 }
@@ -495,13 +481,13 @@ exports[`renders properly 1`] = `
 }
 
 @media (max-width:600px) {
-  .c13 {
+  .c12 {
     margin-bottom: 10px;
   }
 }
 
 @media (max-width:600px) {
-  .c16 {
+  .c15 {
     margin-bottom: 10px;
   }
 }
@@ -588,16 +574,16 @@ exports[`renders properly 1`] = `
       </a>
       <div>
         <div
-          className="c9 c10"
+          className="c9 sc-htpNat hoYAXX"
           color="#C2C2C2"
           fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
           fontSize="14px"
         >
           <span
-            className="c11"
+            className="c10"
           >
             <span
-              className="c12"
+              className="c11"
             >
               <a
                 href="/artist/fernando-botero"
@@ -659,7 +645,7 @@ exports[`renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c13"
+    className="c12"
     width={168}
   >
     <div
@@ -731,10 +717,10 @@ exports[`renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c14"
+        className="c13"
       >
         <div
-          className="c15"
+          className="c14"
         >
           <div
             dangerouslySetInnerHTML={
@@ -748,7 +734,7 @@ exports[`renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c16"
+    className="c15"
     width={178}
   >
     <div
@@ -820,10 +806,10 @@ exports[`renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c14"
+        className="c13"
       >
         <div
-          className="c15"
+          className="c14"
         >
           <div
             dangerouslySetInnerHTML={

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -1,57 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Sections snapshots tests renders properly 1`] = `
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c18 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  color: #C2C2C2;
-}
-
-.c32 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 16px;
-  line-height: 26px;
-  padding-bottom: 8px;
-}
-
-.c34 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-}
-
-.c35 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 12px;
-  line-height: 16px;
-  padding-left: 20px;
-}
-
-.c41 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 16px;
-  line-height: 26px;
-}
-
-.c45 {
+.c39 {
   font-family: artsy-icons;
   color: black;
   font-size: 24px;
@@ -65,7 +15,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
   color: black;
 }
 
-.c40 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -78,26 +28,26 @@ exports[`Sections snapshots tests renders properly 1`] = `
   color: black;
 }
 
-.c40 a {
+.c35 a {
   color: black;
 }
 
-.c42 {
+.c36 {
   margin-right: 20px;
 }
 
-.c43 {
+.c37 {
   -webkit-text-decoration: none;
   text-decoration: none;
   white-space: nowrap;
 }
 
-.c43 .c44 {
+.c37 .c38 {
   vertical-align: middle;
   margin: 0;
 }
 
-.c39 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -107,16 +57,16 @@ exports[`Sections snapshots tests renders properly 1`] = `
   flex-direction: column;
 }
 
-.c24 {
+.c23 {
   width: 100%;
   height: 1000px;
 }
 
-.c19 {
+.c18 {
   margin-right: 30px;
 }
 
-.c20 {
+.c19 {
   white-space: nowrap;
 }
 
@@ -262,43 +212,43 @@ exports[`Sections snapshots tests renders properly 1`] = `
   width: 264px;
 }
 
-.c21 {
+.c20 {
   margin-right: 10px;
+  width: 219px;
+}
+
+.c21 {
+  margin-right: 0px;
   width: 219px;
 }
 
 .c22 {
   margin-right: 0px;
-  width: 219px;
-}
-
-.c23 {
-  margin-right: 0px;
   width: 100%;
 }
 
-.c25 {
+.c24 {
   margin-right: 10px;
   width: 216px;
 }
 
-.c26 {
+.c25 {
   margin-right: 0px;
   width: 222px;
 }
 
-.c36 {
+.c31 {
   height: 45px;
   position: relative;
   margin-left: 40px;
   text-align: right;
 }
 
-.c36 > svg {
+.c31 > svg {
   height: 98%;
 }
 
-.c30 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -315,19 +265,19 @@ exports[`Sections snapshots tests renders properly 1`] = `
   width: 100%;
 }
 
-.c33 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c28 {
+.c27 {
   position: relative;
   width: 100%;
 }
 
-.c29 {
+.c28 {
   position: absolute;
   bottom: 20px;
   left: 20px;
@@ -340,17 +290,17 @@ exports[`Sections snapshots tests renders properly 1`] = `
   cursor: pointer;
 }
 
-.c29:hover {
+.c28:hover {
   background: rgba(0,0,0,0.6);
   color: white;
 }
 
-.c29:hover path,
-.c29:hover polygon {
+.c28:hover path,
+.c28:hover polygon {
   fill: white;
 }
 
-.c37 {
+.c32 {
   height: auto;
   width: 100%;
 }
@@ -379,7 +329,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
   max-width: 100%;
 }
 
-.c27 {
+.c26 {
   box-sizing: border-box;
   margin: auto;
   margin-bottom: 40px;
@@ -387,7 +337,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
   max-width: 100%;
 }
 
-.c38 {
+.c33 {
   box-sizing: border-box;
   margin: auto;
   margin-bottom: 40px;
@@ -508,7 +458,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
   background-size: 1.25px 1px;
 }
 
-.c2 h2 .c46 {
+.c2 h2 .c40 {
   background-position: bottom !important;
 }
 
@@ -603,44 +553,8 @@ exports[`Sections snapshots tests renders properly 1`] = `
   max-width: 780px;
 }
 
-@media screen and (min-width:40em) {
-  .c32 {
-    font-size: 18px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c32 {
-    line-height: 30px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c34 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c34 {
-    line-height: 24px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c35 {
-    font-size: 14px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c35 {
-    line-height: 24px;
-  }
-}
-
 @media (max-width:720px) {
-  .c24 {
+  .c23 {
     height: 1300px;
     width: 100%;
   }
@@ -691,6 +605,12 @@ exports[`Sections snapshots tests renders properly 1`] = `
 }
 
 @media (max-width:600px) {
+  .c20 {
+    margin-bottom: 10px;
+  }
+}
+
+@media (max-width:600px) {
   .c21 {
     margin-bottom: 10px;
   }
@@ -703,7 +623,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
 }
 
 @media (max-width:600px) {
-  .c23 {
+  .c24 {
     margin-bottom: 10px;
   }
 }
@@ -714,62 +634,56 @@ exports[`Sections snapshots tests renders properly 1`] = `
   }
 }
 
-@media (max-width:600px) {
+@media (max-width:1280px) {
+  .c1 {
+    width: 680px;
+  }
+}
+
+@media (max-width:900px) {
+  .c1 {
+    padding: 0 20px;
+  }
+}
+
+@media (max-width:1280px) {
+  .c3 {
+    width: 680px;
+  }
+}
+
+@media (max-width:900px) {
+  .c3 {
+    padding: 0 20px;
+  }
+}
+
+@media (max-width:1280px) {
+  .c4 {
+    width: 680px;
+  }
+}
+
+@media (max-width:900px) {
+  .c4 {
+    padding: 0;
+  }
+}
+
+@media (max-width:1280px) {
   .c26 {
-    margin-bottom: 10px;
-  }
-}
-
-@media (max-width:1280px) {
-  .c1 {
     width: 680px;
   }
 }
 
 @media (max-width:900px) {
-  .c1 {
-    padding: 0 20px;
-  }
-}
-
-@media (max-width:1280px) {
-  .c3 {
-    width: 680px;
-  }
-}
-
-@media (max-width:900px) {
-  .c3 {
-    padding: 0 20px;
-  }
-}
-
-@media (max-width:1280px) {
-  .c4 {
-    width: 680px;
-  }
-}
-
-@media (max-width:900px) {
-  .c4 {
-    padding: 0;
-  }
-}
-
-@media (max-width:1280px) {
-  .c27 {
-    width: 680px;
-  }
-}
-
-@media (max-width:900px) {
-  .c27 {
+  .c26 {
     padding: 0;
   }
 }
 
 @media (max-width:900px) {
-  .c38 {
+  .c33 {
     padding: 0 20px;
   }
 }
@@ -1182,16 +1096,16 @@ exports[`Sections snapshots tests renders properly 1`] = `
           </a>
           <div>
             <div
-              className="c17 c18"
+              className="c17 hoYAXX"
               color="#C2C2C2"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="14px"
             >
               <span
-                className="c19"
+                className="c18"
               >
                 <span
-                  className="c20"
+                  className="c19"
                 >
                   <a
                     href="/artist/matt-devine"
@@ -1277,7 +1191,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="c5"
     >
       <div
-        className="c21"
+        className="c20"
         width={219}
       >
         <div
@@ -1366,7 +1280,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c21"
+        className="c20"
         width={219}
       >
         <div
@@ -1455,7 +1369,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c22"
+        className="c21"
         width={219}
       >
         <div
@@ -1568,7 +1482,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="c5"
     >
       <div
-        className="c23"
+        className="c22"
       >
         <div
           className="article-image"
@@ -1677,7 +1591,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
     className="c3"
   >
     <iframe
-      className="c24"
+      className="c23"
       frameBorder="0"
       height={1000}
       scrolling="no"
@@ -1707,7 +1621,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="c5"
     >
       <div
-        className="c25"
+        className="c24"
         width={216}
       >
         <div
@@ -1796,7 +1710,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c21"
+        className="c20"
         width={219}
       >
         <div
@@ -1885,7 +1799,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
         </div>
       </div>
       <div
-        className="c26"
+        className="c25"
         width={222}
       >
         <div
@@ -1992,23 +1906,23 @@ exports[`Sections snapshots tests renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c27"
+    className="c26"
   >
     <div
-      className="c28"
+      className="c27"
     >
       <div
-        className="c29"
+        className="c28"
         onClick={[Function]}
       >
         <div
-          className="c30"
+          className="c29"
         >
           <div
-            className="c31"
+            className="jXywsm"
           >
             <div
-              className="c32"
+              className="hTdRdk"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2025,10 +1939,10 @@ exports[`Sections snapshots tests renders properly 1`] = `
               The Work of Bruce M. Sherman
             </div>
             <div
-              className="c33"
+              className="c30"
             >
               <div
-                className="c34"
+                className="bUZGRr iPLCTR"
                 fontFamily={
                   Object {
                     "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2045,7 +1959,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
                 View Slideshow
               </div>
               <div
-                className="c35"
+                className="bUZGRr gMzPqM"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize={
                   Array [
@@ -2062,7 +1976,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
             className="rrm-container rrm-greaterThanOrEqual-sm"
           >
             <div
-              className="c36"
+              className="c31"
             >
               <svg
                 className="image-set"
@@ -2092,7 +2006,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
       >
         <img
           alt="The Work of Bruce M. Sherman"
-          className="c37"
+          className="c32"
           src="https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FCzofaZln2q-XhtXFqIio5A%252F07272017133815-0001%2B%2528dragged%2529%2Bcopy.jpg&width=800&quality=80"
         />
       </div>
@@ -2115,13 +2029,13 @@ exports[`Sections snapshots tests renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c27"
+    className="c26"
   >
     <div
       className="c5"
     >
       <div
-        className="c23"
+        className="c22"
       >
         <div
           className="article-image"
@@ -2227,17 +2141,17 @@ exports[`Sections snapshots tests renders properly 1`] = `
     </div>
   </div>
   <div
-    className="c38"
+    className="c33"
   >
     <div
-      className="c39"
+      className="c34"
     >
       <div
-        className="c40"
+        className="c35"
         color="black"
       >
         <div
-          className="c41"
+          className="bUZGRr htJRPl"
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -2247,7 +2161,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
           fontSize="16px"
         >
           <span
-            className="c42"
+            className="c36"
           >
             <span>
               <a
@@ -2260,11 +2174,11 @@ exports[`Sections snapshots tests renders properly 1`] = `
           </span>
           <span>
             <a
-              className="c43"
+              className="c37"
               href="http://twitter.com/caseylesser"
             >
               <div
-                className="c44 c45"
+                className="c38 c39"
               >
                 
               </div>

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/VerticalOrSeriesTitle.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/VerticalOrSeriesTitle.test.tsx.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders properly for a feature article 1`] = `
-.c1 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-  color: #000;
-}
-
 .c0 a {
   color: #000;
   -webkit-text-decoration: none;
@@ -16,7 +8,7 @@ exports[`renders properly for a feature article 1`] = `
 }
 
 <div
-  className="c0 c1"
+  className="c0 sc-htpNat gTPxXw"
   color="#000"
   fontFamily={
     Object {
@@ -33,14 +25,6 @@ exports[`renders properly for a feature article 1`] = `
 `;
 
 exports[`renders properly for a standard article 1`] = `
-.c1 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 24px;
-  color: #000;
-}
-
 .c0 a {
   color: #000;
   -webkit-text-decoration: none;
@@ -48,7 +32,7 @@ exports[`renders properly for a standard article 1`] = `
 }
 
 <div
-  className="c0 c1"
+  className="c0 sc-htpNat gTPxXw"
   color="#000"
   fontFamily={
     Object {

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -6,47 +6,6 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: black;
-  margin-bottom: 10px;
-}
-
-.c3 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 18px;
-  line-height: 30px;
-  margin-bottom: 20px;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -56,28 +15,28 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   margin-top: 5px;
 }
 
-.c5 {
+.c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c5:hover {
+.c2:hover {
   opacity: 0.6;
 }
 
-.c5:first-child {
+.c2:first-child {
   padding-left: 0;
 }
 
-.c7 {
+.c3 {
   position: relative;
   width: 100%;
   color: black;
 }
 
-.c7 a {
+.c3 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -87,22 +46,22 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   background-position: bottom;
 }
 
-.c7 a:hover {
+.c3 a:hover {
   color: #C2C2C2;
   opacity: 1;
 }
 
-.c7 div[class*='ToolTip'] a {
+.c3 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c7 p,
-.c7 ul,
-.c7 ol,
-.c7 .paragraph,
-.c7 div[data-block=true] .public-DraftStyleDefault-block {
+.c3 p,
+.c3 ul,
+.c3 ol,
+.c3 .paragraph,
+.c3 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -113,32 +72,32 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   font-style: inherit;
 }
 
-.c7 p:first-child,
-.c7 .paragraph:first-child,
-.c7 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c3 p:first-child,
+.c3 .paragraph:first-child,
+.c3 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c7 p:last-child,
-.c7 .paragraph:last-child,
-.c7 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c3 p:last-child,
+.c3 .paragraph:last-child,
+.c3 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c7 ul,
-.c7 ol {
+.c3 ul,
+.c3 ol {
   padding-left: 1em;
 }
 
-.c7 ul {
+.c3 ul {
   list-style: disc;
 }
 
-.c7 ol {
+.c3 ol {
   list-style: decimal;
 }
 
-.c7 li {
+.c3 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -147,7 +106,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   padding-bottom: .5em;
 }
 
-.c7 h1 {
+.c3 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -160,7 +119,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   text-align: center;
 }
 
-.c7 h1::before {
+.c3 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -171,7 +130,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   right: calc(50% - 4px);
 }
 
-.c7 h2 {
+.c3 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -180,15 +139,15 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   margin: 0;
 }
 
-.c7 h2 a {
+.c3 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c7 h2 .c8 {
+.c3 h2 .c4 {
   background-position: bottom !important;
 }
 
-.c7 h3 {
+.c3 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -198,7 +157,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   margin: 0;
 }
 
-.c7 h3 strong {
+.c3 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -206,11 +165,11 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   line-height: 1.5em;
 }
 
-.c7 h3 a {
+.c3 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c7 blockquote {
+.c3 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -223,11 +182,11 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   word-break: break-word;
 }
 
-.c7 .preventLineBreak {
+.c3 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c7 .content-end {
+.c3 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -238,14 +197,14 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   margin-bottom: 1px;
 }
 
-.c7 .artist-follow {
+.c3 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c7 .artist-follow::before {
+.c3 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -253,7 +212,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   font-size: 32px;
 }
 
-.c7 .artist-follow::after {
+.c3 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -276,111 +235,39 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   width: 100%;
 }
 
-@media screen and (min-width:40em) {
-  .c1 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c6 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c6 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c6 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c3 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
 @media (max-width:600px) {
-  .c7 p,
-  .c7 ul,
-  .c7 ol,
-  .c7 div[data-block=true] .public-DraftStyleDefault-block {
+  .c3 p,
+  .c3 ul,
+  .c3 ol,
+  .c3 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c7 li {
+  .c3 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c7 h1 {
+  .c3 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c7 h2 {
+  .c3 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c7 h3 {
+  .c3 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -388,14 +275,14 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
     line-height: 1.5em;
   }
 
-  .c7 h3 strong {
+  .c3 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c7 blockquote {
+  .c3 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -403,7 +290,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
     margin: 0;
   }
 
-  .c7 .content-start {
+  .c3 .content-start {
     font-size: 55px;
   }
 }
@@ -438,7 +325,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   width="100%"
 >
   <div
-    className="c1"
+    className="sc-bwzfXH ckfosv"
     width={
       Array [
         1,
@@ -450,7 +337,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
   >
     <div>
       <div
-        className="c2"
+        className="sc-bxivhb bUZGRr sc-htpNat cOwCZc"
         color="black"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="28px"
@@ -458,15 +345,15 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
         About the Series
       </div>
       <div
-        className="c3"
+        className="sc-bxivhb bUZGRr sc-htpNat fRcQPt"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="18px"
       >
         <div
-          className="c4"
+          className="c1"
         >
           <a
-            className="c5"
+            className="c2"
             href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art"
             onClick={[Function]}
             target="_blank"
@@ -492,7 +379,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
             </svg>
           </a>
           <a
-            className="c5"
+            className="c2"
             href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&text=undefined&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&via=artsy"
             onClick={[Function]}
             target="_blank"
@@ -518,7 +405,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
             </svg>
           </a>
           <a
-            className="c5"
+            className="c2"
             href="mailto:?subject=undefined&body=Check out undefined on Artsy: https://www.artsy.net/article/future-of-art"
             onClick={[Function]}
             target="_blank"
@@ -551,7 +438,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
     />
   </div>
   <div
-    className="c6"
+    className="sc-bwzfXH bQqYVB"
     width={
       Array [
         1,
@@ -565,7 +452,7 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
       className="SeriesAbout__description"
     >
       <div
-        className="article__text-section c7"
+        className="article__text-section c3"
         color="black"
       >
         <div
@@ -590,47 +477,6 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: black;
-  margin-bottom: 10px;
-}
-
-.c3 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 18px;
-  line-height: 30px;
-  margin-bottom: 20px;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -640,28 +486,28 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   margin-top: 5px;
 }
 
-.c5 {
+.c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c5:hover {
+.c2:hover {
   opacity: 0.6;
 }
 
-.c5:first-child {
+.c2:first-child {
   padding-left: 0;
 }
 
-.c7 {
+.c3 {
   position: relative;
   width: 100%;
   color: black;
 }
 
-.c7 a {
+.c3 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -671,22 +517,22 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   background-position: bottom;
 }
 
-.c7 a:hover {
+.c3 a:hover {
   color: #C2C2C2;
   opacity: 1;
 }
 
-.c7 div[class*='ToolTip'] a {
+.c3 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c7 p,
-.c7 ul,
-.c7 ol,
-.c7 .paragraph,
-.c7 div[data-block=true] .public-DraftStyleDefault-block {
+.c3 p,
+.c3 ul,
+.c3 ol,
+.c3 .paragraph,
+.c3 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -697,32 +543,32 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   font-style: inherit;
 }
 
-.c7 p:first-child,
-.c7 .paragraph:first-child,
-.c7 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c3 p:first-child,
+.c3 .paragraph:first-child,
+.c3 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c7 p:last-child,
-.c7 .paragraph:last-child,
-.c7 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c3 p:last-child,
+.c3 .paragraph:last-child,
+.c3 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c7 ul,
-.c7 ol {
+.c3 ul,
+.c3 ol {
   padding-left: 1em;
 }
 
-.c7 ul {
+.c3 ul {
   list-style: disc;
 }
 
-.c7 ol {
+.c3 ol {
   list-style: decimal;
 }
 
-.c7 li {
+.c3 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -731,7 +577,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   padding-bottom: .5em;
 }
 
-.c7 h1 {
+.c3 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -744,7 +590,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   text-align: center;
 }
 
-.c7 h1::before {
+.c3 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -755,7 +601,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   right: calc(50% - 4px);
 }
 
-.c7 h2 {
+.c3 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -764,15 +610,15 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   margin: 0;
 }
 
-.c7 h2 a {
+.c3 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c7 h2 .c8 {
+.c3 h2 .c4 {
   background-position: bottom !important;
 }
 
-.c7 h3 {
+.c3 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -782,7 +628,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   margin: 0;
 }
 
-.c7 h3 strong {
+.c3 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -790,11 +636,11 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   line-height: 1.5em;
 }
 
-.c7 h3 a {
+.c3 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c7 blockquote {
+.c3 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -807,11 +653,11 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   word-break: break-word;
 }
 
-.c7 .preventLineBreak {
+.c3 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c7 .content-end {
+.c3 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -822,14 +668,14 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   margin-bottom: 1px;
 }
 
-.c7 .artist-follow {
+.c3 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c7 .artist-follow::before {
+.c3 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -837,7 +683,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   font-size: 32px;
 }
 
-.c7 .artist-follow::after {
+.c3 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -860,111 +706,39 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   width: 100%;
 }
 
-@media screen and (min-width:40em) {
-  .c1 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c6 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c6 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c6 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c3 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
 @media (max-width:600px) {
-  .c7 p,
-  .c7 ul,
-  .c7 ol,
-  .c7 div[data-block=true] .public-DraftStyleDefault-block {
+  .c3 p,
+  .c3 ul,
+  .c3 ol,
+  .c3 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c7 li {
+  .c3 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c7 h1 {
+  .c3 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c7 h2 {
+  .c3 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c7 h3 {
+  .c3 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -972,14 +746,14 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
     line-height: 1.5em;
   }
 
-  .c7 h3 strong {
+  .c3 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c7 blockquote {
+  .c3 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -987,7 +761,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
     margin: 0;
   }
 
-  .c7 .content-start {
+  .c3 .content-start {
     font-size: 55px;
   }
 }
@@ -1022,7 +796,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   width="100%"
 >
   <div
-    className="c1"
+    className="sc-bwzfXH ckfosv"
     width={
       Array [
         1,
@@ -1034,7 +808,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
   >
     <div>
       <div
-        className="c2"
+        className="sc-bxivhb bUZGRr sc-htpNat cOwCZc"
         color="black"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="28px"
@@ -1042,15 +816,15 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
         About the Series
       </div>
       <div
-        className="c3"
+        className="sc-bxivhb bUZGRr sc-htpNat fRcQPt"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="18px"
       >
         <div
-          className="c4"
+          className="c1"
         >
           <a
-            className="c5"
+            className="c2"
             href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art"
             onClick={[Function]}
             target="_blank"
@@ -1076,7 +850,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
             </svg>
           </a>
           <a
-            className="c5"
+            className="c2"
             href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&text=undefined&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&via=artsy"
             onClick={[Function]}
             target="_blank"
@@ -1102,7 +876,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
             </svg>
           </a>
           <a
-            className="c5"
+            className="c2"
             href="mailto:?subject=undefined&body=Check out undefined on Artsy: https://www.artsy.net/article/future-of-art"
             onClick={[Function]}
             target="_blank"
@@ -1135,7 +909,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
     />
   </div>
   <div
-    className="c6"
+    className="sc-bwzfXH bQqYVB"
     width={
       Array [
         1,
@@ -1146,7 +920,7 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
     }
   >
     <div
-      className="article__text-section c7"
+      className="article__text-section c3"
       color="black"
     >
       <div>
@@ -1167,47 +941,6 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: black;
-  margin-bottom: 10px;
-}
-
-.c3 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 18px;
-  line-height: 30px;
-  margin-bottom: 20px;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1217,28 +950,28 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   margin-top: 5px;
 }
 
-.c5 {
+.c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c5:hover {
+.c2:hover {
   opacity: 0.6;
 }
 
-.c5:first-child {
+.c2:first-child {
   padding-left: 0;
 }
 
-.c7 {
+.c3 {
   position: relative;
   width: 100%;
   color: black;
 }
 
-.c7 a {
+.c3 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1248,22 +981,22 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   background-position: bottom;
 }
 
-.c7 a:hover {
+.c3 a:hover {
   color: #C2C2C2;
   opacity: 1;
 }
 
-.c7 div[class*='ToolTip'] a {
+.c3 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c7 p,
-.c7 ul,
-.c7 ol,
-.c7 .paragraph,
-.c7 div[data-block=true] .public-DraftStyleDefault-block {
+.c3 p,
+.c3 ul,
+.c3 ol,
+.c3 .paragraph,
+.c3 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -1274,32 +1007,32 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   font-style: inherit;
 }
 
-.c7 p:first-child,
-.c7 .paragraph:first-child,
-.c7 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c3 p:first-child,
+.c3 .paragraph:first-child,
+.c3 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c7 p:last-child,
-.c7 .paragraph:last-child,
-.c7 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c3 p:last-child,
+.c3 .paragraph:last-child,
+.c3 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c7 ul,
-.c7 ol {
+.c3 ul,
+.c3 ol {
   padding-left: 1em;
 }
 
-.c7 ul {
+.c3 ul {
   list-style: disc;
 }
 
-.c7 ol {
+.c3 ol {
   list-style: decimal;
 }
 
-.c7 li {
+.c3 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -1308,7 +1041,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   padding-bottom: .5em;
 }
 
-.c7 h1 {
+.c3 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -1321,7 +1054,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   text-align: center;
 }
 
-.c7 h1::before {
+.c3 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -1332,7 +1065,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   right: calc(50% - 4px);
 }
 
-.c7 h2 {
+.c3 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -1341,15 +1074,15 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   margin: 0;
 }
 
-.c7 h2 a {
+.c3 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c7 h2 .c8 {
+.c3 h2 .c4 {
   background-position: bottom !important;
 }
 
-.c7 h3 {
+.c3 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -1359,7 +1092,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   margin: 0;
 }
 
-.c7 h3 strong {
+.c3 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -1367,11 +1100,11 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   line-height: 1.5em;
 }
 
-.c7 h3 a {
+.c3 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c7 blockquote {
+.c3 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -1384,11 +1117,11 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   word-break: break-word;
 }
 
-.c7 .preventLineBreak {
+.c3 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c7 .content-end {
+.c3 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -1399,14 +1132,14 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   margin-bottom: 1px;
 }
 
-.c7 .artist-follow {
+.c3 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c7 .artist-follow::before {
+.c3 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -1414,7 +1147,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   font-size: 32px;
 }
 
-.c7 .artist-follow::after {
+.c3 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -1437,111 +1170,39 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   width: 100%;
 }
 
-@media screen and (min-width:40em) {
-  .c1 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c6 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c6 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c6 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c3 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
 @media (max-width:600px) {
-  .c7 p,
-  .c7 ul,
-  .c7 ol,
-  .c7 div[data-block=true] .public-DraftStyleDefault-block {
+  .c3 p,
+  .c3 ul,
+  .c3 ol,
+  .c3 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c7 li {
+  .c3 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c7 h1 {
+  .c3 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c7 h2 {
+  .c3 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c7 h3 {
+  .c3 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1549,14 +1210,14 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
     line-height: 1.5em;
   }
 
-  .c7 h3 strong {
+  .c3 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c7 blockquote {
+  .c3 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -1564,7 +1225,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
     margin: 0;
   }
 
-  .c7 .content-start {
+  .c3 .content-start {
     font-size: 55px;
   }
 }
@@ -1599,7 +1260,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   width="100%"
 >
   <div
-    className="c1"
+    className="sc-bwzfXH ckfosv"
     width={
       Array [
         1,
@@ -1611,7 +1272,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
   >
     <div>
       <div
-        className="c2"
+        className="sc-bxivhb bUZGRr sc-htpNat cOwCZc"
         color="black"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="28px"
@@ -1622,15 +1283,15 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
         </div>
       </div>
       <div
-        className="c3"
+        className="sc-bxivhb bUZGRr sc-htpNat fRcQPt"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="18px"
       >
         <div
-          className="c4"
+          className="c1"
         >
           <a
-            className="c5"
+            className="c2"
             href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art"
             onClick={[Function]}
             target="_blank"
@@ -1656,7 +1317,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
             </svg>
           </a>
           <a
-            className="c5"
+            className="c2"
             href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&text=undefined&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&via=artsy"
             onClick={[Function]}
             target="_blank"
@@ -1682,7 +1343,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
             </svg>
           </a>
           <a
-            className="c5"
+            className="c2"
             href="mailto:?subject=undefined&body=Check out undefined on Artsy: https://www.artsy.net/article/future-of-art"
             onClick={[Function]}
             target="_blank"
@@ -1715,7 +1376,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
     />
   </div>
   <div
-    className="c6"
+    className="sc-bwzfXH bQqYVB"
     width={
       Array [
         1,
@@ -1729,7 +1390,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
       className="SeriesAbout__description"
     >
       <div
-        className="article__text-section c7"
+        className="article__text-section c3"
         color="black"
       >
         <div
@@ -1749,56 +1410,7 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
 `;
 
 exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
-.c6 {
-  margin-bottom: 4px;
-}
-
-.c12 {
-  margin-top: 60px;
-}
-
 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: black;
-  margin-bottom: 10px;
-}
-
-.c3 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 18px;
-  line-height: 30px;
-  margin-bottom: 20px;
-}
-
-.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1812,33 +1424,33 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin-top: 5px;
 }
 
-.c5 {
+.c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c5:hover {
+.c2:hover {
   opacity: 0.6;
 }
 
-.c5:first-child {
+.c2:first-child {
   padding-left: 0;
 }
 
-.c7 {
+.c3 {
   display: block;
 }
 
-.c9 img {
+.c5 img {
   max-width: 240px;
   max-height: 40px;
   object-fit: contain;
   object-position: left;
 }
 
-.c8 {
+.c4 {
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 16px;
@@ -1846,13 +1458,13 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin-bottom: 20px;
 }
 
-.c11 {
+.c6 {
   position: relative;
   width: 100%;
   color: black;
 }
 
-.c11 a {
+.c6 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1862,22 +1474,22 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   background-position: bottom;
 }
 
-.c11 a:hover {
+.c6 a:hover {
   color: #C2C2C2;
   opacity: 1;
 }
 
-.c11 div[class*='ToolTip'] a {
+.c6 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c11 p,
-.c11 ul,
-.c11 ol,
-.c11 .paragraph,
-.c11 div[data-block=true] .public-DraftStyleDefault-block {
+.c6 p,
+.c6 ul,
+.c6 ol,
+.c6 .paragraph,
+.c6 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -1888,32 +1500,32 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   font-style: inherit;
 }
 
-.c11 p:first-child,
-.c11 .paragraph:first-child,
-.c11 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c6 p:first-child,
+.c6 .paragraph:first-child,
+.c6 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c11 p:last-child,
-.c11 .paragraph:last-child,
-.c11 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c6 p:last-child,
+.c6 .paragraph:last-child,
+.c6 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c11 ul,
-.c11 ol {
+.c6 ul,
+.c6 ol {
   padding-left: 1em;
 }
 
-.c11 ul {
+.c6 ul {
   list-style: disc;
 }
 
-.c11 ol {
+.c6 ol {
   list-style: decimal;
 }
 
-.c11 li {
+.c6 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -1922,7 +1534,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   padding-bottom: .5em;
 }
 
-.c11 h1 {
+.c6 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -1935,7 +1547,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   text-align: center;
 }
 
-.c11 h1::before {
+.c6 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -1946,7 +1558,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   right: calc(50% - 4px);
 }
 
-.c11 h2 {
+.c6 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -1955,15 +1567,15 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin: 0;
 }
 
-.c11 h2 a {
+.c6 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c11 h2 .c13 {
+.c6 h2 .c7 {
   background-position: bottom !important;
 }
 
-.c11 h3 {
+.c6 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -1973,7 +1585,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin: 0;
 }
 
-.c11 h3 strong {
+.c6 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -1981,11 +1593,11 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   line-height: 1.5em;
 }
 
-.c11 h3 a {
+.c6 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c11 blockquote {
+.c6 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -1998,11 +1610,11 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   word-break: break-word;
 }
 
-.c11 .preventLineBreak {
+.c6 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c11 .content-end {
+.c6 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -2013,14 +1625,14 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   margin-bottom: 1px;
 }
 
-.c11 .artist-follow {
+.c6 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c11 .artist-follow::before {
+.c6 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -2028,7 +1640,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   font-size: 32px;
 }
 
-.c11 .artist-follow::after {
+.c6 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -2051,80 +1663,8 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   width: 100%;
 }
 
-@media screen and (min-width:40em) {
-  .c1 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c1 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c1 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c10 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c10 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c10 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c2 {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c2 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c2 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c3 {
-    margin-bottom: 20px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c3 {
-    margin-bottom: 0px;
-  }
-}
-
 @media (max-width:720px) {
-  .c8 {
+  .c4 {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -2133,38 +1673,38 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
 }
 
 @media (max-width:600px) {
-  .c11 p,
-  .c11 ul,
-  .c11 ol,
-  .c11 div[data-block=true] .public-DraftStyleDefault-block {
+  .c6 p,
+  .c6 ul,
+  .c6 ol,
+  .c6 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c11 li {
+  .c6 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c11 h1 {
+  .c6 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c11 h2 {
+  .c6 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c11 h3 {
+  .c6 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -2172,14 +1712,14 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
     line-height: 1.5em;
   }
 
-  .c11 h3 strong {
+  .c6 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c11 blockquote {
+  .c6 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -2187,7 +1727,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
     margin: 0;
   }
 
-  .c11 .content-start {
+  .c6 .content-start {
     font-size: 55px;
   }
 }
@@ -2222,7 +1762,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   width="100%"
 >
   <div
-    className="c1"
+    className="sc-bwzfXH ckfosv"
     width={
       Array [
         1,
@@ -2234,7 +1774,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
   >
     <div>
       <div
-        className="c2"
+        className="sc-bxivhb bUZGRr sc-htpNat cOwCZc"
         color="black"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="28px"
@@ -2242,15 +1782,15 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
         About the Series
       </div>
       <div
-        className="c3"
+        className="sc-bxivhb bUZGRr sc-htpNat fRcQPt"
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="18px"
       >
         <div
-          className="c4"
+          className="c1"
         >
           <a
-            className="c5"
+            className="c2"
             href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art"
             onClick={[Function]}
             target="_blank"
@@ -2276,7 +1816,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
             </svg>
           </a>
           <a
-            className="c5"
+            className="c2"
             href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&text=undefined&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Ffuture-of-art&via=artsy"
             onClick={[Function]}
             target="_blank"
@@ -2302,7 +1842,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
             </svg>
           </a>
           <a
-            className="c5"
+            className="c2"
             href="mailto:?subject=undefined&body=Check out undefined on Artsy: https://www.artsy.net/article/future-of-art"
             onClick={[Function]}
             target="_blank"
@@ -2334,18 +1874,18 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
       className="rrm-container rrm-greaterThanOrEqual-md"
     >
       <div
-        className="c6"
+        className="hirWLY"
       >
         <div
-          className="PartnerBlock c7"
+          className="PartnerBlock c3"
         >
           <div
-            className="c8"
+            className="c4"
           >
             Presented in Partnership with
           </div>
           <div
-            className="c9"
+            className="c5"
           >
             <a
               href="http://artsy.net"
@@ -2362,7 +1902,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
     </div>
   </div>
   <div
-    className="c10"
+    className="sc-bwzfXH bQqYVB"
     width={
       Array [
         1,
@@ -2376,7 +1916,7 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
       className="SeriesAbout__description"
     >
       <div
-        className="article__text-section c11"
+        className="article__text-section c6"
         color="black"
       >
         <div
@@ -2392,18 +1932,18 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
       className="rrm-container rrm-lessThan-md"
     >
       <div
-        className="c12"
+        className="hhOARf"
       >
         <div
-          className="PartnerBlock c7"
+          className="PartnerBlock c3"
         >
           <div
-            className="c8"
+            className="c4"
           >
             Presented in Partnership with
           </div>
           <div
-            className="c9"
+            className="c5"
           >
             <a
               href="http://artsy.net"

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesTitle.test.tsx.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesTitle.test.tsx.snap
@@ -6,12 +6,12 @@ exports[`renders a series title properly 1`] = `
   text-align: center;
 }
 
-.c0 .PartnerBlock__ImageContainer-ydgi2-1 {
+.c0 .c2 {
   padding-top: 5px;
   padding-bottom: 40px;
 }
 
-.c0 .PartnerBlock__ImageContainer-ydgi2-1 img {
+.c0 .c2 img {
   margin-left: auto;
   margin-right: auto;
 }
@@ -25,7 +25,7 @@ exports[`renders a series title properly 1`] = `
 }
 
 @media (max-width:900px) {
-  .c0 .PartnerBlock__ImageContainer-ydgi2-1 {
+  .c0 .c2 {
     padding-bottom: 0;
   }
 }

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
@@ -2,34 +2,11 @@
 
 exports[`Video About matches the snapshot 1`] = `
 .c5 {
-  margin-top: 40px;
-}
-
-.c13 {
-  width: 100%;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: black;
-  padding-bottom: 10px;
-}
-
-.c8 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c7 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c10 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -43,36 +20,36 @@ exports[`Video About matches the snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c12 {
+.c9 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c12:hover {
+.c9:hover {
   opacity: 0.6;
 }
 
-.c12:first-child {
+.c9:first-child {
   padding-left: 0;
 }
 
-.c11 {
+.c8 {
   margin: 5px 10px 5px 0;
 }
 
-.c6 {
+.c4 {
   color: black;
 }
 
-.c4 {
+.c3 {
   position: relative;
   width: 100%;
   color: black;
 }
 
-.c4 a {
+.c3 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -82,22 +59,22 @@ exports[`Video About matches the snapshot 1`] = `
   background-position: bottom;
 }
 
-.c4 a:hover {
+.c3 a:hover {
   color: #C2C2C2;
   opacity: 1;
 }
 
-.c4 div[class*='ToolTip'] a {
+.c3 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c4 p,
-.c4 ul,
-.c4 ol,
-.c4 .paragraph,
-.c4 div[data-block=true] .public-DraftStyleDefault-block {
+.c3 p,
+.c3 ul,
+.c3 ol,
+.c3 .paragraph,
+.c3 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -108,32 +85,32 @@ exports[`Video About matches the snapshot 1`] = `
   font-style: inherit;
 }
 
-.c4 p:first-child,
-.c4 .paragraph:first-child,
-.c4 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c3 p:first-child,
+.c3 .paragraph:first-child,
+.c3 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c4 p:last-child,
-.c4 .paragraph:last-child,
-.c4 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c3 p:last-child,
+.c3 .paragraph:last-child,
+.c3 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c4 ul,
-.c4 ol {
+.c3 ul,
+.c3 ol {
   padding-left: 1em;
 }
 
-.c4 ul {
+.c3 ul {
   list-style: disc;
 }
 
-.c4 ol {
+.c3 ol {
   list-style: decimal;
 }
 
-.c4 li {
+.c3 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -142,7 +119,7 @@ exports[`Video About matches the snapshot 1`] = `
   padding-bottom: .5em;
 }
 
-.c4 h1 {
+.c3 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -155,7 +132,7 @@ exports[`Video About matches the snapshot 1`] = `
   text-align: center;
 }
 
-.c4 h1::before {
+.c3 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -166,7 +143,7 @@ exports[`Video About matches the snapshot 1`] = `
   right: calc(50% - 4px);
 }
 
-.c4 h2 {
+.c3 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -175,15 +152,15 @@ exports[`Video About matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c4 h2 a {
+.c3 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c4 h2 .c14 {
+.c3 h2 .c10 {
   background-position: bottom !important;
 }
 
-.c4 h3 {
+.c3 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -193,7 +170,7 @@ exports[`Video About matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c4 h3 strong {
+.c3 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -201,11 +178,11 @@ exports[`Video About matches the snapshot 1`] = `
   line-height: 1.5em;
 }
 
-.c4 h3 a {
+.c3 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c4 blockquote {
+.c3 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -218,11 +195,11 @@ exports[`Video About matches the snapshot 1`] = `
   word-break: break-word;
 }
 
-.c4 .preventLineBreak {
+.c3 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c4 .content-end {
+.c3 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -233,14 +210,14 @@ exports[`Video About matches the snapshot 1`] = `
   margin-bottom: 1px;
 }
 
-.c4 .artist-follow {
+.c3 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c4 .artist-follow::before {
+.c3 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -248,7 +225,7 @@ exports[`Video About matches the snapshot 1`] = `
   font-size: 32px;
 }
 
-.c4 .artist-follow::after {
+.c3 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -269,7 +246,7 @@ exports[`Video About matches the snapshot 1`] = `
   width: 100%;
 }
 
-.c1 .c3 p {
+.c1 .c2 p {
   padding: 0;
 }
 
@@ -286,63 +263,45 @@ exports[`Video About matches the snapshot 1`] = `
   margin-right: auto;
 }
 
-@media screen and (min-width:40em) {
-  .c13 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c13 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c13 {
-    width: 66.66666666666666%;
-  }
-}
-
 @media (max-width:768px) {
-  .c6 .c9 {
+  .c4 .c6 {
     margin-top: 0px;
   }
 }
 
 @media (max-width:600px) {
-  .c4 p,
-  .c4 ul,
-  .c4 ol,
-  .c4 div[data-block=true] .public-DraftStyleDefault-block {
+  .c3 p,
+  .c3 ul,
+  .c3 ol,
+  .c3 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c4 li {
+  .c3 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c4 h1 {
+  .c3 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c4 h2 {
+  .c3 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c4 h3 {
+  .c3 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -350,14 +309,14 @@ exports[`Video About matches the snapshot 1`] = `
     line-height: 1.5em;
   }
 
-  .c4 h3 strong {
+  .c3 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c4 blockquote {
+  .c3 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -365,7 +324,7 @@ exports[`Video About matches the snapshot 1`] = `
     margin: 0;
   }
 
-  .c4 .content-start {
+  .c3 .content-start {
     font-size: 55px;
   }
 }
@@ -445,7 +404,7 @@ exports[`Video About matches the snapshot 1`] = `
     }
   >
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat ezBGwr"
       color="black"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="28px"
@@ -453,7 +412,7 @@ exports[`Video About matches the snapshot 1`] = `
       Credits
     </div>
     <div
-      className="article__text-section c3 c4"
+      className="article__text-section c2 c3"
       color="black"
     >
       <div
@@ -468,16 +427,16 @@ exports[`Video About matches the snapshot 1`] = `
       className="rrm-container rrm-greaterThanOrEqual-md"
     >
       <div
-        className="c5"
+        className="jObTem"
       >
         <div
-          className="c6"
+          className="c4"
         >
           <div
-            className="c7"
+            className="c5"
           >
             <div
-              className="c8"
+              className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -490,10 +449,10 @@ exports[`Video About matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c9 c10"
+            className="c6 c7"
           >
             <div
-              className="c11 c8"
+              className="c8 sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -505,7 +464,7 @@ exports[`Video About matches the snapshot 1`] = `
               Share
             </div>
             <a
-              className="c12"
+              className="c9"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
               onClick={[Function]}
               target="_blank"
@@ -531,7 +490,7 @@ exports[`Video About matches the snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="c12"
+              className="c9"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -557,7 +516,7 @@ exports[`Video About matches the snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="c12"
+              className="c9"
               href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
               onClick={[Function]}
               target="_blank"
@@ -588,7 +547,7 @@ exports[`Video About matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c13"
+    className="ffckeT"
     width={
       Array [
         1,
@@ -599,7 +558,7 @@ exports[`Video About matches the snapshot 1`] = `
     }
   >
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat ezBGwr"
       color="black"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="28px"
@@ -607,7 +566,7 @@ exports[`Video About matches the snapshot 1`] = `
       About the Film
     </div>
     <div
-      className="article__text-section c3 c4"
+      className="article__text-section c2 c3"
       color="black"
     >
       <div
@@ -622,16 +581,16 @@ exports[`Video About matches the snapshot 1`] = `
       className="rrm-container rrm-lessThan-md"
     >
       <div
-        className="c5"
+        className="jObTem"
       >
         <div
-          className="c6"
+          className="c4"
         >
           <div
-            className="c7"
+            className="c5"
           >
             <div
-              className="c8"
+              className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -644,10 +603,10 @@ exports[`Video About matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            className="c9 c10"
+            className="c6 c7"
           >
             <div
-              className="c11 c8"
+              className="c8 sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -659,7 +618,7 @@ exports[`Video About matches the snapshot 1`] = `
               Share
             </div>
             <a
-              className="c12"
+              className="c9"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
               onClick={[Function]}
               target="_blank"
@@ -685,7 +644,7 @@ exports[`Video About matches the snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="c12"
+              className="c9"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -711,7 +670,7 @@ exports[`Video About matches the snapshot 1`] = `
               </svg>
             </a>
             <a
-              className="c12"
+              className="c9"
               href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
               onClick={[Function]}
               target="_blank"
@@ -746,34 +705,11 @@ exports[`Video About matches the snapshot 1`] = `
 
 exports[`Video About matches the snapshot with editable props 1`] = `
 .c5 {
-  margin-top: 40px;
-}
-
-.c13 {
-  width: 100%;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  color: black;
-  padding-bottom: 10px;
-}
-
-.c8 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c7 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
 }
 
-.c10 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -787,36 +723,36 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   margin-top: 5px;
 }
 
-.c12 {
+.c9 {
   -webkit-text-decoration: none;
   text-decoration: none;
   padding-left: 7px;
   padding-right: 7px;
 }
 
-.c12:hover {
+.c9:hover {
   opacity: 0.6;
 }
 
-.c12:first-child {
+.c9:first-child {
   padding-left: 0;
 }
 
-.c11 {
+.c8 {
   margin: 5px 10px 5px 0;
 }
 
-.c6 {
+.c4 {
   color: black;
 }
 
-.c4 {
+.c3 {
   position: relative;
   width: 100%;
   color: black;
 }
 
-.c4 a {
+.c3 a {
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -826,22 +762,22 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   background-position: bottom;
 }
 
-.c4 a:hover {
+.c3 a:hover {
   color: #C2C2C2;
   opacity: 1;
 }
 
-.c4 div[class*='ToolTip'] a {
+.c3 div[class*='ToolTip'] a {
   background-image: none;
   opacity: 1;
   color: inherit;
 }
 
-.c4 p,
-.c4 ul,
-.c4 ol,
-.c4 .paragraph,
-.c4 div[data-block=true] .public-DraftStyleDefault-block {
+.c3 p,
+.c3 ul,
+.c3 ol,
+.c3 .paragraph,
+.c3 div[data-block=true] .public-DraftStyleDefault-block {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -852,32 +788,32 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   font-style: inherit;
 }
 
-.c4 p:first-child,
-.c4 .paragraph:first-child,
-.c4 div[data-block=true]:first-child .public-DraftStyleDefault-block {
+.c3 p:first-child,
+.c3 .paragraph:first-child,
+.c3 div[data-block=true]:first-child .public-DraftStyleDefault-block {
   padding-top: 0;
 }
 
-.c4 p:last-child,
-.c4 .paragraph:last-child,
-.c4 div[data-block=true]:last-child .public-DraftStyleDefault-block {
+.c3 p:last-child,
+.c3 .paragraph:last-child,
+.c3 div[data-block=true]:last-child .public-DraftStyleDefault-block {
   padding-bottom: 0;
 }
 
-.c4 ul,
-.c4 ol {
+.c3 ul,
+.c3 ol {
   padding-left: 1em;
 }
 
-.c4 ul {
+.c3 ul {
   list-style: disc;
 }
 
-.c4 ol {
+.c3 ol {
   list-style: decimal;
 }
 
-.c4 li {
+.c3 li {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 23px;
   line-height: 1.5em;
@@ -886,7 +822,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   padding-bottom: .5em;
 }
 
-.c4 h1 {
+.c3 h1 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 40px;
@@ -899,7 +835,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   text-align: center;
 }
 
-.c4 h1::before {
+.c3 h1::before {
   content: "";
   width: 8px;
   height: 8px;
@@ -910,7 +846,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   right: calc(50% - 4px);
 }
 
-.c4 h2 {
+.c3 h2 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 32px;
@@ -919,15 +855,15 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   margin: 0;
 }
 
-.c4 h2 a {
+.c3 h2 a {
   background-size: 1.25px 1px;
 }
 
-.c4 h2 .c14 {
+.c3 h2 .c10 {
   background-position: bottom !important;
 }
 
-.c4 h3 {
+.c3 h3 {
   font-family: Unica77LLWebRegular,Arial,serif;
   -webkit-font-smoothing: antialiased;
   font-size: 19px;
@@ -937,7 +873,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   margin: 0;
 }
 
-.c4 h3 strong {
+.c3 h3 strong {
   font-weight: normal;
   font-family: Unica77LLWebMedium,Arial,serif;
   -webkit-font-smoothing: antialiased;
@@ -945,11 +881,11 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   line-height: 1.5em;
 }
 
-.c4 h3 a {
+.c3 h3 a {
   background-size: 1.25px 1px;
 }
 
-.c4 blockquote {
+.c3 blockquote {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 40px;
   line-height: 1.1em;
@@ -962,11 +898,11 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   word-break: break-word;
 }
 
-.c4 .preventLineBreak {
+.c3 .preventLineBreak {
   white-space: nowrap;
 }
 
-.c4 .content-end {
+.c3 .content-end {
   display: inline-block;
   content: "";
   width: 8px;
@@ -977,14 +913,14 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   margin-bottom: 1px;
 }
 
-.c4 .artist-follow {
+.c3 .artist-follow {
   vertical-align: middle;
   margin-left: 10px;
   cursor: pointer;
   background: none transparent;
 }
 
-.c4 .artist-follow::before {
+.c3 .artist-follow::before {
   font-family: "artsy-icons";
   content: "";
   vertical-align: -8.5px;
@@ -992,7 +928,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   font-size: 32px;
 }
 
-.c4 .artist-follow::after {
+.c3 .artist-follow::after {
   content: "Follow";
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 17px;
@@ -1013,7 +949,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   width: 100%;
 }
 
-.c1 .c3 p {
+.c1 .c2 p {
   padding: 0;
 }
 
@@ -1030,63 +966,45 @@ exports[`Video About matches the snapshot with editable props 1`] = `
   margin-right: auto;
 }
 
-@media screen and (min-width:40em) {
-  .c13 {
-    width: 100%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c13 {
-    width: 66.66666666666666%;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c13 {
-    width: 66.66666666666666%;
-  }
-}
-
 @media (max-width:768px) {
-  .c6 .c9 {
+  .c4 .c6 {
     margin-top: 0px;
   }
 }
 
 @media (max-width:600px) {
-  .c4 p,
-  .c4 ul,
-  .c4 ol,
-  .c4 div[data-block=true] .public-DraftStyleDefault-block {
+  .c3 p,
+  .c3 ul,
+  .c3 ol,
+  .c3 div[data-block=true] .public-DraftStyleDefault-block {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c4 li {
+  .c3 li {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 19px;
     line-height: 1.5em;
     -webkit-font-smoothing: antialiased;
   }
 
-  .c4 h1 {
+  .c3 h1 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 34px;
     line-height: 1.1em;
   }
 
-  .c4 h2 {
+  .c3 h2 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 32px;
     line-height: 1.1em;
   }
 
-  .c4 h3 {
+  .c3 h3 {
     font-family: Unica77LLWebRegular,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
@@ -1094,14 +1012,14 @@ exports[`Video About matches the snapshot with editable props 1`] = `
     line-height: 1.5em;
   }
 
-  .c4 h3 strong {
+  .c3 h3 strong {
     font-family: Unica77LLWebMedium,Arial,serif;
     -webkit-font-smoothing: antialiased;
     font-size: 16px;
     line-height: 1.1em;
   }
 
-  .c4 blockquote {
+  .c3 blockquote {
     font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
     font-size: 34px;
     line-height: 1.1em;
@@ -1109,7 +1027,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
     margin: 0;
   }
 
-  .c4 .content-start {
+  .c3 .content-start {
     font-size: 55px;
   }
 }
@@ -1189,7 +1107,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
     }
   >
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat ezBGwr"
       color="black"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="28px"
@@ -1197,7 +1115,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
       Credits
     </div>
     <div
-      className="article__text-section c3 c4"
+      className="article__text-section c2 c3"
       color="black"
     >
       <div>
@@ -1209,16 +1127,16 @@ exports[`Video About matches the snapshot with editable props 1`] = `
       className="rrm-container rrm-greaterThanOrEqual-md"
     >
       <div
-        className="c5"
+        className="jObTem"
       >
         <div
-          className="c6"
+          className="c4"
         >
           <div
-            className="c7"
+            className="c5"
           >
             <div
-              className="c8"
+              className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1231,10 +1149,10 @@ exports[`Video About matches the snapshot with editable props 1`] = `
             </div>
           </div>
           <div
-            className="c9 c10"
+            className="c6 c7"
           >
             <div
-              className="c11 c8"
+              className="c8 sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1246,7 +1164,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
               Share
             </div>
             <a
-              className="c12"
+              className="c9"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
               onClick={[Function]}
               target="_blank"
@@ -1272,7 +1190,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
               </svg>
             </a>
             <a
-              className="c12"
+              className="c9"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -1298,7 +1216,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
               </svg>
             </a>
             <a
-              className="c12"
+              className="c9"
               href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
               onClick={[Function]}
               target="_blank"
@@ -1329,7 +1247,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
     </div>
   </div>
   <div
-    className="c13"
+    className="ffckeT"
     width={
       Array [
         1,
@@ -1340,7 +1258,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
     }
   >
     <div
-      className="c2"
+      className="sc-bxivhb bUZGRr sc-htpNat ezBGwr"
       color="black"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="28px"
@@ -1348,7 +1266,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
       About the Film
     </div>
     <div
-      className="article__text-section c3 c4"
+      className="article__text-section c2 c3"
       color="black"
     >
       <div>
@@ -1360,16 +1278,16 @@ exports[`Video About matches the snapshot with editable props 1`] = `
       className="rrm-container rrm-lessThan-md"
     >
       <div
-        className="c5"
+        className="jObTem"
       >
         <div
-          className="c6"
+          className="c4"
         >
           <div
-            className="c7"
+            className="c5"
           >
             <div
-              className="c8"
+              className="sc-bxivhb bUZGRr sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1382,10 +1300,10 @@ exports[`Video About matches the snapshot with editable props 1`] = `
             </div>
           </div>
           <div
-            className="c9 c10"
+            className="c6 c7"
           >
             <div
-              className="c11 c8"
+              className="c8 sc-htpNat dOrNHt"
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1397,7 +1315,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
               Share
             </div>
             <a
-              className="c12"
+              className="c9"
               href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
               onClick={[Function]}
               target="_blank"
@@ -1423,7 +1341,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
               </svg>
             </a>
             <a
-              className="c12"
+              className="c9"
               href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Fvideo%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
               onClick={[Function]}
               target="_blank"
@@ -1449,7 +1367,7 @@ exports[`Video About matches the snapshot with editable props 1`] = `
               </svg>
             </a>
             <a
-              className="c12"
+              className="c9"
               href="mailto:?subject=New Study Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/video/joanne-artman-gallery-poetry-naturerefinement-form"
               onClick={[Function]}
               target="_blank"

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoCover.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoCover.test.tsx.snap
@@ -1,61 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video Cover matches the snapshot 1`] = `
-.c4 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-bottom: 12px;
-}
-
-.c6 {
-  padding-right: 20px;
-  width: 60px;
-}
-
-.c13 {
-  max-width: 100%;
-}
-
 .c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c10 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  margin-right: 20px;
-}
-
-.c11 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c12 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 42px;
-  line-height: 50px;
-}
-
-.c14 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  padding-top: 30px;
-}
-
-.c8 {
   width: 32px;
   height: 32px;
 }
 
-.c9 a {
+.c6 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -97,7 +48,7 @@ exports[`Video Cover matches the snapshot 1`] = `
   height: 100%;
 }
 
-.c3 .c7 {
+.c3 .c4 {
   height: 60px;
   width: 44px;
   cursor: pointer;
@@ -114,48 +65,6 @@ exports[`Video Cover matches the snapshot 1`] = `
   visibility: visible;
   -webkit-transition: opacity 0.25s ease,visibility 0.25s ease;
   transition: opacity 0.25s ease,visibility 0.25s ease;
-}
-
-@media screen and (min-width:40em) {
-  .c13 {
-    max-width: 60%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c14 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c14 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c14 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c14 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c14 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c14 {
-    line-height: 32px;
-  }
 }
 
 @media screen and (min-width:40em) {
@@ -179,18 +88,18 @@ exports[`Video Cover matches the snapshot 1`] = `
     width="100%"
   >
     <div
-      className="c4"
+      className="sc-bdVaJa bBcFLq"
     >
       <div
-        className="c5"
+        className="sc-bwzfXH eNmxcA"
       >
         <div
-          className="c6"
+          className="sc-bdVaJa eydErb"
           onClick={[Function]}
           width="60px"
         >
           <svg
-            className="c7 c8"
+            className="c4 c5"
             version="1.1"
             viewBox="0 0 40 56"
             x="0px"
@@ -211,21 +120,21 @@ exports[`Video Cover matches the snapshot 1`] = `
           </svg>
         </div>
         <div
-          className=""
+          className="sc-bdVaJa dVZOZN"
         >
           <div>
             <div
-              className="c5"
+              className="sc-bwzfXH eNmxcA"
             >
               <div
-                className="c9 c10"
+                className="c6 sc-htpNat dszOpy"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize="14px"
               >
                 Future of Art
               </div>
               <div
-                className="c11"
+                className="sc-bxivhb bUZGRr sc-htpNat deJBsu"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize="14px"
               >
@@ -233,7 +142,7 @@ exports[`Video Cover matches the snapshot 1`] = `
               </div>
             </div>
             <div
-              className="c12"
+              className="sc-bxivhb bUZGRr sc-htpNat kUuHSn"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="42px"
             >
@@ -243,10 +152,10 @@ exports[`Video Cover matches the snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c13"
+        className="sc-bdVaJa gdqIDJ"
       >
         <div
-          className="c14"
+          className="sc-ifAKCX cFlEyZ sc-htpNat iwZBau"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize={
             Array [
@@ -266,61 +175,12 @@ exports[`Video Cover matches the snapshot 1`] = `
 `;
 
 exports[`Video Cover matches the snapshot with edit props 1`] = `
-.c4 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-bottom: 12px;
-}
-
-.c6 {
-  padding-right: 20px;
-  width: 60px;
-}
-
-.c13 {
-  max-width: 100%;
-}
-
 .c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c10 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  margin-right: 20px;
-}
-
-.c11 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c12 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 42px;
-  line-height: 50px;
-}
-
-.c14 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 18px;
-  line-height: 26px;
-  padding-top: 30px;
-}
-
-.c8 {
   width: 32px;
   height: 32px;
 }
 
-.c9 a {
+.c6 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -362,7 +222,7 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
   height: 100%;
 }
 
-.c3 .c7 {
+.c3 .c4 {
   height: 60px;
   width: 44px;
   cursor: pointer;
@@ -379,48 +239,6 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
   visibility: visible;
   -webkit-transition: opacity 0.25s ease,visibility 0.25s ease;
   transition: opacity 0.25s ease,visibility 0.25s ease;
-}
-
-@media screen and (min-width:40em) {
-  .c13 {
-    max-width: 60%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c14 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c14 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c14 {
-    font-size: 22px;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c14 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c14 {
-    line-height: 32px;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c14 {
-    line-height: 32px;
-  }
 }
 
 @media screen and (min-width:40em) {
@@ -444,18 +262,18 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
     width="100%"
   >
     <div
-      className="c4"
+      className="sc-bdVaJa bBcFLq"
     >
       <div
-        className="c5"
+        className="sc-bwzfXH eNmxcA"
       >
         <div
-          className="c6"
+          className="sc-bdVaJa eydErb"
           onClick={[Function]}
           width="60px"
         >
           <svg
-            className="c7 c8"
+            className="c4 c5"
             version="1.1"
             viewBox="0 0 40 56"
             x="0px"
@@ -476,21 +294,21 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
           </svg>
         </div>
         <div
-          className=""
+          className="sc-bdVaJa dVZOZN"
         >
           <div>
             <div
-              className="c5"
+              className="sc-bwzfXH eNmxcA"
             >
               <div
-                className="c9 c10"
+                className="c6 sc-htpNat dszOpy"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize="14px"
               >
                 Future of Art
               </div>
               <div
-                className="c11"
+                className="sc-bxivhb bUZGRr sc-htpNat deJBsu"
                 fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
                 fontSize="14px"
               >
@@ -498,7 +316,7 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
               </div>
             </div>
             <div
-              className="c12"
+              className="sc-bxivhb bUZGRr sc-htpNat kUuHSn"
               fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
               fontSize="42px"
             >
@@ -511,10 +329,10 @@ exports[`Video Cover matches the snapshot with edit props 1`] = `
         </div>
       </div>
       <div
-        className="c13"
+        className="sc-bdVaJa gdqIDJ"
       >
         <div
-          className="c14"
+          className="sc-ifAKCX cFlEyZ sc-htpNat iwZBau"
           fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
           fontSize={
             Array [

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoInfoBlock.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoInfoBlock.test.tsx.snap
@@ -1,33 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video Info Block matches the snapshot 1`] = `
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  margin-right: 20px;
-}
-
-.c3 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 42px;
-  line-height: 50px;
-}
-
-.c1 a {
+.c0 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -35,17 +9,17 @@ exports[`Video Info Block matches the snapshot 1`] = `
 
 <div>
   <div
-    className="c0"
+    className="sc-bwzfXH eNmxcA"
   >
     <div
-      className="c1 c2"
+      className="c0 sc-htpNat dszOpy"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="14px"
     >
       The Future of Art
     </div>
     <div
-      className="c3"
+      className="sc-bxivhb bUZGRr sc-htpNat deJBsu"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="14px"
     >
@@ -53,7 +27,7 @@ exports[`Video Info Block matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c4"
+    className="sc-bxivhb bUZGRr sc-htpNat kUuHSn"
     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
     fontSize="42px"
   >
@@ -63,33 +37,7 @@ exports[`Video Info Block matches the snapshot 1`] = `
 `;
 
 exports[`Video Info Block matches the snapshot with edit props 1`] = `
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  margin-right: 20px;
-}
-
-.c3 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-.c4 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 42px;
-  line-height: 50px;
-}
-
-.c1 a {
+.c0 a {
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -97,17 +45,17 @@ exports[`Video Info Block matches the snapshot with edit props 1`] = `
 
 <div>
   <div
-    className="c0"
+    className="sc-bwzfXH eNmxcA"
   >
     <div
-      className="c1 c2"
+      className="c0 sc-htpNat dszOpy"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="14px"
     >
       The Future of Art
     </div>
     <div
-      className="c3"
+      className="sc-bxivhb bUZGRr sc-htpNat deJBsu"
       fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
       fontSize="14px"
     >
@@ -115,7 +63,7 @@ exports[`Video Info Block matches the snapshot with edit props 1`] = `
     </div>
   </div>
   <div
-    className="c4"
+    className="sc-bxivhb bUZGRr sc-htpNat kUuHSn"
     fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
     fontSize="42px"
   >

--- a/src/Components/__tests__/__snapshots__/Artwork.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/Artwork.test.tsx.snap
@@ -1,25 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Artwork renders correctly 1`] = `
-.c7 {
-  margin-bottom: 0.3px;
-}
-
-.c5 {
-  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-  color: #000;
-}
-
-.c6 {
-  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 12px;
-  line-height: 16px;
-  color: #000;
-}
-
 .c3 {
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
   font-size: 15px;
@@ -30,7 +11,7 @@ exports[`Artwork renders correctly 1`] = `
   text-decoration: none;
 }
 
-.c8 {
+.c5 {
   display: block;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -121,7 +102,7 @@ exports[`Artwork renders correctly 1`] = `
     >
       <div>
         <div
-          className="c5"
+          className="sc-bxivhb bUZGRr sc-htpNat dwGIWc"
           color="#000"
           fontFamily={
             Object {
@@ -140,7 +121,7 @@ exports[`Artwork renders correctly 1`] = `
            
         </div>
         <div
-          className="c6"
+          className="sc-bxivhb bUZGRr sc-htpNat bhbzGl"
           color="#000"
           fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
           fontSize="12px"
@@ -151,17 +132,17 @@ exports[`Artwork renders correctly 1`] = `
           }
         />
         <div
-          className="c7"
+          className="sc-bdVaJa hyqAoT"
         />
         <div
-          className="c8"
+          className="c5"
         >
           <strong>
             Mikael Olson
           </strong>
         </div>
         <div
-          className="c8"
+          className="c5"
         >
           <em>
             Some Kind of Dinosaur
@@ -169,7 +150,7 @@ exports[`Artwork renders correctly 1`] = `
           , 2015
         </div>
         <div
-          className="c8"
+          className="c5"
         >
           Gallery 1261
         </div>

--- a/src/Components/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/Input.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Input renders as a snapshot 1`] = `
 }
 
 <div
-  className=""
+  className="sc-bdVaJa dVZOZN"
 >
   <div
     className="c0"

--- a/src/Components/__tests__/__snapshots__/PasswordInput.test.tsx.snap
+++ b/src/Components/__tests__/__snapshots__/PasswordInput.test.tsx.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PasswordInput renders masked as a snapshot 1`] = `
-.c5 {
-  position: relative;
-}
-
 .c0 {
   padding-bottom: 5px;
 }
@@ -146,7 +142,7 @@ exports[`PasswordInput renders masked as a snapshot 1`] = `
       onClick={[Function]}
     >
       <svg
-        className="c5"
+        className="Icon-sc-1eovgys-0 lmJieb"
         fill="black100"
         height="18px"
         onClick={[Function]}
@@ -173,10 +169,6 @@ exports[`PasswordInput renders masked as a snapshot 1`] = `
 `;
 
 exports[`PasswordInput renders unmasked as a snapshot 1`] = `
-.c5 {
-  position: relative;
-}
-
 .c0 {
   padding-bottom: 5px;
 }
@@ -318,7 +310,7 @@ exports[`PasswordInput renders unmasked as a snapshot 1`] = `
       onClick={[Function]}
     >
       <svg
-        className="c5"
+        className="Icon-sc-1eovgys-0 lmJieb"
         fill="black100"
         height="18px"
         onClick={[Function]}

--- a/src/Components/v2/__tests__/CountdownTimer.test.tsx
+++ b/src/Components/v2/__tests__/CountdownTimer.test.tsx
@@ -61,7 +61,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Dec 04, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
       )
     })
 
@@ -71,7 +71,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Dec 04, 1:50 PM GMTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
       )
     })
   })
@@ -85,7 +85,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Aug 04, 9:50 AM EDTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Aug 4, 6:50am PDTExpired offers end the negotiation process permanently."`
       )
     })
 
@@ -95,7 +95,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Aug 04, 2:50 PM BSTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Aug 4, 6:50am PDTExpired offers end the negotiation process permanently."`
       )
     })
   })
@@ -114,7 +114,7 @@ describe("CountdownTimer", () => {
 
     const text = timer.text()
     expect(text).toMatchInlineSnapshot(
-      `"time remaining01d 30m 00s leftRespond by Dec 04, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01d 30m 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
     )
   })
 
@@ -132,7 +132,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining01d 15h 10m 05s leftRespond by Dec 05, 12:00 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01d 15h 10m 05s leftRespond by Dec 4, 9:00pm PSTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -147,7 +147,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining15h 10m 05s leftRespond by Dec 04, 12:00 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining15h 10m 05s leftRespond by Dec 3, 9:00pm PSTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -159,7 +159,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining15m 10s leftRespond by Dec 03, 9:05 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining15m 10s leftRespond by Dec 3, 6:05am PSTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -169,7 +169,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining01s leftRespond by Dec 03, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01s leftRespond by Dec 3, 5:50am PSTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -179,7 +179,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining0 days leftRespond by Dec 03, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining0 days leftRespond by Dec 3, 5:50am PSTExpired offers end the negotiation process permanently."`
     )
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,7 +54,7 @@
   optionalDependencies:
     chokidar "^2.0.3"
 
-"@babel/code-frame@7.0.0", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
+"@babel/code-frame@7.0.0", "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
   integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
@@ -101,6 +101,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.1.0":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
+  integrity sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helpers" "^7.4.4"
+    "@babel/parser" "^7.4.5"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.5"
+    "@babel/types" "^7.4.4"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.11"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/core@^7.3.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
@@ -132,7 +152,7 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/generator@^7.4.4":
+"@babel/generator@^7.4.0", "@babel/generator@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
   integrity sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==
@@ -411,6 +431,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
   integrity sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==
 
+"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
+  integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
+
 "@babel/parser@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
@@ -557,7 +582,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-object-rest-spread@^7.2.0":
+"@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
   integrity sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
@@ -1257,7 +1282,7 @@
     "@babel/parser" "^7.2.2"
     "@babel/types" "^7.2.2"
 
-"@babel/template@^7.4.4":
+"@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
   integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
@@ -1277,6 +1302,21 @@
     "@babel/helper-split-export-declaration" "^7.0.0"
     "@babel/parser" "^7.3.4"
     "@babel/types" "^7.3.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
+"@babel/traverse@^7.4.3", "@babel/traverse@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
+  integrity sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.4.5"
+    "@babel/types" "^7.4.4"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.11"
@@ -1305,7 +1345,7 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.4.4":
+"@babel/types@^7.4.0", "@babel/types@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
   integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
@@ -1313,6 +1353,14 @@
     esutils "^2.0.2"
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
+
+"@cnakazawa/watch@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
+  integrity sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==
+  dependencies:
+    exec-sh "^0.3.2"
+    minimist "^1.2.0"
 
 "@emmetio/extract-abbreviation@0.1.6":
   version "0.1.6"
@@ -1432,12 +1480,158 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
   integrity sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==
 
+"@jest/console@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
+  integrity sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==
+  dependencies:
+    "@jest/source-map" "^24.3.0"
+    chalk "^2.0.1"
+    slash "^2.0.0"
+
+"@jest/core@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.8.0.tgz#fbbdcd42a41d0d39cddbc9f520c8bab0c33eed5b"
+  integrity sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==
+  dependencies:
+    "@jest/console" "^24.7.1"
+    "@jest/reporters" "^24.8.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/transform" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    graceful-fs "^4.1.15"
+    jest-changed-files "^24.8.0"
+    jest-config "^24.8.0"
+    jest-haste-map "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-regex-util "^24.3.0"
+    jest-resolve-dependencies "^24.8.0"
+    jest-runner "^24.8.0"
+    jest-runtime "^24.8.0"
+    jest-snapshot "^24.8.0"
+    jest-util "^24.8.0"
+    jest-validate "^24.8.0"
+    jest-watcher "^24.8.0"
+    micromatch "^3.1.10"
+    p-each-series "^1.0.0"
+    pirates "^4.0.1"
+    realpath-native "^1.1.0"
+    rimraf "^2.5.4"
+    strip-ansi "^5.0.0"
+
+"@jest/environment@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.8.0.tgz#0342261383c776bdd652168f68065ef144af0eac"
+  integrity sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==
+  dependencies:
+    "@jest/fake-timers" "^24.8.0"
+    "@jest/transform" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    jest-mock "^24.8.0"
+
+"@jest/fake-timers@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.8.0.tgz#2e5b80a4f78f284bcb4bd5714b8e10dd36a8d3d1"
+  integrity sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==
+  dependencies:
+    "@jest/types" "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-mock "^24.8.0"
+
+"@jest/reporters@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.8.0.tgz#075169cd029bddec54b8f2c0fc489fd0b9e05729"
+  integrity sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==
+  dependencies:
+    "@jest/environment" "^24.8.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/transform" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    istanbul-lib-coverage "^2.0.2"
+    istanbul-lib-instrument "^3.0.1"
+    istanbul-lib-report "^2.0.4"
+    istanbul-lib-source-maps "^3.0.1"
+    istanbul-reports "^2.1.1"
+    jest-haste-map "^24.8.0"
+    jest-resolve "^24.8.0"
+    jest-runtime "^24.8.0"
+    jest-util "^24.8.0"
+    jest-worker "^24.6.0"
+    node-notifier "^5.2.1"
+    slash "^2.0.0"
+    source-map "^0.6.0"
+    string-length "^2.0.0"
+
+"@jest/source-map@^24.3.0":
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.3.0.tgz#563be3aa4d224caf65ff77edc95cd1ca4da67f28"
+  integrity sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.1.15"
+    source-map "^0.6.0"
+
+"@jest/test-result@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.8.0.tgz#7675d0aaf9d2484caa65e048d9b467d160f8e9d3"
+  integrity sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==
+  dependencies:
+    "@jest/console" "^24.7.1"
+    "@jest/types" "^24.8.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+
+"@jest/test-sequencer@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz#2f993bcf6ef5eb4e65e8233a95a3320248cf994b"
+  integrity sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==
+  dependencies:
+    "@jest/test-result" "^24.8.0"
+    jest-haste-map "^24.8.0"
+    jest-runner "^24.8.0"
+    jest-runtime "^24.8.0"
+
+"@jest/transform@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.8.0.tgz#628fb99dce4f9d254c6fd9341e3eea262e06fef5"
+  integrity sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^24.8.0"
+    babel-plugin-istanbul "^5.1.0"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.1.15"
+    jest-haste-map "^24.8.0"
+    jest-regex-util "^24.3.0"
+    jest-util "^24.8.0"
+    micromatch "^3.1.10"
+    realpath-native "^1.1.0"
+    slash "^2.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "2.4.1"
+
 "@jest/types@^24.5.0":
   version "24.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.5.0.tgz#feee214a4d0167b0ca447284e95a57aa10b3ee95"
   integrity sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==
   dependencies:
     "@types/istanbul-lib-coverage" "^1.1.0"
+    "@types/yargs" "^12.0.9"
+
+"@jest/types@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.8.0.tgz#f31e25948c58f0abd8c845ae26fcea1491dea7ad"
+  integrity sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -2058,6 +2252,39 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
+"@types/babel__core@^7.1.0":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"
+  integrity sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.0.2.tgz#d2112a6b21fad600d7674274293c85dce0cb47fc"
+  integrity sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
+  integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.6.tgz#328dd1a8fc4cfe3c8458be9477b219ea158fd7b2"
+  integrity sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==
+  dependencies:
+    "@babel/types" "^7.3.0"
+
 "@types/chalk@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
@@ -2105,10 +2332,30 @@
   resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz#3c3483e606c041378438e951464f00e4e60706d6"
   integrity sha1-PDSD5gbAQTeEOOlRRk8A5OYHBtY=
 
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
+  integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
+
 "@types/istanbul-lib-coverage@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
+
+"@types/istanbul-lib-report@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
+  integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
+  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
 
 "@types/jest@23.3.9":
   version "23.3.9"
@@ -2229,6 +2476,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
   integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
 
+"@types/stack-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
 "@types/storybook__react@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/storybook__react/-/storybook__react-4.0.1.tgz#b6320c9d027b8ee7ef1445fef8b4cba196d48ace"
@@ -2295,6 +2547,11 @@
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.13.6.tgz#128d1685a7c34d31ed17010fc87d6a12c1de6976"
   integrity sha512-5Th3OsZ4gTRdr9Mho83BQ23cex4sRhOR4XTG+m+cJc0FhtUBK9Vn62hBJ+pnQYnSxoPOsKoAPOx6FcphxBC8ng==
+
+"@types/yargs@^12.0.2":
+  version "12.0.12"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
+  integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
 "@types/yargs@^12.0.9":
   version "12.0.9"
@@ -2565,20 +2822,6 @@ ajv@^6.1.0, ajv@^6.5.0, ajv@^6.5.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-align-text@^0.1.1, align-text@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
-  integrity sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=
-  dependencies:
-    kind-of "^3.0.2"
-    longest "^1.0.1"
-    repeat-string "^1.5.2"
-
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
-
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
@@ -2683,13 +2926,6 @@ app-root-path@^2.0.0:
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
   integrity sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=
 
-append-transform@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
-  integrity sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==
-  dependencies:
-    default-require-extensions "^2.0.0"
-
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -2710,19 +2946,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-arr-diff@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
-  integrity sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=
-  dependencies:
-    arr-flatten "^1.0.1"
-
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
   integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
-arr-flatten@^1.0.1, arr-flatten@^1.1.0:
+arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
   integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
@@ -2791,11 +3020,6 @@ array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
-
-array-unique@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
-  integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -2903,11 +3127,6 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
-async@^1.4.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
-
 async@^2.1.4, async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
@@ -2963,12 +3182,12 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@7.0.0-bridge.0, babel-core@^6.0.0, babel-core@^7.0.0-bridge.0:
+babel-core@7.0.0-bridge.0, babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
-babel-generator@^6.18.0, babel-generator@^6.26.0:
+babel-generator@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
   integrity sha1-rBriAHC3n248odMmlhMFN3TyDcU=
@@ -3093,13 +3312,18 @@ babel-helper-to-multiple-sequence-expressions@^0.5.0:
   resolved "https://registry.yarnpkg.com/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz#a3f924e3561882d42fcf48907aa98f7979a4588d"
   integrity sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==
 
-babel-jest@23.6.0, babel-jest@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.6.0.tgz#a644232366557a2240a0c083da6b25786185a2f1"
-  integrity sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==
+babel-jest@24.8.0, babel-jest@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.8.0.tgz#5c15ff2b28e20b0f45df43fe6b7f2aae93dba589"
+  integrity sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==
   dependencies:
-    babel-plugin-istanbul "^4.1.6"
-    babel-preset-jest "^23.2.0"
+    "@jest/transform" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    "@types/babel__core" "^7.1.0"
+    babel-plugin-istanbul "^5.1.0"
+    babel-preset-jest "^24.6.0"
+    chalk "^2.4.2"
+    slash "^2.0.0"
 
 babel-loader@8.0.5:
   version "8.0.5"
@@ -3160,20 +3384,21 @@ babel-plugin-emotion@^10.0.7:
     find-root "^1.1.0"
     source-map "^0.5.7"
 
-babel-plugin-istanbul@^4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
-  integrity sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==
+babel-plugin-istanbul@^5.1.0:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz#841d16b9a58eeb407a0ddce622ba02fe87a752ba"
+  integrity sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==
   dependencies:
-    babel-plugin-syntax-object-rest-spread "^6.13.0"
-    find-up "^2.1.0"
-    istanbul-lib-instrument "^1.10.1"
-    test-exclude "^4.2.1"
+    find-up "^3.0.0"
+    istanbul-lib-instrument "^3.3.0"
+    test-exclude "^5.2.3"
 
-babel-plugin-jest-hoist@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
-  integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
+babel-plugin-jest-hoist@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz#f7f7f7ad150ee96d7a5e8e2c5da8319579e78019"
+  integrity sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==
+  dependencies:
+    "@types/babel__traverse" "^7.0.6"
 
 babel-plugin-lodash@3.3.3:
   version "3.3.3"
@@ -3336,7 +3561,7 @@ babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
-babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
@@ -3661,13 +3886,13 @@ babel-preset-fbjs@^2.1.4:
     babel-plugin-transform-react-display-name "^6.8.0"
     babel-plugin-transform-react-jsx "^6.8.0"
 
-babel-preset-jest@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
-  integrity sha1-jsegOhOPABoaj7HoETZSvxpV2kY=
+babel-preset-jest@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz#66f06136eefce87797539c0d63f1769cc3915984"
+  integrity sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==
   dependencies:
-    babel-plugin-jest-hoist "^23.2.0"
-    babel-plugin-syntax-object-rest-spread "^6.13.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
+    babel-plugin-jest-hoist "^24.6.0"
 
 "babel-preset-minify@^0.5.0 || 0.6.0-alpha.5":
   version "0.5.0"
@@ -3736,7 +3961,7 @@ babel-standalone@^6.26.0:
   resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.26.0.tgz#15fb3d35f2c456695815ebf1ed96fe7f015b6886"
   integrity sha1-Ffs9NfLEVmlYFevx7Zb+fwFbaIY=
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.3.0:
+babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.3.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
@@ -3747,7 +3972,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-te
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
@@ -3762,7 +3987,7 @@ babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-tra
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
@@ -3916,15 +4141,6 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-braces@^1.8.2:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
-  integrity sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=
-  dependencies:
-    expand-range "^1.8.1"
-    preserve "^0.2.0"
-    repeat-element "^1.1.2"
 
 braces@^2.3.0, braces@^2.3.1:
   version "2.3.2"
@@ -4189,6 +4405,11 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
 camel-case@3.0.x:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -4205,11 +4426,6 @@ camelcase-keys@^4.0.0:
     camelcase "^4.1.0"
     map-obj "^2.0.0"
     quick-lru "^1.0.0"
-
-camelcase@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
 
 camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
@@ -4236,12 +4452,12 @@ caniuse-lite@^1.0.30000960:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz#5be481d5292f22aff5ee0db4a6c049b65b5798b1"
   integrity sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==
 
-capture-exit@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
-  integrity sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=
+capture-exit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
+  integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
   dependencies:
-    rsvp "^3.3.3"
+    rsvp "^4.8.4"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -4267,14 +4483,6 @@ ccount@^1.0.0, ccount@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
   integrity sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==
-
-center-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
-  integrity sha1-qg0yYptu6XIgBBHL1EYckHvCt60=
-  dependencies:
-    align-text "^0.1.3"
-    lazy-cache "^1.0.3"
 
 chain-function@^1.0.0:
   version "1.0.0"
@@ -4536,15 +4744,6 @@ clipboard@^2.0.0:
     select "^1.1.2"
     tiny-emitter "^2.0.0"
 
-cliui@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
-  integrity sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=
-  dependencies:
-    center-align "^0.1.1"
-    right-align "^0.1.1"
-    wordwrap "0.0.2"
-
 cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
@@ -4704,7 +4903,7 @@ commander@^2.11.0, commander@^2.12.1, commander@^2.14.1, commander@^2.19.0, comm
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
-commander@^2.18.0:
+commander@^2.18.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -4737,11 +4936,6 @@ commonmark@^0.24.0:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"
     string.prototype.repeat "^0.2.0"
-
-compare-versions@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.2.1.tgz#a49eb7689d4caaf0b6db5220173fd279614000f7"
-  integrity sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA==
 
 component-classes@^1.2.5:
   version "1.2.6"
@@ -5343,7 +5537,7 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -5384,13 +5578,6 @@ deepmerge@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
   integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
-
-default-require-extensions@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
-  integrity sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
-  dependencies:
-    strip-bom "^3.0.0"
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -5524,6 +5711,11 @@ diacritic@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/diacritic/-/diacritic-0.0.2.tgz#fc2a887b5a5bc0a0a854fb614c7c2f209061ee04"
   integrity sha1-/CqIe1pbwKCoVPthTHwvIJBh7gQ=
+
+diff-sequences@^24.3.0:
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
+  integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
 diff@^3.2.0, diff@^3.5.0:
   version "3.5.0"
@@ -6059,12 +6251,10 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-exec-sh@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
-  integrity sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==
-  dependencies:
-    merge "^1.1.3"
+exec-sh@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
+  integrity sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==
 
 execa@^0.7.0:
   version "0.7.0"
@@ -6127,13 +6317,6 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
-expand-brackets@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
-  integrity sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=
-  dependencies:
-    is-posix-bracket "^0.1.0"
-
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -6147,13 +6330,6 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expand-range@^1.8.1:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
-  integrity sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
-  dependencies:
-    fill-range "^2.1.0"
-
 expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
@@ -6161,17 +6337,17 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-23.6.0.tgz#1e0c8d3ba9a581c87bd71fb9bc8862d443425f98"
-  integrity sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==
+expect@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-24.8.0.tgz#471f8ec256b7b6129ca2524b2a62f030df38718d"
+  integrity sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==
   dependencies:
+    "@jest/types" "^24.8.0"
     ansi-styles "^3.2.0"
-    jest-diff "^23.6.0"
-    jest-get-type "^22.1.0"
-    jest-matcher-utils "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-regex-util "^23.3.0"
+    jest-get-type "^24.8.0"
+    jest-matcher-utils "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-regex-util "^24.3.0"
 
 express@^4.16.3:
   version "4.16.3"
@@ -6237,13 +6413,6 @@ external-editor@^3.0.0:
     chardet "^0.5.0"
     iconv-lite "^0.4.22"
     tmp "^0.0.33"
-
-extglob@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
-  integrity sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=
-  dependencies:
-    is-extglob "^1.0.0"
 
 extglob@^2.0.4:
   version "2.0.4"
@@ -6400,34 +6569,10 @@ file-system-cache@^1.0.5:
     fs-extra "^0.30.0"
     ramda "^0.21.0"
 
-filename-regex@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
-  integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
-
-fileset@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
-  integrity sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=
-  dependencies:
-    glob "^7.0.3"
-    minimatch "^3.0.3"
-
 filesize@3.6.1, filesize@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
   integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
-
-fill-range@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
-  integrity sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==
-  dependencies:
-    is-number "^2.1.0"
-    isobject "^2.0.0"
-    randomatic "^3.0.0"
-    repeat-element "^1.1.2"
-    repeat-string "^1.5.2"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -6489,14 +6634,6 @@ find-up@3.0.0, find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
-
-find-up@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
-  integrity sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
-  dependencies:
-    path-exists "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
@@ -6574,7 +6711,7 @@ for-in@^1.0.1, for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
-for-own@^0.1.3, for-own@^0.1.4:
+for-own@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
@@ -6758,13 +6895,21 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^1.2.2, fsevents@^1.2.3:
+fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
+
+fsevents@^1.2.7:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
+  integrity sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
+  dependencies:
+    nan "^2.12.1"
+    node-pre-gyp "^0.12.0"
 
 function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
@@ -6857,21 +7002,6 @@ github-username@^4.0.0:
   integrity sha1-y+KABBiDIG2kISrp5LXxacML9Bc=
   dependencies:
     gh-got "^6.0.0"
-
-glob-base@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
-  integrity sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=
-  dependencies:
-    glob-parent "^2.0.0"
-    is-glob "^2.0.0"
-
-glob-parent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
-  integrity sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
-  dependencies:
-    is-glob "^2.0.0"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -7040,7 +7170,7 @@ got@^7.0.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -7124,16 +7254,16 @@ gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-handlebars@^4.0.3:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
-  integrity sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=
+handlebars@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
-    async "^1.4.0"
+    neo-async "^2.6.0"
     optimist "^0.6.1"
-    source-map "^0.4.4"
+    source-map "^0.6.1"
   optionalDependencies:
-    uglify-js "^2.6"
+    uglify-js "^3.1.4"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -7570,12 +7700,12 @@ import-lazy@^3.1.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
   integrity sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==
 
-import-local@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
-  integrity sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==
+import-local@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
+  integrity sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==
   dependencies:
-    pkg-dir "^2.0.0"
+    pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
@@ -7695,6 +7825,11 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
+
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
 ip@^1.1.5:
   version "1.1.5"
@@ -7843,18 +7978,6 @@ is-dom@^1.0.9:
   resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.0.9.tgz#483832d52972073de12b9fe3f60320870da8370d"
   integrity sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0=
 
-is-dotfile@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
-  integrity sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=
-
-is-equal-shallow@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
-  integrity sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=
-  dependencies:
-    is-primitive "^2.0.0"
-
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -7866,11 +7989,6 @@ is-extendable@^1.0.0, is-extendable@^1.0.1:
   integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
     is-plain-object "^2.0.4"
-
-is-extglob@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
-  integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
 
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
@@ -7901,17 +8019,10 @@ is-function@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
   integrity sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=
 
-is-generator-fn@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
-  integrity sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=
-
-is-glob@^2.0.0, is-glob@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
-  integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
-  dependencies:
-    is-extglob "^1.0.0"
+is-generator-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
 is-glob@^3.1.0:
   version "3.1.0"
@@ -7949,13 +8060,6 @@ is-number-object@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
   integrity sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=
-
-is-number@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
-  integrity sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=
-  dependencies:
-    kind-of "^3.0.2"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -8016,16 +8120,6 @@ is-plain-object@2.0.4, is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
-
-is-posix-bracket@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
-  integrity sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=
-
-is-primitive@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
-  integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
 is-promise@^2.1.0:
   version "2.1.0"
@@ -8170,76 +8264,50 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-istanbul-api@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
-  integrity sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==
-  dependencies:
-    async "^2.1.4"
-    compare-versions "^3.1.0"
-    fileset "^2.0.2"
-    istanbul-lib-coverage "^1.2.0"
-    istanbul-lib-hook "^1.2.0"
-    istanbul-lib-instrument "^1.10.1"
-    istanbul-lib-report "^1.1.4"
-    istanbul-lib-source-maps "^1.2.4"
-    istanbul-reports "^1.3.0"
-    js-yaml "^3.7.0"
-    mkdirp "^0.5.1"
-    once "^1.4.0"
+istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
+  integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
 
-istanbul-lib-coverage@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
-  integrity sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==
-
-istanbul-lib-hook@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz#f614ec45287b2a8fc4f07f5660af787575601805"
-  integrity sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==
+istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
+  integrity sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
   dependencies:
-    append-transform "^1.0.0"
+    "@babel/generator" "^7.4.0"
+    "@babel/parser" "^7.4.3"
+    "@babel/template" "^7.4.0"
+    "@babel/traverse" "^7.4.3"
+    "@babel/types" "^7.4.0"
+    istanbul-lib-coverage "^2.0.5"
+    semver "^6.0.0"
 
-istanbul-lib-instrument@^1.10.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
-  integrity sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==
+istanbul-lib-report@^2.0.4:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
+  integrity sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==
   dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.18.0"
-    istanbul-lib-coverage "^1.2.0"
-    semver "^5.3.0"
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    supports-color "^6.1.0"
 
-istanbul-lib-report@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
-  integrity sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==
+istanbul-lib-source-maps@^3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
+  integrity sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
   dependencies:
-    istanbul-lib-coverage "^1.2.0"
-    mkdirp "^0.5.1"
-    path-parse "^1.0.5"
-    supports-color "^3.1.2"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    rimraf "^2.6.3"
+    source-map "^0.6.1"
 
-istanbul-lib-source-maps@^1.2.4:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
-  integrity sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==
+istanbul-reports@^2.1.1:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.6.tgz#7b4f2660d82b29303a8fe6091f8ca4bf058da1af"
+  integrity sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==
   dependencies:
-    debug "^3.1.0"
-    istanbul-lib-coverage "^1.2.0"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
-
-istanbul-reports@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
-  integrity sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==
-  dependencies:
-    handlebars "^4.0.3"
+    handlebars "^4.1.2"
 
 istextorbinary@^2.2.1:
   version "2.3.0"
@@ -8263,163 +8331,163 @@ iterall@^1.1.3, iterall@^1.2.1:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
-jest-changed-files@^23.4.2:
-  version "23.4.2"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
-  integrity sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==
+jest-changed-files@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.8.0.tgz#7e7eb21cf687587a85e50f3d249d1327e15b157b"
+  integrity sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==
   dependencies:
+    "@jest/types" "^24.8.0"
+    execa "^1.0.0"
     throat "^4.0.0"
 
-jest-cli@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.6.0.tgz#61ab917744338f443ef2baa282ddffdd658a5da4"
-  integrity sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==
+jest-cli@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.8.0.tgz#b075ac914492ed114fa338ade7362a301693e989"
+  integrity sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==
   dependencies:
-    ansi-escapes "^3.0.0"
+    "@jest/core" "^24.8.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
     chalk "^2.0.1"
     exit "^0.1.2"
-    glob "^7.1.2"
-    graceful-fs "^4.1.11"
-    import-local "^1.0.0"
-    is-ci "^1.0.10"
-    istanbul-api "^1.3.1"
-    istanbul-lib-coverage "^1.2.0"
-    istanbul-lib-instrument "^1.10.1"
-    istanbul-lib-source-maps "^1.2.4"
-    jest-changed-files "^23.4.2"
-    jest-config "^23.6.0"
-    jest-environment-jsdom "^23.4.0"
-    jest-get-type "^22.1.0"
-    jest-haste-map "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-regex-util "^23.3.0"
-    jest-resolve-dependencies "^23.6.0"
-    jest-runner "^23.6.0"
-    jest-runtime "^23.6.0"
-    jest-snapshot "^23.6.0"
-    jest-util "^23.4.0"
-    jest-validate "^23.6.0"
-    jest-watcher "^23.4.0"
-    jest-worker "^23.2.0"
-    micromatch "^2.3.11"
-    node-notifier "^5.2.1"
-    prompts "^0.1.9"
-    realpath-native "^1.0.0"
-    rimraf "^2.5.4"
-    slash "^1.0.0"
-    string-length "^2.0.0"
-    strip-ansi "^4.0.0"
-    which "^1.2.12"
-    yargs "^11.0.0"
+    import-local "^2.0.0"
+    is-ci "^2.0.0"
+    jest-config "^24.8.0"
+    jest-util "^24.8.0"
+    jest-validate "^24.8.0"
+    prompts "^2.0.1"
+    realpath-native "^1.1.0"
+    yargs "^12.0.2"
 
-jest-config@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.6.0.tgz#f82546a90ade2d8c7026fbf6ac5207fc22f8eb1d"
-  integrity sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==
+jest-config@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.8.0.tgz#77db3d265a6f726294687cbbccc36f8a76ee0f4f"
+  integrity sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==
   dependencies:
-    babel-core "^6.0.0"
-    babel-jest "^23.6.0"
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    babel-jest "^24.8.0"
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^23.4.0"
-    jest-environment-node "^23.4.0"
-    jest-get-type "^22.1.0"
-    jest-jasmine2 "^23.6.0"
-    jest-regex-util "^23.3.0"
-    jest-resolve "^23.6.0"
-    jest-util "^23.4.0"
-    jest-validate "^23.6.0"
-    micromatch "^2.3.11"
-    pretty-format "^23.6.0"
+    jest-environment-jsdom "^24.8.0"
+    jest-environment-node "^24.8.0"
+    jest-get-type "^24.8.0"
+    jest-jasmine2 "^24.8.0"
+    jest-regex-util "^24.3.0"
+    jest-resolve "^24.8.0"
+    jest-util "^24.8.0"
+    jest-validate "^24.8.0"
+    micromatch "^3.1.10"
+    pretty-format "^24.8.0"
+    realpath-native "^1.1.0"
 
-jest-diff@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.6.0.tgz#1500f3f16e850bb3d71233408089be099f610c7d"
-  integrity sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==
+jest-diff@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.8.0.tgz#146435e7d1e3ffdf293d53ff97e193f1d1546172"
+  integrity sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==
   dependencies:
     chalk "^2.0.1"
-    diff "^3.2.0"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.6.0"
+    diff-sequences "^24.3.0"
+    jest-get-type "^24.8.0"
+    pretty-format "^24.8.0"
 
-jest-docblock@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
-  integrity sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=
+jest-docblock@^24.3.0:
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.3.0.tgz#b9c32dac70f72e4464520d2ba4aec02ab14db5dd"
+  integrity sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==
   dependencies:
     detect-newline "^2.1.0"
 
-jest-each@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.6.0.tgz#ba0c3a82a8054387016139c733a05242d3d71575"
-  integrity sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==
+jest-each@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.8.0.tgz#a05fd2bf94ddc0b1da66c6d13ec2457f35e52775"
+  integrity sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==
   dependencies:
+    "@jest/types" "^24.8.0"
     chalk "^2.0.1"
-    pretty-format "^23.6.0"
+    jest-get-type "^24.8.0"
+    jest-util "^24.8.0"
+    pretty-format "^24.8.0"
 
-jest-environment-jsdom@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
-  integrity sha1-BWp5UrP+pROsYqFAosNox52eYCM=
+jest-environment-jsdom@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz#300f6949a146cabe1c9357ad9e9ecf9f43f38857"
+  integrity sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==
   dependencies:
-    jest-mock "^23.2.0"
-    jest-util "^23.4.0"
+    "@jest/environment" "^24.8.0"
+    "@jest/fake-timers" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    jest-mock "^24.8.0"
+    jest-util "^24.8.0"
     jsdom "^11.5.1"
 
-jest-environment-node@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
-  integrity sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=
+jest-environment-node@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.8.0.tgz#d3f726ba8bc53087a60e7a84ca08883a4c892231"
+  integrity sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==
   dependencies:
-    jest-mock "^23.2.0"
-    jest-util "^23.4.0"
+    "@jest/environment" "^24.8.0"
+    "@jest/fake-timers" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    jest-mock "^24.8.0"
+    jest-util "^24.8.0"
 
 jest-get-type@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
   integrity sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==
 
-jest-get-type@^22.1.0:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
-  integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
-
 jest-get-type@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.3.0.tgz#582cfd1a4f91b5cdad1d43d2932f816d543c65da"
   integrity sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==
 
-jest-haste-map@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.6.0.tgz#2e3eb997814ca696d62afdb3f2529f5bbc935e16"
-  integrity sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.11"
-    invariant "^2.2.4"
-    jest-docblock "^23.2.0"
-    jest-serializer "^23.0.1"
-    jest-worker "^23.2.0"
-    micromatch "^2.3.11"
-    sane "^2.0.0"
+jest-get-type@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.8.0.tgz#a7440de30b651f5a70ea3ed7ff073a32dfe646fc"
+  integrity sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==
 
-jest-jasmine2@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz#840e937f848a6c8638df24360ab869cc718592e0"
-  integrity sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==
+jest-haste-map@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.8.0.tgz#51794182d877b3ddfd6e6d23920e3fe72f305800"
+  integrity sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==
   dependencies:
-    babel-traverse "^6.0.0"
+    "@jest/types" "^24.8.0"
+    anymatch "^2.0.0"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.15"
+    invariant "^2.2.4"
+    jest-serializer "^24.4.0"
+    jest-util "^24.8.0"
+    jest-worker "^24.6.0"
+    micromatch "^3.1.10"
+    sane "^4.0.3"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
+jest-jasmine2@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz#a9c7e14c83dd77d8b15e820549ce8987cc8cd898"
+  integrity sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^24.8.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^23.6.0"
-    is-generator-fn "^1.0.0"
-    jest-diff "^23.6.0"
-    jest-each "^23.6.0"
-    jest-matcher-utils "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-snapshot "^23.6.0"
-    jest-util "^23.4.0"
-    pretty-format "^23.6.0"
+    expect "^24.8.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^24.8.0"
+    jest-matcher-utils "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-runtime "^24.8.0"
+    jest-snapshot "^24.8.0"
+    jest-util "^24.8.0"
+    pretty-format "^24.8.0"
+    throat "^4.0.0"
 
 jest-junit@6.3.0:
   version "6.3.0"
@@ -8431,130 +8499,154 @@ jest-junit@6.3.0:
     strip-ansi "^4.0.0"
     xml "^1.0.1"
 
-jest-leak-detector@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz#e4230fd42cf381a1a1971237ad56897de7e171de"
-  integrity sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==
+jest-leak-detector@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz#c0086384e1f650c2d8348095df769f29b48e6980"
+  integrity sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==
   dependencies:
-    pretty-format "^23.6.0"
+    pretty-format "^24.8.0"
 
-jest-matcher-utils@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz#726bcea0c5294261a7417afb6da3186b4b8cac80"
-  integrity sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==
+jest-matcher-utils@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz#2bce42204c9af12bde46f83dc839efe8be832495"
+  integrity sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.6.0"
+    jest-diff "^24.8.0"
+    jest-get-type "^24.8.0"
+    pretty-format "^24.8.0"
 
-jest-message-util@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
-  integrity sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=
+jest-message-util@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.8.0.tgz#0d6891e72a4beacc0292b638685df42e28d6218b"
+  integrity sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==
   dependencies:
-    "@babel/code-frame" "^7.0.0-beta.35"
+    "@babel/code-frame" "^7.0.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    "@types/stack-utils" "^1.0.1"
     chalk "^2.0.1"
-    micromatch "^2.3.11"
-    slash "^1.0.0"
+    micromatch "^3.1.10"
+    slash "^2.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
-  integrity sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=
+jest-mock@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.8.0.tgz#2f9d14d37699e863f1febf4e4d5a33b7fdbbde56"
+  integrity sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==
+  dependencies:
+    "@jest/types" "^24.8.0"
+
+jest-pnp-resolver@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
+  integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
 
 jest-raw-loader@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/jest-raw-loader/-/jest-raw-loader-1.0.1.tgz#ce9f56d54650f157c4a7d16d224ba5d613bcd626"
   integrity sha1-zp9W1UZQ8VfEp9FtIkul1hO81iY=
 
-jest-regex-util@^23.3.0:
-  version "23.3.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
-  integrity sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U=
+jest-regex-util@^24.3.0:
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.3.0.tgz#d5a65f60be1ae3e310d5214a0307581995227b36"
+  integrity sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==
 
-jest-resolve-dependencies@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz#b4526af24c8540d9a3fab102c15081cf509b723d"
-  integrity sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==
+jest-resolve-dependencies@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz#19eec3241f2045d3f990dba331d0d7526acff8e0"
+  integrity sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==
   dependencies:
-    jest-regex-util "^23.3.0"
-    jest-snapshot "^23.6.0"
+    "@jest/types" "^24.8.0"
+    jest-regex-util "^24.3.0"
+    jest-snapshot "^24.8.0"
 
-jest-resolve@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.6.0.tgz#cf1d1a24ce7ee7b23d661c33ba2150f3aebfa0ae"
-  integrity sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==
+jest-resolve@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.8.0.tgz#84b8e5408c1f6a11539793e2b5feb1b6e722439f"
+  integrity sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==
   dependencies:
+    "@jest/types" "^24.8.0"
     browser-resolve "^1.11.3"
     chalk "^2.0.1"
-    realpath-native "^1.0.0"
+    jest-pnp-resolver "^1.2.1"
+    realpath-native "^1.1.0"
 
-jest-runner@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.6.0.tgz#3894bd219ffc3f3cb94dc48a4170a2e6f23a5a38"
-  integrity sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==
+jest-runner@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-24.8.0.tgz#4f9ae07b767db27b740d7deffad0cf67ccb4c5bb"
+  integrity sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==
   dependencies:
+    "@jest/console" "^24.7.1"
+    "@jest/environment" "^24.8.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    chalk "^2.4.2"
     exit "^0.1.2"
-    graceful-fs "^4.1.11"
-    jest-config "^23.6.0"
-    jest-docblock "^23.2.0"
-    jest-haste-map "^23.6.0"
-    jest-jasmine2 "^23.6.0"
-    jest-leak-detector "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-runtime "^23.6.0"
-    jest-util "^23.4.0"
-    jest-worker "^23.2.0"
+    graceful-fs "^4.1.15"
+    jest-config "^24.8.0"
+    jest-docblock "^24.3.0"
+    jest-haste-map "^24.8.0"
+    jest-jasmine2 "^24.8.0"
+    jest-leak-detector "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-resolve "^24.8.0"
+    jest-runtime "^24.8.0"
+    jest-util "^24.8.0"
+    jest-worker "^24.6.0"
     source-map-support "^0.5.6"
     throat "^4.0.0"
 
-jest-runtime@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.6.0.tgz#059e58c8ab445917cd0e0d84ac2ba68de8f23082"
-  integrity sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==
+jest-runtime@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-24.8.0.tgz#05f94d5b05c21f6dc54e427cd2e4980923350620"
+  integrity sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==
   dependencies:
-    babel-core "^6.0.0"
-    babel-plugin-istanbul "^4.1.6"
+    "@jest/console" "^24.7.1"
+    "@jest/environment" "^24.8.0"
+    "@jest/source-map" "^24.3.0"
+    "@jest/transform" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    "@types/yargs" "^12.0.2"
     chalk "^2.0.1"
-    convert-source-map "^1.4.0"
     exit "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.1.11"
-    jest-config "^23.6.0"
-    jest-haste-map "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-regex-util "^23.3.0"
-    jest-resolve "^23.6.0"
-    jest-snapshot "^23.6.0"
-    jest-util "^23.4.0"
-    jest-validate "^23.6.0"
-    micromatch "^2.3.11"
-    realpath-native "^1.0.0"
-    slash "^1.0.0"
-    strip-bom "3.0.0"
-    write-file-atomic "^2.1.0"
-    yargs "^11.0.0"
+    glob "^7.1.3"
+    graceful-fs "^4.1.15"
+    jest-config "^24.8.0"
+    jest-haste-map "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-mock "^24.8.0"
+    jest-regex-util "^24.3.0"
+    jest-resolve "^24.8.0"
+    jest-snapshot "^24.8.0"
+    jest-util "^24.8.0"
+    jest-validate "^24.8.0"
+    realpath-native "^1.1.0"
+    slash "^2.0.0"
+    strip-bom "^3.0.0"
+    yargs "^12.0.2"
 
-jest-serializer@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
-  integrity sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=
+jest-serializer@^24.4.0:
+  version "24.4.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.4.0.tgz#f70c5918c8ea9235ccb1276d232e459080588db3"
+  integrity sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==
 
-jest-snapshot@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.6.0.tgz#f9c2625d1b18acda01ec2d2b826c0ce58a5aa17a"
-  integrity sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==
+jest-snapshot@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.8.0.tgz#3bec6a59da2ff7bc7d097a853fb67f9d415cb7c6"
+  integrity sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==
   dependencies:
-    babel-types "^6.0.0"
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^24.8.0"
     chalk "^2.0.1"
-    jest-diff "^23.6.0"
-    jest-matcher-utils "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-resolve "^23.6.0"
+    expect "^24.8.0"
+    jest-diff "^24.8.0"
+    jest-matcher-utils "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-resolve "^24.8.0"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^23.6.0"
+    pretty-format "^24.8.0"
     semver "^5.5.0"
 
 jest-styled-components@7.0.0-2:
@@ -8564,18 +8656,22 @@ jest-styled-components@7.0.0-2:
   dependencies:
     css "^2.2.4"
 
-jest-util@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
-  integrity sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=
+jest-util@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.8.0.tgz#41f0e945da11df44cc76d64ffb915d0716f46cd1"
+  integrity sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==
   dependencies:
-    callsites "^2.0.0"
+    "@jest/console" "^24.7.1"
+    "@jest/fake-timers" "^24.8.0"
+    "@jest/source-map" "^24.3.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    callsites "^3.0.0"
     chalk "^2.0.1"
-    graceful-fs "^4.1.11"
-    is-ci "^1.0.10"
-    jest-message-util "^23.4.0"
+    graceful-fs "^4.1.15"
+    is-ci "^2.0.0"
     mkdirp "^0.5.1"
-    slash "^1.0.0"
+    slash "^2.0.0"
     source-map "^0.6.0"
 
 jest-validate@^21.1.0:
@@ -8587,16 +8683,6 @@ jest-validate@^21.1.0:
     jest-get-type "^21.2.0"
     leven "^2.1.0"
     pretty-format "^21.2.1"
-
-jest-validate@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
-  integrity sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==
-  dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    leven "^2.1.0"
-    pretty-format "^23.6.0"
 
 jest-validate@^24.0.0:
   version "24.5.0"
@@ -8610,29 +8696,46 @@ jest-validate@^24.0.0:
     leven "^2.1.0"
     pretty-format "^24.5.0"
 
-jest-watcher@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
-  integrity sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=
+jest-validate@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.8.0.tgz#624c41533e6dfe356ffadc6e2423a35c2d3b4849"
+  integrity sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==
   dependencies:
+    "@jest/types" "^24.8.0"
+    camelcase "^5.0.0"
+    chalk "^2.0.1"
+    jest-get-type "^24.8.0"
+    leven "^2.1.0"
+    pretty-format "^24.8.0"
+
+jest-watcher@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.8.0.tgz#58d49915ceddd2de85e238f6213cef1c93715de4"
+  integrity sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==
+  dependencies:
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    "@types/yargs" "^12.0.9"
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
+    jest-util "^24.8.0"
     string-length "^2.0.0"
 
-jest-worker@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
-  integrity sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=
+jest-worker@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.6.0.tgz#7f81ceae34b7cde0c9827a6980c35b7cdc0161b3"
+  integrity sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==
   dependencies:
     merge-stream "^1.0.1"
+    supports-color "^6.1.0"
 
-jest@23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
-  integrity sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==
+jest@24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-24.8.0.tgz#d5dff1984d0d1002196e9b7f12f75af1b2809081"
+  integrity sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==
   dependencies:
-    import-local "^1.0.0"
-    jest-cli "^23.6.0"
+    import-local "^2.0.0"
+    jest-cli "^24.8.0"
 
 js-beautify@^1.8.9:
   version "1.9.0"
@@ -8898,10 +9001,10 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-kleur@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-1.0.2.tgz#637f126d3cda40a423b1297da88cf753bd04ebdd"
-  integrity sha512-4u2TF1/mKmiawrkjzCxRKszdCvqRsPgTJwjmZZt0RE4OiZMzvFfb4kwqfFP/p0gvakH1lhQOfCMYXUOYI9dTgA==
+kleur@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
 known-css-properties@^0.9.0:
   version "0.9.0"
@@ -8947,6 +9050,13 @@ lcid@^1.0.0:
   integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
   dependencies:
     invert-kv "^1.0.0"
+
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+  dependencies:
+    invert-kv "^2.0.0"
 
 left-pad@^1.2.0:
   version "1.3.0"
@@ -9037,17 +9147,6 @@ listr@^0.12.0:
     rxjs "^5.0.0-beta.11"
     stream-to-observable "^0.1.0"
     strip-ansi "^3.0.1"
-
-load-json-file@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
-  integrity sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
 
 load-json-file@^2.0.0:
   version "2.0.0"
@@ -9318,11 +9417,6 @@ longest-streak@^2.0.1:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.2.tgz#2421b6ba939a443bb9ffebf596585a50b4c38e2e"
   integrity sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==
 
-longest@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
-  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -9383,6 +9477,14 @@ make-dir@^1.0.0, make-dir@^1.1.0:
   dependencies:
     pify "^3.0.0"
 
+make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -9394,6 +9496,13 @@ mamacro@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
   integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
+
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -9453,11 +9562,6 @@ marksy@^6.1.0:
     babel-standalone "^6.26.0"
     he "^1.1.1"
     marked "^0.3.12"
-
-math-random@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
-  integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
 
 mathml-tag-names@^2.0.1:
   version "2.1.0"
@@ -9527,6 +9631,15 @@ mem@^1.1.0:
   integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
+
+mem@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
 
 memoize-one@^4.0.0, memoize-one@^4.0.3:
   version "4.1.0"
@@ -9604,34 +9717,10 @@ merge2@^1.2.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.2.tgz#03212e3da8d86c4d8523cebd6318193414f94e34"
   integrity sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==
 
-merge@^1.1.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
-  integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
-
 methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
-
-micromatch@^2.3.11:
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
-  integrity sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=
-  dependencies:
-    arr-diff "^2.0.0"
-    array-unique "^0.2.1"
-    braces "^1.8.2"
-    expand-brackets "^0.1.4"
-    extglob "^0.3.1"
-    filename-regex "^2.0.0"
-    is-extglob "^1.0.0"
-    is-glob "^2.0.1"
-    kind-of "^3.0.2"
-    normalize-path "^2.0.1"
-    object.omit "^2.0.0"
-    parse-glob "^3.0.4"
-    regex-cache "^0.4.2"
 
 micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
@@ -9692,6 +9781,11 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+mimic-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
 mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
@@ -9723,7 +9817,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -9886,6 +9980,11 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
+nan@^2.12.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
@@ -9942,6 +10041,11 @@ neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
   integrity sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==
+
+neo-async@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
 nested-object-assign@^1.0.1:
   version "1.0.2"
@@ -10050,6 +10154,22 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
+node-pre-gyp@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
 node-releases@^1.1.14:
   version "1.1.17"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.17.tgz#71ea4631f0a97d5cd4f65f7d04ecf9072eac711a"
@@ -10095,7 +10215,7 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.1, normalize-path@^2.1.1:
+normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
@@ -10269,14 +10389,6 @@ object.getownpropertydescriptors@^2.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.5.1"
 
-object.omit@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
-  integrity sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=
-  dependencies:
-    for-own "^0.1.4"
-    is-extendable "^0.1.1"
-
 object.omit@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-3.0.0.tgz#0e3edc2fce2ba54df5577ff529f6d97bd8a522af"
@@ -10410,6 +10522,15 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
+os-locale@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  dependencies:
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -10437,10 +10558,27 @@ p-cancelable@^0.3.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
   integrity sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==
 
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
+
+p-each-series@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
+  integrity sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=
+  dependencies:
+    p-reduce "^1.0.0"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-is-promise@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -10474,6 +10612,11 @@ p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
   integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
+
+p-reduce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
+  integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
 
 p-timeout@^1.1.1:
   version "1.2.1"
@@ -10553,16 +10696,6 @@ parse-entities@^1.0.2, parse-entities@^1.1.0, parse-entities@^1.1.2:
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
 
-parse-glob@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
-  integrity sha1-ssN2z7EfNVE7rdFz7wu246OIORw=
-  dependencies:
-    glob-base "^0.3.0"
-    is-dotfile "^1.0.0"
-    is-extglob "^1.0.0"
-    is-glob "^2.0.0"
-
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -10637,13 +10770,6 @@ path-dirname@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
   integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
-path-exists@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
-  integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
-  dependencies:
-    pinkie-promise "^2.0.0"
-
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -10664,7 +10790,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-parse@^1.0.5, path-parse@^1.0.6:
+path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
@@ -10685,15 +10811,6 @@ path-to-regexp@^2.2.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
   integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
-
-path-type@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
-  integrity sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -10769,6 +10886,13 @@ pirates@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.0.tgz#850b18781b4ac6ec58a43c9ed9ec5fe6796addbd"
   integrity sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==
+  dependencies:
+    node-modules-regexp "^1.0.0"
+
+pirates@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
+  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
 
@@ -11018,11 +11142,6 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-preserve@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
-  integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
-
 prettier@1.16.4:
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
@@ -11054,20 +11173,22 @@ pretty-format@^21.2.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
-  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
-  dependencies:
-    ansi-regex "^3.0.0"
-    ansi-styles "^3.2.0"
-
 pretty-format@^24.5.0:
   version "24.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.5.0.tgz#cc69a0281a62cd7242633fc135d6930cd889822d"
   integrity sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==
   dependencies:
     "@jest/types" "^24.5.0"
+    ansi-regex "^4.0.0"
+    ansi-styles "^3.2.0"
+    react-is "^16.8.4"
+
+pretty-format@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
+  integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
+  dependencies:
+    "@jest/types" "^24.8.0"
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
@@ -11137,13 +11258,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prompts@^0.1.9:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.12.tgz#39dc42de7d2f0ec3e2af76bf40713fcb8726090d"
-  integrity sha512-pgR1GE1JM8q8UsHVIgjdK62DPwvrf0kvaKWJ/mfMoCm2lwfIReX/giQ1p0AlMoUXNhQap/8UiOdqi3bOROm/eg==
+prompts@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
+  integrity sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==
   dependencies:
-    kleur "^1.0.0"
-    sisteransi "^0.1.1"
+    kleur "^3.0.2"
+    sisteransi "^1.0.0"
 
 prop-types-extra@^1.0.1, prop-types-extra@^1.1.0:
   version "1.1.0"
@@ -11328,15 +11449,6 @@ randexp@0.4.6:
   dependencies:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
-
-randomatic@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"
-  integrity sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==
-  dependencies:
-    is-number "^4.0.0"
-    kind-of "^6.0.0"
-    math-random "^1.0.1"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.0.6"
@@ -11981,14 +12093,6 @@ read-chunk@^3.0.0:
     pify "^4.0.0"
     with-open-file "^0.1.3"
 
-read-pkg-up@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
-  integrity sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=
-  dependencies:
-    find-up "^1.0.0"
-    read-pkg "^1.0.0"
-
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
@@ -12012,15 +12116,6 @@ read-pkg-up@^4.0.0:
   dependencies:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
-
-read-pkg@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
-  integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
-  dependencies:
-    load-json-file "^1.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^1.0.0"
 
 read-pkg@^2.0.0:
   version "2.0.0"
@@ -12100,10 +12195,10 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-realpath-native@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
-  integrity sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==
+realpath-native@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
+  integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
 
@@ -12218,13 +12313,6 @@ regenerator-transform@^0.13.4:
   integrity sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==
   dependencies:
     private "^0.1.6"
-
-regex-cache@^0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
-  integrity sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
-  dependencies:
-    is-equal-shallow "^0.1.3"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -12442,7 +12530,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
   integrity sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=
 
-repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -12534,6 +12622,11 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 require-package-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
@@ -12622,19 +12715,19 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-right-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
-  integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
-  dependencies:
-    align-text "^0.1.1"
-
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
+
+rimraf@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@~2.2.6:
   version "2.2.8"
@@ -12657,10 +12750,10 @@ rst-selector-parser@^2.2.3:
     lodash.flattendeep "^4.4.0"
     nearley "^2.7.10"
 
-rsvp@^3.3.3:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
-  integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
+rsvp@^4.8.4:
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
+  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^0.1.0:
   version "0.1.0"
@@ -12739,21 +12832,20 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sane@^2.0.0:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
-  integrity sha1-tNwYYcIbQn6SlQej51HiosuKs/o=
+sane@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
+  integrity sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
   dependencies:
+    "@cnakazawa/watch" "^1.0.3"
     anymatch "^2.0.0"
-    capture-exit "^1.2.0"
-    exec-sh "^0.2.0"
+    capture-exit "^2.0.0"
+    exec-sh "^0.3.2"
+    execa "^1.0.0"
     fb-watchman "^2.0.0"
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
-    watch "~0.18.0"
-  optionalDependencies:
-    fsevents "^1.2.3"
 
 sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
@@ -13025,10 +13117,10 @@ simple-progress-webpack-plugin@1.1.2:
     figures "2.0.x"
     log-update "2.3.x"
 
-sisteransi@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
-  integrity sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==
+sisteransi@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
+  integrity sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==
 
 slash@^1.0.0:
   version "1.0.0"
@@ -13123,14 +13215,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
-  dependencies:
-    amdefine ">=0.0.4"
-
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -13486,17 +13571,17 @@ strip-bom-stream@^2.0.0:
     first-chunk-stream "^2.0.0"
     strip-bom "^2.0.0"
 
-strip-bom@3.0.0, strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
-
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -13677,7 +13762,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
@@ -13850,16 +13935,15 @@ terser@^3.16.1:
     source-map "~0.6.1"
     source-map-support "~0.5.9"
 
-test-exclude@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
-  integrity sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==
+test-exclude@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
+  integrity sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==
   dependencies:
-    arrify "^1.0.1"
-    micromatch "^3.1.8"
-    object-assign "^4.1.0"
-    read-pkg-up "^1.0.1"
-    require-main-filename "^1.0.1"
+    glob "^7.1.3"
+    minimatch "^3.0.4"
+    read-pkg-up "^4.0.0"
+    require-main-filename "^2.0.0"
 
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
@@ -14196,20 +14280,13 @@ uglify-js@3.4.x:
     commander "~2.17.1"
     source-map "~0.6.1"
 
-uglify-js@^2.6:
-  version "2.8.29"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
-  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
+uglify-js@^3.1.4:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
+  integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
   dependencies:
-    source-map "~0.5.1"
-    yargs "~3.10.0"
-  optionalDependencies:
-    uglify-to-browserify "~1.0.0"
-
-uglify-to-browserify@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
-  integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
+    commander "~2.20.0"
+    source-map "~0.6.1"
 
 underscore.string@^3.3.5:
   version "3.3.5"
@@ -14693,7 +14770,7 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-walker@~1.0.5:
+walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
@@ -14713,14 +14790,6 @@ warning@^4.0.1, warning@^4.0.2:
   integrity sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==
   dependencies:
     loose-envify "^1.0.0"
-
-watch@~0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
-  integrity sha1-KAlUdsbffJDJYxOJkMClQj60uYY=
-  dependencies:
-    exec-sh "^0.2.0"
-    minimist "^1.2.0"
 
 watchpack@^1.5.0:
   version "1.6.0"
@@ -14877,7 +14946,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
+which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -14905,11 +14974,6 @@ widest-line@^2.0.1:
   dependencies:
     string-width "^2.1.1"
 
-window-size@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-  integrity sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
-
 with-open-file@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/with-open-file/-/with-open-file-0.1.4.tgz#797e32055cbe55c58727ad026482fb0776474b2c"
@@ -14918,11 +14982,6 @@ with-open-file@^0.1.3:
     p-finally "^1.0.0"
     p-try "^2.0.0"
     pify "^3.0.0"
-
-wordwrap@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-  integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
 wordwrap@~0.0.2:
   version "0.0.3"
@@ -14971,7 +15030,16 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
+write-file-atomic@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
+  integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
   integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
@@ -15037,7 +15105,7 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
-y18n@^4.0.0:
+"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
@@ -15059,6 +15127,14 @@ yargs-parser@^10.0.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
@@ -15066,30 +15142,23 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
-  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
-  integrity sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==
+yargs@^12.0.2:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
   dependencies:
     cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
     get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
+    os-locale "^3.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
     string-width "^2.0.0"
     which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^11.1.1"
 
 yargs@^9.0.0:
   version "9.0.1"
@@ -15109,16 +15178,6 @@ yargs@^9.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
-
-yargs@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  integrity sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
-  dependencies:
-    camelcase "^1.0.2"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
 
 yeoman-environment@^2.0.5, yeoman-environment@^2.3.4:
   version "2.3.4"


### PR DESCRIPTION
This fixes an issue we've observed related to running tests while yarn linking to other packages, triggering "cannot use hooks outside body of function" error. Also updates Jest to latest. 

See https://github.com/facebook/react/issues/13991 for more context.