### PR TITLE
Fixes date regression bug in News Header 

### DIFF
--- a/src/Components/Publishing/News/NewsPanel.tsx
+++ b/src/Components/Publishing/News/NewsPanel.tsx
@@ -15,7 +15,7 @@ export const NewsPanel: React.SFC<Props> = props => {
     <NewsPanelContainer>
       <Header>
         <HeaderTitle>News</HeaderTitle>
-        <HeaderText>{getDate(new Date(), "monthDay")}</HeaderText>
+        <HeaderText>{getDate(new Date().toISOString(), "monthDay")}</HeaderText>
       </Header>
 
       <ArticlesContainer>
@@ -53,7 +53,7 @@ const Header = styled.div`
   position: relative;
 `
 
-const HeaderText = styled.div`
+export const HeaderText = styled.div`
   ${unica("s19", "medium")};
   ${pMedia.sm`
     ${unica("s16", "medium")}

--- a/src/Components/Publishing/News/__tests__/NewsPanel.test.tsx
+++ b/src/Components/Publishing/News/__tests__/NewsPanel.test.tsx
@@ -1,3 +1,4 @@
+import { getDate } from "Components/Publishing/Constants"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
@@ -6,7 +7,7 @@ import {
   FeatureArticle,
   NewsArticle,
 } from "Components/Publishing/Fixtures/Articles"
-import { NewsPanel } from "../NewsPanel"
+import { HeaderText, NewsPanel } from "../NewsPanel"
 
 it("Renders article headlines", () => {
   const wrapper = mount(<NewsPanel articles={[NewsArticle, FeatureArticle]} />)
@@ -18,4 +19,16 @@ it("Links headlines to article", () => {
   const wrapper = mount(<NewsPanel articles={[NewsArticle, FeatureArticle]} />)
   expect(wrapper.html()).toMatch(`/news/${NewsArticle.slug}`)
   expect(wrapper.html()).toMatch(`/news/${FeatureArticle.slug}`)
+})
+
+it("Renders the date correctly in the News Panel Header", () => {
+  const wrapper = mount(<NewsPanel articles={[NewsArticle, FeatureArticle]} />)
+  const today = getDate(new Date().toISOString(), "monthDay")
+
+  expect(
+    wrapper
+      .find(HeaderText)
+      .first()
+      .text()
+  ).toBe(today)
 })


### PR DESCRIPTION
This PR fixes a bug caused by the upgrade from `moment` to `luxon` that caused some dates to render incorrectly. 

[Links to GROW-1309](https://artsyproduct.atlassian.net/browse/GROW-1309)

Before:
![Screen Shot 2019-06-17 at 11 08 08 AM](https://user-images.githubusercontent.com/10385964/59615269-378c4080-90f0-11e9-835f-c2b13979a86d.png)

After:
![Screen Shot 2019-06-17 at 11 09 22 AM](https://user-images.githubusercontent.com/10385964/59615391-673b4880-90f0-11e9-988a-3017af288ee9.png)
