### PR TITLE
PURCHASE-1197 - Adds TabCarousel

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -2,7 +2,7 @@ import { Flex, Sans } from "@artsy/palette"
 import { NavigationTabs_searchableConnection } from "__generated__/NavigationTabs_searchableConnection.graphql"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
-import { RouteTab, RouteTabs } from "Components/v2"
+import { RouteTab, TabCarousel } from "Components/v2"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
@@ -86,7 +86,7 @@ export class NavigationTabs extends React.Component<Props> {
     return typeAggregation.find(agg => agg.name === type)
   }
 
-  renderTabs() {
+  tabs() {
     const { term, artworkCount } = this.props
 
     const route = tab => `/search${tab}?term=${term}`
@@ -115,35 +115,39 @@ export class NavigationTabs extends React.Component<Props> {
         ))
     )
 
-    return (
-      <>
-        {!!artworkCount &&
-          this.renderTab("Artworks", route(""), {
-            exact: true,
-            count: artworkCount,
-          })}
+    const tabs = []
 
-        {Object.entries(tabCountMap).map(([key, value]: [string, number]) => {
-          return this.renderTab(key, route(`/${key.toLowerCase()}`), {
-            count: value,
-          })
-        })}
+    !!artworkCount &&
+      tabs.push(
+        this.renderTab("Artworks", route(""), {
+          exact: true,
+          count: artworkCount,
+        })
+      )
 
-        {!!restAggregationCount &&
-          this.renderTab("More", route("/more"), {
-            count: restAggregationCount,
-          })}
-      </>
-    )
+    Object.entries(tabCountMap).map(([key, value]: [string, number]) => {
+      tabs.push(
+        this.renderTab(key, route(`/${key.toLowerCase()}`), {
+          count: value,
+        })
+      )
+    })
+
+    !!restAggregationCount &&
+      tabs.push(
+        this.renderTab("More", route("/more"), {
+          count: restAggregationCount,
+        })
+      )
+
+    return tabs
   }
 
   render() {
     return (
-      <>
-        <Flex mx={[-2, 0]}>
-          <RouteTabs>{this.renderTabs()}</RouteTabs>
-        </Flex>
-      </>
+      <Flex mx={[-2, 0]}>
+        <TabCarousel tabs={this.tabs()} />
+      </Flex>
     )
   }
 }

