### PR TITLE
Prepare Reaction for Palette luxon updates 

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "1.0.0",
-    "@artsy/palette": "4.14.12",
+    "@artsy/palette": "4.14.13",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.3.4",
     "@babel/plugin-proposal-class-properties": "7.3.4",
@@ -177,6 +177,7 @@
     "isomorphic-fetch": "^2.2.1",
     "jsonp": "^0.2.1",
     "lodash": "^4.17.4",
+    "luxon": "^1.15",
     "memoize-one": "^4.0.3",
     "moment-timezone": "^0.5.25",
     "numeral": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
     ],
     "testURL": "http://localhost/",
     "moduleNameMapper": {
+      "^luxon$": "<rootDir>/node_modules/luxon",
       "^react$": "<rootDir>/node_modules/react",
       "Assets(.*)$": "<rootDir>/src/Assets/$1",
       "^Components(.*)$": "<rootDir>/src/Components/$1"

--- a/src/Components/WithCurrentTime.tsx
+++ b/src/Components/WithCurrentTime.tsx
@@ -1,4 +1,4 @@
-import moment from "moment"
+import { DateTime } from "luxon"
 import React from "react"
 import { getCurrentTimeAsIsoString } from "Utils/getCurrentTimeAsIsoString"
 import { getOffsetBetweenGravityClock } from "Utils/time"
@@ -70,9 +70,9 @@ export class WithCurrentTime extends React.Component<
   render() {
     const { currentTime, timeOffsetInMilliseconds } = this.state
     return this.props.children(
-      moment(currentTime)
-        .subtract(timeOffsetInMilliseconds, "ms")
-        .toISOString()
+      DateTime.fromISO(currentTime)
+        .minus({ millisecond: timeOffsetInMilliseconds })
+        .toString()
     )
   }
 }

--- a/src/Components/v2/__tests__/CountdownTimer.test.tsx
+++ b/src/Components/v2/__tests__/CountdownTimer.test.tsx
@@ -61,7 +61,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Dec 04, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
       )
     })
 
@@ -71,7 +71,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Dec 04, 1:50 PM GMTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
       )
     })
   })
@@ -85,7 +85,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Aug 04, 9:50 AM EDTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Aug 4, 6:50am PDTExpired offers end the negotiation process permanently."`
       )
     })
 
@@ -95,7 +95,7 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Aug 04, 2:50 PM BSTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Aug 4, 6:50am PDTExpired offers end the negotiation process permanently."`
       )
     })
   })
@@ -114,7 +114,7 @@ describe("CountdownTimer", () => {
 
     const text = timer.text()
     expect(text).toMatchInlineSnapshot(
-      `"time remaining01d 30m 00s leftRespond by Dec 04, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01d 30m 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
     )
   })
 
@@ -132,7 +132,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining01d 15h 10m 05s leftRespond by Dec 05, 12:00 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01d 15h 10m 05s leftRespond by Dec 4, 9:00pm PSTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -147,7 +147,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining15h 10m 05s leftRespond by Dec 04, 12:00 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining15h 10m 05s leftRespond by Dec 3, 9:00pm PSTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -159,7 +159,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining15m 10s leftRespond by Dec 03, 9:05 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining15m 10s leftRespond by Dec 3, 6:05am PSTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -169,7 +169,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining01s leftRespond by Dec 03, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining01s leftRespond by Dec 3, 5:50am PSTExpired offers end the negotiation process permanently."`
     )
 
     expect(
@@ -179,7 +179,7 @@ describe("CountdownTimer", () => {
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining0 days leftRespond by Dec 03, 8:50 AM ESTExpired offers end the negotiation process permanently."`
+      `"time remaining0 days leftRespond by Dec 3, 5:50am PSTExpired offers end the negotiation process permanently."`
     )
   })
 })

--- a/src/Components/v2/__tests__/CountdownTimer.test.tsx
+++ b/src/Components/v2/__tests__/CountdownTimer.test.tsx
@@ -4,8 +4,6 @@ import React from "react"
 import { ExtractProps } from "Utils/ExtractProps"
 import { CountdownTimer } from "../CountdownTimer"
 
-Settings.defaultZoneName = "America/New_York"
-
 const DATE = "2018-12-03T13:50:31.641Z"
 const SUMMER_DATE = "2018-08-03T13:50:31.641Z"
 
@@ -53,7 +51,13 @@ describe("CountdownTimer", () => {
     mockGetOffsetBetweenGravityClock.mockReturnValue(Promise.resolve(0))
   })
 
+  const realDefaultZone = Settings.defaultZoneName
+
   afterEach(() => {
+    Settings.defaultZoneName = realDefaultZone
+  })
+
+  beforeEach(() => {
     Settings.defaultZoneName = "America/New_York"
   })
 

--- a/src/Components/v2/__tests__/CountdownTimer.test.tsx
+++ b/src/Components/v2/__tests__/CountdownTimer.test.tsx
@@ -1,12 +1,10 @@
 import { mount } from "enzyme"
