### PR TITLE
Extract action sheet management from Artist/state into Artist/ArtworkFilter

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/__tests__/ArtworkFilter.test.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/__tests__/ArtworkFilter.test.tsx
@@ -1,14 +1,20 @@
 // FIXME: Uncomment tests, currently WIP
 
-import { ArtworkFilter_Test_Query } from "__generated__/ArtworkFilter_Test_Query.graphql"
+import { ArtworkFilterFixture } from "Apps/__tests__/Fixtures/Artist/Components/ArtworkFilter"
 import { ArtworkFilterFragmentContainer as ArtworkFilter } from "Apps/Artist/Routes/Overview/Components/ArtworkFilter"
 import { FilterState } from "Apps/Artist/Routes/Overview/state"
-import { MockBoot, MockRelayRenderer, renderUntil } from "DevTools"
+import { MockBoot, renderRelayTree } from "DevTools"
 import React from "react"
 import { graphql } from "react-relay"
 import { Provider } from "unstated"
+import { flushPromiseQueue } from "Utils/flushPromiseQueue"
+import { get } from "Utils/get"
+import { Breakpoint } from "Utils/Responsive"
 
 jest.unmock("react-relay")
+jest.mock("../ArtworkFilterRefetch", () => ({
+  ArtworkFilterRefetchContainer: () => <div>Mock ArtworkFilterRefetch</div>,
+}))
 
 describe("ArtworkFilter", () => {
   let filterState: FilterState = null
@@ -17,154 +23,76 @@ describe("ArtworkFilter", () => {
     filterState = new FilterState({} as any)
   })
 
-  it("renders the current mediums", async () => {
-    const tree = await renderUntil(
-      wrapper => {
-        return wrapper.find(ArtworkFilter).length > 0
+  async function getWrapper(breakpoint: Breakpoint = "lg") {
+    return await renderRelayTree({
+      Component: ArtworkFilter,
+      query: graphql`
+        query ArtworkFilter_Test_Query {
+          artist(id: "andy-warhol") {
+            ...ArtworkFilter_artist
+          }
+        }
+      `,
+      mockData: {
+        artist: ArtworkFilterFixture,
       },
-      <MockBoot breakpoint="lg">
-        <Provider inject={[filterState]}>
-          <MockRelayRenderer<ArtworkFilter_Test_Query>
-            Component={ArtworkFilter}
-            query={graphql`
-              query ArtworkFilter_Test_Query {
-                artist(id: "andy-warhol") {
-                  ...ArtworkFilter_artist
-                }
-              }
-            `}
-            mockResolvers={{
-              Artist: () => data,
-            }}
-          />
-        </Provider>
-      </MockBoot>
-    )
+
+      wrapper: children => (
+        <MockBoot breakpoint={breakpoint}>
+          <Provider inject={[filterState]}>{children}</Provider>
+        </MockBoot>
+      ),
+    })
+  }
+
+  it("renders the current mediums", async () => {
+    const tree = await getWrapper()
+
     const html = tree.html()
     expect(html).toContain("Catty Painting")
   })
-})
 
-const data = {
-  id: "cecily-brown",
-  __id: "blah",
-  name: "Cecily Brown",
-  is_followed: false,
-  counts: {
-    for_sale_artworks: 28,
-    ecommerce_artworks: 4,
-    auction_artworks: 1,
-    artworks: 116,
-    follows: 20,
-  },
-  filtered_artworks: {
-    __id: "testest",
-    aggregations: [
-      {
-        slice: "INSTITUTION",
-        counts: [
-          {
-            name: "The FLAG Art Foundation",
-            id: "the-flag-art-foundation",
-            __id: "QWdncmVnYXRpb25Db3VudDp0aGUtZmxhZy1hcnQtZm91bmRhdGlvbg==",
-          },
-        ],
-      },
-      {
-        slice: "GALLERY",
-        counts: [
-          {
-            name: "The FLAG Art Foundation",
-            id: "the-flag-art-foundation",
-            __id: "QWdncmVnYXRpb25Db3VudDp0aGUtZmxhZy1hcnQtZm91bmRhdGlvbg==",
-          },
-        ],
-      },
-      {
-        slice: "MAJOR_PERIOD",
-        counts: [
-          {
-            name: "The 90s",
-            id: "90s",
-            __id: "blah==",
-          },
-        ],
-      },
-      {
-        slice: "MEDIUM",
-        counts: [
-          {
-            name: "Catty Painting",
-            id: "painting",
-            __id: "QWdncmVnYXRpb25Db3VudDpwYWludGluZw==",
-          },
-        ],
-      },
-    ],
-  },
-  grid: {
-    __id:
-      "RmlsdGVyQXJ0d29ya3M6eyJhY3F1aXJlYWJsZSI6dHJ1ZSwiYWdncmVnYXRpb25zIjpbInRvdGFsIl0sIm1ham9yX3BlcmlvZHMiOltdLCJzaXplIjowLCJzb3J0IjoiLWRlY2F5ZWRfbWVyY2giLCJhcnRpc3RfaWQiOiJjZWNpbHktYnJvd24ifQ==",
-    artworks: {
-      pageInfo: {
-        hasNextPage: false,
-        endCursor: "YXJyYXljb25uZWN0aW9uOjM=",
-      },
-      pageCursors: {
-        around: [
-          {
-            cursor: "YXJyYXljb25uZWN0aW9uOi0x",
-            page: 1,
-            isCurrent: true,
-          },
-        ],
-        first: null,
-        last: null,
-        previous: null,
-      },
-      edges: [
-        {
-          node: {
-            artists: [
-              {
-                __id: "QXJ0aXN0OmNlY2lseS1icm93bg==",
-                href: "/artist/cecily-brown",
-                name: "Cecily Brown",
-              },
-            ],
-            collecting_institution: null,
-            cultural_maker: null,
-            date: "2009",
-            href:
-              "/artwork/cecily-brown-cecily-brown-deichtorhallen-hamburg-germany-signed-3",
-            id:
-              "cecily-brown-cecily-brown-deichtorhallen-hamburg-germany-signed-3",
-            image: {
-              aspect_ratio: 1,
-              placeholder: "100.18382352941177%",
-              url:
-                "https://d32dm0rphc51dk.cloudfront.net/DnTE4ynxczEq8rFHRMWeqQ/large.jpg",
-            },
-            is_acquireable: true,
-            is_biddable: false,
-            is_inquireable: true,
-            is_saved: false,
-            partner: {
-              href: "/alpha-137-gallery",
-              name: "Alpha 137 Gallery",
-              type: "Gallery",
-              __id: "UGFydG5lcjphbHBoYS0xMzctZ2FsbGVyeQ==",
-            },
-            sale: null,
-            sale_artwork: null,
-            sale_message: "$800",
-            title: "Cecily Brown, Deichtorhallen Hamburg, Germany (Signed) ",
-            __id:
-              "QXJ0d29yazpjZWNpbHktYnJvd24tY2VjaWx5LWJyb3duLWRlaWNodG9yaGFsbGVuLWhhbWJ1cmctZ2VybWFueS1zaWduZWQtMw==",
-            _id: "59227f8e7622dd4d747b6993",
-          },
-        },
-      ],
-    },
-  },
-}
+  describe("Mobile Action Sheet", () => {
+    it("Doesn't display the filters by default at xs", async () => {
+      const wrapper = await getWrapper("xs")
+
+      expect(wrapper.find("Filters").length).toEqual(0)
+    })
+
+    it("Displays the filters after clicking the 'Filter' button at xs", async () => {
+      const wrapper = await getWrapper("xs")
+      const filterButton = findButtonWithText(wrapper, "Filter")
+
+      filterButton.simulate("click")
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(wrapper.find("Filters").length).toEqual(1)
+    })
+
+    it("Closes the filters after clicking the 'Apply' button at xs", async () => {
+      const wrapper = await getWrapper("xs")
+
+      const filterButton = findButtonWithText(wrapper, "Filter")
+      filterButton.simulate("click")
+      await flushPromiseQueue()
+      wrapper.update()
+
+      const applyButton = findButtonWithText(wrapper, "Apply")
+      applyButton.simulate("click")
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(wrapper.find("Filters").length).toEqual(0)
+    })
+
+    function findButtonWithText(wrapper, buttonText) {
+      return wrapper
+        .find("Button")
+        .findWhere(button => {
+          return get(button, b => b.text().includes(buttonText), false)
+        })
+        .first()
+    }
+  })
+})

--- a/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtworkFilter/index.tsx
@@ -27,7 +27,7 @@ import {
 } from "@artsy/palette"
 import { AuthModalIntent, openAuthModal } from "Utils/openAuthModal"
 
-interface Props {
+interface ArtworkFilterProps {
   artist: ArtworkFilter_artist
   hideTopBorder?: boolean
   filterState?: FilterState
@@ -35,10 +35,18 @@ interface Props {
   mediator?: Mediator
 }
 
+interface ArtworkFilterState {
+  showMobileActionSheet: boolean
+}
+
 @track()
-class Filter extends Component<Props> {
+class Filter extends Component<ArtworkFilterProps, ArtworkFilterState> {
   static defaultProps = {
     hideTopBorder: false,
+  }
+
+  state = {
+    showMobileActionSheet: false,
   }
 
   get existy() {
@@ -55,6 +63,16 @@ class Filter extends Component<Props> {
 
   get showZeroState() {
     return !this.existy.hasArtworks
+  }
+
+  hideMobileActionSheet = () => {
+    this.setState({ showMobileActionSheet: false })
+    document.body.style.overflowY = "auto"
+  }
+
+  showMobileActionSheet = () => {
+    this.setState({ showMobileActionSheet: true })
+    document.body.style.overflowY = "hidden"
   }
 
   renderFilters({ hideTopBorder }) {
@@ -280,10 +298,7 @@ class Filter extends Component<Props> {
         </Box>
 
         <Media at="xs">
-          <Button
-            size="small"
-            onClick={() => filterState.showActionSheet(true)}
-          >
+          <Button size="small" onClick={this.showMobileActionSheet}>
             <Flex justifyContent="space-between" alignItems="center">
               <FilterIcon fill={"white100"} />
               <Spacer mr={0.5} />
@@ -304,10 +319,8 @@ class Filter extends Component<Props> {
       <Flex flexDirection={["column", "row"]}>
         <Box width={["100%", "25%"]} mr={2}>
           <Media at="xs">
-            {filterState.state.showActionSheet && (
-              <MobileActionSheet
-                onClose={() => filterState.showActionSheet(false)}
-              >
+            {this.state.showMobileActionSheet && (
+              <MobileActionSheet onClose={this.hideMobileActionSheet}>
                 <Filters />
               </MobileActionSheet>
             )}
@@ -343,7 +356,7 @@ class Filter extends Component<Props> {
 }
 
 export const ArtworkFilterFragmentContainer = createFragmentContainer(
-  (props: Props) => {
+  (props: ArtworkFilterProps) => {
     return (
       <SystemContextConsumer>
         {({ user, mediator }) => (

--- a/src/Apps/Artist/Routes/Overview/state.ts
+++ b/src/Apps/Artist/Routes/Overview/state.ts
@@ -18,7 +18,6 @@ interface State {
 
   // UI
   selectedFilters: string[]
-  showActionSheet: boolean
   showZeroState: boolean
 }
 
@@ -37,7 +36,6 @@ export const initialState = {
   inquireable_only: null,
   price_range: "*-*",
   selectedFilters: [],
-  showActionSheet: false,
   showZeroState: false,
 }
 
@@ -136,17 +134,6 @@ export class FilterState extends Container<State> {
     })
   }
 
-  showActionSheet = show => {
-    if (show) {
-      // TODO: Manage this side-effect in a more react-like fashion
-      document.body.style.overflowY = "hidden"
-    } else {
-      document.body.style.overflowY = "auto"
-    }
-
-    this.setState({ showActionSheet: show })
-  }
-
   showZeroState = showZeroState => {
     this.setState({
       showZeroState,
@@ -157,7 +144,6 @@ export class FilterState extends Container<State> {
     this.setState(
       {
         ...initialState,
-        showActionSheet: true,
       },
       () => {
         this.pushHistory()

--- a/src/Apps/__tests__/Fixtures/Artist/Components/ArtworkFilter.tsx
+++ b/src/Apps/__tests__/Fixtures/Artist/Components/ArtworkFilter.tsx
@@ -1,0 +1,126 @@
+export const ArtworkFilterFixture = {
+  id: "cecily-brown",
+  __id: "blah",
+  name: "Cecily Brown",
+  is_followed: false,
+  counts: {
+    for_sale_artworks: 28,
+    ecommerce_artworks: 4,
+    auction_artworks: 1,
+    artworks: 116,
+    follows: 20,
+    has_make_offer_artworks: true,
+  },
+  filtered_artworks: {
+    __id: "testest",
+    aggregations: [
+      {
+        slice: "INSTITUTION",
+        counts: [
+          {
+            name: "The FLAG Art Foundation",
+            id: "the-flag-art-foundation",
+            __id: "QWdncmVnYXRpb25Db3VudDp0aGUtZmxhZy1hcnQtZm91bmRhdGlvbg==",
+          },
+        ],
+      },
+      {
+        slice: "GALLERY",
+        counts: [
+          {
+            name: "The FLAG Art Foundation",
+            id: "the-flag-art-foundation",
+            __id: "QWdncmVnYXRpb25Db3VudDp0aGUtZmxhZy1hcnQtZm91bmRhdGlvbg==",
+          },
+        ],
+      },
+      {
+        slice: "MAJOR_PERIOD",
+        counts: [
+          {
+            name: "The 90s",
+            id: "90s",
+            __id: "blah==",
+          },
+        ],
+      },
+      {
+        slice: "MEDIUM",
+        counts: [
+          {
+            name: "Catty Painting",
+            id: "painting",
+            __id: "QWdncmVnYXRpb25Db3VudDpwYWludGluZw==",
+          },
+        ],
+      },
+    ],
+  },
+  grid: {
+    __id:
+      "RmlsdGVyQXJ0d29ya3M6eyJhY3F1aXJlYWJsZSI6dHJ1ZSwiYWdncmVnYXRpb25zIjpbInRvdGFsIl0sIm1ham9yX3BlcmlvZHMiOltdLCJzaXplIjowLCJzb3J0IjoiLWRlY2F5ZWRfbWVyY2giLCJhcnRpc3RfaWQiOiJjZWNpbHktYnJvd24ifQ==",
+    artworks: {
+      pageInfo: {
+        hasNextPage: false,
+        endCursor: "YXJyYXljb25uZWN0aW9uOjM=",
+      },
+      pageCursors: {
+        around: [
+          {
+            cursor: "YXJyYXljb25uZWN0aW9uOi0x",
+            page: 1,
+            isCurrent: true,
+          },
+        ],
+        first: null,
+        last: null,
+        previous: null,
+      },
+      edges: [
+        {
+          node: {
+            artists: [
+              {
+                __id: "QXJ0aXN0OmNlY2lseS1icm93bg==",
+                href: "/artist/cecily-brown",
+                name: "Cecily Brown",
+              },
+            ],
+            collecting_institution: null,
+            cultural_maker: null,
+            date: "2009",
+            href:
+              "/artwork/cecily-brown-cecily-brown-deichtorhallen-hamburg-germany-signed-3",
+            id:
+              "cecily-brown-cecily-brown-deichtorhallen-hamburg-germany-signed-3",
+            image: {
+              aspect_ratio: 1,
+              placeholder: "100.18382352941177%",
+              url:
+                "https://d32dm0rphc51dk.cloudfront.net/DnTE4ynxczEq8rFHRMWeqQ/large.jpg",
+            },
+            image_title: "an image",
+            is_acquireable: true,
+            is_biddable: false,
+            is_inquireable: true,
+            is_offerable: true,
+            is_saved: false,
+            partner: {
+              href: "/alpha-137-gallery",
+              name: "Alpha 137 Gallery",
+              type: "Gallery",
+              __id: "UGFydG5lcjphbHBoYS0xMzctZ2FsbGVyeQ==",
+            },
+            sale: null,
+            sale_artwork: null,
+            sale_message: "$800",
+            title: "Cecily Brown, Deichtorhallen Hamburg, Germany (Signed) ",
+            __id:
+              "QXJ0d29yazpjZWNpbHktYnJvd24tY2VjaWx5LWJyb3duLWRlaWNodG9yaGFsbGVuLWhhbWJ1cmctZ2VybWFueS1zaWduZWQtMw==",
+            _id: "59227f8e7622dd4d747b6993",
+          },
+        },
+      ],
+    },
+  },
+}


### PR DESCRIPTION
This PR is early stage preparation for unifying the 3 different-but-similar FilterState components. It moves the management of the mobile action sheet from Artist/...state.ts into Artist/...ArtworkFilter.ts, so that the three filter state components are even more similar. 

* Tests were added to guide the refactor. 
* Test fixture data was moved into the Fixtures folder.
* I did not modernize ArtworkFilter or state.ts with hooks, because I was more focused on moving the outliers out of state.ts. Hooks conversion will come in future work.