### PR TITLE
Update featured articles to only render a max of 2 ads

### DIFF
--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -231,6 +231,7 @@ export class Sections extends Component<Props, State> {
   renderSections() {
     const { article, isMobile, isSponsored, isSuper } = this.props
     const { shouldInjectMobileDisplay } = this.state
+    let quantityOfAdsRendered = 0
     let firstAdInjected = false
     let placementCount = 1
     let displayMarkerInjected = false
@@ -260,11 +261,14 @@ export class Sections extends Component<Props, State> {
         placementCount++
       }
 
-      if (placementCount % 6 === 0) {
+      if (placementCount % 6 === 0 && quantityOfAdsRendered < 2) {
+        // only render 2 ads on Features
         shouldInjectNewAds = true
       }
 
       if (shouldInjectNewAds) {
+        quantityOfAdsRendered++
+
         const adDimension = isMobile
           ? isSponsored
             ? AdDimension.Mobile_Sponsored_Feature_InContentLeaderboard1

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
@@ -196,7 +196,7 @@ describe("Sections", () => {
       const wrapper = mountWrapper(props)
 
       const ads = wrapper.find(DisplayAd)
-      expect(ads.length).toBe(8)
+      expect(ads.length).toBe(2)
 
       let ad = ads.at(0).props()
       expect(ad.adUnit).toBe("Desktop_Leaderboard1")
@@ -204,30 +204,6 @@ describe("Sections", () => {
 
       ad = ads.at(1).props()
       expect(ad.adUnit).toBe("Desktop_Leaderboard2")
-      expect(ad.adDimension).toBe("970x250")
-
-      ad = ads.at(2).props()
-      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
-      expect(ad.adDimension).toBe("970x250")
-
-      ad = ads.at(3).props()
-      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
-      expect(ad.adDimension).toBe("970x250")
-
-      ad = ads.at(4).props()
-      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
-      expect(ad.adDimension).toBe("970x250")
-
-      ad = ads.at(5).props()
-      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
-      expect(ad.adDimension).toBe("970x250")
-
-      ad = ads.at(6).props()
-      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
-      expect(ad.adDimension).toBe("970x250")
-
-      ad = ads.at(7).props()
-      expect(ad.adUnit).toBe("Desktop_LeaderboardRepeat")
       expect(ad.adDimension).toBe("970x250")
     })
 
@@ -237,7 +213,7 @@ describe("Sections", () => {
       const wrapper = mountWrapper(props)
 
       const ads = wrapper.find(DisplayAd)
-      expect(ads.length).toBe(8)
+      expect(ads.length).toBe(2)
 
       let ad = ads.at(0).props()
       expect(ad.adUnit).toBe("Mobile_InContentLB1")
@@ -245,30 +221,6 @@ describe("Sections", () => {
 
       ad = ads.at(1).props()
       expect(ad.adUnit).toBe("Mobile_InContentLB2")
-      expect(ad.adDimension).toBe("300x50")
-
-      ad = ads.at(2).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x50")
-
-      ad = ads.at(3).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x50")
-
-      ad = ads.at(4).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x50")
-
-      ad = ads.at(5).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x50")
-
-      ad = ads.at(6).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x50")
-
-      ad = ads.at(7).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
       expect(ad.adDimension).toBe("300x50")
     })
 
@@ -279,7 +231,7 @@ describe("Sections", () => {
       const wrapper = mountWrapper(props)
 
       const ads = wrapper.find(DisplayAd)
-      expect(ads.length).toBe(8)
+      expect(ads.length).toBe(2)
 
       let ad = ads.at(0).props()
       expect(ad.adUnit).toBe("Mobile_InContentLB1")
@@ -287,30 +239,6 @@ describe("Sections", () => {
 
       ad = ads.at(1).props()
       expect(ad.adUnit).toBe("Mobile_InContentLB2")
-      expect(ad.adDimension).toBe("300x250")
-
-      ad = ads.at(2).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x250")
-
-      ad = ads.at(3).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x250")
-
-      ad = ads.at(4).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x250")
-
-      ad = ads.at(5).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x250")
-
-      ad = ads.at(6).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
-      expect(ad.adDimension).toBe("300x250")
-
-      ad = ads.at(7).props()
-      expect(ad.adUnit).toBe("Mobile_InContentLBRepeat")
       expect(ad.adDimension).toBe("300x250")
     })
   })


### PR DESCRIPTION
This PR addresses:

Per this Slack discussion: https://artsy.slack.com/archives/GK7Q3BZ6K/p1563203452000700

Design and Content Marketing have updated the ad server requirements such that Featured articles are now expected to render a maximum of 2 ads per article.

[Links to GROW-1401](https://artsyproduct.atlassian.net/browse/GROW-1401}