### PR TITLE
@yuki24 => [Collect] Remove unneeded medium aggregation call

### DIFF
--- a/src/Apps/Collect/CollectApp.tsx
+++ b/src/Apps/Collect/CollectApp.tsx
@@ -94,10 +94,7 @@ export const CollectAppFragmentContainer = createFragmentContainer(CollectApp, {
         acquireable: { type: "Boolean" }
         offerable: { type: "Boolean" }
         inquireable_only: { type: "Boolean" }
-        aggregations: {
-          type: "[ArtworkAggregation]"
-          defaultValue: [MEDIUM, TOTAL]
-        }
+        aggregations: { type: "[ArtworkAggregation]", defaultValue: [TOTAL] }
         sort: { type: "String", defaultValue: "-partner_updated_at" }
         price_range: { type: "String" }
         height: { type: "String" }
@@ -108,7 +105,7 @@ export const CollectAppFragmentContainer = createFragmentContainer(CollectApp, {
         page: { type: "Int" }
         dimension_range: { type: "String" }
       ) {
-      filter_artworks(aggregations: $aggregations, size: 0) {
+      filter_artworks(aggregations: $aggregations, sort: $sort) {
         ...SeoProductsForArtworks_artworks
       }
 

--- a/src/Apps/Collect/Components/Base/CollectFilterContainer.tsx
+++ b/src/Apps/Collect/Components/Base/CollectFilterContainer.tsx
@@ -14,18 +14,11 @@ export class CollectFilterContainer extends Component<
   CollectFilterContainerProps
 > {
   render() {
-    const { filter_artworks } = this.props.viewer
-    const { aggregations } = filter_artworks
-    const mediumAggregation = aggregations.find(agg => agg.slice === "MEDIUM")
-
     return (
       <SystemContextConsumer>
         {({ user }) => {
           return (
-            <FilterContainer
-              user={user}
-              mediums={mediumAggregation.counts as any}
-            >
+            <FilterContainer user={user}>
               {(filters: FilterState) => (
                 <CollectRefetchContainer
                   viewer={this.props.viewer}
@@ -54,10 +47,7 @@ export const CollectFilterFragmentContainer = createFragmentContainer(
           acquireable: { type: "Boolean" }
           offerable: { type: "Boolean" }
           inquireable_only: { type: "Boolean" }
-          aggregations: {
-            type: "[ArtworkAggregation]"
-            defaultValue: [MEDIUM, TOTAL]
-          }
+          aggregations: { type: "[ArtworkAggregation]", defaultValue: [TOTAL] }
           sort: { type: "String", defaultValue: "-partner_updated_at" }
           price_range: { type: "String" }
           height: { type: "String" }
@@ -68,15 +58,6 @@ export const CollectFilterFragmentContainer = createFragmentContainer(
           page: { type: "Int" }
           dimension_range: { type: "String" }
         ) {
-        filter_artworks(aggregations: $aggregations, size: 0) {
-          aggregations {
-            slice
-            counts {
-              name
-              id
-            }
-          }
-        }
         ...CollectRefetch_viewer
           @arguments(
             medium: $medium

--- a/src/Apps/Collect/Components/Filters/FilterContainer.tsx
+++ b/src/Apps/Collect/Components/Filters/FilterContainer.tsx
@@ -18,7 +18,7 @@ import { Media } from "Utils/Responsive"
 
 export interface FilterContainerProps {
   user?: any
-  mediums: Array<{ id: string; name: string }>
+  mediums?: Array<{ id: string; name: string }>
   timePeriods?: Array<{ name: string }>
   children?: (filters: FilterState) => JSX.Element
   sortType?: SortTypes

--- a/src/Apps/Collect/Components/Filters/MediumFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/MediumFilter.tsx
@@ -4,7 +4,7 @@ import { FilterState } from "../../FilterState"
 
 export const MediumFilter: React.SFC<{
   filters: FilterState
-  mediums: Array<{
+  mediums?: Array<{
     id: string
     name: string
   }>

--- a/src/Apps/Collect/Components/Seo/SeoProductsForArtworks.tsx
+++ b/src/Apps/Collect/Components/Seo/SeoProductsForArtworks.tsx
@@ -118,7 +118,7 @@ export const SeoProductsForArtworks = createFragmentContainer(SeoProducts, {
             price
             price_currency
             title
-            artists {
+            artists(shallow: true) {
               name
             }
             image {

--- a/src/__generated__/CollectAppTestQuery.graphql.ts
+++ b/src/__generated__/CollectAppTestQuery.graphql.ts
@@ -23,7 +23,7 @@ query CollectAppTestQuery {
 }
 
 fragment CollectApp_viewer on Viewer {
-  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
+  filter_artworks(aggregations: [TOTAL], sort: "-partner_updated_at") {
     ...SeoProductsForArtworks_artworks
     __id
   }
@@ -44,7 +44,7 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
         price
         price_currency
         title
-        artists {
+        artists(shallow: true) {
           name
           __id
         }
@@ -84,17 +84,6 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
 }
 
 fragment CollectFilterContainer_viewer_3xtvvd on Viewer {
-  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
-    aggregations {
-      slice
-      counts {
-        name
-        id
-        __id
-      }
-    }
-    __id
-  }
   ...CollectRefetch_viewer_3xtvvd
 }
 
@@ -278,11 +267,19 @@ fragment Contact_artwork on Artwork {
 const node: ConcreteRequest = (function(){
 var v0 = {
   "kind": "Literal",
-  "name": "size",
-  "value": 0,
-  "type": "Int"
+  "name": "aggregations",
+  "value": [
+    "TOTAL"
+  ],
+  "type": "[ArtworkAggregation]"
 },
-v1 = [
+v1 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "-partner_updated_at",
+  "type": "String"
+},
+v2 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -296,56 +293,64 @@ v1 = [
     "type": "Int"
   }
 ],
-v2 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v3 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v8 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v10 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v9 = [
+v11 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -360,27 +365,12 @@ v9 = [
     ],
     "storageKey": "url(version:\"larger\")"
   },
-  v8
+  v10
 ],
-v10 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true,
-    "type": "Boolean"
-  }
-],
-v11 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "type",
-  "args": null,
-  "storageKey": null
-},
 v12 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "type",
   "args": null,
   "storageKey": null
 },
@@ -421,7 +411,7 @@ return {
   "operationKind": "query",
   "name": "CollectAppTestQuery",
   "id": null,
-  "text": "query CollectAppTestQuery {\n  viewer {\n    ...CollectApp_viewer\n  }\n}\n\nfragment CollectApp_viewer on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectFilterContainer_viewer_3xtvvd\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectFilterContainer_viewer_3xtvvd on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectRefetch_viewer_3xtvvd\n}\n\nfragment CollectRefetch_viewer_3xtvvd on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query CollectAppTestQuery {\n  viewer {\n    ...CollectApp_viewer\n  }\n}\n\nfragment CollectApp_viewer on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: \"-partner_updated_at\") {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectFilterContainer_viewer_3xtvvd\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectFilterContainer_viewer_3xtvvd on Viewer {\n  ...CollectRefetch_viewer_3xtvvd\n}\n\nfragment CollectRefetch_viewer_3xtvvd on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -466,18 +456,10 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "filter_artworks",
-            "storageKey": "filter_artworks(aggregations:[\"MEDIUM\",\"TOTAL\"],size:0)",
+            "storageKey": "filter_artworks(aggregations:[\"TOTAL\"],sort:\"-partner_updated_at\")",
             "args": [
-              {
-                "kind": "Literal",
-                "name": "aggregations",
-                "value": [
-                  "MEDIUM",
-                  "TOTAL"
-                ],
-                "type": "[ArtworkAggregation]"
-              },
-              v0
+              v0,
+              v1
             ],
             "concreteType": "FilterArtworks",
             "plural": false,
@@ -487,7 +469,7 @@ return {
                 "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v1,
+                "args": v2,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -516,7 +498,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v2,
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -524,9 +506,9 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
                           v4,
                           v5,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -548,18 +530,18 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v6,
+                          v7,
                           {
                             "kind": "LinkedField",
                             "alias": null,
                             "name": "artists",
-                            "storageKey": null,
-                            "args": null,
+                            "storageKey": "artists(shallow:true)",
+                            "args": v8,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v7,
-                              v2
+                              v9,
+                              v3
                             ]
                           },
                           {
@@ -570,7 +552,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v9
+                            "selections": v11
                           },
                           {
                             "kind": "LinkedField",
@@ -595,12 +577,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v10,
+                            "args": v8,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v7,
-                              v11,
+                              v9,
+                              v12,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -618,9 +600,9 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v9
+                                    "selections": v11
                                   },
-                                  v2
+                                  v3
                                 ]
                               },
                               {
@@ -688,10 +670,10 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  v2
+                                  v3
                                 ]
                               },
-                              v2
+                              v3
                             ]
                           }
                         ]
@@ -700,39 +682,7 @@ return {
                   }
                 ]
               },
-              v2,
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "aggregations",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "slice",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "counts",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "plural": true,
-                    "selections": [
-                      v7,
-                      v12,
-                      v2
-                    ]
-                  }
-                ]
-              }
+              v3
             ]
           },
           {
@@ -741,38 +691,31 @@ return {
             "name": "filter_artworks",
             "storageKey": "filter_artworks(aggregations:[\"TOTAL\"],medium:\"*\",size:0,sort:\"-partner_updated_at\")",
             "args": [
-              {
-                "kind": "Literal",
-                "name": "aggregations",
-                "value": [
-                  "TOTAL"
-                ],
-                "type": "[ArtworkAggregation]"
-              },
+              v0,
               {
                 "kind": "Literal",
                 "name": "medium",
                 "value": "*",
                 "type": "String"
               },
-              v0,
               {
                 "kind": "Literal",
-                "name": "sort",
-                "value": "-partner_updated_at",
-                "type": "String"
-              }
+                "name": "size",
+                "value": 0,
+                "type": "Int"
+              },
+              v1
             ],
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v2,
+              v3,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v1,
+                "args": v2,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -878,17 +821,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v10,
+                            "args": v8,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v2,
-                              v4,
-                              v7
+                              v3,
+                              v5,
+                              v9
                             ]
                           },
-                          v2,
-                          v4,
+                          v3,
+                          v5,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -905,7 +848,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v8,
+                              v10,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -936,7 +879,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v6,
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -944,7 +887,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -959,7 +902,13 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v12,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -972,14 +921,14 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v10,
+                            "args": v8,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v7,
-                              v4,
-                              v2,
-                              v11
+                              v9,
+                              v5,
+                              v3,
+                              v12
                             ]
                           },
                           {
@@ -1005,7 +954,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v2,
+                              v3,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1073,7 +1022,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   v16,
-                                  v8
+                                  v10
                                 ]
                               },
                               {
@@ -1088,7 +1037,7 @@ return {
                                   v16
                                 ]
                               },
-                              v2
+                              v3
                             ]
                           },
                           {
@@ -1112,7 +1061,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v5,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/CollectAppTestWithMediumQuery.graphql.ts
+++ b/src/__generated__/CollectAppTestWithMediumQuery.graphql.ts
@@ -23,7 +23,7 @@ query CollectAppTestWithMediumQuery {
 }
 
 fragment CollectApp_viewer on Viewer {
-  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
+  filter_artworks(aggregations: [TOTAL], sort: "-partner_updated_at") {
     ...SeoProductsForArtworks_artworks
     __id
   }
@@ -44,7 +44,7 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
         price
         price_currency
         title
-        artists {
+        artists(shallow: true) {
           name
           __id
         }
@@ -84,17 +84,6 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
 }
 
 fragment CollectFilterContainer_viewer_3xtvvd on Viewer {
-  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
-    aggregations {
-      slice
-      counts {
-        name
-        id
-        __id
-      }
-    }
-    __id
-  }
   ...CollectRefetch_viewer_3xtvvd
 }
 
@@ -278,11 +267,19 @@ fragment Contact_artwork on Artwork {
 const node: ConcreteRequest = (function(){
 var v0 = {
   "kind": "Literal",
-  "name": "size",
-  "value": 0,
-  "type": "Int"
+  "name": "aggregations",
+  "value": [
+    "TOTAL"
+  ],
+  "type": "[ArtworkAggregation]"
 },
-v1 = [
+v1 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "-partner_updated_at",
+  "type": "String"
+},
+v2 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -296,56 +293,64 @@ v1 = [
     "type": "Int"
   }
 ],
-v2 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v3 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v8 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v10 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v9 = [
+v11 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -360,27 +365,12 @@ v9 = [
     ],
     "storageKey": "url(version:\"larger\")"
   },
-  v8
+  v10
 ],
-v10 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true,
-    "type": "Boolean"
-  }
-],
-v11 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "type",
-  "args": null,
-  "storageKey": null
-},
 v12 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "type",
   "args": null,
   "storageKey": null
 },
