### PR TITLE
[Bugfix] Fix navBar zIndex #trivial 

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -244,7 +244,7 @@ const NavBarContainer = styled(Flex)`
   background-color: ${color("white100")};
   border-bottom: 1px solid ${color("black10")};
   position: relative;
-  z-index: 1;
+  z-index: 3;
   height: ${NavBarHeight}px;
 `
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-1553

Fixes a z-index issue in auto-suggestions when the mobile nav is open: 

<img width="409" alt="Screen Shot 2019-06-17 at 2 32 27 PM" src="https://user-images.githubusercontent.com/236943/59638278-ceff8c80-910c-11e9-9a0f-460eb1e7b52f.png">

#trivial 