### PR TITLE
[GROW-1314] refactor to be able to use image with authentication modal

### DIFF
--- a/src/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/Components/Authentication/Desktop/ModalManager.tsx
@@ -32,6 +32,7 @@ export interface ModalManagerProps {
   onModalOpen?: () => void
   onModalClose?: () => void
   showRecaptchaDisclaimer?: boolean
+  image?: string
 }
 
 export interface ModalManagerState {
@@ -125,6 +126,7 @@ export class ModalManager extends Component<
         onClose={this.closeModal}
         subtitle={this.getSubtitle()}
         type={currentType}
+        image={options.image}
       >
         <FormSwitcher
           type={currentType}

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -95,6 +95,10 @@ export interface ModalOptions {
    * The form or modal title in case it needs to be customized
    */
   title?: string
+  /**
+   * The image rendered with the modal
+   */
+  image?: string
 }
 
 export type FormComponentType =

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -99,8 +99,8 @@ export const ModalContent = styled.div.attrs<{
       : "20px 40px 40px"};
   width: 100%;
 
-  width: ${props => (props.cta && props.hasImage ? "50%" : "100%")};
-  margin-left: ${props => props.cta && props.hasImage && "50%"};
+  width: ${props => (props.hasImage ? "50%" : "100%")};
+  margin-left: ${props => props.hasImage && "50%"};
   ${media.sm`
     padding: ${props =>
       props.cta && props.cta.isFixed ? "20px 20px 110px" : "20px"};

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -97,10 +97,9 @@ export const ModalContent = styled.div.attrs<{
         ? "20px 40px 100px"
         : "20px 40px 0"
       : "20px 40px 40px"};
-  width: 100%;
 
   width: ${props => (props.hasImage ? "50%" : "100%")};
-  margin-left: ${props => props.hasImage && "50%"};
+  ${props => props.hasImage && "margin-left: 50%"};
   ${media.sm`
     padding: ${props =>
       props.cta && props.cta.isFixed ? "20px 20px 110px" : "20px"};
@@ -126,7 +125,7 @@ export const CloseButton = styled(Icon).attrs({
   cursor: pointer;
 `
 
-const Image = styled.div.attrs<{ image: string }>({})`
+export const Image = styled.div.attrs<{ image: string }>({})`
   background-image: url(${props => props.image});
   background-size: cover;
   background-position: center;

--- a/src/Components/Modal/__tests__/Modal.test.tsx
+++ b/src/Components/Modal/__tests__/Modal.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { Modal } from "../Modal"
+import { Image, Modal, ModalContent } from "../Modal"
 import { ModalCta } from "../ModalCta"
 import { ModalHeader } from "../ModalHeader"
 
@@ -51,6 +51,14 @@ describe("Modal", () => {
 
       expect(component.find(ModalCta)).toHaveLength(1)
       expect(component.html()).toMatch("Learn More")
+    })
+
+    it("Renders Image if props.image", () => {
+      props.image = "an_image.jpg"
+      const component = getWrapper(props)
+
+      expect(component.find(Image)).toHaveLength(1)
+      expect(component.find(ModalContent)).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
Addresses: [GROW-1314](https://artsyproduct.atlassian.net/browse/GROW-1314)

This updates the ModalManager and ModalOptions interfaces to be able to accept an image url so that we can have signup modals that support images. There is a subsequent force PR that makes use of the  image property.