@@ -421,7 +411,7 @@ return {
   "operationKind": "query",
   "name": "CollectAppTestWithMediumQuery",
   "id": null,
-  "text": "query CollectAppTestWithMediumQuery {\n  viewer {\n    ...CollectApp_viewer\n  }\n}\n\nfragment CollectApp_viewer on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectFilterContainer_viewer_3xtvvd\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectFilterContainer_viewer_3xtvvd on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectRefetch_viewer_3xtvvd\n}\n\nfragment CollectRefetch_viewer_3xtvvd on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query CollectAppTestWithMediumQuery {\n  viewer {\n    ...CollectApp_viewer\n  }\n}\n\nfragment CollectApp_viewer on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: \"-partner_updated_at\") {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectFilterContainer_viewer_3xtvvd\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectFilterContainer_viewer_3xtvvd on Viewer {\n  ...CollectRefetch_viewer_3xtvvd\n}\n\nfragment CollectRefetch_viewer_3xtvvd on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -466,18 +456,10 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "filter_artworks",
-            "storageKey": "filter_artworks(aggregations:[\"MEDIUM\",\"TOTAL\"],size:0)",
+            "storageKey": "filter_artworks(aggregations:[\"TOTAL\"],sort:\"-partner_updated_at\")",
             "args": [
-              {
-                "kind": "Literal",
-                "name": "aggregations",
-                "value": [
-                  "MEDIUM",
-                  "TOTAL"
-                ],
-                "type": "[ArtworkAggregation]"
-              },
-              v0
+              v0,
+              v1
             ],
             "concreteType": "FilterArtworks",
             "plural": false,
@@ -487,7 +469,7 @@ return {
                 "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v1,
+                "args": v2,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -516,7 +498,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v2,
+                          v3,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -524,9 +506,9 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
                           v4,
                           v5,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -548,18 +530,18 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v6,
+                          v7,
                           {
                             "kind": "LinkedField",
                             "alias": null,
                             "name": "artists",
-                            "storageKey": null,
-                            "args": null,
+                            "storageKey": "artists(shallow:true)",
+                            "args": v8,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v7,
-                              v2
+                              v9,
+                              v3
                             ]
                           },
                           {
@@ -570,7 +552,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v9
+                            "selections": v11
                           },
                           {
                             "kind": "LinkedField",
@@ -595,12 +577,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v10,
+                            "args": v8,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v7,
-                              v11,
+                              v9,
+                              v12,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -618,9 +600,9 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v9
+                                    "selections": v11
                                   },
-                                  v2
+                                  v3
                                 ]
                               },
                               {
@@ -688,10 +670,10 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  v2
+                                  v3
                                 ]
                               },
