### PR TITLE
Update VSCode launch configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,16 +24,30 @@
       "webRoot": "${workspaceRoot}/src"
     },
     {
-      "name": "Run Tests With Debugger (slower, use yarn for normal work)",
       "type": "node",
       "request": "launch",
-      "port": 5858,
-      "address": "localhost",
-      "sourceMaps": true,
-      "stopOnEntry": false,
-      "runtimeExecutable": null,
-      "runtimeArgs": ["debug", "--debug-brk", "./node_modules/.bin/jest", "-i"],
-      "cwd": "${workspaceRoot}"
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["**/__tests__/**/${fileBasename}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,25 +7,6 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Server",
-      "preLaunchTask": "compile:server",
-      "program": "${workspaceRoot}/index.js",
-      "args": ["${workspaceRoot}/dist"],
-      "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/dist/**/*.js"],
-      "internalConsoleOptions": "openOnSessionStart"
-    },
-    {
-      "type": "chrome",
-      "request": "launch",
-      "preLaunchTask": "storybook",
-      "name": "Launch Chrome",
-      "url": "http://localhost:4444",
-      "webRoot": "${workspaceRoot}/src"
-    },
-    {
-      "type": "node",
-      "request": "launch",
       "name": "Jest All",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["--runInBand"],


### PR DESCRIPTION
This PR updates the VSCode launch configurations related to running Jest tests with a debugger attached. They're adapted from this resource from Microsoft's VSCode Recipes:

https://github.com/microsoft/vscode-recipes/tree/851693ce90da46a36a28edeb743e09b3da6b6e6f/debugging-jest-tests

The formerly defined "Run Tests With Debugger" launch configuration used an explicitly defined and deprecated `node debug` invocation and wouldn't attach properly without some adjustments.

I couldn't get the "Launch Server" or "Launch Chrome" tasks to work so I've removed those as well thinking that they're probably not used, but let me know if I'm mistaken.

cc/ @dleve123 because you were asking about testing with a debugger in artsy/reaction recently!