### PR TITLE
@joeyAghion => [Collection Rail] Be more defensive about missing artists in artwork results

### DIFF
--- a/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionEntity.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionEntity.tsx
@@ -7,6 +7,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
+import { get } from "Utils/get"
 
 export interface CollectionProps {
   collection: ArtistCollectionEntity_collection
@@ -47,7 +48,10 @@ export class ArtistCollectionEntity extends React.Component<CollectionProps> {
           <ImgWrapper pb={1}>
             {bgImages.length ? (
               bgImages.map((url, i) => {
-                const alt = `${hits[i].artist.name}, ${hits[i].title}`
+                const artistName = get(hits[i].artist, a => a.name)
+                const alt = `${artistName ? artistName + ", " : ""}${
+                  hits[i].title
+                }`
                 return (
                   <SingleImgContainer key={i}>
                     <ImgOverlay width={imageSize} />

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -23,7 +23,7 @@ storiesOf("Apps", module)
     return (
       <MockRouter
         routes={collectRoutes}
-        initialRoute="/collection/david-hockney-ipad-drawings"
+        initialRoute="/collection/pablo-picasso-doves"
         context={{
           mediator: {
             trigger: x => x,

--- a/src/Apps/__stories__/ArtistApp.story.tsx
+++ b/src/Apps/__stories__/ArtistApp.story.tsx
@@ -7,7 +7,7 @@ storiesOf("Apps/Artist", module).add("Artist", () => {
   return (
     <MockRouter
       routes={artistRoutes}
-      initialRoute="/artist/andy-warhol"
+      initialRoute="/artist/pablo-picasso"
       context={{
         mediator: {
           trigger: x => x,

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -8,6 +8,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
+import { get } from "Utils/get"
 
 export interface CollectionProps {
   collection: RelatedCollectionEntity_collection
@@ -47,7 +48,10 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
           <ImgWrapper pb={1}>
             {bgImages.length ? (
               bgImages.map((url, i) => {
-                const alt = `${hits[i].artist.name}, ${hits[i].title}`
+                const artistName = get(hits[i].artist, a => a.name)
+                const alt = `${artistName ? artistName + ", " : ""}${
+                  hits[i].title
+                }`
                 return (
                   <SingleImgContainer key={i}>
                     <ImgOverlay width={imageSize} />


### PR DESCRIPTION
We saw this when testing the ES5 branch. It resulted in some odd sorting and returning artworks that lacked artists. Since artworks _can_ in fact lack artists, this component should just be a bit more defensive (in constructing the alt text).