-                              v2
+                              v3
                             ]
                           }
                         ]
@@ -700,39 +682,7 @@ return {
                   }
                 ]
               },
-              v2,
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "aggregations",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "slice",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "counts",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "plural": true,
-                    "selections": [
-                      v7,
-                      v12,
-                      v2
-                    ]
-                  }
-                ]
-              }
+              v3
             ]
           },
           {
@@ -741,38 +691,31 @@ return {
             "name": "filter_artworks",
             "storageKey": "filter_artworks(aggregations:[\"TOTAL\"],medium:\"*\",size:0,sort:\"-partner_updated_at\")",
             "args": [
-              {
-                "kind": "Literal",
-                "name": "aggregations",
-                "value": [
-                  "TOTAL"
-                ],
-                "type": "[ArtworkAggregation]"
-              },
+              v0,
               {
                 "kind": "Literal",
                 "name": "medium",
                 "value": "*",
                 "type": "String"
               },
-              v0,
               {
                 "kind": "Literal",
-                "name": "sort",
-                "value": "-partner_updated_at",
-                "type": "String"
-              }
+                "name": "size",
+                "value": 0,
+                "type": "Int"
+              },
+              v1
             ],
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v2,
+              v3,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v1,
+                "args": v2,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -878,17 +821,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v10,
+                            "args": v8,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v2,
-                              v4,
-                              v7
+                              v3,
+                              v5,
+                              v9
                             ]
                           },
