### PR TITLE
Removes no cache from jest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           requires:
             - yarn/workflow-queue
       - yarn/jest:
-          args: --runInBand --no-cache -u
+          args: --runInBand
           requires:
             - yarn/workflow-queue
       - yarn/auto-release:


### PR DESCRIPTION
- Follow up to https://github.com/artsy/reaction/pull/2517#event-2398609072
- Removes `no-cache -u` from yarn which was necessary for major version bump of Jest