### PR TITLE
[ArtistRecommendations] Fix carousel alignment

### DIFF
--- a/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -1,4 +1,4 @@
-import { Box, Sans, Spacer } from "@artsy/palette"
+import { Box, Sans, space, Spacer } from "@artsy/palette"
 import { ArtistCollectionsRail_collections } from "__generated__/ArtistCollectionsRail_collections.graphql"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
@@ -89,11 +89,10 @@ export class ArtistCollectionsRail extends React.Component<
 }
 
 const ArrowContainer = styled(Box)`
-  align-self: flex-start;
+  position: relative;
 
   ${ArrowButton} {
-    min-height: 130px;
-    align-self: flex-start;
+    top: -${space(3)}px;
   }
 `
 

--- a/src/Components/Artist/ArtistCollectionsRail/index.tsx
+++ b/src/Components/Artist/ArtistCollectionsRail/index.tsx
@@ -1,5 +1,6 @@
 import { ArtistCollectionsRailQuery } from "__generated__/ArtistCollectionsRailQuery.graphql"
 import { useSystemContext } from "Artsy"
+import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { ArtistCollectionsRailFragmentContainer as ArtistCollectionsRail } from "./ArtistCollectionsRail"
@@ -34,13 +35,7 @@ export const ArtistCollectionsRailContent: React.SFC<Props> = passedProps => {
           }
         }
       `}
-      render={({ props }) => {
-        if (props) {
-          return <ArtistCollectionsRail {...props} />
-        } else {
-          return null
-        }
-      }}
+      render={renderWithLoadProgress(ArtistCollectionsRail)}
       cacheConfig={{ force: true }}
     />
   )


### PR DESCRIPTION
Fixes an issue where the arrows where vertically centered according to the entire carousel height, which includes a top title, thereby throwing off the alignment of the center arrows according to the visual content in the center.

Also fixes missing `renderWithLoadProgress` spinner.  

![align](https://user-images.githubusercontent.com/236943/59966586-1f8f3500-94d3-11e9-8f2e-10953302461e.gif)
