### PR TITLE
artist collection rail now hides dots, scrolls 4-at-a-time

### DIFF
--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -55,9 +55,10 @@ export class ArtistCollectionsRail extends React.Component<
           <Carousel
             height="200px"
             options={{
-              groupCells: 1,
+              groupCells: 4,
               wrapAround: true,
               cellAlign: "left",
+              pageDots: false,
             }}
             onArrowClick={this.trackCarouselNav.bind(this)}
             data={collections as object[]} // type required by slider


### PR DESCRIPTION
We hide page dots and scroll 4-collections-at-a-time as per [Grow-1296](https://artsyproduct.atlassian.net/browse/GROW-1296)