### PR TITLE
Corrects ad dimensions in mobile ads on feature articles

### DIFF
--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -1203,6 +1203,10 @@ export const FeatureBasicArticle: ArticleData = {
 }
 
 export const SponsoredArticle = extend(cloneDeep(FeatureArticle), Sponsor)
+export const SponsoredFeatureArticle = extend(
+  cloneDeep(FeatureArticleHostedAds),
+  Sponsor
+)
 
 export const SuperArticle = extend(cloneDeep(FeatureArticle), {
   is_super_article: true,

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -268,7 +268,9 @@ export class Sections extends Component<Props, State> {
 
       if (areHostedAdsEnabled && shouldInjectNewAds) {
         const adDimension = isMobile
-          ? AdDimension.Mobile_Feature_InContentLeaderboard1
+          ? isSponsored
+            ? AdDimension.Mobile_Sponsored_Feature_InContentLeaderboard1
+            : AdDimension.Mobile_Feature_InContentLeaderboard1
           : AdDimension.Desktop_NewsLanding_Leaderboard1
 
         const marginTop = this.getAdMarginTop(section)

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
@@ -2,6 +2,7 @@ import { NewDisplayCanvas } from "Components/Publishing/Display/NewDisplayCanvas
 import {
   FeatureArticle,
   FeatureArticleHostedAds,
+  SponsoredFeatureArticle,
   StandardArticle,
 } from "Components/Publishing/Fixtures/Articles"
 import { WrapperWithFullscreenContext } from "Components/Publishing/Fixtures/Helpers"
@@ -352,9 +353,23 @@ describe("Sections", () => {
       expect(
         wrapper
           .find(NewDisplayCanvas)
+          .at(3)
+          .props().adDimension
+      ).toBe("300x50")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
           .at(4)
           .props().adUnit
       ).toBe("Mobile_InContentLBRepeat")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(4)
+          .props().adDimension
+      ).toBe("300x50")
 
       expect(
         wrapper
@@ -366,6 +381,13 @@ describe("Sections", () => {
       expect(
         wrapper
           .find(NewDisplayCanvas)
+          .at(5)
+          .props().adDimension
+      ).toBe("300x50")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
           .at(6)
           .props().adUnit
       ).toBe("Mobile_InContentLBRepeat")
@@ -373,9 +395,144 @@ describe("Sections", () => {
       expect(
         wrapper
           .find(NewDisplayCanvas)
+          .at(5)
+          .props().adDimension
+      ).toBe("300x50")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
           .at(7)
           .props().adUnit
       ).toBe("Mobile_InContentLBRepeat")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(7)
+          .props().adDimension
+      ).toBe("300x50")
+
+      expect(wrapper.find(NewDisplayCanvas).length).toBe(8)
+    })
+    it("it injects display ads after correct sections if sponsored feature on mobile", () => {
+      props.article = SponsoredFeatureArticle
+      props.isMobile = true
+      props.areHostedAdsEnabled = true
+      props.isSponsored = true
+      const wrapper = mountWrapper(props)
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(0)
+          .props().adUnit
+      ).toBe("Mobile_InContentLB1")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(0)
+          .props().adDimension
+      ).toBe("300x250")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(1)
+          .props().adUnit
+      ).toBe("Mobile_InContentLB2")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(1)
+          .props().adDimension
+      ).toBe("300x250")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(2)
+          .props().adUnit
+      ).toBe("Mobile_InContentLBRepeat")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(2)
+          .props().adDimension
+      ).toBe("300x250")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(3)
+          .props().adUnit
+      ).toBe("Mobile_InContentLBRepeat")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(3)
+          .props().adDimension
+      ).toBe("300x250")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(4)
+          .props().adUnit
+      ).toBe("Mobile_InContentLBRepeat")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(4)
+          .props().adDimension
+      ).toBe("300x250")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(5)
+          .props().adUnit
+      ).toBe("Mobile_InContentLBRepeat")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(5)
+          .props().adDimension
+      ).toBe("300x250")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(6)
+          .props().adUnit
+      ).toBe("Mobile_InContentLBRepeat")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(6)
+          .props().adDimension
+      ).toBe("300x250")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(7)
+          .props().adUnit
+      ).toBe("Mobile_InContentLBRepeat")
+
+      expect(
+        wrapper
+          .find(NewDisplayCanvas)
+          .at(7)
+          .props().adDimension
+      ).toBe("300x250")
 
       expect(wrapper.find(NewDisplayCanvas).length).toBe(8)
     })

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -62,6 +62,7 @@ export enum AdDimension {
   Desktop_NewsLanding_Leaderboard2 = "970x250",
   Desktop_NewsLanding_LeaderboardRepeat = "970x250",
   Mobile_Feature_InContentLeaderboard1 = "300x50",
+  Mobile_Sponsored_Feature_InContentLeaderboard1 = "300x250",
   Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom = "970x250",
   Mobile_TopLeaderboard = "300x50",
   Mobile_InContentMR1 = "300x250",


### PR DESCRIPTION
This PR addresses the following:

On Sponsored Features ads should be 300x250, on non Sponsored Features ads should be 300x50. 

[Links to GROW-1356](https://artsyproduct.atlassian.net/browse/GROW-1356)

Post-fix:
<img width="498" alt="Screen Shot 2019-06-26 at 2 49 50 PM" src="https://user-images.githubusercontent.com/10385964/60206571-e849bc80-9821-11e9-89b4-e2f7b5800426.png">

Pre-fix:
<img width="531" alt="Screen Shot 2019-06-26 at 2 50 06 PM" src="https://user-images.githubusercontent.com/10385964/60206565-e253db80-9821-11e9-8174-c7eddc8b087a.png">