-                          v2,
-                          v4,
+                          v3,
+                          v5,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -905,7 +848,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v8,
+                              v10,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -936,7 +879,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v6,
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -944,7 +887,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -959,7 +902,13 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v12,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -972,14 +921,14 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v10,
+                            "args": v8,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v7,
-                              v4,
-                              v2,
-                              v11
+                              v9,
+                              v5,
+                              v3,
+                              v12
                             ]
                           },
                           {
@@ -1005,7 +954,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v2,
+                              v3,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1073,7 +1022,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   v16,
-                                  v8
+                                  v10
                                 ]
                               },
                               {
@@ -1088,7 +1037,7 @@ return {
                                   v16
                                 ]
                               },
-                              v2
+                              v3
                             ]
                           },
                           {
@@ -1112,7 +1061,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v5,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/CollectApp_viewer.graphql.ts
+++ b/src/__generated__/CollectApp_viewer.graphql.ts
@@ -74,7 +74,6 @@ const node: ConcreteFragment = {
       "name": "aggregations",
       "type": "[ArtworkAggregation]",
       "defaultValue": [
-        "MEDIUM",
         "TOTAL"
       ]
     },
@@ -147,10 +146,10 @@ const node: ConcreteFragment = {
           "type": "[ArtworkAggregation]"
         },
         {
-          "kind": "Literal",
-          "name": "size",
-          "value": 0,
-          "type": "Int"
+          "kind": "Variable",
+          "name": "sort",
+          "variableName": "sort",
+          "type": "String"
         }
       ],
       "concreteType": "FilterArtworks",
@@ -280,5 +279,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '3bd6b91bb3994bb1fdc300d654a3a602';
+(node as any).hash = '149ee7fd827db1b5d09f5be6f81d5d3e';
 export default node;

