### PR TITLE
featured artists now always positioned below summary

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -278,10 +278,10 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     </Col>
                     <Col
                       sm={12}
-                      md={isColumnLayout ? "12" : "3"}
-                      mdOffset={isColumnLayout ? null : 1}
-                      lgOffset={isColumnLayout ? null : 1}
-                      xlOffset={isColumnLayout ? null : 1}
+                      md={12}
+                      mdOffset={null}
+                      lgOffset={null}
+                      xlOffset={null}
                     >
                       {featuredArtists.length > 0 && (
                         <Box pb={10}>

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -276,13 +276,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                         </ExtendedSerif>
                       </Flex>
                     </Col>
-                    <Col
-                      sm={12}
-                      md={12}
-                      mdOffset={null}
-                      lgOffset={null}
-                      xlOffset={null}
-                    >
+                    <Col sm={12} md={12}>
                       {featuredArtists.length > 0 && (
                         <Box pb={10}>
                           <Sans size="2" weight="medium" pb={15}>
@@ -399,6 +393,7 @@ const ViewMore = styled(Box)`
       text-decoration: underline;
       ${unica("s14")};
     }
+
     div:first-child {
       text-decoration: none;
     }


### PR DESCRIPTION
This implements [GROW-1316](https://artsyproduct.atlassian.net/browse/GROW-1316). Easy enough, removed the responsive positioning logic and the module now sits in the same place regardless of screen size. @xtina-starr tagging you for PR #3 today, woo! :)