### PR TITLE
@damassi => [SearchResults] Remove unneeded call for medium aggregations

### DIFF
--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/FilterContainer.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/FilterContainer.tsx
@@ -24,7 +24,7 @@ import { Media } from "Utils/Responsive"
 
 export interface FilterContainerProps {
   user?: any
-  mediums: Array<{ id: string; name: string }>
+  mediums?: Array<{ id: string; name: string }>
   timePeriods?: Array<{ name: string }>
   children?: (filters: FilterState) => JSX.Element
 }

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/MediumFilter.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/Filters/MediumFilter.tsx
@@ -4,7 +4,7 @@ import React from "react"
 
 interface Props {
   filters: FilterState
-  mediums: Array<{
+  mediums?: Array<{
     id: string
     name: string
   }>

--- a/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsFilterContainer.tsx
+++ b/src/Apps/Search/Routes/Artworks/Components/Filter/SearchResultsFilterContainer.tsx
@@ -15,19 +15,13 @@ export class SearchResultsFilterContainer extends Component<
   SearchFilterContainerProps
 > {
   render() {
-    const { viewer, term } = this.props
-    const { filter_artworks } = viewer
-    const { aggregations } = filter_artworks
-    const mediumAggregation = aggregations.find(agg => agg.slice === "MEDIUM")
+    const { term } = this.props
 
     return (
       <SystemContextConsumer>
         {({ user }) => {
           return (
-            <FilterContainer
-              user={user}
-              mediums={mediumAggregation.counts as any}
-            >
+            <FilterContainer user={user}>
               {(filters: FilterState) => (
                 <SearchResultsRefetchContainer
                   viewer={this.props.viewer}
@@ -57,10 +51,7 @@ export const SearchResultsFilterFragmentContainer = createFragmentContainer(
           acquireable: { type: "Boolean" }
           offerable: { type: "Boolean" }
           inquireable_only: { type: "Boolean" }
-          aggregations: {
-            type: "[ArtworkAggregation]"
-            defaultValue: [MEDIUM, TOTAL]
-          }
+          aggregations: { type: "[ArtworkAggregation]", defaultValue: [TOTAL] }
           sort: { type: "String", defaultValue: "-partner_updated_at" }
           price_range: { type: "String" }
           height: { type: "String" }
@@ -71,15 +62,6 @@ export const SearchResultsFilterFragmentContainer = createFragmentContainer(
           keyword: { type: "String!", defaultValue: "" }
           page: { type: "Int" }
         ) {
-        filter_artworks(aggregations: $aggregations, size: 0) {
-          aggregations {
-            slice
-            counts {
-              name
-              id
-            }
-          }
-        }
         ...SearchResultsRefetch_viewer
           @arguments(
             medium: $medium

--- a/src/Apps/Search/Routes/Artworks/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/Artworks/SearchResultsArtworks.tsx
@@ -40,10 +40,7 @@ export const SearchResultsArtworksRouteFragmentContainer = createFragmentContain
           acquireable: { type: "Boolean" }
           offerable: { type: "Boolean" }
           inquireable_only: { type: "Boolean" }
-          aggregations: {
-            type: "[ArtworkAggregation]"
-            defaultValue: [MEDIUM, TOTAL]
-          }
+          aggregations: { type: "[ArtworkAggregation]", defaultValue: [TOTAL] }
           sort: { type: "String", defaultValue: "-partner_updated_at" }
           price_range: { type: "String" }
           height: { type: "String" }

--- a/src/__generated__/SearchResultsArtworks_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArtworks_viewer.graphql.ts
@@ -76,7 +76,6 @@ const node: ConcreteFragment = {
       "name": "aggregations",
       "type": "[ArtworkAggregation]",
       "defaultValue": [
-        "MEDIUM",
         "TOTAL"
       ]
     },
@@ -240,5 +239,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '229cc64fab743e3ec642a06ea70b40cd';
+(node as any).hash = '22920c5a7f9e5d9c5f1fa28ccd08cad2';
 export default node;

--- a/src/__generated__/SearchResultsFilterContainer_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsFilterContainer_viewer.graphql.ts
@@ -2,34 +2,16 @@
 
 import { ConcreteFragment } from "relay-runtime";
 import { SearchResultsRefetch_viewer$ref } from "./SearchResultsRefetch_viewer.graphql";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 declare const _SearchResultsFilterContainer_viewer$ref: unique symbol;
 export type SearchResultsFilterContainer_viewer$ref = typeof _SearchResultsFilterContainer_viewer$ref;
 export type SearchResultsFilterContainer_viewer = {
-    readonly filter_artworks: ({
-        readonly aggregations: ReadonlyArray<({
-            readonly slice: ArtworkAggregation | null;
-            readonly counts: ReadonlyArray<({
-                readonly name: string | null;
-                readonly id: string;
-            }) | null> | null;
-        }) | null> | null;
-    }) | null;
     readonly " $fragmentRefs": SearchResultsRefetch_viewer$ref;
     readonly " $refType": SearchResultsFilterContainer_viewer$ref;
 };
 
 
 
-const node: ConcreteFragment = (function(){
-var v0 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-};
-return {
+const node: ConcreteFragment = {
   "kind": "Fragment",
   "name": "SearchResultsFilterContainer_viewer",
   "type": "Viewer",
@@ -88,7 +70,6 @@ return {
       "name": "aggregations",
       "type": "[ArtworkAggregation]",
       "defaultValue": [
-        "MEDIUM",
         "TOTAL"
       ]
     },
@@ -148,75 +129,6 @@ return {
     }
   ],
   "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "filter_artworks",
-      "storageKey": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "aggregations",
-          "variableName": "aggregations",
-          "type": "[ArtworkAggregation]"
-        },
-        {
-          "kind": "Literal",
-          "name": "size",
-          "value": 0,
-          "type": "Int"
-        }
-      ],
-      "concreteType": "FilterArtworks",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "aggregations",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "ArtworksAggregationResults",
-          "plural": true,
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "slice",
-              "args": null,
-              "storageKey": null
-            },
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "counts",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "AggregationCount",
-              "plural": true,
-              "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "name",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "id",
-                  "args": null,
-                  "storageKey": null
-                },
-                v0
-              ]
-            }
-          ]
-        },
-        v0
-      ]
-    },
     {
       "kind": "FragmentSpread",
       "name": "SearchResultsRefetch_viewer",
@@ -327,6 +239,5 @@ return {
     }
   ]
 };
-})();
-(node as any).hash = '10c3756d2b9d072fb78f6bbf1a733644';
+(node as any).hash = '3eaead19601726ca8f3897511110f3ba';
 export default node;

--- a/src/__generated__/routes_SearchResultsArtworksQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArtworksQuery.graphql.ts
@@ -63,17 +63,6 @@ fragment SearchResultsArtworks_viewer_2cv3lY on Viewer {
 }
 
 fragment SearchResultsFilterContainer_viewer_2cv3lY on Viewer {
-  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
-    aggregations {
-      slice
-      counts {
-        name
-        id
-        __id
-      }
-    }
-    __id
-  }
   ...SearchResultsRefetch_viewer_2cv3lY
 }
 
@@ -360,49 +349,29 @@ var v0 = [
   }
 ],
 v1 = {
-  "kind": "Literal",
-  "name": "size",
-  "value": 0,
-  "type": "Int"
-},
-v2 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v2 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v7 = [
-  v5,
-  v6,
+v4 = [
+  v2,
+  v3,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -411,7 +380,7 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -419,21 +388,28 @@ v8 = [
     "type": "Boolean"
   }
 ],
-v9 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -445,7 +421,7 @@ return {
   "operationKind": "query",
   "name": "routes_SearchResultsArtworksQuery",
   "id": null,
-  "text": "query routes_SearchResultsArtworksQuery(\n  $term: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $artist_id: String\n  $attribution_class: [String]\n  $color: String\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtworks_viewer_2cv3lY\n  }\n}\n\nfragment SearchResultsArtworks_viewer_2cv3lY on Viewer {\n  ...SearchResultsFilterContainer_viewer_2cv3lY\n}\n\nfragment SearchResultsFilterContainer_viewer_2cv3lY on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...SearchResultsRefetch_viewer_2cv3lY\n}\n\nfragment SearchResultsRefetch_viewer_2cv3lY on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $term, page: $page) {\n    ...SearchResultsArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment SearchResultsArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_SearchResultsArtworksQuery(\n  $term: String!\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $artist_id: String\n  $attribution_class: [String]\n  $color: String\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtworks_viewer_2cv3lY\n  }\n}\n\nfragment SearchResultsArtworks_viewer_2cv3lY on Viewer {\n  ...SearchResultsFilterContainer_viewer_2cv3lY\n}\n\nfragment SearchResultsFilterContainer_viewer_2cv3lY on Viewer {\n  ...SearchResultsRefetch_viewer_2cv3lY\n}\n\nfragment SearchResultsRefetch_viewer_2cv3lY on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, keyword: $term, page: $page) {\n    ...SearchResultsArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment SearchResultsArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -591,61 +567,6 @@ return {
         "selections": [
           {
             "kind": "LinkedField",
-            "alias": null,
-            "name": "filter_artworks",
-            "storageKey": "filter_artworks(aggregations:[\"MEDIUM\",\"TOTAL\"],size:0)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "aggregations",
-                "value": [
-                  "MEDIUM",
-                  "TOTAL"
-                ],
-                "type": "[ArtworkAggregation]"
-              },
-              v1
-            ],
-            "concreteType": "FilterArtworks",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "aggregations",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "slice",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "counts",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "plural": true,
-                    "selections": [
-                      v2,
-                      v3,
-                      v4
-                    ]
-                  }
-                ]
-              },
-              v4
-            ]
-          },
-          {
-            "kind": "LinkedField",
             "alias": "filtered_artworks",
             "name": "filter_artworks",
             "storageKey": null,
@@ -748,7 +669,12 @@ return {
                 "variableName": "price_range",
                 "type": "String"
               },
-              v1,
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 0,
+                "type": "Int"
+              },
               {
                 "kind": "Variable",
                 "name": "sort",
@@ -765,7 +691,7 @@ return {
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v4,
+              v1,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
@@ -830,7 +756,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": true,
-                        "selections": v7
+                        "selections": v4
                       },
                       {
                         "kind": "LinkedField",
@@ -840,7 +766,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v7
+                        "selections": v4
                       },
                       {
                         "kind": "LinkedField",
@@ -850,7 +776,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v7
+                        "selections": v4
                       },
                       {
                         "kind": "LinkedField",
@@ -861,8 +787,8 @@ return {
                         "concreteType": "PageCursor",
                         "plural": false,
                         "selections": [
-                          v5,
-                          v6
+                          v2,
+                          v3
                         ]
                       }
                     ]
@@ -890,17 +816,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v8,
+                            "args": v5,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v4,
-                              v9,
-                              v2
+                              v1,
+                              v6,
+                              v7
                             ]
                           },
-                          v4,
-                          v9,
+                          v1,
+                          v6,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -917,7 +843,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v10,
+                              v8,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -983,7 +909,13 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -996,13 +928,13 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v8,
+                            "args": v5,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v2,
-                              v9,
-                              v4,
+                              v7,
+                              v6,
+                              v1,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1035,7 +967,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v4,
+                              v1,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1102,8 +1034,8 @@ return {
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
                                 "selections": [
-                                  v11,
-                                  v10
+                                  v9,
+                                  v8
                                 ]
                               },
                               {
@@ -1115,10 +1047,10 @@ return {
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
                                 "selections": [
-                                  v11
+                                  v9
                                 ]
                               },
-                              v4
+                              v1
                             ]
                           },
                           {


### PR DESCRIPTION
This repeats https://github.com/artsy/reaction/pull/2626 , but in the search results page filter component.

The only thing this wholly extra call was doing, was providing a potentially smaller truncated list of mediums. Since this is...pretty minor (plus we have nice 'zero states'), let's just remove it.

The search results filter now just makes 1 request to the filter endpoint, for any operation (pagination, filtering, initial render).