--- a/src/Apps/Search/__tests__/SearchApp.test.tsx
+++ b/src/Apps/Search/__tests__/SearchApp.test.tsx
@@ -6,13 +6,13 @@ import { SearchApp } from "../SearchApp"
 
 jest.mock("Components/v2/RouteTabs", () => ({
   RouteTab: ({ children }) => children,
-  RouteTabs: ({ children }) => children,
+  TabCarousel: ({ tabs }) => tabs,
 }))
 
 describe("SearchApp", () => {
   const getWrapper = (searchProps: any) => {
     return mount(
-      <MockBoot>
+      <MockBoot breakpoint="lg">
         <SystemContextProvider>
           <SearchApp {...searchProps} />
         </SystemContextProvider>

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
@@ -90,6 +90,7 @@ export class RelatedCollectionsRail extends React.Component<
 
 const ArrowContainer = styled(Box)`
   align-self: flex-start;
+
   ${ArrowButton} {
     min-height: 130px;
     align-self: flex-start;

--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -1,4 +1,4 @@
-import { ChevronIcon, color, Flex, space } from "@artsy/palette"
+import { Box, ChevronIcon, color, Flex, space } from "@artsy/palette"
 import { Options as FlickityOptions } from "flickity"
 import React, { Fragment } from "react"
 import styled from "styled-components"
@@ -52,6 +52,11 @@ interface CarouselProps {
   options?: FlickityOptions
 
   /**
+   * Pass an optional position for left and right for the arrow wrapper element otherwise defaults to -40
+   */
+  arrowPosition?: number
+
+  /**
    * Show or hide arrows. Defaults to true
    */
   showArrows?: boolean
@@ -84,14 +89,14 @@ export class Carousel extends React.Component<CarouselProps> {
 
   render() {
     return (
-      <>
+      <Box width="100%">
         <Media greaterThan="xs">
           <LargeCarousel {...this.props} />
         </Media>
         <Media at="xs">
           <SmallCarousel {...this.props} />
         </Media>
-      </>
+      </Box>
     )
   }
 }
@@ -150,7 +155,7 @@ export class BaseCarousel extends React.Component<
 > {
   state = {
     currentSlideIndex: 0,
-    lastItemVisible: false,
+    lastItemVisible: true,
     isMounted: false,
   }
 
@@ -210,30 +215,39 @@ export class BaseCarousel extends React.Component<
   handleSlideChange = index => {
     this.setState({
       currentSlideIndex: index,
-      lastItemVisible: this.checkLastItemVisible(),
     })
   }
 
   checkLastItemVisible = () => {
-    const lastItemVisible = this.flickity.selectedElements.includes(
-      this.flickity.getLastCell().element
-    )
-    return lastItemVisible
+    if (this.flickity && this.flickity.selectedElements) {
+      const lastItemVisible = this.flickity.selectedElements.includes(
+        this.flickity.getLastCell().element
+      )
+      return lastItemVisible
+    } else {
+      return true
+    }
   }
 
   renderLeftArrow = () => {
-    const { onArrowClick, renderLeftArrow, showArrows } = this.props
+    const { onArrowClick, renderLeftArrow, showArrows, height } = this.props
 
     if (!showArrows) {
       return null
     }
 
+    const leftPosition =
+      this.props.arrowPosition !== null &&
+      this.props.arrowPosition !== undefined
+        ? this.props.arrowPosition
+        : -space(4)
     const showLeftArrow =
       this.state.currentSlideIndex !== 0 || this.options.wrapAround === true
 
     const Arrow = () => (
-      <ArrowWrapper left={-space(4)} showArrow={showLeftArrow}>
+      <ArrowWrapper left={leftPosition} showArrow={showLeftArrow}>
         <ArrowButton
+          height={height}
           onClick={() => {
             this.flickity.previous()
 
@@ -243,10 +257,10 @@ export class BaseCarousel extends React.Component<
           }}
         >
           <ChevronIcon
+            height={30}
             direction="left"
             fill="black100"
             width={30}
-            height={30}
           />
         </ArrowButton>
       </ArrowWrapper>
@@ -265,18 +279,25 @@ export class BaseCarousel extends React.Component<
   }
 
   renderRightArrow = () => {
-    const { onArrowClick, renderRightArrow, showArrows } = this.props
+    const { onArrowClick, renderRightArrow, showArrows, height } = this.props
 
     if (!showArrows) {
       return null
     }
 
+    const rightPosition =
+      this.props.arrowPosition !== null &&
+      this.props.arrowPosition !== undefined
+        ? this.props.arrowPosition
+        : -space(4)
+
     const showRightArrow =
-      !this.state.lastItemVisible || this.options.wrapAround === true
+      !this.checkLastItemVisible() || this.options.wrapAround === true
 
     const Arrow = () => (
-      <ArrowWrapper right={-space(4)} showArrow={showRightArrow}>
+      <ArrowWrapper right={rightPosition} showArrow={showRightArrow}>
         <ArrowButton
+          height={height}
           onClick={() => {
             this.flickity.next()
 
@@ -286,10 +307,10 @@ export class BaseCarousel extends React.Component<
           }}
         >
           <ChevronIcon
+            height={30}
             direction="right"
             fill="black100"
             width={30}
-            height={30}
           />
         </ArrowButton>
       </ArrowWrapper>
@@ -409,7 +430,7 @@ export const ArrowButton = styled(Flex)<
   opacity: 0.3;
 
   transition: opacity 0.25s;
-  min-height: ${p => p.height || "200px"};
+  height: ${p => p.height || "200px"};
 
   &:hover {
     opacity: 1;
@@ -425,9 +446,11 @@ const ArrowWrapper = styled.div<{
   top: 50%;
   transform: translateY(-50%);
   min-width: 30px;
+  z-index: 10;
   transition: opacity 0.25s;
   opacity: ${props => (props.showArrow ? 1 : 0)};
   pointer-events: ${props => (props.showArrow ? "auto" : "none")};
+  height: 100%;
   ${left};
   ${right};
 `

--- a/src/Components/v2/RouteTabs.tsx
+++ b/src/Components/v2/RouteTabs.tsx
@@ -1,15 +1,22 @@
 import {
+  Box,
   color,
+  Flex,
   Sans,
   sharedTabsStyles,
   space,
   TabsContainer,
 } from "@artsy/palette"
+import { ArrowButton, Carousel } from "Components/v2"
 import { Link, LinkProps } from "found"
 import React from "react"
 import styled from "styled-components"
+import { left, right } from "styled-system"
+import { Media } from "Utils/Responsive"
 
 export const RouteTabs = styled(TabsContainer)`
+  width: 100%;
+
   a {
     ${sharedTabsStyles.tabContainer};
 
@@ -36,5 +43,78 @@ export const RouteTab: React.FC<LinkProps> = ({ children, ...props }) => {
   )
 }
 
+export interface TabCarouselProps {
+  tabs: Array<React.ReactElement<any>>
+}
+
+export const TabCarousel: React.FC<TabCarouselProps> = ({ tabs }) => {
+  return (
+    <Box width="100%">
+      <Media greaterThan="xs">
+        <RouteTabs>
+          <Carousel
+            renderLeftArrow={({ Arrow }) => {
+              return (
+                <TabArrowWrapper left={0}>
+                  <Arrow />
+                </TabArrowWrapper>
+              )
+            }}
+            renderRightArrow={({ Arrow }) => {
+              return (
+                <TabArrowWrapper right={0}>
+                  <Arrow />
+                </TabArrowWrapper>
+              )
+            }}
+            options={{
+              wrapAround: false,
+              pageDots: false,
+              cellAlign: "left",
+              contain: true,
+              draggable: false,
+              groupCells: true,
+            }}
+            height="34px"
+            arrowPosition={0}
+            data={tabs}
+            showArrows
+            render={tab => tab}
+          />
+        </RouteTabs>
+      </Media>
+      <Media at="xs">
+        <RouteTabs>
+          <Flex pr={2}>{tabs}</Flex>
+        </RouteTabs>
+      </Media>
+    </Box>
+  )
+}
+
 RouteTabs.displayName = "RouteTabs"
 RouteTab.displayName = "RouteTab"
+
+const TabArrowWrapper = styled.div<{
+  left?: number
+  right?: number
+}>`
+  height: 34px;
+  width: 30px;
+  top: -7px;
+  z-index: 10;
+  position: absolute;
+  ${right};
+  ${left};
+
+  ${ArrowButton} {
+    height: 34px;
+    background-color: ${color("white100")};
+    opacity: 1;
+    box-shadow: 0 -9px 0 0 #fff, 12px 0 15px -4px #fff, -12px 0 15px -4px #fff;
+
+    > svg {
+      height: 18px;
+    }
+  }
+`

--- a/src/Components/v2/__stories__/Tabs.Router.story.tsx
+++ b/src/Components/v2/__stories__/Tabs.Router.story.tsx
@@ -1,10 +1,27 @@
-import { RouteTab, RouteTabs } from "Components/v2"
+import { RouteTab, TabCarousel } from "Components/v2"
 import { MockRouter } from "DevTools/MockRouter"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Utils/Section"
 
 storiesOf("Styleguide/Components", module).add("Tabs (Router)", () => {
+  const tabs = [
+    <RouteTab to="/overview">Overview</RouteTab>,
+    <RouteTab to="/cv">CV</RouteTab>,
+    <RouteTab to="/shows">Shows</RouteTab>,
+    <RouteTab to="/overview">Overview</RouteTab>,
+    <RouteTab to="/cv">CV</RouteTab>,
+    <RouteTab to="/shows">Shows</RouteTab>,
+    <RouteTab to="/overview">Overview</RouteTab>,
+    <RouteTab to="/cv">CV</RouteTab>,
+    <RouteTab to="/shows">Shows</RouteTab>,
+    <RouteTab to="/overview">Overview</RouteTab>,
+    <RouteTab to="/cv">CV</RouteTab>,
+    <RouteTab to="/shows">Shows</RouteTab>,
+    <RouteTab to="/overview">Overview</RouteTab>,
+    <RouteTab to="/cv">CV</RouteTab>,
+    <RouteTab to="/shows">Shows</RouteTab>,
+  ]
   return (
     <React.Fragment>
       <Section title="Route Tabs">
@@ -14,13 +31,7 @@ storiesOf("Styleguide/Components", module).add("Tabs (Router)", () => {
             {
               path: "/",
               Component: () => {
-                return (
-                  <RouteTabs>
-                    <RouteTab to="/overview">Overview</RouteTab>
-                    <RouteTab to="/cv">CV</RouteTab>
-                    <RouteTab to="/shows">Shows</RouteTab>
-                  </RouteTabs>
-                )
+                return <TabCarousel tabs={tabs} />
               },
               children: [
                 {


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/PURCHASE-1197

- Adds solution for overflow tabs. On desktop when tabs exceed the viewport width an arrow will appear for the user to advance through the tabs in a carousel. On mobile the tabs are simply rendered in a `Flex` element which allows for swiping right and left.

- Depends on https://github.com/artsy/palette/pull/529

## Example:

![2019-07-01 14 32 34](https://user-images.githubusercontent.com/21182806/60531728-985b7180-9cc9-11e9-9fbe-1d1a1295be7c.gif)

