### PR TITLE
Add redirects to AuctionApp bidder registration flow

### DIFF
--- a/src/Apps/Auction/__tests__/AuctionApp.test.tsx
+++ b/src/Apps/Auction/__tests__/AuctionApp.test.tsx
@@ -1,0 +1,64 @@
+import { routes } from "Apps/Auction/routes"
+import { createMockNetworkLayer2 } from "DevTools"
+import { createRender } from "found"
+import { Resolver } from "found-relay"
+import getFarceResult from "found/lib/server/getFarceResult"
+import { Environment, RecordSource, Store } from "relay-runtime"
+import { SaleAuction } from "../../__tests__/Fixtures/Sale"
+
+describe("AuctionApp", () => {
+  describe("redirects", () => {
+    async function render(url, mockData) {
+      const network = createMockNetworkLayer2({ mockData })
+      const source = new RecordSource()
+      const store = new Store(source)
+      const environment = new Environment({ network, store })
+
+      return await getFarceResult({
+        url,
+        routeConfig: routes,
+        resolver: new Resolver(environment),
+        render: createRender({}),
+      })
+    }
+
+    const mockResolver = data => ({ sale: data, me: { name: "Emmett Brown" } })
+
+    it("does not redirect if a sale is found", async () => {
+      const { redirect } = await render(
+        `/auction-registration2/${SaleAuction.id}`,
+        mockResolver(SaleAuction)
+      )
+
+      expect(redirect).toBeUndefined
+    })
+
+    it("redirects back to the auction if the registration window has closed", async () => {
+      const { redirect } = await render(
+        `/auction-registration2/${SaleAuction.id}`,
+        mockResolver({
+          ...SaleAuction,
+          is_registration_closed: true,
+        })
+      )
+
+      expect(redirect.url).toBe(`/auction/${SaleAuction.id}`)
+    })
+
+    it("redirects to the auction confirm registration route if bidder has already registered", async () => {
+      const { redirect } = await render(
+        `/auction-registration2/${SaleAuction.id}`,
+        mockResolver({
+          ...SaleAuction,
+          registrationStatus: {
+            qualified_for_bidding: true,
+          },
+        })
+      )
+
+      expect(redirect.url).toBe(
+        `/auction/${SaleAuction.id}/confirm-registration`
+      )
+    })
+  })
+})

--- a/src/Apps/Auction/__tests__/AuctionApp.test.tsx
+++ b/src/Apps/Auction/__tests__/AuctionApp.test.tsx
@@ -1,3 +1,4 @@
+import { routes_AuctionQueryResponse } from "__generated__/routes_AuctionQuery.graphql"
 import { routes } from "Apps/Auction/routes"
 import { createMockNetworkLayer2 } from "DevTools"
 import { createRender } from "found"
@@ -5,6 +6,10 @@ import { Resolver } from "found-relay"
 import getFarceResult from "found/lib/server/getFarceResult"
 import { Environment, RecordSource, Store } from "relay-runtime"
 import { SaleAuction } from "../../__tests__/Fixtures/Sale"
