### PR TITLE
change sync correlator to true

### DIFF
--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -25,6 +25,8 @@ export interface DisplayAdContainerProps extends FlexProps {
   isAdEmpty?: boolean
 }
 
+GPT.syncCorrelator(true)
+
 export const DisplayAd: SFC<DisplayAdProps> = props => {
   const {
     adDimension,


### PR DESCRIPTION
This PR sets the updateCorrelator option to true to prevent a bug that caused GAM to be unaware of which pages ads were being served on.

[For context on correlators in GAM visit this link](https://support.google.com/admanager/answer/183281?hl=en)