### PR TITLE
Scroll to top on all search results pagination

### DIFF
--- a/src/Apps/Artist/Routes/Articles/ArtistArticles.tsx
+++ b/src/Apps/Artist/Routes/Articles/ArtistArticles.tsx
@@ -66,9 +66,12 @@ export class ArtistArticles extends Component<
   }
 
   toggleLoading = isLoading => {
-    this.setState({
-      isLoading,
-    })
+    this.setState(
+      {
+        isLoading,
+      },
+      () => window.scrollTo(0, 0)
+    )
   }
 
   render() {

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -96,9 +96,12 @@ class AuctionResultsContainer extends Component<
   }
 
   toggleLoading = isLoading => {
-    this.setState({
-      isLoading,
-    })
+    this.setState(
+      {
+        isLoading,
+      },
+      () => window.scrollTo(0, 0)
+    )
   }
 
   render() {

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -62,9 +62,12 @@ class Artworks extends Component<Props, LoadingAreaState> {
   }
 
   toggleLoading = isLoading => {
-    this.setState({
-      isLoading,
-    })
+    this.setState(
+      {
+        isLoading,
+      },
+      () => window.scrollTo(0, 0)
+    )
   }
 
   componentDidUpdate(prevProps) {

--- a/src/Apps/Artist/Routes/Shows/ArtistShows.tsx
+++ b/src/Apps/Artist/Routes/Shows/ArtistShows.tsx
@@ -70,9 +70,12 @@ class ArtistShows extends Component<ArtistShowsProps, LoadingAreaState> {
   }
 
   toggleLoading = isLoading => {
-    this.setState({
-      isLoading,
-    })
+    this.setState(
+      {
+        isLoading,
+      },
+      () => window.scrollTo(0, 0)
+    )
   }
 
   render() {

--- a/src/Apps/Collect/Components/Base/CollectArtworkGrid.tsx
+++ b/src/Apps/Collect/Components/Base/CollectArtworkGrid.tsx
@@ -63,9 +63,12 @@ class CollectArtworkGrid extends Component<Props, LoadingAreaState> {
   }
 
   toggleLoading = isLoading => {
-    this.setState({
-      isLoading,
-    })
+    this.setState(
+      {
+        isLoading,
+      },
+      () => window.scrollTo(0, 0)
+    )
   }
 
   render() {

--- a/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -37,9 +37,12 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
   }
 
   toggleLoading = isLoading => {
-    this.setState({
-      isLoading,
-    })
+    this.setState(
+      {
+        isLoading,
+      },
+      () => window.scrollTo(0, 0)
+    )
   }
 
   loadNext = () => {

--- a/src/Apps/Search/Routes/Entity/SearchResultsEntity.tsx
+++ b/src/Apps/Search/Routes/Entity/SearchResultsEntity.tsx
@@ -39,9 +39,12 @@ export class SearchResultsEntityRoute extends React.Component<Props, State> {
   }
 
   toggleLoading = isLoading => {
-    this.setState({
-      isLoading,
-    })
+    this.setState(
+      {
+        isLoading,
+      },
+      () => window.scrollTo(0, 0)
+    )
   }
 
   loadNext = () => {


### PR DESCRIPTION
- After clicking `next` or a different page number on a search results' tab the page should scroll to top.
- Had implemented a fix for this on Artworks without adding to all tabs

## After fix

![2019-06-13 11 05 31](https://user-images.githubusercontent.com/21182806/59444107-43fc5a80-8dcb-11e9-9416-3e75cd974cb0.gif)
