### PR TITLE
Bring padding on mobile leaderboard ads up to spec

### DIFF
--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -1,4 +1,5 @@
 import { Box, color, Flex, FlexProps, Sans } from "@artsy/palette"
+import { is300x50AdUnit } from "Components/Publishing/Display/DisplayTargeting"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import React, { SFC, useState } from "react"
 import { Bling as GPT } from "react-gpt"
@@ -34,7 +35,7 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
 
   const [width, height] = adDimension.split("x").map(a => parseInt(a))
   const [isAdEmpty, setAdEmpty] = useState(false)
-  const is300x50Display = height === 50
+  const isMobileLeaderboardAd = is300x50AdUnit(adDimension)
 
   const ad = (
     <GPT
@@ -54,9 +55,9 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
   return (
     <DisplayAdContainer
       flexDirection="column"
-      pt={is300x50Display ? 0 : 2}
-      pb={is300x50Display ? 2 : 1}
-      height={is300x50Display ? "100px" : "334px"}
+      pt={isMobileLeaderboardAd ? 0 : 2}
+      pb={isMobileLeaderboardAd ? 2 : 1}
+      height={isMobileLeaderboardAd ? "100px" : "334px"}
       {...otherProps}
     >
       <Box m="auto">

--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -18,9 +18,9 @@ export interface DisplayAdProps extends FlexProps {
 }
 
 export interface DisplayAdContainerProps extends FlexProps {
-  displayNewAds?: boolean
   isSeries?: boolean
   isStandard?: boolean
+  adDimension?: AdDimension
 }
 
 export const DisplayAd: SFC<DisplayAdProps> = props => {
@@ -34,6 +34,7 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
 
   const [width, height] = adDimension.split("x").map(a => parseInt(a))
   const [isAdEmpty, setAdEmpty] = useState(false)
+  const is300x50Display = height === 50
 
   const ad = (
     <GPT
@@ -51,7 +52,13 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
   }
 
   return (
-    <DisplayAdContainer flexDirection="column" pt={2} pb={1} {...otherProps}>
+    <DisplayAdContainer
+      flexDirection="column"
+      pt={is300x50Display ? 0 : 2}
+      pb={is300x50Display ? 2 : 1}
+      height={is300x50Display ? "100px" : "334px"}
+      {...otherProps}
+    >
       <Box m="auto">
         {ad}
         <Sans size="1" color="black30" m={1}>
@@ -70,5 +77,4 @@ const DisplayAdContainer = styled(Flex)<DisplayAdContainerProps>`
     props.isSeries ? color("black100") : color("black5")};
   text-align: center;
   width: 100%;
-  height: 334px;
 `

--- a/src/Components/Publishing/Display/DisplayTargeting.tsx
+++ b/src/Components/Publishing/Display/DisplayTargeting.tsx
@@ -8,3 +8,7 @@ export const targetingData = (id: string, pageType: string) => {
     post_id: id,
   }
 }
+
+export const is300x50AdUnit = (unit: string): boolean => {
+  return unit.slice(-3) === "x50"
+}

--- a/src/Components/Publishing/Display/NewDisplayCanvas.tsx
+++ b/src/Components/Publishing/Display/NewDisplayCanvas.tsx
@@ -2,5 +2,5 @@ import React, { SFC } from "react"
 import { DisplayAd, DisplayAdProps } from "./DisplayAd"
 
 export const NewDisplayCanvas: SFC<DisplayAdProps> = props => (
-  <DisplayAd {...props} pt={4} />
+  <DisplayAd {...props} />
 )

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`renders the new canvas in standard layout 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 334px;
   padding-bottom: 4px;
   padding-top: 8px;
   margin: 0 auto;
@@ -28,11 +29,11 @@ exports[`renders the new canvas in standard layout 1`] = `
   background: #F8F8F8;
   text-align: center;
   width: 100%;
-  height: 334px;
 }
 
 <div
   className="c0"
+  height="334px"
 >
   <div
     className="c1"

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayCanvas.test.tsx.snap
@@ -21,18 +21,19 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 334px;
   padding-bottom: 4px;
-  padding-top: 32px;
+  padding-top: 8px;
   margin: 0 auto;
   border-top: none;
   background: #F8F8F8;
   text-align: center;
   width: 100%;
-  height: 334px;
 }
 
 <div
   className="c0"
+  height="334px"
 >
   <div
     className="c1"

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayPanel.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 334px;
   padding-bottom: 4px;
   padding-top: 8px;
   margin: 0 auto;
@@ -28,11 +29,11 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
   background: #F8F8F8;
   text-align: center;
   width: 100%;
-  height: 334px;
 }
 
 <div
   className="c0"
+  height="334px"
 >
   <div
     className="c1"

--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -1,6 +1,9 @@
 import { color } from "@artsy/palette"
 import { unica } from "Assets/Fonts"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  is300x50AdUnit,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { once } from "lodash"
 import React, { Component } from "react"
 import track, { TrackingProp } from "react-tracking"
