### PR TITLE
Add initial auction registration flow

### DIFF
--- a/src/Apps/Auction/AuctionApp.tsx
+++ b/src/Apps/Auction/AuctionApp.tsx
@@ -1,0 +1,95 @@
+import { Box, Separator, Serif } from "@artsy/palette"
+import { AuctionApp_sale } from "__generated__/AuctionApp_sale.graphql"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
+import { ErrorPage } from "Components/ErrorPage"
+import React, { Component } from "react"
+import { createFragmentContainer, graphql, RelayProp } from "react-relay"
+import {
+  Elements,
+  ReactStripeElements,
+  StripeProvider,
+} from "react-stripe-elements"
+import RegistrationForm from "./Components/RegistrationForm"
+
+declare global {
+  interface Window {
+    Stripe?: (key: string) => stripe.Stripe
+    sd: {
+      STRIPE_PUBLISHABLE_KEY: string
+    }
+  }
+}
+
+interface AuctionAppProps extends ReactStripeElements.InjectedStripeProps {
+  sale: AuctionApp_sale
+  relay?: RelayProp
+}
+
+interface AuctionAppState {
+  stripe: stripe.Stripe
+}
+
+export class AuctionApp extends Component<AuctionAppProps, AuctionAppState> {
+  state: AuctionAppState = { stripe: null }
+  CreditCardInput
+  componentDidMount() {
+    if (window.Stripe) {
+      this.setState({
+        stripe: window.Stripe(window.sd.STRIPE_PUBLISHABLE_KEY),
+      })
+    } else {
+      document.querySelector("#stripe-js").addEventListener("load", () => {
+        // Create Stripe instance once Stripe.js loads
+        this.setState({
+          stripe: window.Stripe(window.sd.STRIPE_PUBLISHABLE_KEY),
+        })
+      })
+    }
+  }
+
+  render() {
+    const { sale } = this.props
+
+    if (!sale) {
+      return <ErrorPage code={404} />
+    }
+
+    return (
+      <AppContainer>
+        <Box maxWidth={550} px={[2, 0]} mx="auto" my={[1, 0]}>
+          <Serif size="10">Register to Bid on Artsy</Serif>
+          <Separator mt={1} mb={2} />
+          <Serif size="4" color="black100">
+            Please enter your credit card information below. The name on your
+            Artsy account must match the name on the card, and a valid credit
+            card is required in order to bid.
+          </Serif>
+          <Serif size="4" mt={2} color="black100">
+            Registration is free. Artsy will never charge this card without your
+            permission, and you are not required to use this card to pay if you
+            win.
+          </Serif>
+          <StripeProvider stripe={this.state.stripe}>
+            <Elements>
+              <Box mt={2}>
+                <RegistrationForm sale={sale} relay={this.props.relay} />
+              </Box>
+            </Elements>
+          </StripeProvider>
+        </Box>
+      </AppContainer>
+    )
+  }
+}
+
+export const AuctionAppFragmentContainer = createFragmentContainer(
+  trackPageViewWrapper(AuctionApp),
+  {
+    sale: graphql`
+      fragment AuctionApp_sale on Sale {
+        id
+      }
+    `,
+  }
+)

--- a/src/Apps/Auction/AuctionApp.tsx
+++ b/src/Apps/Auction/AuctionApp.tsx
@@ -10,16 +10,8 @@ import {
   ReactStripeElements,
   StripeProvider,
 } from "react-stripe-elements"
