### PR TITLE
Handle Flicker Affect When Ad Server Content is Empty

### DIFF
--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -45,6 +45,7 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
       onSlotRenderEnded={event => {
         setAdEmpty(event.isEmpty)
       }}
+      collapseEmptyDiv
     />
   )
 


### PR DESCRIPTION
This PR adds a boolean from the `react-gpt` API to collapse empty divs when no ad content is served. 