--- a/src/__generated__/CollectFilterContainer_viewer.graphql.ts
+++ b/src/__generated__/CollectFilterContainer_viewer.graphql.ts
@@ -2,34 +2,16 @@
 
 import { ConcreteFragment } from "relay-runtime";
 import { CollectRefetch_viewer$ref } from "./CollectRefetch_viewer.graphql";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 declare const _CollectFilterContainer_viewer$ref: unique symbol;
 export type CollectFilterContainer_viewer$ref = typeof _CollectFilterContainer_viewer$ref;
 export type CollectFilterContainer_viewer = {
-    readonly filter_artworks: ({
-        readonly aggregations: ReadonlyArray<({
-            readonly slice: ArtworkAggregation | null;
-            readonly counts: ReadonlyArray<({
-                readonly name: string | null;
-                readonly id: string;
-            }) | null> | null;
-        }) | null> | null;
-    }) | null;
     readonly " $fragmentRefs": CollectRefetch_viewer$ref;
     readonly " $refType": CollectFilterContainer_viewer$ref;
 };
 
 
 
-const node: ConcreteFragment = (function(){
-var v0 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-};
-return {
+const node: ConcreteFragment = {
   "kind": "Fragment",
   "name": "CollectFilterContainer_viewer",
   "type": "Viewer",
@@ -88,7 +70,6 @@ return {
       "name": "aggregations",
       "type": "[ArtworkAggregation]",
       "defaultValue": [
-        "MEDIUM",
         "TOTAL"
       ]
     },
@@ -148,75 +129,6 @@ return {
     }
   ],
   "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "filter_artworks",
-      "storageKey": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "aggregations",
-          "variableName": "aggregations",
-          "type": "[ArtworkAggregation]"
-        },
-        {
-          "kind": "Literal",
-          "name": "size",
-          "value": 0,
-          "type": "Int"
-        }
-      ],
-      "concreteType": "FilterArtworks",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "aggregations",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "ArtworksAggregationResults",
-          "plural": true,
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "slice",
-              "args": null,
-              "storageKey": null
-            },
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "counts",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "AggregationCount",
-              "plural": true,
-              "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "name",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "id",
-                  "args": null,
-                  "storageKey": null
-                },
-                v0
-              ]
-            }
-          ]
-        },
-        v0
-      ]
-    },
     {
       "kind": "FragmentSpread",
       "name": "CollectRefetch_viewer",
@@ -327,6 +239,5 @@ return {
     }
   ]
 };
-})();
-(node as any).hash = '11d23b9c1d40d96f9befd525c101f2c6';
+(node as any).hash = 'b096708743b2c0d949397a5555fec08d';
 export default node;

--- a/src/__generated__/CollectionAppTestQuery.graphql.ts
+++ b/src/__generated__/CollectionAppTestQuery.graphql.ts
@@ -84,7 +84,7 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
         price
         price_currency
         title
