### PR TITLE
Fixes DateTime Bug on Sponsored Series Video Landing Page

### DIFF
--- a/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCard.tsx
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/ArticleCard.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components"
 
 import { media } from "Components/Helpers"
 import { Byline } from "Components/Publishing/Byline/Byline"
-import { Date } from "Components/Publishing/Byline/Date"
+import { Date as DateComponent } from "Components/Publishing/Byline/Date"
 import { formatTime, getMediaDate } from "Components/Publishing/Constants"
 import { IconVideoPlay } from "Components/Publishing/Icon/IconVideoPlay"
 import { crop } from "Utils/resizer"
@@ -75,18 +75,19 @@ export class ArticleCard extends Component<Props> {
     const { article } = this.props
     const mediaDate = getMediaDate(article)
     const date = article.layout === "video" ? mediaDate : article.published_at
+    const formatedDate = new Date(date).toISOString()
 
     if (this.isUnpublishedMedia()) {
       return (
         <Sans size="3t" weight="medium">
           <Flex alignItems="flex-end">
             <Box mr="5px">Available</Box>
-            <Date format="monthYear" date={mediaDate} />
+            <DateComponent format="monthYear" date={mediaDate} />
           </Flex>
         </Sans>
       )
     } else {
-      return <Date layout="condensed" size="3t" date={date} />
+      return <DateComponent layout="condensed" size="3t" date={formatedDate} />
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug introduced from the upgrade to the Luxon library causing invalid dates to appear on these pages.

[Links to GROW-1324](https://artsyproduct.atlassian.net/browse/GROW-1324)

<img width="1213" alt="Screen Shot 2019-06-24 at 5 38 55 PM" src="https://user-images.githubusercontent.com/10385964/60053986-400fe880-96a7-11e9-9b31-5eadcc55a12c.png">
<img width="1259" alt="Screen Shot 2019-06-24 at 5 39 07 PM" src="https://user-images.githubusercontent.com/10385964/60053987-400fe880-96a7-11e9-996b-5eef4d19cdc1.png">