-import moment from "moment"
+import { DateTime, Duration, Settings } from "luxon"
 import React from "react"
 import { ExtractProps } from "Utils/ExtractProps"
 import { CountdownTimer } from "../CountdownTimer"
 
-const guessTimezone = jest.fn(() => "America/New_York")
-
-require("moment-timezone").tz.guess = guessTimezone
+Settings.defaultZoneName = "America/New_York"
 
 const DATE = "2018-12-03T13:50:31.641Z"
 const SUMMER_DATE = "2018-08-03T13:50:31.641Z"
@@ -21,32 +19,32 @@ const mockGetOffsetBetweenGravityClock = getOffsetBetweenGravityClock as jest.Mo
 const defaultProps: ExtractProps<typeof CountdownTimer> = {
   action: "Respond",
   note: "Expired offers end the negotiation process permanently.",
-  countdownStart: moment(DATE)
-    .subtract(1, "days")
-    .toISOString(),
-  countdownEnd: moment(DATE)
-    .add(1, "days")
-    .toISOString(),
+  countdownStart: DateTime.fromISO(DATE)
+    .minus({ days: 1 })
+    .toString(),
+  countdownEnd: DateTime.fromISO(DATE)
+    .plus({ days: 1 })
+    .toString(),
 }
 
 const summerProps: typeof defaultProps = {
   ...defaultProps,
-  countdownStart: moment(SUMMER_DATE)
-    .subtract(1, "days")
-    .toISOString(),
-  countdownEnd: moment(SUMMER_DATE)
-    .add(1, "days")
-    .toISOString(),
+  countdownStart: DateTime.fromISO(SUMMER_DATE)
+    .minus({ days: 1 })
+    .toString(),
+  countdownEnd: DateTime.fromISO(SUMMER_DATE)
+    .plus({ days: 1 })
+    .toString(),
 }
 
