### PR TITLE
Removes jsx and js from test regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
       "^.+\\.(ts|tsx|js|jsx)$": "babel-jest",
       "\\.graphql$": "jest-raw-loader"
     },
-    "testRegex": "/__tests__/.+?\\.test\\.(ts|tsx|js|jsx)$",
+    "testRegex": "/__tests__/.+?\\.test\\.(ts|tsx)$",
     "testPathIgnorePatterns": [
       "<rootDir>/dist/",
       "<rootDir>/externals/"


### PR DESCRIPTION
- Removes `jsx` and `js` files from test regex as all files should be typescript