### PR TITLE
@damassi => [ArtworkFilter] Remove unneeded call for medium aggregations

### DIFF
--- a/src/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -3,7 +3,7 @@ import React, { FC } from "react"
 import { useFilterContext } from "../ArtworkFilterContext"
 
 interface Props {
-  mediums: Array<{
+  mediums?: Array<{
     id: string
     name: string
   }>

--- a/src/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
@@ -9,7 +9,7 @@ import { TimePeriodFilter } from "./TimePeriodFilter"
 import { WaysToBuyFilter } from "./WaysToBuyFilter"
 
 interface ArtworkFilterProps {
-  mediums: Array<{
+  mediums?: Array<{
     id: string
     name: string
   }>

--- a/src/Components/v2/ArtworkFilter/index.tsx
+++ b/src/Components/v2/ArtworkFilter/index.tsx
@@ -153,10 +153,6 @@ const ArtworkFilter: React.FC<ArtworkFilterProps> = props => {
     })
   }
 
-  const filterMediums = viewer.filter_artworks.aggregations.find(
-    agg => agg.slice === "MEDIUM"
-  )
-
   const ArtworkGrid = () => {
     return (
       <ArtworkFilterArtworkGrid
@@ -176,7 +172,7 @@ const ArtworkFilter: React.FC<ArtworkFilterProps> = props => {
             <ArtworkFilterMobileActionSheet
               onClose={() => toggleMobileActionSheet(false)}
             >
-              <ArtworkFilters mediums={filterMediums as any} />
+              <ArtworkFilters />
             </ArtworkFilterMobileActionSheet>
           )}
 
@@ -205,7 +201,7 @@ const ArtworkFilter: React.FC<ArtworkFilterProps> = props => {
       <Media greaterThan="xs">
         <Flex>
           <Box width="25%" mr={2}>
-            <ArtworkFilters mediums={filterMediums as any} />
+            <ArtworkFilters />
             <Separator mb={2} />
           </Box>
           <Box width="75%">
@@ -225,11 +221,7 @@ const ArtworkFilterFragmentContainer = createRefetchContainer(
     viewer: graphql`
       fragment ArtworkFilter_viewer on Viewer
         @argumentDefinitions(
-          aggregations: {
-            type: "[ArtworkAggregation]"
-            defaultValue: [MEDIUM, TOTAL]
-          }
-
+          aggregations: { type: "[ArtworkAggregation]", defaultValue: [TOTAL] }
           acquireable: { type: "Boolean" }
           artist_id: { type: "String" }
           at_auction: { type: "Boolean" }
@@ -248,17 +240,8 @@ const ArtworkFilterFragmentContainer = createRefetchContainer(
           sort: { type: "String", defaultValue: "-partner_updated_at" }
           width: { type: "String" }
         ) {
-        filter_artworks(aggregations: $aggregations, size: 0) {
-          aggregations {
-            slice
-            counts {
-              name
-              id
-            }
-          }
-        }
         filtered_artworks: filter_artworks(
-          aggregations: [TOTAL]
+          aggregations: $aggregations
           medium: $medium
           major_periods: $major_periods
           partner_id: $partner_id

--- a/src/__generated__/ArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/ArtworkFilterQuery.graphql.ts
@@ -59,17 +59,6 @@ query ArtworkFilterQuery(
 }
 
 fragment ArtworkFilter_viewer_2cv3lY on Viewer {
-  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
-    aggregations {
-      slice
-      counts {
-        name
-        id
-        __id
-      }
-    }
-    __id
-  }
   filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $term, page: $page) {
     ...ArtworkFilterArtworkGrid2_filtered_artworks
     __id
@@ -352,49 +341,29 @@ var v0 = [
   }
 ],
 v1 = {
-  "kind": "Literal",
-  "name": "size",
-  "value": 0,
-  "type": "Int"
-},
-v2 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v2 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v7 = [
-  v5,
-  v6,
+v4 = [
+  v2,
+  v3,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -403,7 +372,7 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -411,21 +380,28 @@ v8 = [
     "type": "Boolean"
   }
 ],
-v9 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -437,7 +413,7 @@ return {
   "operationKind": "query",
   "name": "ArtworkFilterQuery",
   "id": null,
-  "text": "query ArtworkFilterQuery(\n  $acquireable: Boolean\n  $artist_id: String\n  $at_auction: Boolean\n  $attribution_class: [String]\n  $color: String\n  $for_sale: Boolean\n  $height: String\n  $inquireable_only: Boolean\n  $major_periods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partner_id: ID\n  $price_range: String\n  $sort: String\n  $term: String!\n  $width: String\n) {\n  viewer {\n    ...ArtworkFilter_viewer_2cv3lY\n  }\n}\n\nfragment ArtworkFilter_viewer_2cv3lY on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $term, page: $page) {\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __id\n      }\n    }\n    ...ArtworkGrid_artworks\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query ArtworkFilterQuery(\n  $acquireable: Boolean\n  $artist_id: String\n  $at_auction: Boolean\n  $attribution_class: [String]\n  $color: String\n  $for_sale: Boolean\n  $height: String\n  $inquireable_only: Boolean\n  $major_periods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partner_id: ID\n  $price_range: String\n  $sort: String\n  $term: String!\n  $width: String\n) {\n  viewer {\n    ...ArtworkFilter_viewer_2cv3lY\n  }\n}\n\nfragment ArtworkFilter_viewer_2cv3lY on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $term, page: $page) {\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n    __id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __id\n      }\n    }\n    ...ArtworkGrid_artworks\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -583,61 +559,6 @@ return {
         "selections": [
           {
             "kind": "LinkedField",
-            "alias": null,
-            "name": "filter_artworks",
-            "storageKey": "filter_artworks(aggregations:[\"MEDIUM\",\"TOTAL\"],size:0)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "aggregations",
-                "value": [
-                  "MEDIUM",
-                  "TOTAL"
-                ],
-                "type": "[ArtworkAggregation]"
-              },
-              v1
-            ],
-            "concreteType": "FilterArtworks",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "aggregations",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "slice",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "counts",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "plural": true,
-                    "selections": [
-                      v2,
-                      v3,
-                      v4
-                    ]
-                  }
-                ]
-              },
-              v4
-            ]
-          },
-          {
-            "kind": "LinkedField",
             "alias": "filtered_artworks",
             "name": "filter_artworks",
             "storageKey": null,
@@ -740,7 +661,12 @@ return {
                 "variableName": "price_range",
                 "type": "String"
               },
-              v1,
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 0,
+                "type": "Int"
+              },
               {
                 "kind": "Variable",
                 "name": "sort",
@@ -757,7 +683,7 @@ return {
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v4,
+              v1,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
@@ -822,7 +748,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": true,
-                        "selections": v7
+                        "selections": v4
                       },
                       {
                         "kind": "LinkedField",
@@ -832,7 +758,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v7
+                        "selections": v4
                       },
                       {
                         "kind": "LinkedField",
@@ -842,7 +768,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v7
+                        "selections": v4
                       },
                       {
                         "kind": "LinkedField",
@@ -853,8 +779,8 @@ return {
                         "concreteType": "PageCursor",
                         "plural": false,
                         "selections": [
-                          v5,
-                          v6
+                          v2,
+                          v3
                         ]
                       }
                     ]
@@ -882,17 +808,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v8,
+                            "args": v5,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v4,
-                              v9,
-                              v2
+                              v1,
+                              v6,
+                              v7
                             ]
                           },
-                          v4,
-                          v9,
+                          v1,
+                          v6,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -909,7 +835,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v10,
+                              v8,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -975,7 +901,13 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -988,13 +920,13 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v8,
+                            "args": v5,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v2,
-                              v9,
-                              v4,
+                              v7,
+                              v6,
+                              v1,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1027,7 +959,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v4,
+                              v1,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1094,8 +1026,8 @@ return {
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
                                 "selections": [
-                                  v11,
-                                  v10
+                                  v9,
+                                  v8
                                 ]
                               },
                               {
@@ -1107,10 +1039,10 @@ return {
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
                                 "selections": [
-                                  v11
+                                  v9
                                 ]
                               },
-                              v4
+                              v1
                             ]
                           },
                           {

--- a/src/__generated__/ArtworkFilter_viewer.graphql.ts
+++ b/src/__generated__/ArtworkFilter_viewer.graphql.ts
@@ -2,19 +2,9 @@
 
 import { ConcreteFragment } from "relay-runtime";
 import { ArtworkFilterArtworkGrid2_filtered_artworks$ref } from "./ArtworkFilterArtworkGrid2_filtered_artworks.graphql";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 declare const _ArtworkFilter_viewer$ref: unique symbol;
 export type ArtworkFilter_viewer$ref = typeof _ArtworkFilter_viewer$ref;
 export type ArtworkFilter_viewer = {
-    readonly filter_artworks: ({
-        readonly aggregations: ReadonlyArray<({
-            readonly slice: ArtworkAggregation | null;
-            readonly counts: ReadonlyArray<({
-                readonly name: string | null;
-                readonly id: string;
-            }) | null> | null;
-        }) | null> | null;
-    }) | null;
     readonly filtered_artworks: ({
         readonly " $fragmentRefs": ArtworkFilterArtworkGrid2_filtered_artworks$ref;
     }) | null;
@@ -23,21 +13,7 @@ export type ArtworkFilter_viewer = {
 
 
 
-const node: ConcreteFragment = (function(){
-var v0 = {
-  "kind": "Literal",
-  "name": "size",
-  "value": 0,
-  "type": "Int"
-},
-v1 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-};
-return {
+const node: ConcreteFragment = {
   "kind": "Fragment",
   "name": "ArtworkFilter_viewer",
   "type": "Viewer",
@@ -48,7 +24,6 @@ return {
       "name": "aggregations",
       "type": "[ArtworkAggregation]",
       "defaultValue": [
-        "MEDIUM",
         "TOTAL"
       ]
     },
@@ -158,70 +133,6 @@ return {
   "selections": [
     {
       "kind": "LinkedField",
-      "alias": null,
-      "name": "filter_artworks",
-      "storageKey": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "aggregations",
-          "variableName": "aggregations",
-          "type": "[ArtworkAggregation]"
-        },
-        v0
-      ],
-      "concreteType": "FilterArtworks",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "aggregations",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "ArtworksAggregationResults",
-          "plural": true,
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "slice",
-              "args": null,
-              "storageKey": null
-            },
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "counts",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "AggregationCount",
-              "plural": true,
-              "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "name",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "id",
-                  "args": null,
-                  "storageKey": null
-                },
-                v1
-              ]
-            }
-          ]
-        },
-        v1
-      ]
-    },
-    {
-      "kind": "LinkedField",
       "alias": "filtered_artworks",
       "name": "filter_artworks",
       "storageKey": null,
@@ -233,11 +144,9 @@ return {
           "type": "Boolean"
         },
         {
-          "kind": "Literal",
+          "kind": "Variable",
           "name": "aggregations",
-          "value": [
-            "TOTAL"
-          ],
+          "variableName": "aggregations",
           "type": "[ArtworkAggregation]"
         },
         {
@@ -324,7 +233,12 @@ return {
           "variableName": "price_range",
           "type": "String"
         },
-        v0,
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 0,
+          "type": "Int"
+        },
         {
           "kind": "Variable",
           "name": "sort",
@@ -346,11 +260,16 @@ return {
           "name": "ArtworkFilterArtworkGrid2_filtered_artworks",
           "args": null
         },
-        v1
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "__id",
+          "args": null,
+          "storageKey": null
+        }
       ]
     }
   ]
 };
-})();
-(node as any).hash = '58c18a92fab06059404f33933ddc517b';
+(node as any).hash = '7e68fa0f5cb3b5e0085521c03b1d8293';
 export default node;


### PR DESCRIPTION
This removes an entire call, just to get the list of mediums available for the given query. The underlying component, since it hardcodes the valid total list of mediums, and can potentially display the shorter list: https://github.com/artsy/reaction/blob/db559d3f92f70f81a309bf3771c3d65ad3da22e6/src/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx#L15 , means that we can just drop this call entirely, in favor of simply displaying the fuller list.

I suppose, on mobile, the list of mediums might be slightly increased...but we save an expensive call!