### PR TITLE
[FeaturedArtistModule] refactor featured artist module to truncate on both desktop and mobile

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -3,6 +3,7 @@ import { unica } from "Assets/Fonts"
 import { cloneDeep, filter, take } from "lodash"
 import React, { FC, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { data as sd } from "sharify"
 import styled from "styled-components"
 import { slugify } from "underscore.string"
 import { resize } from "Utils/resizer"
@@ -177,12 +178,13 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
     artworks.merchandisable_artists &&
     artworks.merchandisable_artists.length > 1
 
-  const truncateForMobile = (featuredArtists, isColumnLayout) => {
-    if (featuredArtists.length < 3) {
+  const truncateFeaturedArtists = (featuredArtists, isColumnLayout) => {
+    const truncatedLength = sd.IS_MOBILE ? 3 : 7
+    if (featuredArtists.length <= truncatedLength) {
       return featuredArtists
     }
 
-    const remainingArtists = featuredArtists.length - 3
+    const remainingArtists = featuredArtists.length - truncatedLength
     const viewMore = (
       <EntityContainer
         width={["100%", "25%"]}
@@ -200,7 +202,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
       </EntityContainer>
     )
     const artists = cloneDeep(featuredArtists)
-    artists.splice(3, remainingArtists, viewMore)
+    artists.splice(truncatedLength, remainingArtists, viewMore)
 
     return showMore ? featuredArtists : artists
   }
@@ -283,12 +285,10 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                             {`Featured Artist${hasMultipleArtists ? "s" : ""}`}
                           </Sans>
                           <Flex flexWrap={isColumnLayout ? "wrap" : "nowrap"}>
-                            {smallerScreen
-                              ? truncateForMobile(
-                                  featuredArtists,
-                                  isColumnLayout
-                                )
-                              : featuredArtists}
+                            {truncateFeaturedArtists(
+                              featuredArtists,
+                              isColumnLayout
+                            )}
                           </Flex>
                         </Box>
                       )}


### PR DESCRIPTION
Addresses: [GROW-1333](https://artsyproduct.atlassian.net/browse/GROW-1333)

This is follow-up to https://github.com/artsy/gravity/pull/12357 which allows us to show a maximum of 12 featured artists. This PR implements truncation for desktop where it was previously only implemented for mobile. The [design spec](https://app.zeplin.io/project/5aabc5e0786bbb29b6e3dc7f/screen/5cd31ca42e4f02039b718fd7) for reference.

**Before:**
<img width="1220" alt="Screen Shot 2019-06-24 at 5 00 26 PM" src="https://user-images.githubusercontent.com/5201004/60051769-bd385f00-96a1-11e9-807a-c23af5a50b19.png">

**After:**
<img width="1218" alt="Screen Shot 2019-06-24 at 4 59 52 PM" src="https://user-images.githubusercontent.com/5201004/60051748-ad207f80-96a1-11e9-8ef4-a0bafaf27c78.png">