-        artists {
+        artists(shallow: true) {
           name
           __id
         }
@@ -522,6 +522,14 @@ v17 = {
 },
 v18 = [
   {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v19 = [
+  {
     "kind": "ScalarField",
     "alias": null,
     "name": "url",
@@ -536,14 +544,6 @@ v18 = [
     "storageKey": "url(version:\"larger\")"
   },
   v1
-],
-v19 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true,
-    "type": "Boolean"
-  }
 ],
 v20 = {
   "kind": "ScalarField",
@@ -589,7 +589,7 @@ return {
   "operationKind": "query",
   "name": "CollectionAppTestQuery",
   "id": null,
-  "text": "query CollectionAppTestQuery {\n  collection: marketingCollection(slug: \"kaws-companions\") {\n    ...CollectionApp_collection\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true, sort: \"-decayed_merch\", size: 12) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_33e20w\n  __id: id\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  ...DefaultHeader_headerArtworks\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_33e20w on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true, sort: \"-decayed_merch\", size: 12) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_33e20w\n  __id: id\n}\n\nfragment CollectionRefetch_collection_33e20w on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworks {\n  hits {\n    href\n    id\n    image {\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n      large: resized(height: 220) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(size: 3, sort: \"-decayed_merch\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n        __id: id\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query CollectionAppTestQuery {\n  collection: marketingCollection(slug: \"kaws-companions\") {\n    ...CollectionApp_collection\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true, sort: \"-decayed_merch\", size: 12) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_33e20w\n  __id: id\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  ...DefaultHeader_headerArtworks\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_33e20w on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true, sort: \"-decayed_merch\", size: 12) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_33e20w\n  __id: id\n}\n\nfragment CollectionRefetch_collection_33e20w on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: \"*\", size: 0, sort: \"-partner_updated_at\") {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworks {\n  hits {\n    href\n    id\n    image {\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n      large: resized(height: 220) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(size: 3, sort: \"-decayed_merch\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n        __id: id\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -989,8 +989,8 @@ return {
                             "kind": "LinkedField",
                             "alias": null,
                             "name": "artists",
-                            "storageKey": null,
-                            "args": null,
+                            "storageKey": "artists(shallow:true)",
+                            "args": v18,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": v11
@@ -1003,7 +1003,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v18
+                            "selections": v19
                           },
                           {
                             "kind": "LinkedField",
@@ -1022,7 +1022,7 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v19,
+                            "args": v18,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
@@ -1045,7 +1045,7 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v18
+                                    "selections": v19
                                   },
                                   v10
                                 ]
@@ -1316,7 +1316,7 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v19,
+                            "args": v18,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
@@ -1404,7 +1404,7 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v19,
+                            "args": v18,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [

--- a/src/__generated__/SeoProductsForArtworks_artworks.graphql.ts
+++ b/src/__generated__/SeoProductsForArtworks_artworks.graphql.ts
@@ -60,14 +60,22 @@ var v0 = {
   "args": null,
   "storageKey": null
 },
-v1 = {
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v2 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v2 = [
+v3 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -218,12 +226,12 @@ return {
                   "kind": "LinkedField",
                   "alias": null,
                   "name": "artists",
-                  "storageKey": null,
-                  "args": null,
+                  "storageKey": "artists(shallow:true)",
+                  "args": v1,
                   "concreteType": "Artist",
                   "plural": true,
                   "selections": [
-                    v1,
+                    v2,
                     v0
                   ]
                 },
@@ -235,7 +243,7 @@ return {
                   "args": null,
                   "concreteType": "Image",
                   "plural": false,
-                  "selections": v2
+                  "selections": v3
                 },
                 {
                   "kind": "LinkedField",
@@ -260,18 +268,11 @@ return {
                   "alias": null,
                   "name": "partner",
                   "storageKey": "partner(shallow:true)",
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "shallow",
-                      "value": true,
-                      "type": "Boolean"
-                    }
-                  ],
+                  "args": v1,
                   "concreteType": "Partner",
                   "plural": false,
                   "selections": [
-                    v1,
+                    v2,
                     {
                       "kind": "ScalarField",
                       "alias": null,
@@ -296,7 +297,7 @@ return {
                           "args": null,
                           "concreteType": "Image",
                           "plural": false,
-                          "selections": v2
+                          "selections": v3
                         },
                         v0
                       ]
@@ -382,5 +383,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'a50f86d40cc0e1c4a683fd0f73fa5b20';
+(node as any).hash = 'afaa66a6f2b7f10590f77f0064ab18e2';
 export default node;

--- a/src/__generated__/routes_CollectAppQuery.graphql.ts
+++ b/src/__generated__/routes_CollectAppQuery.graphql.ts
@@ -59,7 +59,7 @@ query routes_CollectAppQuery(
 }
 
 fragment CollectApp_viewer_3XOIsA on Viewer {
-  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
+  filter_artworks(aggregations: [TOTAL], sort: $sort) {
     ...SeoProductsForArtworks_artworks
     __id
   }
@@ -80,7 +80,7 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
         price
         price_currency
         title
-        artists {
+        artists(shallow: true) {
           name
           __id
         }
@@ -120,17 +120,6 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
 }
 
 fragment CollectFilterContainer_viewer_3XOIsA on Viewer {
-  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
-    aggregations {
-      slice
-      counts {
-        name
-        id
-        __id
-      }
-    }
-    __id
-  }
   ...CollectRefetch_viewer_3XOIsA
 }
 
@@ -418,11 +407,19 @@ var v0 = [
 ],
 v1 = {
   "kind": "Literal",
-  "name": "size",
-  "value": 0,
-  "type": "Int"
+  "name": "aggregations",
+  "value": [
+    "TOTAL"
+  ],
+  "type": "[ArtworkAggregation]"
 },
-v2 = [
+v2 = {
+  "kind": "Variable",
+  "name": "sort",
+  "variableName": "sort",
+  "type": "String"
+},
+v3 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -436,56 +433,64 @@ v2 = [
     "type": "Int"
   }
 ],
-v3 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v9 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v11 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v10 = [
+v12 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -500,27 +505,12 @@ v10 = [
     ],
     "storageKey": "url(version:\"larger\")"
   },
-  v9
+  v11
 ],
-v11 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true,
-    "type": "Boolean"
-  }
-],
-v12 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "type",
-  "args": null,
-  "storageKey": null
-},
 v13 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "type",
   "args": null,
   "storageKey": null
 },
@@ -561,7 +551,7 @@ return {
   "operationKind": "query",
   "name": "routes_CollectAppQuery",
   "id": null,
-  "text": "query routes_CollectAppQuery(\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $dimension_range: String\n  $artist_id: String\n  $attribution_class: [String]\n  $color: String\n  $page: Int\n) {\n  viewer {\n    ...CollectApp_viewer_3XOIsA\n  }\n}\n\nfragment CollectApp_viewer_3XOIsA on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectFilterContainer_viewer_3XOIsA\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectFilterContainer_viewer_3XOIsA on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectRefetch_viewer_3XOIsA\n}\n\nfragment CollectRefetch_viewer_3XOIsA on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, page: $page, dimension_range: $dimension_range) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_CollectAppQuery(\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $dimension_range: String\n  $artist_id: String\n  $attribution_class: [String]\n  $color: String\n  $page: Int\n) {\n  viewer {\n    ...CollectApp_viewer_3XOIsA\n  }\n}\n\nfragment CollectApp_viewer_3XOIsA on Viewer {\n  filter_artworks(aggregations: [TOTAL], sort: $sort) {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectFilterContainer_viewer_3XOIsA\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectFilterContainer_viewer_3XOIsA on Viewer {\n  ...CollectRefetch_viewer_3XOIsA\n}\n\nfragment CollectRefetch_viewer_3XOIsA on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, page: $page, dimension_range: $dimension_range) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -709,18 +699,10 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "filter_artworks",
-            "storageKey": "filter_artworks(aggregations:[\"MEDIUM\",\"TOTAL\"],size:0)",
+            "storageKey": null,
             "args": [
-              {
-                "kind": "Literal",
-                "name": "aggregations",
-                "value": [
-                  "MEDIUM",
-                  "TOTAL"
-                ],
-                "type": "[ArtworkAggregation]"
-              },
-              v1
+              v1,
+              v2
             ],
             "concreteType": "FilterArtworks",
             "plural": false,
@@ -730,7 +712,7 @@ return {
                 "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v2,
+                "args": v3,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -759,7 +741,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          v4,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -767,9 +749,9 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v4,
                           v5,
                           v6,
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -791,18 +773,18 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v7,
+                          v8,
                           {
                             "kind": "LinkedField",
                             "alias": null,
                             "name": "artists",
-                            "storageKey": null,
-                            "args": null,
+                            "storageKey": "artists(shallow:true)",
+                            "args": v9,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v8,
-                              v3
+                              v10,
+                              v4
                             ]
                           },
                           {
@@ -813,7 +795,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v10
+                            "selections": v12
                           },
                           {
                             "kind": "LinkedField",
@@ -838,12 +820,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v11,
+                            "args": v9,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v8,
-                              v12,
+                              v10,
+                              v13,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -861,9 +843,9 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v10
+                                    "selections": v12
                                   },
-                                  v3
+                                  v4
                                 ]
                               },
                               {
@@ -931,10 +913,10 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  v3
+                                  v4
                                 ]
                               },
