### PR TITLE
remove a/b test tracking logic

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -10,7 +10,6 @@ import { ArtistCollectionsRailContent as ArtistCollectionsRail } from "Component
 import { hasSections as showMarketInsights } from "Components/Artist/MarketInsights/MarketInsights"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { data as sd } from "sharify"
 import { ArtistRecommendationsQueryRenderer as ArtistRecommendations } from "./Components/ArtistRecommendations"
 import { CurrentEventFragmentContainer as CurrentEvent } from "./Components/CurrentEvent"
 
@@ -21,7 +20,6 @@ import {
 import { get } from "Utils/get"
 
 export interface OverviewRouteProps {
-  showCollectionsRail?: boolean // TODO: remove after CollectionsRail a/b test
   artist: Overview_artist & {
     __fragments: object[]
   }
@@ -46,30 +44,6 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     // no-op
   }
 
-  componentDidMount() {
-    if (this.shouldShowCollectionRailTest) {
-      this.trackingCollectionsRailTest()
-    }
-  }
-
-  @track(() => {
-    // TODO: remove after CollectionsRail a/b test
-    const experiment = "artist_collections_rail"
-    const variation = sd.ARTIST_COLLECTIONS_RAIL
-
-    return {
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    }
-  })
-  trackingCollectionsRailTest() {
-    // no-op
-  }
-
   maybeShowGenes() {
     const { isReadMoreExpanded } = this.state
     const hasNoBio = !this.props.artist.biography_blurb.text
@@ -77,19 +51,8 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     return isReadMoreExpanded || hasNoBio
   }
 
-  get shouldShowCollectionRailTest() {
-    const artistIDs = sd.ARTIST_COLLECTIONS_RAIL_IDS
-    if (artistIDs) {
-      const urlComponents = window.location.pathname.split("/")
-      const id = urlComponents[urlComponents.length - 1]
-      return artistIDs.includes(id)
-    }
-
-    return false
-  }
-
   render() {
-    const { artist, showCollectionsRail } = this.props
+    const { artist } = this.props
 
     const showArtistInsights =
       showMarketInsights(this.props.artist) || artist.insights.length > 0
@@ -169,13 +132,11 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
 
               {!hideMainOverviewSection && <Spacer mb={4} />}
 
-              {showCollectionsRail && ( // TODO: remove after CollectionsRail a/b test
-                <div>
-                  <Separator mb={3} />
-                  <ArtistCollectionsRail artistID={artist._id} />
-                  <Spacer mb={3} />
-                </div>
-              )}
+              <div>
+                <Separator mb={3} />
+                <ArtistCollectionsRail artistID={artist._id} />
+                <Spacer mb={3} />
+              </div>
 
               <Row>
                 <Col>


### PR DESCRIPTION
Addresses: [GROW-1277](https://artsyproduct.atlassian.net/browse/GROW-1277) & [GROW-1270](https://artsyproduct.atlassian.net/browse/GROW-1270)

This removes the tracking logic and boolean flag for the artist collections rail a/b test. 