+
+interface MockResponse {
+  sale: routes_AuctionQueryResponse["sale"]
+}
 
 describe("AuctionApp", () => {
   describe("redirects", () => {
@@ -22,7 +27,11 @@ describe("AuctionApp", () => {
       })
     }
 
-    const mockResolver = data => ({ sale: data, me: { name: "Emmett Brown" } })
+    const mockResolver = (
+      data: routes_AuctionQueryResponse["sale"]
+    ): MockResponse => ({
+      sale: data,
+    })
 
     it("does not redirect if a sale is found", async () => {
       const { redirect } = await render(

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -1,14 +1,80 @@
-import { RouteConfig } from "found"
+import { routes_AuctionQueryResponse } from "__generated__/routes_AuctionQuery.graphql"
+import { RedirectException, RouteConfig } from "found"
+import React from "react"
 import { graphql } from "react-relay"
+import createLogger from "Utils/logger"
 import { AuctionAppFragmentContainer } from "./AuctionApp"
+
+const logger = createLogger("Apps/Auction/routes")
+
+interface Redirect {
+  path: string
+  reason: string
+}
+
+function isRegisterable(sale: routes_AuctionQueryResponse["sale"]): boolean {
+  return (sale.is_preview || sale.is_open) && !sale.is_registration_closed
+}
+
+function userRegisteredToBid(sale: routes_AuctionQueryResponse["sale"]) {
+  return !!sale.registrationStatus
+}
+
+function findRedirect(
+  sale: routes_AuctionQueryResponse["sale"]
+): Redirect | null {
+  let redirect
+  if (!sale.is_auction) {
+    redirect = {
+      path: `/sale/${sale.id}`,
+      reason: "sale must be an auction",
+    }
+  } else if (!isRegisterable(sale)) {
+    redirect = {
+      path: `/auction/${sale.id}`,
+      reason: "auction must be registerable",
+    }
+  } else if (userRegisteredToBid(sale)) {
+    redirect = {
+      path: `/auction/${sale.id}/confirm-registration`,
+      reason: "user is already registered to bid",
+    }
+  }
+
+  return redirect
+}
 
 export const routes: RouteConfig[] = [
   {
     path: "/auction-registration2/:saleID",
     Component: AuctionAppFragmentContainer,
+    render: ({ Component, props }) => {
+      const { location, sale } = props as any
+
+      const redirect = findRedirect(sale)
+
+      if (redirect) {
+        logger.warn(
+          `Redirecting from ${location.pathname} to ${redirect.path} because '${
+            redirect.reason
+          }'`
+        )
+        throw new RedirectException(redirect.path)
+      }
+
+      return <Component {...props} />
+    },
     query: graphql`
       query routes_AuctionQuery($saleID: String!) {
         sale: sale(id: $saleID) {
+          id
+          is_registration_closed
+          is_preview
+          is_open
+          is_auction
+          registrationStatus {
+            qualified_for_bidding
+          }
           ...AuctionApp_sale
         }
       }

--- a/src/Apps/__tests__/Fixtures/Sale.ts
+++ b/src/Apps/__tests__/Fixtures/Sale.ts
@@ -1,0 +1,8 @@
+export const SaleAuction = {
+  is_auction: true,
+  id: "yuki-contemporary-art-july-22th",
+  is_registration_closed: false,
+  is_open: true,
+  is_preview: false,
+  registrationStatus: null,
+}

--- a/src/Apps/__tests__/Fixtures/Sale.ts
+++ b/src/Apps/__tests__/Fixtures/Sale.ts
@@ -1,4 +1,7 @@
-export const SaleAuction = {
+import { routes_AuctionQueryResponse } from "__generated__/routes_AuctionQuery.graphql"
+
+export const SaleAuction: routes_AuctionQueryResponse["sale"] = {
+  " $fragmentRefs": undefined,
   is_auction: true,
   id: "yuki-contemporary-art-july-22th",
   is_registration_closed: false,

--- a/src/__generated__/routes_AuctionQuery.graphql.ts
+++ b/src/__generated__/routes_AuctionQuery.graphql.ts
@@ -7,6 +7,14 @@ export type routes_AuctionQueryVariables = {
 };
 export type routes_AuctionQueryResponse = {
     readonly sale: ({
+        readonly id: string;
+        readonly is_registration_closed: boolean | null;
+        readonly is_preview: boolean | null;
+        readonly is_open: boolean | null;
+        readonly is_auction: boolean | null;
+        readonly registrationStatus: ({
+            readonly qualified_for_bidding: boolean | null;
+        }) | null;
         readonly " $fragmentRefs": AuctionApp_sale$ref;
     }) | null;
 };
@@ -22,6 +30,15 @@ query routes_AuctionQuery(
   $saleID: String!
 ) {
   sale: sale(id: $saleID) {
+    id
+    is_registration_closed
+    is_preview
+    is_open
+    is_auction
+    registrationStatus {
+      qualified_for_bidding
+      __id
+    }
     ...AuctionApp_sale
     __id
   }
@@ -53,16 +70,70 @@ v1 = [
 v2 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_registration_closed",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_preview",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_open",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_auction",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
+},
+v8 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "registrationStatus",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Bidder",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "qualified_for_bidding",
+      "args": null,
+      "storageKey": null
+    },
+    v7
+  ]
 };
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_AuctionQuery",
   "id": null,
-  "text": "query routes_AuctionQuery(\n  $saleID: String!\n) {\n  sale: sale(id: $saleID) {\n    ...AuctionApp_sale\n    __id\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  id\n  __id\n}\n",
+  "text": "query routes_AuctionQuery(\n  $saleID: String!\n) {\n  sale: sale(id: $saleID) {\n    id\n    is_registration_closed\n    is_preview\n    is_open\n    is_auction\n    registrationStatus {\n      qualified_for_bidding\n      __id\n    }\n    ...AuctionApp_sale\n    __id\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  id\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -80,12 +151,18 @@ return {
         "concreteType": "Sale",
         "plural": false,
         "selections": [
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v8,
           {
             "kind": "FragmentSpread",
             "name": "AuctionApp_sale",
             "args": null
           },
-          v2
+          v7
         ]
       }
     ]
@@ -104,19 +181,18 @@ return {
         "concreteType": "Sale",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "id",
-            "args": null,
-            "storageKey": null
-          },
-          v2
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v8,
+          v7
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = 'a5285cf4d4cb9a1749faf0271ffae9d0';
+(node as any).hash = '5c3e73279a26f03ba2cf9aeb7cc4ada6';
 export default node;


### PR DESCRIPTION
Add redirects within the bidder registration flow for the following cases:

- Requested sale is not an auction
- Auction is not in a preview or open state
- Registration window for auction has already closed
- Authenticated user is already registered to bid in the auction

Some open questions:
- I'm not sure I'm covering every scenario here. Would be great to brainstorm other appropriate redirects.
- Some of the redirect structure here is based on what I found in the OrderApp. Is there anything worth abstracting? Maybe the `Redirect` interface with path + reason?

cc/ @ds300 