-                              v3
+                              v4
                             ]
                           }
                         ]
@@ -943,39 +925,7 @@ return {
                   }
                 ]
               },
-              v3,
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "aggregations",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "slice",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "counts",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "plural": true,
-                    "selections": [
-                      v8,
-                      v13,
-                      v3
-                    ]
-                  }
-                ]
-              }
+              v4
             ]
           },
           {
@@ -990,14 +940,7 @@ return {
                 "variableName": "acquireable",
                 "type": "Boolean"
               },
-              {
-                "kind": "Literal",
-                "name": "aggregations",
-                "value": [
-                  "TOTAL"
-                ],
-                "type": "[ArtworkAggregation]"
-              },
+              v1,
               {
                 "kind": "Variable",
                 "name": "artist_id",
@@ -1082,13 +1025,13 @@ return {
                 "variableName": "price_range",
                 "type": "String"
               },
-              v1,
               {
-                "kind": "Variable",
-                "name": "sort",
-                "variableName": "sort",
-                "type": "String"
+                "kind": "Literal",
+                "name": "size",
+                "value": 0,
+                "type": "Int"
               },
+              v2,
               {
                 "kind": "Variable",
                 "name": "width",
@@ -1099,13 +1042,13 @@ return {
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v3,
+              v4,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v2,
+                "args": v3,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -1211,17 +1154,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v11,
+                            "args": v9,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v3,
-                              v5,
-                              v8
+                              v4,
+                              v6,
+                              v10
                             ]
                           },
-                          v3,
-                          v5,
+                          v4,
+                          v6,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1238,7 +1181,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v9,
+                              v11,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1269,7 +1212,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v7,
+                          v8,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1277,7 +1220,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v4,
+                          v5,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1292,7 +1235,13 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v13,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "id",
+                            "args": null,
+                            "storageKey": null
+                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1305,14 +1254,14 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v11,
+                            "args": v9,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v8,
-                              v5,
-                              v3,
-                              v12
+                              v10,
+                              v6,
+                              v4,
+                              v13
                             ]
                           },
                           {
@@ -1338,7 +1287,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v3,
+                              v4,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1406,7 +1355,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   v17,
-                                  v9
+                                  v11
                                 ]
                               },
                               {
@@ -1421,7 +1370,7 @@ return {
                                   v17
                                 ]
                               },
