### PR TITLE
updates price sort string to account for "sold" #DONTMERGE

### DIFF
--- a/src/Apps/Collect/Components/Filters/SortFilterSortTypes.tsx
+++ b/src/Apps/Collect/Components/Filters/SortFilterSortTypes.tsx
@@ -13,8 +13,8 @@ const sorts = {
   ],
   collection: [
     { value: "-decayed_merch", text: "Default" },
-    { value: "price_missing,-prices", text: "Price (desc.)" },
-    { value: "price_missing,prices", text: "Price (asc.)" },
+    { value: "sold,price_missing,-prices", text: "Price (desc.)" },
+    { value: "sold,price_missing,prices", text: "Price (asc.)" },
     { value: "-partner_updated_at", text: "Recently updated" },
     { value: "-published_at", text: "Recently added" },
     { value: "-year", text: "Artwork year (desc.)" },

--- a/src/Apps/Collect/Components/Filters/SortFilterSortTypes.tsx
+++ b/src/Apps/Collect/Components/Filters/SortFilterSortTypes.tsx
@@ -13,8 +13,8 @@ const sorts = {
   ],
   collection: [
     { value: "-decayed_merch", text: "Default" },
-    { value: "sold,price_missing,-prices", text: "Price (desc.)" },
-    { value: "sold,price_missing,prices", text: "Price (asc.)" },
+    { value: "sold,-has_price,-prices", text: "Price (desc.)" },
+    { value: "sold,-has_price,prices", text: "Price (asc.)" },
     { value: "-partner_updated_at", text: "Recently updated" },
     { value: "-published_at", text: "Recently added" },
     { value: "-year", text: "Artwork year (desc.)" },

--- a/src/Apps/Collect/Components/Filters/__tests__/SortFilterSortTypes.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/SortFilterSortTypes.test.tsx
@@ -23,8 +23,8 @@ describe("SortTypes", () => {
       const values = options.map(o => o.value)
       expect(values).toEqual([
         "-decayed_merch",
-        "price_missing,-prices",
-        "price_missing,prices",
+        "sold,price_missing,-prices",
+        "sold,price_missing,prices",
         "-partner_updated_at",
         "-published_at",
         "-year",

--- a/src/Apps/Collect/Components/Filters/__tests__/SortFilterSortTypes.test.tsx
+++ b/src/Apps/Collect/Components/Filters/__tests__/SortFilterSortTypes.test.tsx
@@ -23,8 +23,8 @@ describe("SortTypes", () => {
       const values = options.map(o => o.value)
       expect(values).toEqual([
         "-decayed_merch",
-        "sold,price_missing,-prices",
-        "sold,price_missing,prices",
+        "sold,-has_price,-prices",
+        "sold,-has_price,prices",
         "-partner_updated_at",
         "-published_at",
         "-year",


### PR DESCRIPTION
This shouldn't be merged until [this gravity PR](https://github.com/artsy/gravity/pull/12409) lands. This will force sold items to be sorted to the end of price-sorted collections, regardless of their price.