### PR TITLE
DISCO-1031 - Don't render related artworks without artworks to display

### DIFF
--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
@@ -85,6 +85,7 @@ class RelatedWorksArtworkGrid extends React.Component<
       return null
     }
 
+    // For sale artworks are already rendered on the page so we filter them from related works
     const names = take(
       layers.filter(layer => layer.name !== "For Sale"),
       MAX_TAB_ITEMS

--- a/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/ArtworkContexts/ArtworkGrids/RelatedWorksArtworkGrid.tsx
@@ -90,6 +90,10 @@ class RelatedWorksArtworkGrid extends React.Component<
       MAX_TAB_ITEMS
     )
 
+    if (!names.length) {
+      return <></>
+    }
+
     return (
       <>
         <Header title="Related works" />


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/DISCO-1031
- Hides Related Artworks carousel if there are no artworks to display
- Adds comment describing why we filter `For Sale` artworks