### PR TITLE
[RecentlyViewed Carousel] Make consistent with recent patterns

### DIFF
--- a/src/Components/v2/RecentlyViewed.tsx
+++ b/src/Components/v2/RecentlyViewed.tsx
@@ -1,4 +1,4 @@
-import { Separator, Serif, Spacer } from "@artsy/palette"
+import { Box, Separator, Serif, Spacer } from "@artsy/palette"
 import { RecentlyViewed_me } from "__generated__/RecentlyViewed_me.graphql"
 import { RecentlyViewedQuery } from "__generated__/RecentlyViewedQuery.graphql"
 import { SystemContext, SystemContextConsumer } from "Artsy"
@@ -6,10 +6,11 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { FillwidthItem } from "Components/Artwork/FillwidthItem"
-import { Carousel } from "Components/v2/Carousel"
+import { ArrowButton, Carousel } from "Components/v2/Carousel"
 import React, { useContext } from "react"
 import { QueryRenderer } from "react-relay"
 import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components"
 
 export interface RecentlyViewedProps {
   me: RecentlyViewed_me
@@ -67,6 +68,22 @@ export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
                       />
                     )
                   }}
+                  renderLeftArrow={({ Arrow }) => {
+                    return (
+                      <ArrowContainer>
+                        <Arrow />
+                      </ArrowContainer>
+                    )
+                  }}
+                  renderRightArrow={({ Arrow }) => {
+                    return (
+                      <ArrowContainer>
+                        {me.recentlyViewedArtworks.edges.length > 4 && (
+                          <Arrow />
+                        )}
+                      </ArrowContainer>
+                    )
+                  }}
                 />
               </React.Fragment>
             )
@@ -76,6 +93,13 @@ export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
     )
   }
 }
+
+const ArrowContainer = styled(Box)`
+  align-self: flex-start;
+  ${ArrowButton} {
+    height: 60%;
+  }
+`
 
 export const RecentlyViewedFragmentContainer = createFragmentContainer(
   RecentlyViewed,

--- a/src/Components/v2/__stories__/RecentlyViewed.story.tsx
+++ b/src/Components/v2/__stories__/RecentlyViewed.story.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@artsy/palette"
-import { artworkBricks } from "Apps/__tests__/Fixtures/Carousel"
-import { RecentlyViewed } from "Components/v2"
+import { SystemContextProvider } from "Artsy"
+import { RecentlyViewedQueryRenderer } from "Components/v2"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Utils/Section"
@@ -10,15 +10,9 @@ storiesOf("Styleguide/Components", module).add("Recently Viewed", () => {
     <React.Fragment>
       <Section title="Recently Viewed">
         <Box width="70%">
-          <RecentlyViewed
-            me={
-              {
-                recentlyViewedArtworks: {
-                  edges: artworkBricks,
-                },
-              } as any
-            }
-          />
+          <SystemContextProvider>
+            <RecentlyViewedQueryRenderer />
+          </SystemContextProvider>
         </Box>
       </Section>
     </React.Fragment>


### PR DESCRIPTION
Noticed that our `RecentlyViewed` carousel hadn't been updated with some of our more recent patterns (show hide arrows, alignment, etc); this brings it in line. 

![recently-viewed](https://user-images.githubusercontent.com/236943/62246519-a2d85c00-b398-11e9-8940-43ab8969c4d2.gif)
