### PR TITLE
Deprecate old ads from featured articles

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
@@ -1,4 +1,4 @@
-import { DisplayCanvas } from "Components/Publishing/Display/Canvas"
+import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
 import {
   FeatureArticle,
   SeriesArticle,
@@ -92,18 +92,19 @@ it("renders a nav if article is in a series", () => {
   expect(article.find(Nav).length).toBe(1)
 })
 
-it("renders display if article is not super or in a series", () => {
+it("renders display ads when feature flagged ads are enabled", () => {
   const article = mount(
     <FeatureLayout
       article={FeatureArticle}
       relatedArticlesForCanvas={RelatedCanvas}
       display={Display("feature")}
+      areHostedAdsEnabled
     />
   )
-  expect(article.find(DisplayCanvas).length).toBe(0)
+  expect(article.find(DisplayAd).length).toBe(2)
 })
 
-it("does not render display if article is in a series", () => {
+it("does not render display ads when feature flagged ads are disabled", () => {
   const Article = extend(cloneDeep(FeatureArticle), {
     seriesArticle: SeriesArticle,
   })
@@ -114,19 +115,7 @@ it("does not render display if article is in a series", () => {
       display={Display("feature")}
     />
   )
-  expect(article.find(DisplayCanvas).length).toBe(0)
-})
-
-it("does not render display if article is super", () => {
-  const article = mount(
-    <FeatureLayout
-      article={FeatureArticle}
-      relatedArticlesForCanvas={RelatedCanvas}
-      display={Display("feature")}
-      isSuper
-    />
-  )
-  expect(article.find(DisplayCanvas).length).toBe(0)
+  expect(article.find(DisplayAd).length).toBe(0)
 })
 
 it("does not render a nav if article has a non-fullscreen header", () => {

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -3,13 +3,13 @@ import {
   is300x50AdUnit,
   targetingData,
 } from "Components/Publishing/Display/DisplayTargeting"
-import { NewDisplayCanvas } from "Components/Publishing/Display/NewDisplayCanvas"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import { clone, compact, findLastIndex, get, once } from "lodash"
 import React, { Component } from "react"
 import ReactDOM from "react-dom"
 import styled, { StyledFunction } from "styled-components"
 import { pMedia } from "../../Helpers"
+import { DisplayAd } from "../Display/DisplayAd"
 import { ArticleData } from "../Typings"
 import { Authors } from "./Authors"
 import { Embed } from "./Embed"
@@ -280,7 +280,7 @@ export class Sections extends Component<Props, State> {
 
         ad = (
           <AdWrapper mt={marginTop}>
-            <NewDisplayCanvas
+            <DisplayAd
               pt={is300x50AdUnit(adDimension) ? 2 : 4} // add 20px to mobile leaderboard ads until this component is converted to <DisplayAd />
               adUnit={this.getAdUnit(placementCount, indexAtFirstAd)}
               adDimension={adDimension}

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -1,8 +1,5 @@
 import { Box } from "@artsy/palette"
-import {
-  is300x50AdUnit,
-  targetingData,
-} from "Components/Publishing/Display/DisplayTargeting"
+import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import { clone, compact, findLastIndex, get, once } from "lodash"
 import React, { Component } from "react"
@@ -281,7 +278,6 @@ export class Sections extends Component<Props, State> {
         ad = (
           <AdWrapper mt={marginTop}>
             <DisplayAd
-              pt={is300x50AdUnit(adDimension) ? 2 : 4} // add 20px to mobile leaderboard ads until this component is converted to <DisplayAd />
               adUnit={this.getAdUnit(placementCount, indexAtFirstAd)}
               adDimension={adDimension}
               displayNewAds

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
@@ -1,4 +1,4 @@
-import { NewDisplayCanvas } from "Components/Publishing/Display/NewDisplayCanvas"
+import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
 import {
   FeatureArticle,
   NonSponsoredFeatureArticle,
@@ -152,23 +152,15 @@ describe("Sections", () => {
       props.isMobile = false
       props.areHostedAdsEnabled = true
       const wrapper = mountWrapper(props)
-      expect(wrapper.find(NewDisplayCanvas).length).toBe(2)
+      expect(wrapper.find(DisplayAd).length).toBe(2)
     })
 
     it("it does not inject display ads if feature when ads are disabled", () => {
       props.article = FeatureArticle
       props.isMobile = false
-      const wrapper = mountWrapper(props)
       props.areHostedAdsEnabled = false
-      expect(wrapper.find(NewDisplayCanvas).length).toBe(0)
-    })
-
-    it("it injects display ads if feature when ads are enabled", () => {
-      props.article = FeatureArticle
-      props.isMobile = false
-      props.areHostedAdsEnabled = true
       const wrapper = mountWrapper(props)
-      expect(wrapper.find(NewDisplayCanvas).length).toBe(2)
+      expect(wrapper.find(DisplayAd).length).toBe(0)
     })
 
     it("it injects display ads with correct targeting data if not sponsored feature", () => {
@@ -180,7 +172,7 @@ describe("Sections", () => {
 
       expect(
         wrapper
-          .find(NewDisplayCanvas)
+          .find(DisplayAd)
           .first()
           .props().targetingData
       ).toEqual({
@@ -199,7 +191,7 @@ describe("Sections", () => {
 
       expect(
         wrapper
-          .find(NewDisplayCanvas)
+          .find(DisplayAd)
           .first()
           .props().targetingData
       ).toEqual({
@@ -215,84 +207,40 @@ describe("Sections", () => {
       props.areHostedAdsEnabled = true
       const wrapper = mountWrapper(props)
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(0)
-          .props().adUnit
-      ).toBe("Desktop_Leaderboard1")
+      const ads = wrapper.find(DisplayAd)
+      expect(ads.length).toBe(8)
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(0)
-          .props().adDimension
-      ).toBe("970x250")
+      let ad = ads.at(0).props()
+      expect(ad.adUnit).toBe("Desktop_Leaderboard1")
+      expect(ad.adDimension).toBe("970x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(1)
-          .props().adUnit
-      ).toBe("Desktop_Leaderboard2")
+      ad = ads.at(1).props()
+      expect(ad.adUnit).toBe("Desktop_Leaderboard2")
+      expect(ad.adDimension).toBe("970x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(1)
-          .props().adDimension
-      ).toBe("970x250")
+      ad = ads.at(2).props()
+      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
+      expect(ad.adDimension).toBe("970x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(2)
-          .props().adUnit
-      ).toBe("Desktop_LeaderboardRepeat")
+      ad = ads.at(3).props()
+      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
+      expect(ad.adDimension).toBe("970x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(2)
-          .props().adDimension
-      ).toBe("970x250")
+      ad = ads.at(4).props()
+      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
+      expect(ad.adDimension).toBe("970x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(3)
-          .props().adUnit
-      ).toBe("Desktop_LeaderboardRepeat")
+      ad = ads.at(5).props()
+      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
+      expect(ad.adDimension).toBe("970x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(4)
-          .props().adUnit
-      ).toBe("Desktop_LeaderboardRepeat")
+      ad = ads.at(6).props()
+      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
+      expect(ad.adDimension).toBe("970x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(5)
-          .props().adUnit
-      ).toBe("Desktop_LeaderboardRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(6)
-          .props().adUnit
-      ).toBe("Desktop_LeaderboardRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(7)
-          .props().adUnit
-      ).toBe("Desktop_LeaderboardRepeat")
-
-      expect(wrapper.find(NewDisplayCanvas).length).toBe(8)
+      ad = ads.at(7).props()
+      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
+      expect(ad.adDimension).toBe("970x250")
     })
 
     it("it injects display ads after correct sections if feature on mobile", () => {
@@ -301,120 +249,42 @@ describe("Sections", () => {
       props.areHostedAdsEnabled = true
       const wrapper = mountWrapper(props)
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(0)
-          .props().adUnit
-      ).toBe("Mobile_InContentLB1")
+      const ads = wrapper.find(DisplayAd)
+      expect(ads.length).toBe(8)
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(0)
-          .props().adDimension
-      ).toBe("300x50")
+      let ad = ads.at(0).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLB1")
+      expect(ad.adDimension).toBe("300x50")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(1)
-          .props().adUnit
-      ).toBe("Mobile_InContentLB2")
+      ad = ads.at(1).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLB2")
+      expect(ad.adDimension).toBe("300x50")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(1)
-          .props().adDimension
-      ).toBe("300x50")
+      ad = ads.at(2).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x50")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(2)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
+      ad = ads.at(3).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x50")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(2)
-          .props().adDimension
-      ).toBe("300x50")
+      ad = ads.at(4).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x50")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(3)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
+      ad = ads.at(5).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x50")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(3)
-          .props().adDimension
-      ).toBe("300x50")
+      ad = ads.at(6).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x50")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(4)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(4)
-          .props().adDimension
-      ).toBe("300x50")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(5)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(5)
-          .props().adDimension
-      ).toBe("300x50")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(6)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(5)
-          .props().adDimension
-      ).toBe("300x50")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(7)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(7)
-          .props().adDimension
-      ).toBe("300x50")
-
-      expect(wrapper.find(NewDisplayCanvas).length).toBe(8)
+      ad = ads.at(7).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x50")
     })
+
     it("it injects display ads after correct sections if sponsored feature on mobile", () => {
       props.article = SponsoredFeatureArticle
       props.isMobile = true
@@ -422,119 +292,40 @@ describe("Sections", () => {
       props.isSponsored = true
       const wrapper = mountWrapper(props)
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(0)
-          .props().adUnit
-      ).toBe("Mobile_InContentLB1")
+      const ads = wrapper.find(DisplayAd)
+      expect(ads.length).toBe(8)
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(0)
-          .props().adDimension
-      ).toBe("300x250")
+      let ad = ads.at(0).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLB1")
+      expect(ad.adDimension).toBe("300x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(1)
-          .props().adUnit
-      ).toBe("Mobile_InContentLB2")
+      ad = ads.at(1).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLB2")
+      expect(ad.adDimension).toBe("300x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(1)
-          .props().adDimension
-      ).toBe("300x250")
+      ad = ads.at(2).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(2)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
+      ad = ads.at(3).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(2)
-          .props().adDimension
-      ).toBe("300x250")
+      ad = ads.at(4).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(3)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
+      ad = ads.at(5).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(3)
-          .props().adDimension
-      ).toBe("300x250")
+      ad = ads.at(6).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x250")
 
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(4)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(4)
-          .props().adDimension
-      ).toBe("300x250")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(5)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(5)
-          .props().adDimension
-      ).toBe("300x250")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(6)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(6)
-          .props().adDimension
-      ).toBe("300x250")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(7)
-          .props().adUnit
-      ).toBe("Mobile_InContentLBRepeat")
-
-      expect(
-        wrapper
-          .find(NewDisplayCanvas)
-          .at(7)
-          .props().adDimension
-      ).toBe("300x250")
-
-      expect(wrapper.find(NewDisplayCanvas).length).toBe(8)
+      ad = ads.at(7).props()
+      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
+      expect(ad.adDimension).toBe("300x250")
     })
   })
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-1345.

1. Updates some tests that have gotten out of date, for FeaturedLayout.tsx.
2. Removes `<NewDisplayCanvas>` from Sections.tsx, in favor of rendering `<DisplayAd>` directly.
3. Refactors tests for Section.tsx to remove duplicated lines & improve readability.
