### PR TITLE
[CollectionFeatureArtists] only use aggregate artists when there is not explicit artist_ids

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/__tests__/Header.test.ts
+++ b/src/Apps/Collect/Components/Collection/Header/__tests__/Header.test.ts
@@ -1,0 +1,97 @@
+import { featuredArtistsEntityCollection, getFeaturedArtists } from "../index"
+
+const mockedFeaturedArtistsEntityCollection = featuredArtistsEntityCollection as jest.Mock
+
+describe("getFeaturedArtists", () => {
+  const mockMediator = jest.fn()
+
+  const collection = {
+    title: "KAWS: Toys",
+    query: {
+      gene_id: null,
+      artist_id: null,
+      artist_ids: ["4e934002e340fa0001005336"],
+    },
+    artworks: {
+      merchandisable_artists: [
+        {
+          id: "kaws",
+          _id: "4e934002e340fa0001005336",
+          name: "KAWS",
+          imageUrl:
+            "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
+          birthday: "1974",
+          nationality: "American",
+        },
+        {
+          id: "robert-lazzarini",
+          _id: "4f5f64c23b555230ac0003ae",
+          name: "Robert Lazzarini",
+          imageUrl:
+            "https://d32dm0rphc51dk.cloudfront.net/1npk1i_Xua5q8Hv0YOq_3g/square.jpg",
+          birthday: "1965",
+          nationality: "American",
+        },
+        {
+          id: "medicom",
+          _id: "58fe85ee275b2450a0fd2b51",
+          name: "Medicom",
+          imageUrl:
+            "https://d32dm0rphc51dk.cloudfront.net/jUMOidRmCQ0RyynXM_sFzQ/square.jpg",
+          birthday: "",
+          nationality: "",
+        },
+        {
+          id: "medicom-toy-slash-china",
+          _id: "5b9821af86c8aa21d364dde5",
+          name: "Medicom Toy/China",
+          imageUrl:
+            "https://d32dm0rphc51dk.cloudfront.net/npEmyaOeaPzkfEHX5VsmQg/square.jpg",
+          birthday: "",
+          nationality: "",
+        },
+      ],
+    },
+  }
+
+  it("returns the queried artists when there is explicit artist_ids", () => {
+    const results = getFeaturedArtists(
+      9,
+      collection,
+      true,
+      collection.artworks.merchandisable_artists,
+      mockMediator,
+      {}
+    )
+
+    expect(results.length).toEqual(1)
+  })
+
+  it("passes correct arguments featuredArtistsEntityCollection", () => {
+    getFeaturedArtists(
+      9,
+      collection,
+      true,
+      collection.artworks.merchandisable_artists,
+      mockMediator,
+      {}
+    )
+
+    expect(mockedFeaturedArtistsEntityCollection).toBeCalledWith(
+      [
+        {
+          id: "kaws",
+          _id: "4e934002e340fa0001005336",
+          name: "KAWS",
+          imageUrl:
+            "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
+          birthday: "1974",
+          nationality: "American",
+        },
+      ],
+      true,
+      mockMediator,
+      {}
+    )
+  })
+})

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -1,7 +1,7 @@
 import { EntityHeader, ReadMore } from "@artsy/palette"
 import { unica } from "Assets/Fonts"
 import { cloneDeep, filter, take } from "lodash"
-import React, { FC, useContext, useState } from "react"
+import React, { FC, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { slugify } from "underscore.string"
@@ -23,7 +23,7 @@ import {
   Spacer,
 } from "@artsy/palette"
 import { Header_artworks } from "__generated__/Header_artworks.graphql"
-import { SystemContext } from "Artsy"
+import { useSystemContext } from "Artsy"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import { AuthModalIntent, openAuthModal } from "Utils/openAuthModal"
 
@@ -62,6 +62,98 @@ const handleOpenAuth = (mediator, artist) => {
   })
 }
 
