### PR TITLE
Upgrade styled-components@4.3.2

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -204,7 +204,7 @@ type AnalyticsPartnerInquiryStats {
 # Sales stats of a partner
 type AnalyticsPartnerSalesStats {
   orderCount: Int!
-  orderResponseTime: Int!
+  orderResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
 
@@ -272,7 +272,7 @@ type AnalyticsPartnerStats {
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
 
-  # Artworks, shows, or artists ranked by views. Capped at 10 by the underlying sql query.
+  # Artworks, shows, or artists ranked by views. Capped at 20 by the underlying sql query.
   rankedStats(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -1376,6 +1376,7 @@ type Artwork implements Node & Searchable & Sellable {
   ): Partner
   pickup_available: Boolean
   price: String
+    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
   priceCents: PriceCents
     @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
@@ -1417,6 +1418,9 @@ type Artwork implements Node & Searchable & Sellable {
   signature(format: Format): String
   title: String
   to_s: String
+    @deprecated(
+      reason: "Unused field named using Ruby idiom. [Will be removed in v2]"
+    )
 
   # Whether this Artwork is Published of not
   published: Boolean!
@@ -1763,34 +1767,34 @@ type ArtworkContextPartnerShow implements Node {
   # A globally unique ID.
   __id: ID!
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A slug ID.
   id: ID!
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A type-specific ID likely used as a database ID.
   _id: ID!
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   cached: Int
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   artists: [Artist]
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # The artworks featured in the show
   artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
-    for_sale: Boolean
+    for_sale: Boolean = false
     published: Boolean = true
     all: Boolean
     page: Int = 1
@@ -1799,14 +1803,14 @@ type ArtworkContextPartnerShow implements Node {
     size: Int = 25
   ): [Artwork]
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A connection of artworks featured in the show
   artworksConnection(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
-    for_sale: Boolean
+    for_sale: Boolean = false
     published: Boolean = true
     after: String
     first: Int
@@ -1814,15 +1818,15 @@ type ArtworkContextPartnerShow implements Node {
     last: Int
   ): ArtworkConnection
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   counts: PartnerShowCounts
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   cover_image: Image
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   created_at(
     # This arg is deprecated, use timezone instead
@@ -1833,15 +1837,15 @@ type ArtworkContextPartnerShow implements Node {
     timezone: String
   ): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   description: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   displayable: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   end_at(
     # This arg is deprecated, use timezone instead
@@ -1852,25 +1856,25 @@ type ArtworkContextPartnerShow implements Node {
     timezone: String
   ): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   events: [PartnerShowEventType]
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A formatted description of the start to end dates
   exhibition_period: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   fair: Fair
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   href: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   images(
     # Number of images to return
@@ -1881,53 +1885,53 @@ type ArtworkContextPartnerShow implements Node {
     page: Int
   ): [Image]
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # Flag showing if show has any location.
   has_location: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
   is_active: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   is_displayable: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   is_fair_booth: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   kind: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   location: Location
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   meta_image: Image
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # The exhibition title
   name: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   partner: Partner
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   press_release(format: Format): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   start_at(
     # This arg is deprecated, use timezone instead
@@ -1938,11 +1942,11 @@ type ArtworkContextPartnerShow implements Node {
     timezone: String
   ): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   status: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A formatted update on upcoming status changes
@@ -1951,11 +1955,11 @@ type ArtworkContextPartnerShow implements Node {
     max_days: Int
   ): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   type: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 }
 
@@ -2396,6 +2400,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
   ): Partner
   pickup_available: Boolean
   price: String
+    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
   priceCents: PriceCents
     @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
@@ -2437,6 +2442,9 @@ type ArtworkItem implements Node & Searchable & Sellable {
   signature(format: Format): String
   title: String
   to_s: String
+    @deprecated(
+      reason: "Unused field named using Ruby idiom. [Will be removed in v2]"
+    )
 
   # Whether this Artwork is Published of not
   published: Boolean!
@@ -6347,7 +6355,7 @@ type HighlightedShow implements Node {
   artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
-    for_sale: Boolean
+    for_sale: Boolean = false
     published: Boolean = true
     all: Boolean
     page: Int = 1
@@ -6363,7 +6371,7 @@ type HighlightedShow implements Node {
   artworks_connection(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
-    for_sale: Boolean
+    for_sale: Boolean = false
     published: Boolean = true
     after: String
     first: Int
@@ -7369,10 +7377,9 @@ type MarketingCollectionCategory {
 }
 
 type MarketingCollectionGroup {
-  id: ID!
   groupType: MarketingGroupTypes!
   name: String!
-  members: [String!]!
+  members: [MarketingCollection!]!
 }
 
 type MarketingCollectionQuery {
@@ -7415,6 +7422,13 @@ enum MarketingGroupTypes {
   ArtistSeries
   FeaturedCollections
   OtherCollections
+}
+
+type MarketingImage {
+  id: ID!
+  small: String!
+  medium: String!
+  large: String!
 }
 
 type Me implements Node {
@@ -7563,7 +7577,7 @@ type Me implements Node {
     last: Int
   ): NotificationsFeedItemConnection
     @deprecated(
-      reason: "Prefer to use `followed_artists_artwork_groups`. [Will be removed in v2]"
+      reason: "Prefer to use `followsAndSaves`. [Will be removed in v2]"
     )
   paddle_number: String
   recentlyViewedArtworkIds: [String]!
@@ -9102,34 +9116,34 @@ type PartnerShow implements Node {
   # A globally unique ID.
   __id: ID!
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A slug ID.
   id: ID!
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A type-specific ID likely used as a database ID.
   _id: ID!
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   cached: Int
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   artists: [Artist]
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # The artworks featured in the show
   artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
-    for_sale: Boolean
+    for_sale: Boolean = false
     published: Boolean = true
     all: Boolean
     page: Int = 1
@@ -9138,14 +9152,14 @@ type PartnerShow implements Node {
     size: Int = 25
   ): [Artwork]
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A connection of artworks featured in the show
   artworksConnection(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
-    for_sale: Boolean
+    for_sale: Boolean = false
     published: Boolean = true
     after: String
     first: Int
@@ -9153,15 +9167,15 @@ type PartnerShow implements Node {
     last: Int
   ): ArtworkConnection
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   counts: PartnerShowCounts
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   cover_image: Image
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   created_at(
     # This arg is deprecated, use timezone instead
@@ -9172,15 +9186,15 @@ type PartnerShow implements Node {
     timezone: String
   ): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   description: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   displayable: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   end_at(
     # This arg is deprecated, use timezone instead
@@ -9191,25 +9205,25 @@ type PartnerShow implements Node {
     timezone: String
   ): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   events: [PartnerShowEventType]
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A formatted description of the start to end dates
   exhibition_period: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   fair: Fair
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   href: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   images(
     # Number of images to return
@@ -9220,53 +9234,53 @@ type PartnerShow implements Node {
     page: Int
   ): [Image]
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # Flag showing if show has any location.
   has_location: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
   is_active: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   is_displayable: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   is_fair_booth: Boolean
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   kind: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   location: Location
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   meta_image: Image
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # The exhibition title
   name: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   partner: Partner
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   press_release(format: Format): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   start_at(
     # This arg is deprecated, use timezone instead
@@ -9277,11 +9291,11 @@ type PartnerShow implements Node {
     timezone: String
   ): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   status: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 
   # A formatted update on upcoming status changes
@@ -9290,11 +9304,11 @@ type PartnerShow implements Node {
     max_days: Int
   ): String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
   type: String
     @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+      reason: "The `PartnerShow` type has been deprecated. Prefer to use the `Show` type instead. [Will be removed in v2]"
     )
 }
 
@@ -10717,6 +10731,7 @@ interface Sellable {
   is_for_sale: Boolean
   is_sold: Boolean
   price: String
+    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
   sale_message: String
 }
 
@@ -10919,7 +10934,7 @@ type Show implements Node {
   artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
-    for_sale: Boolean
+    for_sale: Boolean = false
     published: Boolean = true
     all: Boolean
     page: Int = 1
@@ -10935,7 +10950,7 @@ type Show implements Node {
   artworks_connection(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
-    for_sale: Boolean
+    for_sale: Boolean = false
     published: Boolean = true
     after: String
     first: Int

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "relay-compiler-language-typescript": "1.1.0",
     "simple-progress-webpack-plugin": "1.1.2",
     "static-extend": "0.1.2",
-    "styled-components": "4.0.3",
+    "styled-components": "4.3.2",
     "stylelint": "9.8.0",
     "stylelint-config-standard": "18.2.0",
     "stylelint-config-styled-components": "0.1.1",

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesTitle.test.tsx.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesTitle.test.tsx.snap
@@ -6,12 +6,12 @@ exports[`renders a series title properly 1`] = `
   text-align: center;
 }
 
-.c0 .PartnerBlock__ImageContainer-ydgi2-1 {
+.c0 .c2 {
   padding-top: 5px;
   padding-bottom: 40px;
 }
 
-.c0 .PartnerBlock__ImageContainer-ydgi2-1 img {
+.c0 .c2 img {
   margin-left: auto;
   margin-right: auto;
 }
@@ -25,7 +25,7 @@ exports[`renders a series title properly 1`] = `
 }
 
 @media (max-width:900px) {
-  .c0 .PartnerBlock__ImageContainer-ydgi2-1 {
+  .c0 .c2 {
     padding-bottom: 0;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,22 +1435,22 @@
   dependencies:
     "@emotion/memoize" "0.7.1"
 
-"@emotion/is-prop-valid@^0.6.8":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz#68ad02831da41213a2089d2cab4e8ac8b30cbd85"
-  integrity sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==
+"@emotion/is-prop-valid@^0.8.1":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.2.tgz#b9692080da79041683021fcc32f96b40c54c59dc"
+  integrity sha512-ZQIMAA2kLUWiUeMZNJDTeCwYRx1l8SQL0kHktze4COT22occKpDML1GDUXP5/sxhOMrZO8vZw773ni4H5Snrsg==
   dependencies:
-    "@emotion/memoize" "^0.6.6"
+    "@emotion/memoize" "0.7.2"
 
 "@emotion/memoize@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
   integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
 
-"@emotion/memoize@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
-  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
+"@emotion/memoize@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.2.tgz#7f4c71b7654068dfcccad29553520f984cc66b30"
+  integrity sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w==
 
 "@emotion/serialize@^0.11.4":
   version "0.11.4"
@@ -1506,6 +1506,11 @@
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
   integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
+
+"@emotion/unitless@^0.7.0":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
+  integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
 
 "@emotion/utils@0.11.1":
   version "0.11.1"
@@ -8663,6 +8668,11 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
+is-what@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.2.4.tgz#da528659017bdd4b07892dfe4fd60da6ac500e98"
+  integrity sha512-0awkPsfVd85bYStP99EqLxKvhc5SiE70hSZCPxJN2SYZ5d+IkX+r1Ri0qnPWPnuRVFrqrEnI3JgFN3yrGtjXaw==
+
 is-whitespace-character@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
@@ -10155,10 +10165,15 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^4.0.0, memoize-one@^4.0.3:
+memoize-one@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
   integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
+
+memoize-one@^5.0.0:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.5.tgz#8cd3809555723a07684afafcd6f756072ac75d7e"
+  integrity sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ==
 
 memoizerific@^1.11.3:
   version "1.11.3"
@@ -10194,6 +10209,13 @@ meow@^5.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
     yargs-parser "^10.0.0"
+
+merge-anything@^2.2.4:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.0.tgz#86959caf02bb8969d1ae5e1b652862bc5fe54e44"
+  integrity sha512-MhJcPOEcDUIbwU0LnEfx5S9s9dfQ/KPu4g2UA5T5G1LRKS0XmpDvJ9+UUfTkfhge+nA1gStE4tJAvx6lXLs+rg==
+  dependencies:
+    is-what "^3.2.4"
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -14429,15 +14451,19 @@ styled-bootstrap-grid@1.0.4:
   resolved "https://registry.yarnpkg.com/styled-bootstrap-grid/-/styled-bootstrap-grid-1.0.4.tgz#43417a43097ab00a8f644829f0d11ca226f16455"
   integrity sha512-4zky8nfXzxzJ9laPTd6kpdYgfdffzk+N5kTjeDCCvnIb4qfSjJ3QfWa9Qf+UdHMA0EPAl4fFjA6keLEq8M2yhA==
 
-styled-components@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.0.3.tgz#6c1a95a93857aa613fdfc26ad40899217100d8c3"
-  integrity sha512-oEZovK4xMGAMhOA9h74dCYJsp3IwUFhEvtYe4gwTy0cBZ3a17YMxBfM2oXsEoED9f+HCM5UQZW2h297n4u8hUw==
+styled-components@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.3.2.tgz#4ca81918c812d3006f60ac5fdec7d6b64a9509cc"
+  integrity sha512-NppHzIFavZ3TsIU3R1omtddJ0Bv1+j50AKh3ZWyXHuFvJq1I8qkQ5mZ7uQgD89Y8zJNx2qRo6RqAH1BmoVafHw==
   dependencies:
-    "@emotion/is-prop-valid" "^0.6.8"
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
+    "@emotion/unitless" "^0.7.0"
     babel-plugin-styled-components ">= 1"
     css-to-react-native "^2.2.2"
-    memoize-one "^4.0.0"
+    memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
     prop-types "^15.5.4"
     react-is "^16.6.0"
     stylis "^3.5.0"


### PR DESCRIPTION
Upgrades to latest, which fixes a false-positive warning thrown by earlier version of Styled Components: 

> It looks like you've wrapped styled() around your React component (Component), but the className prop is not being passed down to a child. No styles will be rendered unless className is composed within your React component.