### PR TITLE
[GROW-1314] handle modal width for medium screens

### DIFF
--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -8,6 +8,7 @@ import { CtaProps } from "./ModalCta"
 export enum ModalWidth {
   Narrow = "280px",
   Normal = "440px",
+  Medium = "780px",
   Wide = "900px",
 }
 
@@ -114,6 +115,16 @@ export class ModalWrapper extends React.Component<
     }
   }
 
+  getViewportWidth = () => {
+    let width: number
+    try {
+      width = window.innerWidth
+    } catch (e) {
+      width = 0
+    }
+    return width
+  }
+
   render(): JSX.Element {
     const { children, width, fullscreenResponsiveModal, image } = this.props
     const { isShown, isAnimating } = this.state
@@ -142,6 +153,7 @@ export class ModalWrapper extends React.Component<
               fullscreenResponsiveModal={fullscreenResponsiveModal}
               width={width}
               image={image}
+              viewportWidth={this.getViewportWidth()}
             >
               <ModalInner fullscreenResponsiveModal={fullscreenResponsiveModal}>
                 {children}
@@ -193,6 +205,7 @@ export const ModalContainer = styled.div.attrs<{
   width?: ModalWidth
   fullscreenResponsiveModal?: boolean
   image?: string
+  viewportWidth?: number
 }>({})`
   position: fixed;
   top: 50%;
@@ -201,7 +214,7 @@ export const ModalContainer = styled.div.attrs<{
   background: #fff;
   width: ${props => {
     if (props.image) {
-      return ModalWidth.Wide
+      return props.viewportWidth > 900 ? ModalWidth.Wide : ModalWidth.Medium
     } else {
       return props.width ? props.width : ModalWidth.Normal
     }


### PR DESCRIPTION
This is related to [GROW-1314](https://artsyproduct.atlassian.net/browse/GROW-1314). Based on the viewport width size for modals with images, we determine to render the modal ModalContainer at 900px for larger screens and 780px for medium size screens. 

Medium (< 900):
![Screen Shot 2019-07-12 at 3 54 29 PM](https://user-images.githubusercontent.com/5201004/61154890-6615f500-a4bd-11e9-8ea2-cfd7ae18edf8.png)


Large (> 900):
![Screen Shot 2019-07-12 at 3 55 52 PM](https://user-images.githubusercontent.com/5201004/61154944-92317600-a4bd-11e9-843c-56486b34f5ac.png)