@@ -113,17 +116,17 @@ export class NewsLayout extends Component<Props, State> {
       shouldAdRender,
     } = this.props
     const adUnit = this.getAdUnit()
+    const adDimension = isMobile
+      ? AdDimension.Mobile_NewsLanding_InContent1
+      : AdDimension.Desktop_NewsLanding_Leaderboard1
 
     return (
       <>
         {shouldAdRender && (
           <NewDisplayCanvas
+            pt={is300x50AdUnit(adDimension) ? 2 : 4} // add 20px to mobile leaderboard ads until this component is converted to <DisplayAd />
             adUnit={adUnit}
-            adDimension={
-              isMobile
-                ? AdDimension.Mobile_NewsLanding_InContent1
-                : AdDimension.Desktop_NewsLanding_Leaderboard1
-            }
+            adDimension={adDimension}
             displayNewAds={areHostedAdsEnabled}
             targetingData={targetingData(article.id, "newslanding")}
           />

--- a/src/Components/Publishing/Layouts/SeriesLayout.tsx
+++ b/src/Components/Publishing/Layouts/SeriesLayout.tsx
@@ -1,5 +1,8 @@
 import { Box, color } from "@artsy/palette"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  is300x50AdUnit,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { NewDisplayCanvas } from "Components/Publishing/Display/NewDisplayCanvas"
 import { Nav } from "Components/Publishing/Nav/Nav"
 import { ArticleCards } from "Components/Publishing/RelatedArticles/ArticleCards/ArticleCards"
@@ -39,6 +42,9 @@ export class SeriesLayout extends Component<Props, null> {
     const isSponsored = isEditorialSponsored(sponsor)
     const backgroundUrl =
       hero_section && hero_section.url ? hero_section.url : ""
+    const adDimension = isMobile
+      ? AdDimension.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
+      : AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
 
     return (
       <SeriesContainer
@@ -68,16 +74,13 @@ export class SeriesLayout extends Component<Props, null> {
         </SeriesContent>
         {areHostedAdsEnabled && (
           <NewDisplayCanvas
+            pt={is300x50AdUnit(adDimension) ? 2 : 4} // add 20px to mobile leaderboard ads until this component is converted to <DisplayAd />
             adUnit={
               isMobile
                 ? AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
                 : AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
             }
-            adDimension={
-              isMobile
-                ? AdDimension.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
-                : AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-            }
+            adDimension={adDimension}
             displayNewAds={areHostedAdsEnabled}
             targetingData={targetingData(
               article.id,

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -3,7 +3,10 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { getEditorialHref } from "Components/Publishing/Constants"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  is300x50AdUnit,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
@@ -88,22 +91,21 @@ export class StandardLayout extends React.Component<
 
   renderTopRailDisplayAd(isMobileAd: boolean) {
     const { areHostedAdsEnabled, article } = this.props
+    const adDimension = isMobileAd
+      ? AdDimension.Mobile_TopLeaderboard
+      : AdDimension.Desktop_TopLeaderboard
 
     return (
       // @FIXME: When ads are live on production remove areHostedAdsEnabled check
       areHostedAdsEnabled && (
         <DisplayAd
-          pt={4}
+          pt={is300x50AdUnit(adDimension) ? 2 : 4} // add 20px to mobile leaderboard ads until this component is converted to <DisplayAd />
           adUnit={
             isMobileAd
               ? AdUnit.Mobile_TopLeaderboard
               : AdUnit.Desktop_TopLeaderboard
           }
-          adDimension={
-            isMobileAd
-              ? AdDimension.Mobile_TopLeaderboard
-              : AdDimension.Desktop_TopLeaderboard
-          }
+          adDimension={adDimension}
           displayNewAds={areHostedAdsEnabled}
           targetingData={targetingData(article.id, "article")}
         />

--- a/src/Components/Publishing/Layouts/VideoLayout.tsx
+++ b/src/Components/Publishing/Layouts/VideoLayout.tsx
@@ -1,10 +1,9 @@
 import { Box } from "@artsy/palette"
-import React, { Component } from "react"
-import track from "react-tracking"
-import styled from "styled-components"
-
 import { getEditorialHref } from "Components/Publishing/Constants"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  is300x50AdUnit,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { NewDisplayCanvas } from "Components/Publishing/Display/NewDisplayCanvas"
 import { Nav, NavContainer } from "Components/Publishing/Nav/Nav"
 import { ArticleCardsBlock } from "Components/Publishing/RelatedArticles/ArticleCards/Block"
@@ -16,6 +15,9 @@ import {
 } from "Components/Publishing/Video/Player/VideoPlayer"
 import { VideoAbout } from "Components/Publishing/Video/VideoAbout"
 import { VideoCover } from "Components/Publishing/Video/VideoCover"
+import React, { Component } from "react"
+import track from "react-tracking"
+import styled from "styled-components"
 import Events from "Utils/Events"
 
 interface Props {
@@ -90,6 +92,9 @@ export class VideoLayout extends Component<Props, State> {
     const isSponsored = isEditorialSponsored(sponsor)
     const seriesLink =
       seriesArticle && getEditorialHref("series", seriesArticle.slug)
+    const adDimension = isMobile
+      ? AdDimension.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
+      : AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
 
     return (
       <VideoLayoutContainer>
@@ -126,16 +131,13 @@ export class VideoLayout extends Component<Props, State> {
         </Box>
         {areHostedAdsEnabled && (
           <NewDisplayCanvas
+            pt={is300x50AdUnit(adDimension) ? 2 : 4} // add 20px to mobile leaderboard ads until this component is converted to <DisplayAd />
             adUnit={
               isMobile
                 ? AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
                 : AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
             }
-            adDimension={
-              isMobile
-                ? AdDimension.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
-                : AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-            }
+            adDimension={adDimension}
             displayNewAds={areHostedAdsEnabled}
             targetingData={targetingData(
               article.id,

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayoutAdsEnabled.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 334px;
   padding-bottom: 4px;
   padding-top: 32px;
   margin: 0 auto;
@@ -35,7 +36,6 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   background: #F8F8F8;
   text-align: center;
   width: 100%;
-  height: 334px;
 }
 
 .c2 {
@@ -951,6 +951,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   </div>
   <div
     className="c24"
+    height="334px"
   >
     <div
       className="c25"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayoutAdsEnabled.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 334px;
   padding-bottom: 4px;
   padding-top: 32px;
   margin: 0 auto;
@@ -99,7 +100,6 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   background: #000;
   text-align: center;
   width: 100%;
-  height: 334px;
 }
 
 .c2 {
@@ -911,6 +911,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   </div>
   <div
     className="c24"
+    height="334px"
   >
     <div
       className="c25"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayoutAdsEnabled.test.tsx.snap
@@ -128,6 +128,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 334px;
   padding-bottom: 4px;
   padding-top: 32px;
   margin: 0 auto;
@@ -135,7 +136,6 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   background: #000;
   text-align: center;
   width: 100%;
-  height: 334px;
 }
 
 .c3 {
@@ -1621,6 +1621,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   </div>
   <div
     className="c56"
+    height="334px"
   >
     <div
       className="c57"

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -1,5 +1,8 @@
 import { Box } from "@artsy/palette"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  is300x50AdUnit,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { NewDisplayCanvas } from "Components/Publishing/Display/NewDisplayCanvas"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import { clone, compact, findLastIndex, get, once } from "lodash"
@@ -264,19 +267,21 @@ export class Sections extends Component<Props, State> {
       }
 
       if (areHostedAdsEnabled && shouldInjectNewAds) {
+        const adDimension = isMobile
+          ? AdDimension.Mobile_Feature_InContentLeaderboard1
+          : AdDimension.Desktop_NewsLanding_Leaderboard1
+
         const marginTop = this.getAdMarginTop(section)
+
         firstAdInjected = true
         indexAtFirstAd = indexAtFirstAd === null ? index : indexAtFirstAd // only set this value once; after the index where 1st ad injection is found
 
         ad = (
           <AdWrapper mt={marginTop}>
             <NewDisplayCanvas
+              pt={is300x50AdUnit(adDimension) ? 2 : 4} // add 20px to mobile leaderboard ads until this component is converted to <DisplayAd />
               adUnit={this.getAdUnit(placementCount, indexAtFirstAd)}
-              adDimension={
-                isMobile
-                  ? AdDimension.Mobile_Feature_InContentLeaderboard1
-                  : AdDimension.Desktop_NewsLanding_Leaderboard1
-              }
+              adDimension={adDimension}
               displayNewAds
               targetingData={targetingData(
                 article.id,


### PR DESCRIPTION
This PR fixes the padding on 300x50 mobile leaderboard display ads.
 
Links to GROW-1339(https://artsyproduct.atlassian.net/browse/GROW-1339)

Pre-fix:
<img width="507" alt="Screen Shot 2019-06-26 at 11 48 37 AM" src="https://user-images.githubusercontent.com/10385964/60203282-54c0bd80-981a-11e9-9a3c-222d03b40655.png">


Post-fix:
<img width="506" alt="Screen Shot 2019-06-26 at 11 46 56 AM" src="https://user-images.githubusercontent.com/10385964/60203296-5db18f00-981a-11e9-98c3-4f5b27e24336.png">
<img width="563" alt="Screen Shot 2019-06-26 at 11 47 19 AM" src="https://user-images.githubusercontent.com/10385964/60203297-5db18f00-981a-11e9-8aad-2ccf8aa74e92.png">
<img width="490" alt="Screen Shot 2019-06-26 at 11 48 24 AM" src="https://user-images.githubusercontent.com/10385964/60203298-5db18f00-981a-11e9-8f63-8e6f01530328.png">
