### PR TITLE
Update MP schema with vortex breaking changes

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -44,6 +44,14 @@ type AggregationCount {
   sortable_id: String
 }
 
+type AnalyticsArtist {
+  entityId: String!
+}
+
+type AnalyticsArtwork {
+  entityId: String!
+}
+
 # Publish artwork Series Stats
 type AnalyticsArtworksPublishedStats {
   percentageChanged: Int!
@@ -183,10 +191,27 @@ type AnalyticsPartnerStats {
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
 
+  # Artworks, shows, or artists ranked by views. Capped at 10 by the underlying sql query.
+  rankedStats(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    objectType: AnalyticsRankedStatsObjectTypeEnum!
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsRankedStatsConnection
+
   # Sales stats
   sales(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerSalesStats
 
-  # Artworks ranked by views
+  # Top artworks ranked by views
   topArtworks(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -199,8 +224,8 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-    period: AnalyticsQueryPeriodEnum!
-  ): AnalyticsTopArtworksConnection
+  ): AnalyticsRankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -308,33 +333,56 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
-# Top artworks from a partner
-type AnalyticsTopArtworks {
-  artworkId: String!
+union AnalyticsRankedEntityUnion = Artwork | Show | Artist
+
+# Top artworks, shows, or artists from a partner
+type AnalyticsRankedStats {
   period: AnalyticsQueryPeriodEnum!
+  rankedEntity: AnalyticsRankedStatsUnion!
   value: Int!
-  artwork: Artwork
+  entity: AnalyticsRankedEntityUnion
 }
 
-# The connection type for TopArtworks.
-type AnalyticsTopArtworksConnection {
+# The connection type for RankedStats.
+type AnalyticsRankedStatsConnection {
   # A list of edges.
-  edges: [AnalyticsTopArtworksEdge]
+  edges: [AnalyticsRankedStatsEdge]
 
   # A list of nodes.
-  nodes: [AnalyticsTopArtworks]
+  nodes: [AnalyticsRankedStats]
 
   # Information to aid in pagination.
   pageInfo: AnalyticsPageInfo!
 }
 
 # An edge in a connection.
-type AnalyticsTopArtworksEdge {
+type AnalyticsRankedStatsEdge {
   # A cursor for use in pagination.
   cursor: String!
 
   # The item at the end of the edge.
-  node: AnalyticsTopArtworks
+  node: AnalyticsRankedStats
+}
+
+enum AnalyticsRankedStatsObjectTypeEnum {
+  # Artist
+  ARTIST
+
+  # Artwork
+  ARTWORK
+
+  # Show
+  SHOW
+}
+
+# An artwork, artist, or show
+union AnalyticsRankedStatsUnion =
+    AnalyticsArtist
+  | AnalyticsArtwork
+  | AnalyticsShow
+
+type AnalyticsShow {
+  entityId: String!
 }
 
 input ApproveOrderInput {
@@ -2420,10 +2468,16 @@ type AttributionClass {
   info: String
 
   # Longer version of attribution class display
-  short_description: String @deprecated(reason: "Prefer shortDescription")
+  short_description: String
+    @deprecated(
+      reason: "Prefer to use `shortDescription`. [Will be removed in v2]"
+    )
 
   # Long descriptive phrase used as companion for short_description
-  long_description: String @deprecated(reason: "Prefer longDescription")
+  long_description: String
+    @deprecated(
+      reason: "Prefer to use `longDescription`. [Will be removed in v2]"
+    )
 
   # Longer version of attribution class display
   shortDescription: String


### PR DESCRIPTION
used `yarn run sync-schema` to update MP schema. Schema update might include vortex partner analytics breaking changes. Better to be safe than blocking force deploy.