-                              v3
+                              v4
                             ]
                           },
                           {
@@ -1445,7 +1394,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v6,
+                          v7,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/routes_MarketingCollectionAppQuery.graphql.ts
+++ b/src/__generated__/routes_MarketingCollectionAppQuery.graphql.ts
@@ -114,7 +114,7 @@ fragment SeoProductsForArtworks_artworks on FilterArtworks {
         price
         price_currency
         title
-        artists {
+        artists(shallow: true) {
           name
           __id
         }
@@ -638,6 +638,14 @@ v18 = {
 },
 v19 = [
   {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true,
+    "type": "Boolean"
+  }
+],
+v20 = [
+  {
     "kind": "ScalarField",
     "alias": null,
     "name": "url",
@@ -652,14 +660,6 @@ v19 = [
     "storageKey": "url(version:\"larger\")"
   },
   v2
-],
-v20 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true,
-    "type": "Boolean"
-  }
 ],
 v21 = {
   "kind": "ScalarField",
@@ -705,7 +705,7 @@ return {
   "operationKind": "query",
   "name": "routes_MarketingCollectionAppQuery",
   "id": null,
-  "text": "query routes_MarketingCollectionAppQuery(\n  $slug: String!\n  $medium: String\n  $major_periods: [String]\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $color: String\n  $page: Int\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionApp_collection_3tWJc4\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection_3tWJc4 on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true, sort: \"-decayed_merch\", size: 12) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_3tWJc4\n  __id: id\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  ...DefaultHeader_headerArtworks\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_3tWJc4 on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true, sort: \"-decayed_merch\", size: 12) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_3tWJc4\n  __id: id\n}\n\nfragment CollectionRefetch_collection_3tWJc4 on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, color: $color, page: $page) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworks {\n  hits {\n    href\n    id\n    image {\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n      large: resized(height: 220) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(size: 3, sort: \"-decayed_merch\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n        __id: id\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query routes_MarketingCollectionAppQuery(\n  $slug: String!\n  $medium: String\n  $major_periods: [String]\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $color: String\n  $page: Int\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionApp_collection_3tWJc4\n    __id: id\n  }\n}\n\nfragment CollectionApp_collection_3tWJc4 on MarketingCollection {\n  id\n  slug\n  title\n  description\n  headerImage\n  category\n  credit\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    __id: id\n  }\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true, sort: \"-decayed_merch\", size: 12) {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectionFilterContainer_collection_3tWJc4\n  __id: id\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  __id: id\n}\n\nfragment Header_artworks on FilterArtworks {\n  ...DefaultHeader_headerArtworks\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectionFilterContainer_collection_3tWJc4 on MarketingCollection {\n  artworks(aggregations: [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL], include_medium_filter_in_aggregation: true, sort: \"-decayed_merch\", size: 12) {\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectionRefetch_collection_3tWJc4\n  __id: id\n}\n\nfragment CollectionRefetch_collection_3tWJc4 on MarketingCollection {\n  slug\n  filtered_artworks: artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, color: $color, page: $page) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n  __id: id\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworks {\n  hits {\n    href\n    id\n    image {\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n      large: resized(height: 220) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(size: 3, sort: \"-decayed_merch\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n        __id: id\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -1184,8 +1184,8 @@ return {
                             "kind": "LinkedField",
                             "alias": null,
                             "name": "artists",
-                            "storageKey": null,
-                            "args": null,
+                            "storageKey": "artists(shallow:true)",
+                            "args": v19,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": v12
@@ -1198,7 +1198,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v19
+                            "selections": v20
                           },
                           {
                             "kind": "LinkedField",
@@ -1217,7 +1217,7 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v20,
+                            "args": v19,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
@@ -1240,7 +1240,7 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v19
+                                    "selections": v20
                                   },
                                   v11
                                 ]
@@ -1577,7 +1577,7 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v20,
+                            "args": v19,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
@@ -1665,7 +1665,7 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v20,
+                            "args": v19,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [


### PR DESCRIPTION
This implements https://github.com/artsy/reaction/pull/2638 , but for the Collect page.

Basically, we have an separate call just to fetch the medium aggregations (AKA, the list of mediums and their counts). We then trim off the full [hardcoded list of mediums](https://github.com/artsy/reaction/blob/befdd355f160b717ab6760005600bedd7941adf7/src/Apps/Collect/Components/Filters/MediumFilter.tsx#L33). Since we have a zero-state (and with so much inventory it's very difficult to construct a query where the list is truncated at all), I think it's worth removing this call (especially in light of ongoing Elasticsearch issues....the less queries the better there!).

There was one other thing I noticed, in relations to the SEO 'product' list generated, will comment inline.