### PR TITLE
Fix Modal with image on smaller(xs) screens

### DIFF
--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -101,6 +101,8 @@ export const ModalContent = styled.div.attrs<{
   width: ${props => (props.hasImage ? "50%" : "100%")};
   ${props => props.hasImage && "margin-left: 50%"};
   ${media.sm`
+    width: 100%;
+    margin: 0px;
     padding: ${props =>
       props.cta && props.cta.isFixed ? "20px 20px 110px" : "20px"};
   `};


### PR DESCRIPTION
Fixes some UI issue with the Modal component with image when rendered on a smaller screen. It should take the full with but only renders on half.

## Before
![Screen Shot 2019-07-23 at 5 55 30 PM](https://user-images.githubusercontent.com/296775/61750382-401d0a00-ad73-11e9-9a34-997dc47ade39.png)

## After
![Screen Shot 2019-07-23 at 5 55 41 PM](https://user-images.githubusercontent.com/296775/61750384-401d0a00-ad73-11e9-84e4-99bf326b83ff.png)
