### PR TITLE
PURCHASE-1282: Updates offer views to handle non-USD currencies

### DIFF
--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -168,6 +168,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     }
 
     const listPriceCents = this.props.order.totalListPriceCents
+    const orderCurrency = this.props.order.currencyCode
 
     if (!lowSpeedBumpEncountered && offerValue * 100 < listPriceCents * 0.75) {
       this.showLowSpeedbump()
@@ -189,7 +190,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
           orderId: this.props.order.id,
           offerPrice: {
             amount: offerValue,
-            currencyCode: "USD",
+            currencyCode: orderCurrency,
           },
         },
       })).ecommerceAddInitialOfferToOrder.orderOrError
@@ -210,6 +211,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     const { order, isCommittingMutation } = this.props
 
     const artworkId = order.lineItems.edges[0].node.artwork.id
+    const orderCurrency = order.currencyCode
 
     return (
       <>
@@ -282,7 +284,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                       this.state.offerValue &&
                       this.state.offerValue.toLocaleString("en-US", {
                         style: "currency",
-                        currency: "USD",
+                        currency: orderCurrency,
                         minimumFractionDigits: 2,
                       })
                     }
@@ -319,6 +321,7 @@ export const OfferFragmentContainer = createFragmentContainer(
         id
         mode
         state
+        currencyCode
         totalListPrice(precision: 2)
         totalListPriceCents
         lineItems {

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -159,7 +159,7 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
           offerId: this.props.order.lastOffer.id,
           offerPrice: {
             amount: this.state.offerValue,
-            currencyCode: "USD",
+            currencyCode: this.props.order.currencyCode,
           },
           note: this.state.offerNoteValue && this.state.offerNoteValue.value,
         },
@@ -346,6 +346,7 @@ export const RespondFragmentContainer = createFragmentContainer(
         id
         mode
         state
+        currencyCode
         itemsTotal(precision: 2)
         itemsTotalCents
         totalListPrice(precision: 2)

--- a/src/Apps/Order/Routes/__tests__/Offer.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Offer.test.tsx
@@ -72,6 +72,36 @@ describe("Offer InitialMutation", () => {
     })
   })
 
