### PR TITLE
Video Headers Won't Crash

### DIFF
--- a/src/Components/Publishing/Series/FixedBackground.tsx
+++ b/src/Components/Publishing/Series/FixedBackground.tsx
@@ -9,7 +9,7 @@ interface Props {
 export const FixedBackground: React.SFC<Props> = props => {
   const { backgroundColor, backgroundUrl } = props
 
-  if (backgroundUrl) {
+  if (backgroundUrl && !backgroundUrl.includes(".mp4")) {
     return (
       <FixedBackgroundContainer backgroundColor={backgroundColor}>
         <BackgroundImage backgroundUrl={backgroundUrl} />

--- a/src/Components/Publishing/Series/__tests__/FixedBackground.test.tsx
+++ b/src/Components/Publishing/Series/__tests__/FixedBackground.test.tsx
@@ -1,0 +1,34 @@
+import "jest-styled-components"
+import React from "react"
+import renderer from "react-test-renderer"
+import { FixedBackground } from "../FixedBackground"
+
+const imageURL = "https://foo.com/image.png"
+const videoURL = "https://foo.com/video.mp4"
+
+describe("FixedBackground", () => {
+  it("renders the provided background color if no image available", () => {
+    const component = renderer
+      .create(<FixedBackground backgroundColor={"red"} />)
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
+
+  it("renders the provided background image", () => {
+    const component = renderer
+      .create(
+        <FixedBackground backgroundColor={"red"} backgroundUrl={imageURL} />
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
+
+  it("ignores video for now", () => {
+    const component = renderer
+      .create(
+        <FixedBackground backgroundColor={"red"} backgroundUrl={videoURL} />
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/FixedBackground.test.tsx.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/FixedBackground.test.tsx.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FixedBackground ignores video for now 1`] = `
+.c0 {
+  background-color: red;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
+}
+
+<div
+  className="c0"
+/>
+`;
+
+exports[`FixedBackground renders the provided background color if no image available 1`] = `
+.c0 {
+  background-color: red;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
+}
+
+<div
+  className="c0"
+/>
+`;
+
+exports[`FixedBackground renders the provided background image 1`] = `
+.c0 {
+  background-color: red;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
+}
+
+.c1 {
+  background-image: url(https://foo.com/image.png);
+  background-size: cover;
+  background-position: 50%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -2;
+}
+
+.c2 {
+  background: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.6));
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+  <div
+    className="c2"
+  />
+</div>
+`;


### PR DESCRIPTION
This PR is in support of [GROW-1444](https://artsyproduct.atlassian.net/browse/GROW-1444). The real change for that PR is in Positron, but _this PR should be merged first_.

As the JIRA ticket describes, this is a temporary fix so that videos can be added without causing a crash.

Diff Analysis: 
```
{
  "total_files_changed": 3,
  "test_files_changed": 2,
  "by_type": {
    "tsx": 2,
    "snap": 1
  }
}
```