-import RegistrationForm from "./Components/RegistrationForm"
-
-declare global {
-  interface Window {
-    Stripe?: (key: string) => stripe.Stripe
-    sd: {
-      STRIPE_PUBLISHABLE_KEY: string
-    }
-  }
-}
+import { data as sd } from "sharify"
+import { WrappedRegistrationForm } from "./Components/RegistrationForm"
 
 interface AuctionAppProps extends ReactStripeElements.InjectedStripeProps {
   sale: AuctionApp_sale
@@ -33,19 +25,29 @@ interface AuctionAppState {
 export class AuctionApp extends Component<AuctionAppProps, AuctionAppState> {
   state: AuctionAppState = { stripe: null }
   CreditCardInput
+
   componentDidMount() {
     if (window.Stripe) {
       this.setState({
-        stripe: window.Stripe(window.sd.STRIPE_PUBLISHABLE_KEY),
+        stripe: window.Stripe(sd.STRIPE_PUBLISHABLE_KEY),
       })
     } else {
-      document.querySelector("#stripe-js").addEventListener("load", () => {
-        // Create Stripe instance once Stripe.js loads
-        this.setState({
-          stripe: window.Stripe(window.sd.STRIPE_PUBLISHABLE_KEY),
-        })
-      })
+      document
+        .querySelector("#stripe-js")
+        .addEventListener("load", this.setupStripe)
     }
+  }
+
+  componentWillUnmount() {
+    document
+      .querySelector("#stripe-js")
+      .removeEventListener("load", this.setupStripe)
+  }
+
+  private setupStripe() {
+    this.setState({
+      stripe: window.Stripe(sd.STRIPE_PUBLISHABLE_KEY),
+    })
   }
 
   render() {
@@ -73,7 +75,7 @@ export class AuctionApp extends Component<AuctionAppProps, AuctionAppState> {
           <StripeProvider stripe={this.state.stripe}>
             <Elements>
               <Box mt={2}>
-                <RegistrationForm sale={sale} relay={this.props.relay} />
+                <WrappedRegistrationForm sale={sale} relay={this.props.relay} />
               </Box>
             </Elements>
           </StripeProvider>

--- a/src/Apps/Auction/Components/ConditionsOfSaleCheckbox.tsx
+++ b/src/Apps/Auction/Components/ConditionsOfSaleCheckbox.tsx
@@ -1,0 +1,43 @@
+import { Box, Link, Sans, Serif } from "@artsy/palette"
+import Checkbox from "Components/Checkbox"
+import React from "react"
+import styled from "styled-components"
+
+export const ConditionsOfSaleCheckbox = ({
+  error,
+  name,
+  onChange,
+  onBlur,
+  value,
+  ...props
+}) => {
+  return (
+    <Box mx="auto">
+      <StyledCheckbox {...{ checked: value, error, onChange, onBlur, name }}>
+        <Serif display="inline" color="black60" size="3t" ml={0.5}>
+          {"Agree to "}
+          <Serif display="inline" color="black100" size="3t">
+            <Link
+              color="black100"
+              href="https://www.artsy.net/conditions-of-sale"
+              target="_blank"
+            >
+              Conditions of Sale
+            </Link>
+          </Serif>
+          .
+        </Serif>
+      </StyledCheckbox>
+      {error && (
+        <Sans mt={1} color="red100" size="2">
+          {error}
+        </Sans>
+      )}
+    </Box>
+  )
+}
+
+const StyledCheckbox = styled(Checkbox)`
+  margin: 5px 0;
+  align-items: flex-start;
+`

--- a/src/Apps/Auction/Components/ConditionsOfSaleCheckbox.tsx
+++ b/src/Apps/Auction/Components/ConditionsOfSaleCheckbox.tsx
@@ -1,6 +1,7 @@
 import { Box, Link, Sans, Serif } from "@artsy/palette"
 import Checkbox from "Components/Checkbox"
 import React from "react"
+import { data as sd } from "sharify"
 import styled from "styled-components"
 
 export const ConditionsOfSaleCheckbox = ({
@@ -19,7 +20,7 @@ export const ConditionsOfSaleCheckbox = ({
           <Serif display="inline" color="black100" size="3t">
             <Link
               color="black100"
-              href="https://www.artsy.net/conditions-of-sale"
+              href={`${sd.APP_URL}/conditions-of-sale`}
               target="_blank"
             >
               Conditions of Sale

--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -5,7 +5,7 @@ import { RegistrationFormCreateCreditCardMutation } from "__generated__/Registra
 import { ConditionsOfSaleCheckbox } from "Apps/Auction/Components/ConditionsOfSaleCheckbox"
 import { CreditCardInput } from "Apps/Order/Components/CreditCardInput"
 import { Form, Formik, FormikProps } from "formik"
-import React, { Component } from "react"
+import React from "react"
 import { commitMutation, graphql, RelayProp } from "react-relay"
 import {
   CardElement,
@@ -166,12 +166,12 @@ export interface RegistrationFormProps
   sale: AuctionApp_sale
 }
 
-class RegistrationForm extends Component<RegistrationFormProps> {
-  private createBidder(setSubmitting) {
-    const { sale } = this.props
+const RegistrationForm: React.FC<RegistrationFormProps> = props => {
+  function createBidder(setSubmitting) {
+    const { sale } = props
 
     commitMutation<RegistrationFormCreateBidderMutation>(
-      this.props.relay.environment,
+      props.relay.environment,
       {
         onCompleted: (data, errors) => {
           setSubmitting(false)
@@ -199,10 +199,10 @@ class RegistrationForm extends Component<RegistrationFormProps> {
     )
   }
 
-  private createCreditCard(token) {
+  function createCreditCard(token) {
     return new Promise(async (resolve, reject) => {
       commitMutation<RegistrationFormCreateCreditCardMutation>(
-        this.props.relay.environment,
+        props.relay.environment,
         {
           onCompleted: (data, errors) => {
             const {
@@ -252,45 +252,42 @@ class RegistrationForm extends Component<RegistrationFormProps> {
     })
   }
 
-  render() {
-    return (
-      <Formik
-        initialValues={{
-          name: "",
-          street1: "",
-          city: "",
-          credit_card: null,
-          state: "",
-          postal_code: "",
-          telephone: "",
-          agree_to_terms: false,
-        }}
-        onSubmit={(values: FormValues, { setFieldError, setSubmitting }) => {
-          const address = {
-            name: values.name,
-            address_line1: values.street1,
-            address_city: values.city,
-            address_state: values.state,
-            address_zip: values.postal_code,
-          }
+  return (
+    <Formik
+      initialValues={{
+        name: "",
+        street1: "",
+        city: "",
+        credit_card: null,
+        state: "",
+        postal_code: "",
+        telephone: "",
+        agree_to_terms: false,
+      }}
+      onSubmit={(values: FormValues, { setFieldError, setSubmitting }) => {
+        const address = {
+          name: values.name,
+          address_line1: values.street1,
+          address_city: values.city,
+          address_state: values.state,
+          address_zip: values.postal_code,
+        }
 
-          this.props.stripe.createToken(address).then(({ error, token }) => {
-            if (error) {
-              setFieldError("credit_card", error.message)
-              setSubmitting(false)
-            } else {
-              console.log(token)
-              this.createCreditCard(token.id).then(() => {
-                this.createBidder(setSubmitting)
-              })
-            }
-          })
-        }}
-        validationSchema={validationSchema}
-        render={InnerForm}
-      />
-    )
-  }
+        props.stripe.createToken(address).then(({ error, token }) => {
+          if (error) {
+            setFieldError("credit_card", error.message)
+            setSubmitting(false)
+          } else {
+            createCreditCard(token.id).then(() => {
+              createBidder(setSubmitting)
+            })
+          }
+        })
+      }}
+      validationSchema={validationSchema}
+      render={InnerForm}
+    />
+  )
 }
 
-export default injectStripe(RegistrationForm)
+export const WrappedRegistrationForm = injectStripe(RegistrationForm)

--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -1,0 +1,296 @@
+import { Box, Button, Flex, Input, Serif } from "@artsy/palette"
+import { AuctionApp_sale } from "__generated__/AuctionApp_sale.graphql"
+import { RegistrationFormCreateBidderMutation } from "__generated__/RegistrationFormCreateBidderMutation.graphql"
+import { RegistrationFormCreateCreditCardMutation } from "__generated__/RegistrationFormCreateCreditCardMutation.graphql"
+import { ConditionsOfSaleCheckbox } from "Apps/Auction/Components/ConditionsOfSaleCheckbox"
+import { CreditCardInput } from "Apps/Order/Components/CreditCardInput"
+import { Form, Formik, FormikProps } from "formik"
+import React, { Component } from "react"
+import { commitMutation, graphql, RelayProp } from "react-relay"
+import {
+  CardElement,
+  injectStripe,
+  ReactStripeElements,
+} from "react-stripe-elements"
+import { data as sd } from "sharify"
+import styled from "styled-components"
+import * as Yup from "yup"
+
+export const StyledCardElement = styled(CardElement)`
+  width: 100%;
+  padding: 9px 10px;
+`
+
+interface FormValues {
+  name: string
+  street1: string
+  city: string
+  state: string
+  credit_card: string
+  postal_code: string
+  telephone: string
+  agree_to_terms: boolean
+}
+
+const InnerForm = (props: FormikProps<FormValues>) => {
+  const {
+    touched,
+    errors,
+    handleBlur,
+    isSubmitting,
+    handleChange,
+    values,
+  } = props
+
+  return (
+    <Form>
+      <Box mt={4}>
+        <Serif weight="semibold" size="4t" mb={2}>
+          Card Information
+        </Serif>
+        <Box mb={2}>
+          <Input
+            onBlur={handleBlur}
+            onChange={handleChange}
+            error={touched.name && errors.name}
+            required
+            title="Name on card"
+            placeholder="Add full name"
+            name="name"
+          />
+        </Box>
+
+        <Box mb={2}>
+          <Serif size="3t" mb={0.5}>
+            Credit card number*
+          </Serif>
+          <CreditCardInput
+            error={{ message: errors.credit_card } as stripe.Error}
+          />
+        </Box>
+      </Box>
+      <Box mt={4}>
+        <Serif weight="semibold" size="4t">
+          Billing Address
+        </Serif>
+        <Box mt={2}>
+          <Input
+            onBlur={handleBlur}
+            onChange={handleChange}
+            error={touched.street1 && errors.street1}
+            required
+            title="Address"
+            name="street1"
+          />
+        </Box>
+        <Flex mt={2}>
+          <Flex flexBasis="50%" flexGrow="2" mr={1}>
+            <Input
+              onBlur={handleBlur}
+              onChange={handleChange}
+              error={touched.city && errors.city}
+              required
+              title="City"
+              name="city"
+            />
+          </Flex>
+          <Flex flexBasis="25%" flexGrow="1" mr={1}>
+            <Input
+              onBlur={handleBlur}
+              onChange={handleChange}
+              error={touched.state && errors.state}
+              required
+              title="State"
+              name="state"
+            />
+          </Flex>
+          <Flex flexBasis="25%" flexGrow="1">
+            <Input
+              onBlur={handleBlur}
+              onChange={handleChange}
+              error={touched.postal_code && errors.postal_code}
+              required
+              title="Postal code"
+              name="postal_code"
+            />
+          </Flex>
+        </Flex>
+        <Box mt={2}>
+          <Input
+            onBlur={handleBlur}
+            onChange={handleChange}
+            type="tel"
+            error={touched.telephone && errors.telephone}
+            required
+            title="Telephone"
+            name="telephone"
+          />
+        </Box>
+      </Box>
+
+      <Flex mt={4} mb={2} justifyContent="center">
+        <ConditionsOfSaleCheckbox
+          error={touched.agree_to_terms && errors.agree_to_terms}
+          checked={values.agree_to_terms}
+          value={values.agree_to_terms}
+          type="checkbox"
+          name="agree_to_terms"
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
+      </Flex>
+
+      <Button mt={1} size="large" width="100%" loading={isSubmitting}>
+        Register
+      </Button>
+    </Form>
+  )
+}
+
+const validationSchema = Yup.object().shape({
+  name: Yup.string().required("Name is required"),
+  street1: Yup.string().required("Address is required"),
+  city: Yup.string().required("City is required"),
+  state: Yup.string().required("State is required"),
+  postal_code: Yup.string().required("Postal code is required"),
+  telephone: Yup.string().required("Telephone is required"),
+  agree_to_terms: Yup.bool().oneOf(
+    [true],
+    "You must agree to the Conditions of Sale"
+  ),
+})
+
+export interface RegistrationFormProps
+  extends ReactStripeElements.InjectedStripeProps {
+  relay?: RelayProp
+  sale: AuctionApp_sale
+}
+
+class RegistrationForm extends Component<RegistrationFormProps> {
+  private createBidder(setSubmitting) {
+    const { sale } = this.props
+
+    commitMutation<RegistrationFormCreateBidderMutation>(
+      this.props.relay.environment,
+      {
+        onCompleted: (data, errors) => {
+          setSubmitting(false)
+
+          window.location.href = `${sd.APP_URL}/auction/${
+            sale.id
+          }/confirm-registration`
+        },
+        onError: error => {
+          setSubmitting(false)
+        },
+        mutation: graphql`
+          mutation RegistrationFormCreateBidderMutation(
+            $input: CreateBidderInput!
+          ) {
+            createBidder(input: $input) {
+              clientMutationId
+            }
+          }
+        `,
+        variables: {
+          input: { sale_id: sale.id },
+        },
+      }
+    )
+  }
+
+  private createCreditCard(token) {
+    return new Promise(async (resolve, reject) => {
+      commitMutation<RegistrationFormCreateCreditCardMutation>(
+        this.props.relay.environment,
+        {
+          onCompleted: (data, errors) => {
+            const {
+              createCreditCard: { creditCardOrError },
+            } = data
+
+            if (creditCardOrError.creditCardEdge) {
+              resolve()
+            } else {
+              if (errors) {
+                reject(errors)
+              } else {
+                reject(creditCardOrError.mutationError)
+              }
+            }
+          },
+          onError: reject,
+          mutation: graphql`
+            mutation RegistrationFormCreateCreditCardMutation(
+              $input: CreditCardInput!
+            ) {
+              createCreditCard(input: $input) {
+                creditCardOrError {
+                  ... on CreditCardMutationSuccess {
+                    creditCardEdge {
+                      node {
+                        last_digits
+                      }
+                    }
+                  }
+                  ... on CreditCardMutationFailure {
+                    mutationError {
+                      type
+                      message
+                      detail
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          variables: {
+            input: { token },
+          },
+        }
+      )
+    })
+  }
+
+  render() {
+    return (
+      <Formik
+        initialValues={{
+          name: "",
+          street1: "",
+          city: "",
+          credit_card: null,
+          state: "",
+          postal_code: "",
+          telephone: "",
+          agree_to_terms: false,
+        }}
+        onSubmit={(values: FormValues, { setFieldError, setSubmitting }) => {
+          const address = {
+            name: values.name,
+            address_line1: values.street1,
+            address_city: values.city,
+            address_state: values.state,
+            address_zip: values.postal_code,
+          }
+
+          this.props.stripe.createToken(address).then(({ error, token }) => {
+            if (error) {
+              setFieldError("credit_card", error.message)
+              setSubmitting(false)
+            } else {
+              console.log(token)
+              this.createCreditCard(token.id).then(() => {
+                this.createBidder(setSubmitting)
+              })
+            }
+          })
+        }}
+        validationSchema={validationSchema}
+        render={InnerForm}
+      />
+    )
+  }
+}
+
+export default injectStripe(RegistrationForm)

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -1,0 +1,17 @@
+import { RouteConfig } from "found"
+import { graphql } from "react-relay"
+import { AuctionAppFragmentContainer } from "./AuctionApp"
+
+export const routes: RouteConfig[] = [
+  {
+    path: "/auction-registration2/:saleID",
+    Component: AuctionAppFragmentContainer,
+    query: graphql`
+      query routes_AuctionQuery($saleID: String!) {
+        sale: sale(id: $saleID) {
+          ...AuctionApp_sale
+        }
+      }
+    `,
+  },
+]

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -1,11 +1,25 @@
 import { MockRouter } from "DevTools/MockRouter"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
+import { routes as auctionRoutes } from "../Auction/routes"
 import { routes as collectRoutes } from "../Collect/routes"
 import { routes as collectionsRoutes } from "../Collections/routes"
 import { routes as searchRoutes } from "../Search/routes"
 
 storiesOf("Apps", module)
+  .add("Auction Registration", () => {
+    return (
+      <MockRouter
+        routes={auctionRoutes}
+        initialRoute="/auction-registration2/yuki-contemporary-art-july-22th"
+        context={{
+          mediator: {
+            trigger: x => x,
+          },
+        }}
+      />
+    )
+  })
   .add("Collect", () => {
     return (
       <MockRouter

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -12,11 +12,6 @@ storiesOf("Apps", module)
       <MockRouter
         routes={auctionRoutes}
         initialRoute="/auction-registration2/yuki-contemporary-art-july-22th"
-        context={{
-          mediator: {
-            trigger: x => x,
-          },
-        }}
       />
     )
   })

--- a/src/__generated__/AuctionApp_sale.graphql.ts
+++ b/src/__generated__/AuctionApp_sale.graphql.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+declare const _AuctionApp_sale$ref: unique symbol;
+export type AuctionApp_sale$ref = typeof _AuctionApp_sale$ref;
+export type AuctionApp_sale = {
+    readonly id: string;
+    readonly " $refType": AuctionApp_sale$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "AuctionApp_sale",
+  "type": "Sale",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "__id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '6f562e78150096f19413809fae60ce24';
+export default node;

--- a/src/__generated__/RegistrationFormCreateBidderMutation.graphql.ts
+++ b/src/__generated__/RegistrationFormCreateBidderMutation.graphql.ts
@@ -1,0 +1,93 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type CreateBidderInput = {
+    readonly sale_id: string;
+    readonly clientMutationId?: string | null;
+};
+export type RegistrationFormCreateBidderMutationVariables = {
+    readonly input: CreateBidderInput;
+};
+export type RegistrationFormCreateBidderMutationResponse = {
+    readonly createBidder: ({
+        readonly clientMutationId: string | null;
+    }) | null;
+};
+export type RegistrationFormCreateBidderMutation = {
+    readonly response: RegistrationFormCreateBidderMutationResponse;
+    readonly variables: RegistrationFormCreateBidderMutationVariables;
+};
+
+
+
+/*
+mutation RegistrationFormCreateBidderMutation(
+  $input: CreateBidderInput!
+) {
+  createBidder(input: $input) {
+    clientMutationId
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "CreateBidderInput!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "createBidder",
+    "storageKey": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input",
+        "type": "CreateBidderInput!"
+      }
+    ],
+    "concreteType": "CreateBidderPayload",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "clientMutationId",
+        "args": null,
+        "storageKey": null
+      }
+    ]
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "mutation",
+  "name": "RegistrationFormCreateBidderMutation",
+  "id": null,
+  "text": "mutation RegistrationFormCreateBidderMutation(\n  $input: CreateBidderInput!\n) {\n  createBidder(input: $input) {\n    clientMutationId\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "RegistrationFormCreateBidderMutation",
+    "type": "Mutation",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": v1
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "RegistrationFormCreateBidderMutation",
+    "argumentDefinitions": v0,
+    "selections": v1
+  }
+};
+})();
+(node as any).hash = 'ca8e2c5becc12bd63c8d3bf7ae82be8f';
+export default node;

--- a/src/__generated__/RegistrationFormCreateCreditCardMutation.graphql.ts
+++ b/src/__generated__/RegistrationFormCreateCreditCardMutation.graphql.ts
@@ -1,0 +1,240 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type CreditCardInput = {
+    readonly token: string;
+    readonly oneTimeUse?: boolean | null;
+    readonly clientMutationId?: string | null;
+};
+export type RegistrationFormCreateCreditCardMutationVariables = {
+    readonly input: CreditCardInput;
+};
+export type RegistrationFormCreateCreditCardMutationResponse = {
+    readonly createCreditCard: ({
+        readonly creditCardOrError: ({
+            readonly creditCardEdge?: ({
+                readonly node: ({
+                    readonly last_digits: string;
+                }) | null;
+            }) | null;
+            readonly mutationError?: ({
+                readonly type: string | null;
+                readonly message: string | null;
+                readonly detail: string | null;
+            }) | null;
+        }) | null;
+    }) | null;
+};
+export type RegistrationFormCreateCreditCardMutation = {
+    readonly response: RegistrationFormCreateCreditCardMutationResponse;
+    readonly variables: RegistrationFormCreateCreditCardMutationVariables;
+};
+
+
+
+/*
+mutation RegistrationFormCreateCreditCardMutation(
+  $input: CreditCardInput!
+) {
+  createCreditCard(input: $input) {
+    creditCardOrError {
+      __typename
+      ... on CreditCardMutationSuccess {
+        creditCardEdge {
+          node {
+            last_digits
+            __id
+          }
+        }
+      }
+      ... on CreditCardMutationFailure {
+        mutationError {
+          type
+          message
+          detail
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "CreditCardInput!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input",
+    "type": "CreditCardInput!"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "type": "CreditCardMutationFailure",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "mutationError",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "type",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "message",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "detail",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+},
+v3 = {
+  "kind": "InlineFragment",
+  "type": "CreditCardMutationSuccess",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "creditCardEdge",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CreditCardEdge",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "node",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "CreditCard",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "last_digits",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "__id",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+return {
+  "kind": "Request",
+  "operationKind": "mutation",
+  "name": "RegistrationFormCreateCreditCardMutation",
+  "id": null,
+  "text": "mutation RegistrationFormCreateCreditCardMutation(\n  $input: CreditCardInput!\n) {\n  createCreditCard(input: $input) {\n    creditCardOrError {\n      __typename\n      ... on CreditCardMutationSuccess {\n        creditCardEdge {\n          node {\n            last_digits\n            __id\n          }\n        }\n      }\n      ... on CreditCardMutationFailure {\n        mutationError {\n          type\n          message\n          detail\n        }\n      }\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "RegistrationFormCreateCreditCardMutation",
+    "type": "Mutation",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "createCreditCard",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "CreditCardPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCardOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v2,
+              v3
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "RegistrationFormCreateCreditCardMutation",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "createCreditCard",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "CreditCardPayload",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCardOrError",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "__typename",
+                "args": null,
+                "storageKey": null
+              },
+              v2,
+              v3
+            ]
+          }
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '1d11f4deeda0507b13f1addd1a8bf10c';
+export default node;

--- a/src/__generated__/routes_AuctionQuery.graphql.ts
+++ b/src/__generated__/routes_AuctionQuery.graphql.ts
@@ -1,0 +1,122 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { AuctionApp_sale$ref } from "./AuctionApp_sale.graphql";
+export type routes_AuctionQueryVariables = {
+    readonly saleID: string;
+};
+export type routes_AuctionQueryResponse = {
+    readonly sale: ({
+        readonly " $fragmentRefs": AuctionApp_sale$ref;
+    }) | null;
+};
+export type routes_AuctionQuery = {
+    readonly response: routes_AuctionQueryResponse;
+    readonly variables: routes_AuctionQueryVariables;
+};
+
+
+
+/*
+query routes_AuctionQuery(
+  $saleID: String!
+) {
+  sale: sale(id: $saleID) {
+    ...AuctionApp_sale
+    __id
+  }
+}
+
+fragment AuctionApp_sale on Sale {
+  id
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "saleID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "saleID",
+    "type": "String!"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "routes_AuctionQuery",
+  "id": null,
+  "text": "query routes_AuctionQuery(\n  $saleID: String!\n) {\n  sale: sale(id: $saleID) {\n    ...AuctionApp_sale\n    __id\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  id\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_AuctionQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "sale",
+        "name": "sale",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Sale",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "AuctionApp_sale",
+            "args": null
+          },
+          v2
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_AuctionQuery",
+    "argumentDefinitions": v0,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "sale",
+        "name": "sale",
+        "storageKey": null,
+        "args": v1,
+        "concreteType": "Sale",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          v2
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = 'a5285cf4d4cb9a1749faf0271ffae9d0';
+export default node;


### PR DESCRIPTION
This implements one of our existing auction registration flows which
creates a payment method and registers the user to bid in the auction.

Zeplin spec :lock: :
https://app.zeplin.io/project/5c59f1624a2d813589f91e07/screen/5d123fbcd17e52705b13ae42
Jira ticket :lock: : https://artsyproduct.atlassian.net/browse/AUCT-462

Items to follow-up on:

- Show an error modal when a mutation against Metaphysics fails.
- Redirect routing if a user already has a payment method or if they're
  already registered to build
- Update Country select input to accept onBlur/onChange events and add
  to form
- Look into using `isCommittingMutation` helper instead of Formik's
  `isSubmitting` for loading indicator

Co-authored-by: @erikdstock 

![screenshot 1564007281](https://user-images.githubusercontent.com/123595/61832936-c94e4280-ae40-11e9-82fa-189c4dcd447c.png)