+  describe("a non-usd currency", () => {
+    let page: OrderAppTestPage
+    beforeAll(async () => {
+      page = await buildPage({
+        mockData: {
+          order: {
+            ...testOrder,
+            currencyCode: "GBP",
+            totalListPrice: "£16,000",
+          },
+        },
+      })
+    })
+
+    it("shows the list price just below the input", () => {
+      const container = page.find("div#offer-page-left-column")
+      expect(container.text()).toContain("List price: £16,000")
+    })
+
+    it("can receive input, which updates the transaction summary", () => {
+      expect(page.transactionSummary.text()).toContain("Your offer")
+
+      page.setOfferAmount(1)
+      expect(page.transactionSummary.text()).toContain("Your offer£1.00")
+
+      page.setOfferAmount(1023)
+      expect(page.transactionSummary.text()).toContain("Your offer£1,023.00")
+    })
+  })
+
   describe("mutation", () => {
     let page: OrderAppTestPage
     beforeEach(async () => {

--- a/src/Apps/Order/Routes/__tests__/Respond.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Respond.test.tsx
@@ -270,6 +270,35 @@ describe("The respond page", () => {
           "/orders/2939023/review/counter"
         )
       })
+
+      it("works when a valid number is inputted for a non-usd currency", async () => {
+        const nonUSDPage = await buildPage({
+          mockData: {
+            order: {
+              ...testOrder,
+              currencyCode: "GBP",
+            },
+          },
+        })
+        await nonUSDPage.selectCounterRadio()
+        await nonUSDPage.setOfferAmount(9000)
+
+        expect(mutations.mockFetch).toHaveBeenCalledTimes(0)
+        await nonUSDPage.clickSubmit()
+        expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
+        expect(mutations.lastFetchVariables).toMatchObject({
+          input: {
+            offerId: "myoffer-id",
+            offerPrice: {
+              amount: 9000,
+              currencyCode: "GBP",
+            },
+          },
+        })
+        expect(routes.mockPushRoute).toHaveBeenCalledWith(
+          "/orders/2939023/review/counter"
+        )
+      })
     })
 
     it("shows the error modal if submitting a counter offer fails at network level", async () => {

--- a/src/Apps/__tests__/Fixtures/Order.ts
+++ b/src/Apps/__tests__/Fixtures/Order.ts
@@ -49,6 +49,7 @@ export const UntouchedOrder = {
   buyerTotal: "$12,000",
   requestedFulfillment: null,
   lastTransactionFailed: false,
+  currencyCode: "USD",
   lineItems: {
     edges: [
       {
@@ -133,6 +134,7 @@ export const OfferWithTotals = {
   id: "myoffer-id",
   amount: "$14,000",
   amountCents: 1400000,
+  currencyCode: "USD",
   ...ShippingTotals,
   ...TaxTotals,
   createdAt: null,
@@ -146,6 +148,7 @@ export const UntouchedOfferOrder = {
   ...UntouchedOrder,
   __typename: "OfferOrder",
   mode: "OFFER",
+  currencyCode: "USD",
   totalListPrice: "$16,000",
   totalListPriceCents: 1600000,
   itemsTotal: "$16,000",
@@ -262,6 +265,7 @@ export const Offers = [
   {
     node: {
       id: OfferWithTotals.id,
+      currencyCode: "USD",
       fromParticipant: OfferWithTotals.fromParticipant,
       amount: OfferWithTotals.amount,
       createdAt: "May 22",
@@ -270,6 +274,7 @@ export const Offers = [
   {
     node: {
       id: "0",
+      currencyCode: "USD",
       fromParticipant: "BUYER",
       amount: "$1,200.00",
       createdAt: "May 21",
@@ -278,6 +283,7 @@ export const Offers = [
   {
     node: {
       id: "1",
+      currencyCode: "USD",
       fromParticipant: "SELLER",
       amount: "$1,500.00",
       createdAt: "Apr 30",
@@ -286,6 +292,7 @@ export const Offers = [
   {
     node: {
       id: "2",
+      currencyCode: "USD",
       fromParticipant: "BUYER",
       amount: "$1,100.00",
       createdAt: "Apr 5",

--- a/src/__generated__/OfferTestQuery.graphql.ts
+++ b/src/__generated__/OfferTestQuery.graphql.ts
@@ -28,6 +28,7 @@ fragment Offer_order on Order {
   id
   mode
   state
+  currencyCode
   totalListPrice(precision: 2)
   totalListPriceCents
   lineItems {
@@ -145,18 +146,11 @@ v1 = {
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v4 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -164,11 +158,18 @@ v4 = [
     "type": "Int"
   }
 ],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
 v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v4,
+  "args": v3,
   "storageKey": "shippingTotal(precision:2)"
 },
 v6 = {
@@ -182,7 +183,7 @@ v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v4,
+  "args": v3,
   "storageKey": "taxTotal(precision:2)"
 },
 v8 = {
@@ -196,12 +197,12 @@ v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v4,
+  "args": v3,
   "storageKey": "buyerTotal(precision:2)"
 },
 v10 = [
   v8,
-  v3,
+  v2,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -216,7 +217,7 @@ v10 = [
     "kind": "ScalarField",
     "alias": null,
     "name": "amount",
-    "args": v4,
+    "args": v3,
     "storageKey": "amount(precision:2)"
   },
   v9,
@@ -248,7 +249,7 @@ return {
   "operationKind": "query",
   "name": "OfferTestQuery",
   "id": null,
-  "text": "query OfferTestQuery {\n  order: ecommerceOrder(id: \"unused\") {\n    __typename\n    ...Offer_order\n    __id\n  }\n}\n\nfragment Offer_order on Order {\n  id\n  mode\n  state\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n",
+  "text": "query OfferTestQuery {\n  order: ecommerceOrder(id: \"unused\") {\n    __typename\n    ...Offer_order\n    __id\n  }\n}\n\nfragment Offer_order on Order {\n  id\n  mode\n  state\n  currencyCode\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -290,8 +291,8 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
+          v1,
           v2,
-          v3,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -302,8 +303,15 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "currencyCode",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "totalListPrice",
-            "args": v4,
+            "args": v3,
             "storageKey": "totalListPrice(precision:2)"
           },
           {
@@ -349,7 +357,7 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v3,
+                          v2,
                           v1,
                           {
                             "kind": "ScalarField",
@@ -440,7 +448,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
+              v4,
               v1,
               {
                 "kind": "InlineFragment",
@@ -457,7 +465,6 @@ return {
               }
             ]
           },
-          v1,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -465,6 +472,7 @@ return {
             "args": null,
             "storageKey": null
           },
+          v4,
           v5,
           v6,
           v7,
@@ -473,7 +481,7 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v4,
+            "args": v3,
             "storageKey": "itemsTotal(precision:2)"
           },
           v9,

--- a/src/__generated__/Offer_order.graphql.ts
+++ b/src/__generated__/Offer_order.graphql.ts
@@ -10,6 +10,7 @@ export type Offer_order = {
     readonly id: string;
     readonly mode: OrderModeEnum | null;
     readonly state: string | null;
+    readonly currencyCode: string | null;
     readonly totalListPrice: string | null;
     readonly totalListPriceCents: number | null;
     readonly lineItems: ({
@@ -61,6 +62,13 @@ return {
       "kind": "ScalarField",
       "alias": null,
       "name": "state",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "currencyCode",
       "args": null,
       "storageKey": null
     },
@@ -146,5 +154,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '6ee0e0c309dc3f09604fa6cf229cfbac';
+(node as any).hash = 'ebc253fd306147091715106fa9246ca1';
 export default node;

--- a/src/__generated__/RespondCounterOfferMutation.graphql.ts
+++ b/src/__generated__/RespondCounterOfferMutation.graphql.ts
@@ -65,6 +65,7 @@ fragment Respond_order on Order {
   id
   mode
   state
+  currencyCode
   itemsTotal(precision: 2)
   itemsTotalCents
   totalListPrice(precision: 2)
@@ -337,44 +338,44 @@ v6 = [
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v8 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "shippingTotal",
   "args": v6,
   "storageKey": "shippingTotal(precision:2)"
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
   "args": v6,
   "storageKey": "taxTotal(precision:2)"
 },
-v11 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotalCents",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
   "args": v6,
   "storageKey": "buyerTotal(precision:2)"
+},
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
 },
 v13 = {
   "kind": "ScalarField",
@@ -423,7 +424,7 @@ return {
   "operationKind": "mutation",
   "name": "RespondCounterOfferMutation",
   "id": null,
-  "text": "mutation RespondCounterOfferMutation(\n  $input: buyerCounterOfferInput!\n) {\n  ecommerceBuyerCounterOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          __typename\n          ...Respond_order\n          __id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n\nfragment Respond_order on Order {\n  id\n  mode\n  state\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      createdAt\n      id\n      note\n      __id\n    }\n    myLastOffer {\n      createdAt\n      __id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id\n}\n\nfragment OfferHistoryItem_order on Order {\n  ... on OfferOrder {\n    offers {\n      edges {\n        node {\n          id\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          __id\n        }\n      }\n    }\n    lastOffer {\n      id\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      __id\n    }\n  }\n  totalListPrice(precision: 2)\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "mutation RespondCounterOfferMutation(\n  $input: buyerCounterOfferInput!\n) {\n  ecommerceBuyerCounterOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          __typename\n          ...Respond_order\n          __id\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n\nfragment Respond_order on Order {\n  id\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      createdAt\n      id\n      note\n      __id\n    }\n    myLastOffer {\n      createdAt\n      __id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id\n}\n\nfragment OfferHistoryItem_order on Order {\n  ... on OfferOrder {\n    offers {\n      edges {\n        node {\n          id\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          __id\n        }\n      }\n    }\n    lastOffer {\n      id\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      __id\n    }\n  }\n  totalListPrice(precision: 2)\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -518,12 +519,58 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      v4,
                       v5,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "creditCard",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "CreditCard",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "brand",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "last_digits",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "expiration_year",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "expiration_month",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          v3
+                        ]
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
                         "name": "state",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "currencyCode",
                         "args": null,
                         "storageKey": null
                       },
@@ -681,6 +728,40 @@ return {
                         ]
                       },
                       {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "mode",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v4,
+                      v7,
+                      v8,
+                      v9,
+                      v10,
+                      v11,
+                      v3,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "seller",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          v4,
+                          v3,
+                          {
+                            "kind": "InlineFragment",
+                            "type": "Partner",
+                            "selections": [
+                              v12
+                            ]
+                          }
+                        ]
+                      },
+                      {
                         "kind": "LinkedField",
                         "alias": null,
                         "name": "requestedFulfillment",
@@ -694,7 +775,7 @@ return {
                             "kind": "InlineFragment",
                             "type": "Ship",
                             "selections": [
-                              v7,
+                              v12,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -749,79 +830,6 @@ return {
                         ]
                       },
                       {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "mode",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      v8,
-                      v9,
-                      v10,
-                      v11,
-                      v12,
-                      v3,
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "seller",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": null,
-                        "plural": false,
-                        "selections": [
-                          v4,
-                          v3,
-                          {
-                            "kind": "InlineFragment",
-                            "type": "Partner",
-                            "selections": [
-                              v7
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "creditCard",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": "CreditCard",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "brand",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "last_digits",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "expiration_year",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "expiration_month",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          v3
-                        ]
-                      },
-                      {
                         "kind": "InlineFragment",
                         "type": "OfferOrder",
                         "selections": [
@@ -834,17 +842,17 @@ return {
                             "concreteType": "Offer",
                             "plural": false,
                             "selections": [
-                              v8,
+                              v7,
                               v13,
                               v14,
                               v3,
                               v15,
                               v16,
                               v5,
+                              v8,
                               v9,
                               v10,
                               v11,
-                              v12,
                               v17,
                               v18
                             ]
@@ -858,16 +866,16 @@ return {
                             "concreteType": "Offer",
                             "plural": false,
                             "selections": [
-                              v9,
+                              v8,
                               v13,
                               v5,
                               v15,
                               v16,
-                              v8,
+                              v7,
                               v3,
+                              v9,
                               v10,
                               v11,
-                              v12,
                               v17,
                               v18,
                               v14

--- a/src/__generated__/RespondTestQuery.graphql.ts
+++ b/src/__generated__/RespondTestQuery.graphql.ts
@@ -28,6 +28,7 @@ fragment Respond_order on Order {
   id
   mode
   state
+  currencyCode
   itemsTotal(precision: 2)
   itemsTotalCents
   totalListPrice(precision: 2)
@@ -232,18 +233,11 @@ v1 = {
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v4 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -251,47 +245,54 @@ v4 = [
     "type": "Int"
   }
 ],
-v5 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v4,
+  "args": v3,
   "storageKey": "shippingTotal(precision:2)"
 },
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v4,
+  "args": v3,
   "storageKey": "taxTotal(precision:2)"
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotalCents",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v4,
+  "args": v3,
   "storageKey": "buyerTotal(precision:2)"
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
@@ -311,7 +312,7 @@ v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "amount",
-  "args": v4,
+  "args": v3,
   "storageKey": "amount(precision:2)"
 },
 v14 = {
@@ -340,7 +341,7 @@ return {
   "operationKind": "query",
   "name": "RespondTestQuery",
   "id": null,
-  "text": "query RespondTestQuery {\n  order: ecommerceOrder(id: \"unused\") {\n    __typename\n    ...Respond_order\n    __id\n  }\n}\n\nfragment Respond_order on Order {\n  id\n  mode\n  state\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      createdAt\n      id\n      note\n      __id\n    }\n    myLastOffer {\n      createdAt\n      __id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id\n}\n\nfragment OfferHistoryItem_order on Order {\n  ... on OfferOrder {\n    offers {\n      edges {\n        node {\n          id\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          __id\n        }\n      }\n    }\n    lastOffer {\n      id\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      __id\n    }\n  }\n  totalListPrice(precision: 2)\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query RespondTestQuery {\n  order: ecommerceOrder(id: \"unused\") {\n    __typename\n    ...Respond_order\n    __id\n  }\n}\n\nfragment Respond_order on Order {\n  id\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      createdAt\n      id\n      note\n      __id\n    }\n    myLastOffer {\n      createdAt\n      __id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id\n}\n\nfragment OfferHistoryItem_order on Order {\n  ... on OfferOrder {\n    offers {\n      edges {\n        node {\n          id\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          __id\n        }\n      }\n    }\n    lastOffer {\n      id\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      __id\n    }\n  }\n  totalListPrice(precision: 2)\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -383,7 +384,46 @@ return {
         "plural": false,
         "selections": [
           v2,
-          v3,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCard",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CreditCard",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "brand",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "last_digits",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_year",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_month",
+                "args": null,
+                "storageKey": null
+              },
+              v1
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -394,8 +434,15 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "currencyCode",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "itemsTotal",
-            "args": v4,
+            "args": v3,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
@@ -409,7 +456,7 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v4,
+            "args": v3,
             "storageKey": "totalListPrice(precision:2)"
           },
           {
@@ -462,7 +509,7 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v3,
+                          v2,
                           v1,
                           {
                             "kind": "ScalarField",
@@ -545,6 +592,40 @@ return {
             ]
           },
           {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v1,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "seller",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v4,
+              v1,
+              {
+                "kind": "InlineFragment",
+                "type": "Partner",
+                "selections": [
+                  v10
+                ]
+              }
+            ]
+          },
+          {
             "kind": "LinkedField",
             "alias": null,
             "name": "requestedFulfillment",
@@ -553,12 +634,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v2,
+              v4,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v5,
+                  v10,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -613,79 +694,6 @@ return {
             ]
           },
           {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
-          v6,
-          v7,
-          v8,
-          v9,
-          v10,
-          v1,
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "seller",
-            "storageKey": null,
-            "args": null,
-            "concreteType": null,
-            "plural": false,
-            "selections": [
-              v2,
-              v1,
-              {
-                "kind": "InlineFragment",
-                "type": "Partner",
-                "selections": [
-                  v5
-                ]
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "creditCard",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "CreditCard",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "brand",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "last_digits",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "expiration_year",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "expiration_month",
-                "args": null,
-                "storageKey": null
-              },
-              v1
-            ]
-          },
-          {
             "kind": "InlineFragment",
             "type": "OfferOrder",
             "selections": [
@@ -698,17 +706,17 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v6,
+                  v5,
                   v11,
                   v12,
                   v1,
                   v13,
                   v14,
-                  v3,
+                  v2,
+                  v6,
                   v7,
                   v8,
                   v9,
-                  v10,
                   v15,
                   v16
                 ]
@@ -722,16 +730,16 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v7,
+                  v6,
                   v11,
-                  v3,
+                  v2,
                   v13,
                   v14,
-                  v6,
+                  v5,
                   v1,
+                  v7,
                   v8,
                   v9,
-                  v10,
                   v15,
                   v16,
                   v12
@@ -764,7 +772,7 @@ return {
                         "concreteType": "Offer",
                         "plural": false,
                         "selections": [
-                          v3,
+                          v2,
                           v13,
                           {
                             "kind": "ScalarField",

--- a/src/__generated__/Respond_order.graphql.ts
+++ b/src/__generated__/Respond_order.graphql.ts
@@ -13,6 +13,7 @@ export type Respond_order = {
     readonly id: string;
     readonly mode: OrderModeEnum | null;
     readonly state: string | null;
+    readonly currencyCode: string | null;
     readonly itemsTotal: string | null;
     readonly itemsTotalCents: number | null;
     readonly totalListPrice: string | null;
@@ -49,14 +50,7 @@ var v0 = {
   "args": null,
   "storageKey": null
 },
-v1 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__id",
-  "args": null,
-  "storageKey": null
-},
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -64,6 +58,13 @@ v2 = [
     "type": "Int"
   }
 ],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
 v3 = {
   "kind": "ScalarField",
   "alias": null,
@@ -78,6 +79,63 @@ return {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "stateExpiresAt",
+      "args": null,
+      "storageKey": null
+    },
+    v0,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "state",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "currencyCode",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "itemsTotal",
+      "args": v1,
+      "storageKey": "itemsTotal(precision:2)"
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "itemsTotalCents",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "totalListPrice",
+      "args": v1,
+      "storageKey": "totalListPrice(precision:2)"
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "totalListPriceCents",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "mode",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "LinkedField",
       "alias": null,
@@ -115,65 +173,15 @@ return {
                   "plural": false,
                   "selections": [
                     v0,
-                    v1
+                    v2
                   ]
                 },
-                v1
+                v2
               ]
             }
           ]
         }
       ]
-    },
-    v0,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "state",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "itemsTotal",
-      "args": v2,
-      "storageKey": "itemsTotal(precision:2)"
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "itemsTotalCents",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "totalListPrice",
-      "args": v2,
-      "storageKey": "totalListPrice(precision:2)"
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "totalListPriceCents",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "stateExpiresAt",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "mode",
-      "args": null,
-      "storageKey": null
     },
     {
       "kind": "FragmentSpread",
@@ -200,7 +208,7 @@ return {
       "name": "CreditCardSummaryItem_order",
       "args": null
     },
-    v1,
+    v2,
     {
       "kind": "InlineFragment",
       "type": "OfferOrder",
@@ -223,7 +231,7 @@ return {
               "args": null,
               "storageKey": null
             },
-            v1
+            v2
           ]
         },
         {
@@ -236,7 +244,7 @@ return {
           "plural": false,
           "selections": [
             v3,
-            v1
+            v2
           ]
         }
       ]
@@ -244,5 +252,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '632034c4e26818aaec38a7646bcb5e6e';
+(node as any).hash = '4ad21584216439c19a9b86cbefe3019e';
 export default node;

--- a/src/__generated__/routes_OfferQuery.graphql.ts
+++ b/src/__generated__/routes_OfferQuery.graphql.ts
@@ -32,6 +32,7 @@ fragment Offer_order on Order {
   id
   mode
   state
+  currencyCode
   totalListPrice(precision: 2)
   totalListPriceCents
   lineItems {
@@ -157,18 +158,11 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -176,11 +170,18 @@ v5 = [
     "type": "Int"
   }
 ],
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
 v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "shippingTotal(precision:2)"
 },
 v7 = {
@@ -194,7 +195,7 @@ v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "taxTotal(precision:2)"
 },
 v9 = {
@@ -208,12 +209,12 @@ v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "buyerTotal(precision:2)"
 },
 v11 = [
   v9,
-  v4,
+  v3,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -228,7 +229,7 @@ v11 = [
     "kind": "ScalarField",
     "alias": null,
     "name": "amount",
-    "args": v5,
+    "args": v4,
     "storageKey": "amount(precision:2)"
   },
   v10,
@@ -260,7 +261,7 @@ return {
   "operationKind": "query",
   "name": "routes_OfferQuery",
   "id": null,
-  "text": "query routes_OfferQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Offer_order\n    __id\n  }\n}\n\nfragment Offer_order on Order {\n  id\n  mode\n  state\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n",
+  "text": "query routes_OfferQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Offer_order\n    __id\n  }\n}\n\nfragment Offer_order on Order {\n  id\n  mode\n  state\n  currencyCode\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -302,8 +303,8 @@ return {
         "concreteType": null,
         "plural": false,
         "selections": [
+          v2,
           v3,
-          v4,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -314,8 +315,15 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "currencyCode",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "totalListPrice",
-            "args": v5,
+            "args": v4,
             "storageKey": "totalListPrice(precision:2)"
           },
           {
@@ -361,7 +369,7 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v4,
+                          v3,
                           v2,
                           {
                             "kind": "ScalarField",
@@ -452,7 +460,7 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
+              v5,
               v2,
               {
                 "kind": "InlineFragment",
@@ -469,7 +477,6 @@ return {
               }
             ]
           },
-          v2,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -477,6 +484,7 @@ return {
             "args": null,
             "storageKey": null
           },
+          v5,
           v6,
           v7,
           v8,
@@ -485,7 +493,7 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v5,
+            "args": v4,
             "storageKey": "itemsTotal(precision:2)"
           },
           v10,

--- a/src/__generated__/routes_RespondQuery.graphql.ts
+++ b/src/__generated__/routes_RespondQuery.graphql.ts
@@ -32,6 +32,7 @@ fragment Respond_order on Order {
   id
   mode
   state
+  currencyCode
   itemsTotal(precision: 2)
   itemsTotalCents
   totalListPrice(precision: 2)
@@ -244,18 +245,11 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -263,47 +257,54 @@ v5 = [
     "type": "Int"
   }
 ],
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "shippingTotal(precision:2)"
 },
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "taxTotal(precision:2)"
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotalCents",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v5,
+  "args": v4,
   "storageKey": "buyerTotal(precision:2)"
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
 },
 v12 = {
   "kind": "ScalarField",
@@ -323,7 +324,7 @@ v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "amount",
-  "args": v5,
+  "args": v4,
   "storageKey": "amount(precision:2)"
 },
 v15 = {
@@ -352,7 +353,7 @@ return {
   "operationKind": "query",
   "name": "routes_RespondQuery",
   "id": null,
-  "text": "query routes_RespondQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Respond_order\n    __id\n  }\n}\n\nfragment Respond_order on Order {\n  id\n  mode\n  state\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      createdAt\n      id\n      note\n      __id\n    }\n    myLastOffer {\n      createdAt\n      __id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id\n}\n\nfragment OfferHistoryItem_order on Order {\n  ... on OfferOrder {\n    offers {\n      edges {\n        node {\n          id\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          __id\n        }\n      }\n    }\n    lastOffer {\n      id\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      __id\n    }\n  }\n  totalListPrice(precision: 2)\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query routes_RespondQuery(\n  $orderID: String!\n) {\n  order: ecommerceOrder(id: $orderID) {\n    __typename\n    ...Respond_order\n    __id\n  }\n}\n\nfragment Respond_order on Order {\n  id\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          __id\n        }\n        __id\n      }\n    }\n  }\n  ... on OfferOrder {\n    lastOffer {\n      createdAt\n      id\n      note\n      __id\n    }\n    myLastOffer {\n      createdAt\n      __id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n  __id\n}\n\nfragment TransactionDetailsSummaryItem_order on Order {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on OfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id\n    }\n  }\n  __id\n}\n\nfragment ArtworkSummaryItem_order on Order {\n  seller {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ShippingSummaryItem_order on Order {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment CreditCardSummaryItem_order on Order {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id\n}\n\nfragment OfferHistoryItem_order on Order {\n  ... on OfferOrder {\n    offers {\n      edges {\n        node {\n          id\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          __id\n        }\n      }\n    }\n    lastOffer {\n      id\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      __id\n    }\n  }\n  totalListPrice(precision: 2)\n  __id\n}\n\nfragment ShippingAddress_ship on Ship {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -395,7 +396,46 @@ return {
         "plural": false,
         "selections": [
           v3,
-          v4,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCard",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CreditCard",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "brand",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "last_digits",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_year",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "expiration_month",
+                "args": null,
+                "storageKey": null
+              },
+              v2
+            ]
+          },
           {
             "kind": "ScalarField",
             "alias": null,
@@ -406,8 +446,15 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "currencyCode",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "itemsTotal",
-            "args": v5,
+            "args": v4,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
@@ -421,7 +468,7 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v5,
+            "args": v4,
             "storageKey": "totalListPrice(precision:2)"
           },
           {
@@ -474,7 +521,7 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          v4,
+                          v3,
                           v2,
                           {
                             "kind": "ScalarField",
@@ -557,6 +604,40 @@ return {
             ]
           },
           {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v2,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "seller",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              v5,
+              v2,
+              {
+                "kind": "InlineFragment",
+                "type": "Partner",
+                "selections": [
+                  v11
+                ]
+              }
+            ]
+          },
+          {
             "kind": "LinkedField",
             "alias": null,
             "name": "requestedFulfillment",
@@ -565,12 +646,12 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v3,
+              v5,
               {
                 "kind": "InlineFragment",
                 "type": "Ship",
                 "selections": [
-                  v6,
+                  v11,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -625,79 +706,6 @@ return {
             ]
           },
           {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "mode",
-            "args": null,
-            "storageKey": null
-          },
-          v7,
-          v8,
-          v9,
-          v10,
-          v11,
-          v2,
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "seller",
-            "storageKey": null,
-            "args": null,
-            "concreteType": null,
-            "plural": false,
-            "selections": [
-              v3,
-              v2,
-              {
-                "kind": "InlineFragment",
-                "type": "Partner",
-                "selections": [
-                  v6
-                ]
-              }
-            ]
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "creditCard",
-            "storageKey": null,
-            "args": null,
-            "concreteType": "CreditCard",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "brand",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "last_digits",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "expiration_year",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "expiration_month",
-                "args": null,
-                "storageKey": null
-              },
-              v2
-            ]
-          },
-          {
             "kind": "InlineFragment",
             "type": "OfferOrder",
             "selections": [
@@ -710,17 +718,17 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v7,
+                  v6,
                   v12,
                   v13,
                   v2,
                   v14,
                   v15,
-                  v4,
+                  v3,
+                  v7,
                   v8,
                   v9,
                   v10,
-                  v11,
                   v16,
                   v17
                 ]
@@ -734,16 +742,16 @@ return {
                 "concreteType": "Offer",
                 "plural": false,
                 "selections": [
-                  v8,
+                  v7,
                   v12,
-                  v4,
+                  v3,
                   v14,
                   v15,
-                  v7,
+                  v6,
                   v2,
+                  v8,
                   v9,
                   v10,
-                  v11,
                   v16,
                   v17,
                   v13
@@ -776,7 +784,7 @@ return {
                         "concreteType": "Offer",
                         "plural": false,
                         "selections": [
-                          v4,
+                          v3,
                           v14,
                           {
                             "kind": "ScalarField",


### PR DESCRIPTION
This PR updates the buyer UI to correctly show prices in the order's currency (be it USD or otherwise).

The biggest changes were in [Exchange](https://github.com/artsy/exchange/pull/456) and [Metaphysics](https://github.com/artsy/metaphysics/pull/1858). Now all `amount`-wrapped fields on `Offer`s and `Order`s coming from metaphysics will display in the correct currency.

This just updates the few places where we display a currency symbol based on the `currencyCode` of the `Order` (previously this just used USD).

cc @mdole @iskounen in case this is relevant to the work on the CMS-side!

### Initial offer flow
<img width="1150" alt="Screen Shot 2019-07-31 at 11 28 42 AM" src="https://user-images.githubusercontent.com/2081340/62235653-635f3f00-b39b-11e9-9bc1-ab2b8dc30c05.png">

### Counteroffer flow
<img width="1180" alt="Screen Shot 2019-07-31 at 1 56 06 PM" src="https://user-images.githubusercontent.com/2081340/62235667-68bc8980-b39b-11e9-8004-6171efe2ef8e.png">

<img width="1181" alt="Screen Shot 2019-07-31 at 1 56 15 PM" src="https://user-images.githubusercontent.com/2081340/62235674-6bb77a00-b39b-11e9-9efb-eaada3c5deea.png">
