### PR TITLE
Grow-1391,Collections carousel tweaks QA for artist series and related collections

### DIFF
--- a/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -60,6 +60,7 @@ export class ArtistCollectionsRail extends React.Component<
               wrapAround: sd.IS_MOBILE ? true : false,
               cellAlign: "left",
               pageDots: false,
+              contain: true,
             }}
             onArrowClick={this.trackCarouselNav.bind(this)}
             data={collections as object[]} // type required by slider

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
@@ -51,7 +51,7 @@ export class RelatedCollectionsRail extends React.Component<
         <Box>
           <Waypoint onEnter={once(this.trackImpression.bind(this))} />
           <Serif size="8" color="black100">
-            Related to {title}
+            More like {title}
           </Serif>
           <Spacer pb={4} />
 
@@ -59,8 +59,8 @@ export class RelatedCollectionsRail extends React.Component<
             height="200px"
             options={{
               groupCells: sd.IS_MOBILE ? 1 : 4,
-
               cellAlign: "left",
+              contain: true,
               wrapAround: sd.IS_MOBILE ? true : false,
               pageDots: false,
               draggable: sd.IS_MOBILE ? true : false,

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.test.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.test.tsx
@@ -30,7 +30,7 @@ describe("CollectionsRail", () => {
     ).renderUntil(n => {
       return n.html().search("is-selected") > 0
     })
-    expect(component.text()).toMatch("Related to Street Art")
+    expect(component.text()).toMatch("More like Street Art")
     expect(component.find(RelatedCollectionEntity).length).toBe(8)
     expect(component.text()).toMatch("Flags")
     expect(component.text()).toMatch("From $1,000")


### PR DESCRIPTION
address: [Grow-1391](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1391)

- Based on the feedback from Jeffrey. On the collection page, "Related to [collection name] " -> "More like [collection name]" 

- Also on the collection page, 
  **before changing**, carousel shows 4 items by each clicking on the arrow button. Even though there are less than 4 items, it shows empty space after showing the items. See below.
![empty](https://user-images.githubusercontent.com/45926410/62241352-fea9e180-b3a6-11e9-9da0-f1da9da57f18.gif)

   **after changing**, no more empty space. Also, I found out same story is happen on the artist page. So, for the artist page,  I made the same changing like I did on the collection page. See below.
![collection](https://user-images.githubusercontent.com/45926410/62241538-55afb680-b3a7-11e9-8bf5-902187d887dc.gif)

![artist](https://user-images.githubusercontent.com/45926410/62241628-84c62800-b3a7-11e9-99cb-8d655ba7e27d.gif)