-const getPropsWithTimeRemaining = (duration: moment.Duration) => ({
+const getPropsWithTimeRemaining = duration => ({
   ...defaultProps,
-  countdownStart: moment(DATE)
-    .subtract(1, "day")
-    .toISOString(),
-  countdownEnd: moment(DATE)
-    .add(duration)
-    .toISOString(),
+  countdownStart: DateTime.fromISO(DATE)
+    .minus({ days: 1 })
+    .toString(),
+  countdownEnd: DateTime.fromISO(DATE)
+    .plus(duration)
+    .toString(),
 })
 
 describe("CountdownTimer", () => {
@@ -55,23 +53,27 @@ describe("CountdownTimer", () => {
     mockGetOffsetBetweenGravityClock.mockReturnValue(Promise.resolve(0))
   })
 
+  afterEach(() => {
+    Settings.defaultZoneName = "America/New_York"
+  })
+
   describe("in winter", () => {
     it("shows timezone as EST", () => {
       const timer = mount(<CountdownTimer {...defaultProps} />)
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Dec 4, 8:50am ESTExpired offers end the negotiation process permanently."`
       )
     })
 
-    it("shows timezone as GMT in London", () => {
-      guessTimezone.mockReturnValueOnce("Europe/London")
+    it("shows timezone as UTC in when in UTC", () => {
+      Settings.defaultZoneName = "UTC"
       const timer = mount(<CountdownTimer {...defaultProps} />)
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Dec 4, 1:50pm UTCExpired offers end the negotiation process permanently."`
       )
     })
   })
@@ -85,17 +87,17 @@ describe("CountdownTimer", () => {
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Aug 4, 6:50am PDTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Aug 4, 9:50am EDTExpired offers end the negotiation process permanently."`
       )
     })
 
-    it("shows timezone as BST in London", () => {
-      guessTimezone.mockReturnValueOnce("Europe/London")
+    it("shows timezone as UTC when in UTC", () => {
+      Settings.defaultZoneName = "UTC"
       const timer = mount(<CountdownTimer {...summerProps} />)
 
       const text = timer.text()
       expect(text).toMatchInlineSnapshot(
-        `"time remaining01d 00s leftRespond by Aug 4, 6:50am PDTExpired offers end the negotiation process permanently."`
+        `"time remaining01d 00s leftRespond by Aug 4, 1:50pm UTCExpired offers end the negotiation process permanently."`
       )
     })
   })
@@ -114,7 +116,7 @@ describe("CountdownTimer", () => {
 
     const text = timer.text()
     expect(text).toMatchInlineSnapshot(
-      `"time remaining01d 30m 00s leftRespond by Dec 4, 5:50am PSTExpired offers end the negotiation process permanently."`
+      `"time remaining01d 30m 00s leftRespond by Dec 4, 8:50am ESTExpired offers end the negotiation process permanently."`
     )
   })
 
@@ -123,63 +125,56 @@ describe("CountdownTimer", () => {
       mount(
         <CountdownTimer
           {...getPropsWithTimeRemaining(
-            moment
-              .duration(1, "days")
-              .add(15, "hours")
-              .add(10, "minutes")
-              .add(5, "seconds")
+            Duration.fromObject({ days: 1, hours: 15, minutes: 10, seconds: 5 })
           )}
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining01d 15h 10m 05s leftRespond by Dec 4, 9:00pm PSTExpired offers end the negotiation process permanently."`
+      `"time remaining01d 15h 10m 05s leftRespond by Dec 5, 12:00am ESTExpired offers end the negotiation process permanently."`
     )
 
     expect(
       mount(
         <CountdownTimer
           {...getPropsWithTimeRemaining(
-            moment
-              .duration(15, "hours")
-              .add(10, "minutes")
-              .add(5, "seconds")
+            Duration.fromObject({ hours: 15, minutes: 10, seconds: 5 })
           )}
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining15h 10m 05s leftRespond by Dec 3, 9:00pm PSTExpired offers end the negotiation process permanently."`
+      `"time remaining15h 10m 05s leftRespond by Dec 4, 12:00am ESTExpired offers end the negotiation process permanently."`
     )
 
     expect(
       mount(
         <CountdownTimer
           {...getPropsWithTimeRemaining(
-            moment.duration(15, "minutes").add(10, "seconds")
+            Duration.fromObject({ minutes: 15, seconds: 10 })
           )}
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining15m 10s leftRespond by Dec 3, 6:05am PSTExpired offers end the negotiation process permanently."`
+      `"time remaining15m 10s leftRespond by Dec 3, 9:05am ESTExpired offers end the negotiation process permanently."`
     )
 
     expect(
       mount(
         <CountdownTimer
-          {...getPropsWithTimeRemaining(moment.duration(1, "seconds"))}
+          {...getPropsWithTimeRemaining(Duration.fromObject({ seconds: 1 }))}
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining01s leftRespond by Dec 3, 5:50am PSTExpired offers end the negotiation process permanently."`
+      `"time remaining01s leftRespond by Dec 3, 8:50am ESTExpired offers end the negotiation process permanently."`
     )
 
     expect(
       mount(
         <CountdownTimer
-          {...getPropsWithTimeRemaining(moment.duration(-1, "seconds"))}
+          {...getPropsWithTimeRemaining(Duration.fromObject({ seconds: -1 }))}
         />
       ).text()
     ).toMatchInlineSnapshot(
-      `"time remaining0 days leftRespond by Dec 3, 5:50am PSTExpired offers end the negotiation process permanently."`
+      `"time remaining0 days leftRespond by Dec 3, 8:50am ESTExpired offers end the negotiation process permanently."`
     )
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,17 +12,14 @@
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.0.4.tgz#933c66db24e70186c20e83017af39794a920ef0e"
   integrity sha512-3LfmVWQdTQLjorlNv02y+qdD3h3RS57M46P/PBlG+nHjzUFtNk2B9NAKPurTzDubjlPYx1FUTH+EPm3ZaoTipg==
 
-"@artsy/palette@4.14.12":
-  version "4.14.12"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.14.12.tgz#00af1155932b880d442bb330ad8f2f21f1b08dcc"
-  integrity sha512-x4KUZWrx7fPC8uGh8KmrTozo4hipggul0nU7HQlR69rf9hklP8gfvGrHgm+Ndwj/9vxZVqshl5+Sf5Hmhhm1MQ==
+"@artsy/palette@4.14.13":
+  version "4.14.13"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.14.13.tgz#f96cc118c48eefcb47ceb84a980cc3d328138db8"
+  integrity sha512-RZ+ThamZdPFFKrhyYSKon2b4S6OR5MPa5d9hMy4wCAZeXgX2CKtQkk4bldC6dqQa/UbQPghSks7uYSg297bsAg==
   dependencies:
     babel-plugin-styled-components "^1.10.0"
     d3-interpolate "^1.3.2"
     d3-shape "^1.3.5"
-    luxon "^1.15.0"
-    moment "^2.23.0"
-    moment-timezone "^0.5.25"
     rc-slider "^8.6.2"
     react-lazy-load-image-component "^1.3.2"
     react-live "^1.12.0"
@@ -9458,7 +9455,7 @@ lru-cache@^4.0.1, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-luxon@^1.15.0:
+luxon@^1.15:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.16.0.tgz#93c915cfc3dff4bb806656595018fddc47cc96ec"
   integrity sha512-qaqB+JwpGwtl7UbIXng3A/l4W/ySBr8drQvwtMLZBMiLD2V+0fEnPWMrs+UjnIy9PsktazQaKvwDUCLzoWz0Hw==
@@ -9922,11 +9919,6 @@ moment-timezone@^0.5.25:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"
   integrity sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==
-
-moment@^2.23.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- This PR updates Reaction to use Luxon in components using Palette components also using Luxon. This also includes tests where Luxon's `Settings` API needed to be mocked to pass local timezone.
- Bumps Palette version to version where Luxon is introduced