### PR TITLE
Auct-463 auction registration modal

### DIFF
--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -2,8 +2,8 @@ import { Box, Button, Flex, Input, Serif } from "@artsy/palette"
 import { AuctionApp_sale } from "__generated__/AuctionApp_sale.graphql"
 import { RegistrationFormCreateBidderMutation } from "__generated__/RegistrationFormCreateBidderMutation.graphql"
 import { RegistrationFormCreateCreditCardMutation } from "__generated__/RegistrationFormCreateCreditCardMutation.graphql"
-import { ConditionsOfSaleCheckbox } from "Apps/Auction/Components/ConditionsOfSaleCheckbox"
 import { CreditCardInput } from "Apps/Order/Components/CreditCardInput"
+import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
 import { Form, Formik, FormikProps } from "formik"
 import React from "react"
 import { commitMutation, graphql, RelayProp } from "react-relay"
@@ -131,9 +131,9 @@ const InnerForm = (props: FormikProps<FormValues>) => {
       <Flex mt={4} mb={2} justifyContent="center">
         <ConditionsOfSaleCheckbox
           error={touched.agree_to_terms && errors.agree_to_terms}
-          checked={values.agree_to_terms}
+          // checked={values.agree_to_terms}
           value={values.agree_to_terms}
-          type="checkbox"
+          // type="checkbox"
           name="agree_to_terms"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -170,6 +170,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = props => {
   function createBidder(setSubmitting) {
     const { sale } = props
 
+    // TODO: use mutation in 'Components/Auction/Registration' for this (should be a near copy)
     commitMutation<RegistrationFormCreateBidderMutation>(
       props.relay.environment,
       {

--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -131,9 +131,7 @@ const InnerForm = (props: FormikProps<FormValues>) => {
       <Flex mt={4} mb={2} justifyContent="center">
         <ConditionsOfSaleCheckbox
           error={touched.agree_to_terms && errors.agree_to_terms}
-          // checked={values.agree_to_terms}
           value={values.agree_to_terms}
-          // type="checkbox"
           name="agree_to_terms"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -170,7 +168,6 @@ const RegistrationForm: React.FC<RegistrationFormProps> = props => {
   function createBidder(setSubmitting) {
     const { sale } = props
 
-    // TODO: use mutation in 'Components/Auction/Registration' for this (should be a near copy)
     commitMutation<RegistrationFormCreateBidderMutation>(
       props.relay.environment,
       {

--- a/src/Apps/__stories__/Apps.story.tsx
+++ b/src/Apps/__stories__/Apps.story.tsx
@@ -11,7 +11,7 @@ storiesOf("Apps", module)
     return (
       <MockRouter
         routes={auctionRoutes}
-        initialRoute="/auction-registration2/yuki-contemporary-art-july-22th"
+        initialRoute="/auction-registration2/weekly-mocktion"
       />
     )
   })

--- a/src/Components/Auction/AuctionRegistrationModal.tsx
+++ b/src/Components/Auction/AuctionRegistrationModal.tsx
@@ -1,11 +1,8 @@
 import React, { useState } from "react"
 
 import { Box, Button, Flex, Serif } from "@artsy/palette"
+import { Modal } from "@artsy/palette"
 import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
-import { Modal } from "Components/Modal/Modal"
-/** TODO: Swap for palette's modal
- * import { Modal } from "@artsy/palette"
-//  */
 
 // For convenience even though sale is for now a single value
 interface Sale {

--- a/src/Components/Auction/AuctionRegistrationModal.tsx
+++ b/src/Components/Auction/AuctionRegistrationModal.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react"
+
+import { Box, Button, Flex, Serif } from "@artsy/palette"
+import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
+import { Modal } from "Components/Modal/Modal"
+/** TODO: Swap for palette's modal
+ * import { Modal } from "@artsy/palette"
+//  */
+
+// For convenience even though sale is for now a single value
+interface Sale {
+  name: string
+}
+
+export type SubmitRegistrationHandler = (opts: {
+  setSubmitting: (isSubmitting: boolean) => void
+  setError: (message: string) => void
+  auction: Sale
+  acceptedTerms: boolean
+}) => void
+
+interface Props {
+  /** The auction attributes */
+  auction: Sale
+  /** Any cleanup that needs to happen when the modal closes */
+  onClose: () => void
+  /** Handle a successful submission (commence registration) */
+  onSubmit: SubmitRegistrationHandler
+}
+
+export const AuctionRegistrationModal: React.FC<Props> = ({
+  auction,
+  onClose,
+  onSubmit,
+}) => {
+  const [show, setShow] = useState(true)
+  const [acceptedConditions, setAcceptedConditions] = useState(false)
+  const [error, setError] = useState<string>("")
+  const [submitting, setSubmitting] = useState(false)
+
+  function closeModal() {
+    setShow(false)
+    onClose()
+  }
+
+  function validate() {
+    if (acceptedConditions) {
+      setError("")
+      return true
+    } else {
+      setError("You must agree to our terms.")
+      return false
+    }
+  }
+
+  function handleSubmit(acceptedTerms: boolean) {
+    setSubmitting(true)
+    onSubmit({ setSubmitting, setError, auction, acceptedTerms })
+  }
+
+  function validateAndSubmit() {
+    if (validate()) {
+      handleSubmit(true)
+    }
+  }
+
+  return (
+    <Modal show={show} onClose={closeModal}>
+      <Box pt={[3, 0]} textAlign="center">
+        <Serif size="6">Register for {auction.name}</Serif>
+        <Serif my={3} size="4">
+          Welcome back. To complete your registration, please confirm that you
+          agree to the Conditions of Sale.
+        </Serif>
+        <Flex my={4} justifyContent="center">
+          <ConditionsOfSaleCheckbox
+            name="accept_cos"
+            value={acceptedConditions}
+            onChange={e => {
+              setAcceptedConditions(e.target.checked)
+            }}
+            onBlur={() => null}
+            error={error}
+          />
+        </Flex>
+        <Button
+          block
+          loading={submitting}
+          width="100%"
+          onClick={validateAndSubmit}
+        >
+          Register
+        </Button>
+      </Box>
+    </Modal>
+  )
+}

--- a/src/Components/Auction/ConditionsOfSaleCheckbox.tsx
+++ b/src/Components/Auction/ConditionsOfSaleCheckbox.tsx
@@ -4,7 +4,15 @@ import React from "react"
 import { data as sd } from "sharify"
 import styled from "styled-components"
 
-export const ConditionsOfSaleCheckbox = ({
+interface Props {
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  name: string
+  error?: string
+  onBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  value: boolean
+}
+
+export const ConditionsOfSaleCheckbox: React.FC<Props> = ({
   error,
   name,
   onChange,

--- a/src/Components/Auction/__stories__/AuctionRegistrationModal.story.tsx
+++ b/src/Components/Auction/__stories__/AuctionRegistrationModal.story.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { AuctionRegistrationModal } from "../AuctionRegistrationModal"
+
+const submitHandler = p => {
+  setTimeout(() => {
+    p.setSubmitting(false)
+    alert("Your Submission Callback Here")
+  }, 1000)
+}
+storiesOf("Components/Auction/AuctionRegistrationModal", module).add(
+  "Default",
+  () => {
+    return (
+      <>
+        <AuctionRegistrationModal
+          onSubmit={submitHandler}
+          onClose={() => null}
+          auction={{ name: "Big Time Sale" }}
+        />
+      </>
+    )
+  }
+)

--- a/src/Components/Auction/__stories__/AuctionRegistrationModal.story.tsx
+++ b/src/Components/Auction/__stories__/AuctionRegistrationModal.story.tsx
@@ -2,14 +2,14 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { AuctionRegistrationModal } from "../AuctionRegistrationModal"
 
-const submitHandler = p => {
+const submitHandler = submitUtils => {
   setTimeout(() => {
-    p.setSubmitting(false)
+    submitUtils.setSubmitting(false)
     alert("Your Submission Callback Here")
   }, 1000)
 }
-storiesOf("Components/Auction/AuctionRegistrationModal", module).add(
-  "Default",
+storiesOf("Components/AuctionRegistrationModal", module).add(
+  "AuctionRegistrationModal",
   () => {
     return (
       <>

--- a/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
+++ b/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
@@ -1,10 +1,10 @@
+import { Modal } from "@artsy/palette"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
-import renderer from "react-test-renderer"
 
 import { Button } from "@artsy/palette"
-import { CloseButton } from "Components/Modal/Modal"
+import { flushPromiseQueue } from "Utils/flushPromiseQueue"
 import { AuctionRegistrationModal } from "../AuctionRegistrationModal"
 
 const submitMock = jest.fn()
@@ -17,38 +17,37 @@ const defaultProps = {
 
 describe("AuctionRegistrationModal", () => {
   let wrapper
-  beforeEach(() => {
+  beforeEach(async () => {
     wrapper = mount(<AuctionRegistrationModal {...defaultProps} />)
     jest.restoreAllMocks()
+    // We need to await the promises to let this wrapper render
+    await flushPromiseQueue()
+    wrapper.update()
   })
 
-  xit("matches snapshot (TODO: Try to reenable with new palette modal)", () => {
-    const modal = renderer
-      .create(<AuctionRegistrationModal {...defaultProps} />)
-      .toJSON()
-    expect(modal).toMatchSnapshot()
+  it("renders a Modal with the sale name", async done => {
+    expect(wrapper.find(Modal).text()).toMatch("Register for Big Sale")
+    done()
   })
 
-  it("renders a Modal with the sale name", () => {
-    expect(wrapper.text()).toMatch("Register for Big Sale")
-  })
-
-  it("adds an error when trying to submit without accepting terms", () => {
+  it("adds an error when trying to submit without accepting terms", async () => {
     wrapper.find(Button).simulate("click")
+    await flushPromiseQueue()
     expect(wrapper.text()).toMatch("You must agree to our terms.")
   })
 
-  it("calls the onSubmit prop when trying to submit after accepting terms", () => {
+  it("calls the onSubmit prop when trying to submit after accepting terms", async () => {
     wrapper
       .find('input[type="checkbox"]')
       .simulate("change", { target: { checked: true } })
+    await flushPromiseQueue()
     wrapper.find(Button).simulate("click")
     expect(wrapper.text()).not.toMatch("You must agree to our terms.")
     expect(defaultProps.onSubmit).toHaveBeenCalled()
   })
 
-  it("calls the onClose prop when the modal closes", () => {
-    wrapper.find(CloseButton).simulate("click")
+  it("calls the onClose prop when the modal closes", async () => {
+    wrapper.find("CloseIcon").simulate("click")
     expect(defaultProps.onClose).toHaveBeenCalled()
   })
 })

--- a/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
+++ b/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
@@ -22,7 +22,7 @@ describe("AuctionRegistrationModal", () => {
     jest.restoreAllMocks()
   })
 
-  xit("matches snapshot", () => {
+  xit("matches snapshot (TODO: Try to reenable with new palette modal)", () => {
     const modal = renderer
       .create(<AuctionRegistrationModal {...defaultProps} />)
       .toJSON()

--- a/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
+++ b/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
@@ -1,0 +1,54 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import renderer from "react-test-renderer"
+
+import { Button } from "@artsy/palette"
+import { CloseButton } from "Components/Modal/Modal"
+import { AuctionRegistrationModal } from "../AuctionRegistrationModal"
+
+const submitMock = jest.fn()
+const closeMock = jest.fn()
+const defaultProps = {
+  onSubmit: submitMock,
+  onClose: closeMock,
+  auction: { name: "Big Sale", id: 1 },
+}
+
+describe("AuctionRegistrationModal", () => {
+  let wrapper
+  beforeEach(() => {
+    wrapper = mount(<AuctionRegistrationModal {...defaultProps} />)
+    jest.restoreAllMocks()
+  })
+
+  xit("matches snapshot", () => {
+    const modal = renderer
+      .create(<AuctionRegistrationModal {...defaultProps} />)
+      .toJSON()
+    expect(modal).toMatchSnapshot()
+  })
+
+  it("renders a Modal with the sale name", () => {
+    expect(wrapper.text()).toMatch("Register for Big Sale")
+  })
+
+  it("adds an error when trying to submit without accepting terms", () => {
+    wrapper.find(Button).simulate("click")
+    expect(wrapper.text()).toMatch("You must agree to our terms.")
+  })
+
+  it("calls the onSubmit prop when trying to submit after accepting terms", () => {
+    wrapper
+      .find('input[type="checkbox"]')
+      .simulate("change", { target: { checked: true } })
+    wrapper.find(Button).simulate("click")
+    expect(wrapper.text()).not.toMatch("You must agree to our terms.")
+    expect(defaultProps.onSubmit).toHaveBeenCalled()
+  })
+
+  it("calls the onClose prop when the modal closes", () => {
+    wrapper.find(CloseButton).simulate("click")
+    expect(defaultProps.onClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Related Force PR: artsy/force#4346

This PR:
- copies some common registration logic from `Apps/Auction` to `/Components/Auction` (some bits of the app can source from this now)
- Creates a modal in reaction that can do bidder registration using the same mutation as the full registration form. *It uses the new artsy/palette Modal.*

![image](https://user-images.githubusercontent.com/9088720/62250813-f1e3b880-b3bb-11e9-9343-24a22a303494.png)

There is a discrepancy with the Zeplin Spec's desktop modal width. This is not configurable in the Reaction Modal as far as I can tell but I will look into it when palette's modal is ready for testing.