### PR TITLE
Handles empty divs when ad blocker is enabled

### DIFF
--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -47,6 +47,7 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
       onSlotRenderEnded={event => {
         setAdEmpty(event.isEmpty)
       }}
+      viewableThreshold={1.0}
     />
   )
 
@@ -59,7 +60,13 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
       flexDirection="column"
       pt={isMobileLeaderboardAd ? 0 : 2}
       pb={isMobileLeaderboardAd ? 2 : 1}
-      height={isMobileLeaderboardAd ? "100px" : "334px"}
+      height={
+        isAdEmpty || isAdEmpty === null
+          ? "1px" // on initial render OR when no ad content returned from Google, set 1px height to ad container to prevent jarring UX effect
+          : isMobileLeaderboardAd
+          ? "100px" // on mobile 300x50 ads reduce ad container height to 100px
+          : "334px"
+      }
       isAdEmpty={isAdEmpty}
       {...otherProps}
     >

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders the new canvas in standard layout 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  height: 334px;
+  height: 1px;
   padding-bottom: 4px;
   padding-top: 8px;
   margin: 0 auto;
@@ -34,7 +34,7 @@ exports[`renders the new canvas in standard layout 1`] = `
 
 <div
   className="c0"
-  height="334px"
+  height="1px"
 >
   <div
     className="c1"

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayCanvas.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayCanvas.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  height: 334px;
+  height: 1px;
   padding-bottom: 4px;
   padding-top: 8px;
   margin: 0 auto;
@@ -34,7 +34,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
 
 <div
   className="c0"
-  height="334px"
+  height="1px"
 >
   <div
     className="c1"

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayPanel.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/NewDisplayPanel.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  height: 334px;
+  height: 1px;
   padding-bottom: 4px;
   padding-top: 8px;
   margin: 0 auto;
@@ -34,7 +34,7 @@ exports[`snapshot renders the new canvas in standard layout 1`] = `
 
 <div
   className="c0"
-  height="334px"
+  height="1px"
 >
   <div
     className="c1"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayoutAdsEnabled.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  height: 334px;
+  height: 1px;
   padding-bottom: 4px;
   padding-top: 32px;
   margin: 0 auto;
@@ -952,7 +952,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   </div>
   <div
     className="c24"
-    height="334px"
+    height="1px"
   >
     <div
       className="c25"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayoutAdsEnabled.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  height: 334px;
+  height: 1px;
   padding-bottom: 4px;
   padding-top: 32px;
   margin: 0 auto;
@@ -912,7 +912,7 @@ exports[`News Layout with new ads enabled renders the news layout properly when 
   </div>
   <div
     className="c24"
-    height="334px"
+    height="1px"
   >
     <div
       className="c25"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayoutAdsEnabled.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayoutAdsEnabled.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  height: 334px;
+  height: 1px;
   padding-bottom: 4px;
   padding-top: 32px;
   margin: 0 auto;
@@ -1622,7 +1622,7 @@ exports[`Video Layout with new ads enabled renders the video layout properly whe
   </div>
   <div
     className="c56"
-    height="334px"
+    height="1px"
   >
     <div
       className="c57"


### PR DESCRIPTION
This PR removes the large empty div on articles when ad blockers are enabled.