+export const getFeaturedArtists = (
+  artistsCount: number,
+  collection,
+  isColumnLayout: boolean,
+  merchandisableArtists,
+  mediator,
+  user
+) => {
+  let featuredArtists
+
+  if (collection.query.artist_ids.length > 0) {
+    featuredArtists = filter(merchandisableArtists, artist =>
+      collection.query.artist_ids.includes(artist._id)
+    )
+
+    return featuredArtistsEntityCollection(
+      featuredArtists,
+      isColumnLayout,
+      mediator,
+      user
+    )
+  }
+
+  if (merchandisableArtists.length > 0) {
+    return featuredArtistsEntityCollection(
+      take(merchandisableArtists, artistsCount),
+      isColumnLayout,
+      mediator,
+      user
+    )
+  }
+}
+
+const featuredArtistsEntityCollection = (
+  artists,
+  isColumnLayout,
+  mediator,
+  user
+) => {
+  return artists.map((artist, index) => {
+    const hasArtistMetaData = artist.nationality && artist.birthday
+    return (
+      <EntityContainer
+        width={["100%", "25%"]}
+        isColumnLayout={isColumnLayout}
+        key={index}
+        pb={20}
+      >
+        <EntityHeader
+          imageUrl={artist.imageUrl}
+          name={artist.name}
+          meta={
+            hasArtistMetaData
+              ? `${artist.nationality}, b. ${artist.birthday}`
+              : null
+          }
+          href={`/artist/${artist.id}`}
+          FollowButton={
+            <FollowArtistButton
+              artist={artist}
+              user={user}
+              trackingData={{
+                modelName: AnalyticsSchema.OwnerType.Artist,
+                context_module:
+                  AnalyticsSchema.ContextModule.CollectionDescription,
+                entity_id: artist._id,
+                entity_slug: artist.id,
+              }}
+              onOpenAuthModal={() => handleOpenAuth(mediator, artist)}
+              render={({ is_followed }) => {
+                return (
+                  <Sans
+                    size="2"
+                    weight="medium"
+                    color="black"
+                    style={{
+                      cursor: "pointer",
+                      textDecoration: "underline",
+                    }}
+                  >
+                    {is_followed ? "Following" : "Follow"}
+                  </Sans>
+                )
+              }}
+            />
+          }
+        />
+      </EntityContainer>
+    )
+  })
+}
+
 const maxChars = {
   xs: 350,
   sm: 730,
@@ -79,7 +171,7 @@ const imageWidthSizes = {
 }
 
 export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
-  const { user, mediator } = useContext(SystemContext)
+  const { user, mediator } = useSystemContext()
   const [showMore, setShowMore] = useState(false)
   const hasMultipleArtists =
     artworks.merchandisable_artists &&
@@ -113,82 +205,6 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
     return showMore ? featuredArtists : artists
   }
 
-  const featuredArtistsEntityCollection = (artists, isColumnLayout) => {
-    return artists.map((artist, index) => {
-      const hasArtistMetaData = artist.nationality && artist.birthday
-      return (
-        <EntityContainer
-          width={["100%", "25%"]}
-          isColumnLayout={isColumnLayout}
-          key={index}
-          pb={20}
-        >
-          <EntityHeader
-            imageUrl={artist.imageUrl}
-            name={artist.name}
-            meta={
-              hasArtistMetaData
-                ? `${artist.nationality}, b. ${artist.birthday}`
-                : null
-            }
-            href={`/artist/${artist.id}`}
-            FollowButton={
-              <FollowArtistButton
-                artist={artist}
-                user={user}
-                trackingData={{
-                  modelName: AnalyticsSchema.OwnerType.Artist,
-                  context_module:
-                    AnalyticsSchema.ContextModule.CollectionDescription,
-                  entity_id: artist._id,
-                  entity_slug: artist.id,
-                }}
-                onOpenAuthModal={() => handleOpenAuth(mediator, artist)}
-                render={({ is_followed }) => {
-                  return (
-                    <Sans
-                      size="2"
-                      weight="medium"
-                      color="black"
-                      style={{
-                        cursor: "pointer",
-                        textDecoration: "underline",
-                      }}
-                    >
-                      {is_followed ? "Following" : "Follow"}
-                    </Sans>
-                  )
-                }}
-              />
-            }
-          />
-        </EntityContainer>
-      )
-    })
-  }
-
-  const getFeaturedArtists = (
-    artistsCount: number,
-    isColumnLayout: boolean
-  ) => {
-    let featuredArtists
-
-    if (collection.query.artist_ids.length > 0) {
-      featuredArtists = filter(artworks.merchandisable_artists, artist =>
-        collection.query.artist_ids.includes(artist._id)
-      )
-
-      return featuredArtistsEntityCollection(featuredArtists, isColumnLayout)
-    }
-
-    if (artworks.merchandisable_artists.length > 0) {
-      return featuredArtistsEntityCollection(
-        take(artworks.merchandisable_artists, artistsCount),
-        isColumnLayout
-      )
-    }
-  }
-
   return (
     <Responsive>
       {({ xs, sm, md, lg }) => {
@@ -201,7 +217,14 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
         const isColumnLayout =
           hasMultipleArtists || !collection.description || size === "xs"
         const smallerScreen = size === "xs" || size === "sm"
-        const featuredArtists = getFeaturedArtists(artistsCount, isColumnLayout)
+        const featuredArtists = getFeaturedArtists(
+          artistsCount,
+          collection,
+          isColumnLayout,
+          artworks.merchandisable_artists,
+          mediator,
+          user
+        )
 
         return (
           <header>

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -95,7 +95,7 @@ export const getFeaturedArtists = (
   }
 }
 
-const featuredArtistsEntityCollection = (
+export const featuredArtistsEntityCollection = (
   artists,
   isColumnLayout,
   mediator,


### PR DESCRIPTION
Address: [GROW-1262](https://artsyproduct.atlassian.net/browse/GROW-1262) 

**Work In Progress:**
This PR handles displaying featured artist based on `artist_ids` if they are explicitly provide and then falling back to `merchandisable_artists` when there is no value for `artist_ids`.

### Before:
![Screen Shot 2019-06-07 at 7 39 22 PM](https://user-images.githubusercontent.com/5201004/59138597-024b5a00-895c-11e9-8ccc-ebf4bbaaf85d.png)


### After:
![Screen Shot 2019-06-07 at 7 40 00 PM](https://user-images.githubusercontent.com/5201004/59138609-14c59380-895c-11e9-9bb0-3d6fd605f016.png)
