### PR TITLE
grow-1391 Collections carousel tweaks QA for artist series and related collections

### DIFF
--- a/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -1,4 +1,4 @@
-import { Box, Sans, space, Spacer } from "@artsy/palette"
+import { Box, Sans, Spacer } from "@artsy/palette"
 import { ArtistCollectionsRail_collections } from "__generated__/ArtistCollectionsRail_collections.graphql"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
@@ -90,10 +90,10 @@ export class ArtistCollectionsRail extends React.Component<
 }
 
 const ArrowContainer = styled(Box)`
-  position: relative;
+  align-self: flex-start;
 
   ${ArrowButton} {
-    top: -${space(3)}px;
+    height: 60%;
   }
 `
 

--- a/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
@@ -1,13 +1,14 @@
-import { EntityHeader, Sans, Spacer } from "@artsy/palette"
+import { Box, EntityHeader, Sans, Spacer } from "@artsy/palette"
 import { RecommendedArtist_artist } from "__generated__/RecommendedArtist_artist.graphql"
 import { SystemContext } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import FillwidthItem from "Components/Artwork/FillwidthItem"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
-import { Carousel } from "Components/v2/Carousel"
+import { ArrowButton, Carousel } from "Components/v2/Carousel"
 import React, { FC, useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components"
 import { get } from "Utils/get"
 import { AuthModalIntent, openAuthModal } from "Utils/openAuthModal"
 
@@ -103,7 +104,6 @@ const RecommendedArtist: FC<
         data={artistData}
         render={artwork => {
           const aspect_ratio = get(artwork, a => a.node.image.aspect_ratio, 1)
-
           return (
             <FillwidthItem
               artwork={artwork.node}
@@ -118,10 +118,31 @@ const RecommendedArtist: FC<
             />
           )
         }}
+        renderLeftArrow={({ Arrow }) => {
+          return (
+            <ArrowContainer>
+              <Arrow />
+            </ArrowContainer>
+          )
+        }}
+        renderRightArrow={({ Arrow }) => {
+          return (
+            <ArrowContainer>
+              <Arrow />
+            </ArrowContainer>
+          )
+        }}
       />
     </>
   )
 }
+
+const ArrowContainer = styled(Box)`
+  align-self: flex-start;
+  ${ArrowButton} {
+    height: 60%;
+  }
+`
 
 export const RecommendedArtistFragmentContainer = createFragmentContainer(
   RecommendedArtistWithTracking,

--- a/src/Apps/Collect/CollectionApp.tsx
+++ b/src/Apps/Collect/CollectionApp.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@artsy/palette"
+import { Box, Separator } from "@artsy/palette"
 import { CollectionApp_collection } from "__generated__/CollectionApp_collection.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { track } from "Artsy/Analytics"
@@ -69,9 +69,11 @@ export class CollectionApp extends Component<CollectionAppProps> {
           <Box>
             <CollectionFilterContainer collection={collection} />
           </Box>
+          <Separator mt={6} mb={3} />
           <Box mt="3">
             <RelatedCollectionsRail
               collections={collection.relatedCollections}
+              title={collection.title}
             />
           </Box>
         </FrameWithRecentlyViewed>

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
@@ -1,4 +1,4 @@
-import { Box, Sans, space, Spacer } from "@artsy/palette"
+import { Box, Serif, Spacer } from "@artsy/palette"
 import { RelatedCollectionsRail_collections } from "__generated__/RelatedCollectionsRail_collections.graphql"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
@@ -14,6 +14,7 @@ import { RelatedCollectionEntityFragmentContainer as RelatedCollectionEntity } f
 
 interface RelatedCollectionsRailProps {
   collections: RelatedCollectionsRail_collections
+  title?: string
 }
 
 @track(null, {
@@ -44,14 +45,15 @@ export class RelatedCollectionsRail extends React.Component<
 
   render() {
     const { collections } = this.props
+    const { title } = this.props
     if (collections.length > 3) {
       return (
         <Box>
           <Waypoint onEnter={once(this.trackImpression.bind(this))} />
-          <Sans size="3" weight="medium">
-            Browse by iconic collections
-          </Sans>
-          <Spacer pb={1} />
+          <Serif size="8" color="black100">
+            Related to {title}
+          </Serif>
+          <Spacer pb={4} />
 
           <Carousel
             height="200px"
@@ -64,7 +66,7 @@ export class RelatedCollectionsRail extends React.Component<
               draggable: sd.IS_MOBILE ? true : false,
             }}
             onArrowClick={this.trackCarouselNav.bind(this)}
-            data={take(collections, 8)}
+            data={take(collections, 16)}
             render={slide => {
               return <RelatedCollectionEntity collection={slide} />
             }}
@@ -92,10 +94,10 @@ export class RelatedCollectionsRail extends React.Component<
 }
 
 const ArrowContainer = styled(Box)`
-  position: relative;
+  align-self: flex-start;
 
   ${ArrowButton} {
-    top: -${space(3)}px;
+    height: 60%;
   }
 `
 

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.test.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.test.tsx
@@ -19,6 +19,7 @@ describe("CollectionsRail", () => {
 
   beforeEach(() => {
     props = {
+      title: "Street Art",
       collections: CollectionsRailFixture,
     }
   })
@@ -29,7 +30,7 @@ describe("CollectionsRail", () => {
     ).renderUntil(n => {
       return n.html().search("is-selected") > 0
     })
-    expect(component.text()).toMatch("Browse by iconic collections")
+    expect(component.text()).toMatch("Related to Street Art")
     expect(component.find(RelatedCollectionEntity).length).toBe(8)
     expect(component.text()).toMatch("Flags")
     expect(component.text()).toMatch("From $1,000")


### PR DESCRIPTION
Address : [Grow-1391](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1391)

- L(<-) , R(->) arrow are centered.

- Related collections carousel shows 16 collections, not 8.

- correctly show the name of the collection page you’re on

- add a hairline to the bottom 


<img width="1253" alt="Screen Shot 2019-07-16 at 15 39 54" src="https://user-images.githubusercontent.com/45926410/61332800-2ddf2100-a7f3-11e9-8c6c-c8efd8bb17e4.png">
**************************************************************************************
<img width="1262" alt="Screen Shot 2019-07-16 at 15 40 48" src="https://user-images.githubusercontent.com/45926410/61332813-39324c80-a7f3-11e9-8938-723a9fcbb75c.png">
**************************************************************************************
<img width="992" alt="Screen Shot 2019-07-16 at 15 41 01" src="https://user-images.githubusercontent.com/45926410/61332855-56671b00-a7f3-11e9-88b7-304a6e6e8eea.png">

