### PR TITLE
Updates mobile ad dimensions on news articles

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/NewsLayoutAdsEnabled.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/NewsLayoutAdsEnabled.test.tsx
@@ -82,7 +82,7 @@ describe("News Layout with new ads enabled", () => {
       "Mobile_InContentMR1"
     )
     expect(component.find(NewDisplayCanvas).prop("adDimension")).toEqual(
-      "300x250"
+      "300x50"
     )
   })
 
@@ -108,7 +108,7 @@ describe("News Layout with new ads enabled", () => {
       "Mobile_InContentMR2"
     )
     expect(component.find(NewDisplayCanvas).prop("adDimension")).toEqual(
-      "300x250"
+      "300x50"
     )
   })
 
@@ -133,7 +133,7 @@ describe("News Layout with new ads enabled", () => {
       "Mobile_InContentMRRepeat"
     )
     expect(component.find(NewDisplayCanvas).prop("adDimension")).toEqual(
-      "300x250"
+      "300x50"
     )
   })
 })

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -36,6 +36,7 @@ export enum AdUnit {
   Mobile_NewsLanding_InContent1 = "Mobile_InContentMR1",
   Mobile_NewsLanding_InContent2 = "Mobile_InContentMR2",
   Mobile_NewsLanding_InContent3 = "Mobile_InContentMRRepeat",
+
   Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom = "Mobile_InContentLB2",
   Mobile_Feature_InContentLeaderboard1 = "Mobile_InContentLB1",
   Mobile_Feature_InContentLeaderboard2 = "Mobile_InContentLB2",
@@ -56,10 +57,10 @@ export enum AdDimension {
   Mobile_InContentMR1 = "300x250",
   Mobile_InContentLB1 = "300x50",
   Mobile_InContentLB2 = "300x50",
-  Mobile_NewsLanding_InContent1 = "300x250",
-  Mobile_NewsLanding_InContent2 = "300x250",
-  Mobile_NewsLanding_InContent3 = "300x250",
   Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom = "300x250",
+  Mobile_NewsLanding_InContent1 = "300x50",
+  Mobile_NewsLanding_InContent2 = "300x50",
+  Mobile_NewsLanding_InContent3 = "300x50",
 }
 
 export type SectionLayout =


### PR DESCRIPTION
This PR corrects the ad dimensions on news article mobile ads.

[Links to GROW-1357 ](https://artsyproduct.atlassian.net/browse/GROW-1357)

**Post-fix:**
![Image from iOS (3)](https://user-images.githubusercontent.com/10385964/60280627-4da8b680-98d1-11e9-9a67-968c624faf3a.png)


**Pre-fix:**
![Image from iOS (4)](https://user-images.githubusercontent.com/10385964/60280642-54372e00-98d1-11e9-833d-c54ab0a9d01e.png)
