### PR TITLE
DISCO-1070 - Better handling of long artist names/origins

### DIFF
--- a/src/Components/v2/ArtistCard.tsx
+++ b/src/Components/v2/ArtistCard.tsx
@@ -73,7 +73,7 @@ export const LargeArtistCard: SFC<Props> = props => (
       <Sans size="2">{props.artist.formatted_nationality_and_birthday}</Sans>
     </Flex>
 
-    <Flex flexDirection="column" alignItems="center" mt={3}>
+    <Flex flexDirection="column" alignItems="center" mt="auto">
       <FollowArtistButton
         artist={props.artist}
         user={props.user}

--- a/src/Components/v2/ArtistCard.tsx
+++ b/src/Components/v2/ArtistCard.tsx
@@ -21,6 +21,7 @@ import {
   space,
   Spacer,
 } from "@artsy/palette"
+import styled from "styled-components"
 
 interface Props {
   artist: ArtistCard_artist
@@ -54,6 +55,17 @@ export class ArtistCard extends React.Component<Props> {
   }
 }
 
+// Why not use <Truncator>? Because with only one line for the artist origin/
+//  birth year, the Truncator prematurely truncates, showing "American, b. 1938"
+//  as "American, b. ...".
+const SingleLineTruncation = styled(Sans)`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 100%;
+  text-align: center;
+`
+
 export const LargeArtistCard: SFC<Props> = props => (
   <BorderBox hover flexDirection="column" width="100%" height="254px">
     <Flex flexDirection="column" flexGrow="0" alignItems="center" pt={1} mb={1}>
@@ -70,7 +82,9 @@ export const LargeArtistCard: SFC<Props> = props => (
         <Truncator maxLineCount={2}>{props.artist.name}</Truncator>
       </Serif>
 
-      <Sans size="2">{props.artist.formatted_nationality_and_birthday}</Sans>
+      <SingleLineTruncation size="2">
+        {props.artist.formatted_nationality_and_birthday}
+      </SingleLineTruncation>
     </Flex>
 
     <Flex flexDirection="column" alignItems="center" mt="auto">


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-1070.

This PR modifies the `ArtistCard` component to better handle long artist names/origins, in two ways:

1. It removes the static `margin-top` from the Follow button, replacing it with `margin-top: auto`. This allows the button to flow to the end of the parent container, instead of being placed relative to the ending of the artist text.

2. It applies `text-overflow:ellipsis` (and associated styles) to the artist origin, so that it doesn't flow to a second line. I did not use the `<Truncator>` component, for the reason described at the end of this PR.

These changes are only applied to the `LargeArtistCard`; mobile is not affected.

## Wide resolution

### What it looks like now

![1070-wide-desktop](https://user-images.githubusercontent.com/1627089/59220956-c991c780-8b8b-11e9-92c1-8863347493e4.jpg)

### What it looked like before

<img width="1127" alt="1070-wide-before" src="https://user-images.githubusercontent.com/1627089/59220720-3f496380-8b8b-11e9-9b16-9634b1ccc03d.png">

## Narrow resolution

### What it looks like now

![1070-narrow-desktop](https://user-images.githubusercontent.com/1627089/59220296-3c9a3e80-8b8a-11e9-816c-fddb8a0e5e43.jpg)

### What it looked like before

![1070-narrow-before](https://user-images.githubusercontent.com/1627089/59220968-d1ea0280-8b8b-11e9-82ab-7a58c4cade3a.jpg)

## Why I didn't use the `<Truncator>` component for truncation/ellipsis

Weirdly, I found that using the `<Truncator>` component to handle long text on the artist origin resulted in premature truncation. Even when I had plenty of width, and there was plenty of room horizontally for the entire origin to show, the `Truncator` would truncate the year and show an ellipsis, like below:

![1070-truncator](https://user-images.githubusercontent.com/1627089/59220225-16749e80-8b8a-11e9-9367-8a7f77b5470d.jpg)

This is an issue with `react-lines-ellipsis`, but I'm not sure if it's a bug or working as intended. It is a non-ideal experience, though, so I opted to just use plain-old CSS to handle the ellipsis, and included an explanatory comment.