### PR TITLE
[RelatedCollectionsRail]  fix related collections carousel

### DIFF
--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -34,7 +34,6 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
       slug,
       title,
     } = this.props.collection
-    const formattedTitle = (title && title.split(": ")[1]) || title
     const bgImages = map(hits, "image.url")
     const imageSize =
       bgImages.length === 1 ? 265 : bgImages.length === 2 ? 131 : 85
@@ -66,7 +65,7 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
             )}
           </ImgWrapper>
 
-          <CollectionTitle size="3">{formattedTitle}</CollectionTitle>
+          <CollectionTitle size="3">{title}</CollectionTitle>
           {price_guidance && (
             <Sans size="2" color="black60">
               From $

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
@@ -55,9 +55,10 @@ export class RelatedCollectionsRail extends React.Component<
           <Carousel
             height="200px"
             options={{
-              groupCells: 1,
+              groupCells: 4,
               wrapAround: true,
               cellAlign: "left",
+              pageDots: false,
             }}
             onArrowClick={this.trackCarouselNav.bind(this)}
             data={take(collections, 8)}

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionEntity.test.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionEntity.test.tsx
@@ -21,7 +21,7 @@ describe("RelatedCollectionEntity", () => {
   it("Renders expected fields", () => {
     const component = mount(<RelatedCollectionEntity {...props} />)
 
-    expect(component.text()).not.toMatch("Jasper Johns:")
+    expect(component.text()).toMatch("Jasper Johns:")
     expect(component.text()).toMatch("Flags")
     expect(component.text()).toMatch("From $1,000")
     expect(component.find(ArtworkImage).length).toBe(3)


### PR DESCRIPTION
addresses: [GROW-1332](https://artsyproduct.atlassian.net/browse/GROW-1332)

In this PR, we addresses the following:
- remove dots in the bottom
- group by 4
- do not strip anything from collections title

<img width="1235" alt="Screen Shot 2019-06-21 at 3 11 03 PM" src="https://user-images.githubusercontent.com/45926410/59945859-df7a7480-9436-11e9-991d-a34d7188b88c.png">
