### PR TITLE
[Vanguard] Display video in headers/intro

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -30,7 +30,7 @@ export class VanguardArtistWrapper extends React.Component<
     const { isExpanded } = this.state
 
     return (
-      <ArtistContainer pb={4} maxWidth={1000} mx="auto">
+      <ArtistContainer pb={4} maxWidth={1000} px={4} mx="auto">
         <Box textAlign="center">
           <ArtistTitle size="8">{title}</ArtistTitle>
           <Box position="absolute">

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
@@ -1,35 +1,54 @@
 import { Box, Flex, Sans, Serif } from "@artsy/palette"
-import { Byline } from "Components/Publishing/Byline/Byline"
+import { Byline, BylineContainer } from "Components/Publishing/Byline/Byline"
 import { Text } from "Components/Publishing/Sections/Text"
 import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
+import { VanguardVideoBackground } from "./VideoBackground"
 
 export const VanguardIntroduction: React.SFC<{
   article: ArticleData
 }> = props => {
   const { description } = props.article.series
+
   return (
-    <Box pb={4} pt={70}>
-      <Flex
-        justifyContent="space-between"
-        flexDirection="column"
-        alignItems="center"
-        height="90vh"
-      >
-        <HeaderText size="8">The Artsy</HeaderText>
-        <Box pb={4}>
-          <Serif size="8">The Artists To Know Right Now</Serif>
-          <Byline article={props.article} />
-        </Box>
-      </Flex>
-      <Box pb={4} mx="auto" maxWidth={800}>
-        <Text layout="standard" html={description} />
+    <IntroContainer>
+      <Box minHeight="calc(100vh - 50px)" mb={150}>
+        <VanguardVideoBackground {...props} />
+        <HeaderText pt={70} size="8" textAlign="center">
+          The Artsy
+        </HeaderText>
       </Box>
-    </Box>
+
+      <Box mx="auto" maxWidth={980} px={4}>
+        <Flex flexDirection="column" alignItems="center" pb={75}>
+          <Title size="12" element="h1" textAlign="center" pb={1}>
+            The Artists To Know Right Now
+          </Title>
+          <Byline {...props} />
+        </Flex>
+        <Box pb={12}>
+          <Text layout="standard" html={description} width="800px" />
+        </Box>
+      </Box>
+    </IntroContainer>
   )
 }
 
 const HeaderText = styled(Sans)`
   font-size: 100px;
+`
+
+const IntroContainer = styled(Box)`
+  ${BylineContainer} {
+    div::before {
+      display: none;
+    }
+  }
+`
+
+const Title = styled(Serif)`
+  text-transform: uppercase;
+  font-size: 90px;
+  line-height: 1em;
 `

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
@@ -6,35 +6,37 @@ import { times } from "lodash"
 import React from "react"
 import styled from "styled-components"
 import { VanguardArtistWrapper } from "./ArtistWrapper"
+import { VanguardVideoBackground } from "./VideoBackground"
 
 export const VanguardSeriesWrapper: React.SFC<{
   article: ArticleData
   index: number
 }> = props => {
   const { article, index } = props
-  const { relatedArticles, title, series, hero_section } = article
-  const url = (hero_section && hero_section.url) || ""
-  const isVideo = url.includes("mp4")
+  const { relatedArticles, title, layout, series, slug } = article
 
   return (
-    <Box pb={4}>
-      <Box background={url && !isVideo && `url(${url})`}>
-        <Box mx="auto" maxWidth={1000} height="70vh">
-          {isVideo && (
-            <Video src={url} autoPlay controls={false} loop muted playsInline />
-          )}
-          <Numeral size="8">{times(index + 1, () => "I")}</Numeral>
-          <Sans size="8" textAlign="center">
+    <Box>
+      <Box height="95vh" mb={80}>
+        <VanguardVideoBackground article={article} />
+        <Box mx="auto" maxWidth={1400} px={4}>
+          <Numeral size="12">{times(index + 1, () => "I")}</Numeral>
+          <Title size="16" textAlign="center" element="h2">
             {title}
-          </Sans>
+          </Title>
         </Box>
       </Box>
-      <Box mx="auto" maxWidth={1000}>
-        <Flex pb={4} flexDirection="column" alignItems="center">
-          {series && <Serif size="8">{series.sub_title}</Serif>}
+
+      <Box mx="auto" maxWidth="65%" px={4} pb={150}>
+        <Flex flexDirection="column" alignItems="center">
+          {series && (
+            <SubTitle size="12" element="h3" pb={2}>
+              {series.sub_title}
+            </SubTitle>
+          )}
           <Share
             // TODO: We may need to use custom urls here for in-page routing
-            url={getFullEditorialHref(article.layout, article.slug)}
+            url={getFullEditorialHref(layout, slug)}
             title={title}
           />
         </Flex>
@@ -49,12 +51,18 @@ export const VanguardSeriesWrapper: React.SFC<{
   )
 }
 
-const Numeral = styled(Serif)`
-  position: absolute;
+const Title = styled(Sans)`
+  text-transform: uppercase;
+  text-align: center;
 `
 
-const Video = styled.video`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+const SubTitle = styled(Serif)`
+  text-transform: uppercase;
+  text-align: center;
+`
+
+const Numeral = styled(Serif)`
+  position: absolute;
+  font-size: 100px;
+  line-height: 1em;
 `

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VideoBackground.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VideoBackground.tsx
@@ -1,0 +1,26 @@
+import { ArticleData } from "Components/Publishing/Typings"
+import React from "react"
+import styled from "styled-components"
+
+export const VanguardVideoBackground: React.SFC<{
+  article: ArticleData
+}> = props => {
+  const { hero_section } = props.article
+  const url = (hero_section && hero_section.url) || ""
+  const isVideo = url.includes("mp4")
+
+  if (isVideo) {
+    return <Video src={url} autoPlay controls={false} loop muted playsInline />
+  } else {
+    return null
+  }
+}
+
+const Video = styled.video`
+  width: 100%;
+  height: 100%;
+  max-height: 95vh;
+  object-fit: cover;
+  position: absolute;
+  z-index: -1;
+`

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/index.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/index.tsx
@@ -20,8 +20,8 @@ export class Vanguard2019 extends React.Component<EditorialFeaturesProps> {
           backgroundColor="white"
           title={article.title}
         />
-        <FrameTextLeft size="8">2019</FrameTextLeft>
-        <FrameTextRight size="8">Vanguard</FrameTextRight>
+        <FrameTextLeft size="16">2019</FrameTextLeft>
+        <FrameTextRight size="16">Vanguard</FrameTextRight>
 
         {/** header landing video & intro text */}
         <VanguardIntroduction article={article} />
@@ -43,7 +43,6 @@ export class Vanguard2019 extends React.Component<EditorialFeaturesProps> {
 }
 
 const FrameText = styled(Sans)`
-  font-size: 100px;
   position: fixed;
   top: 50%;
   text-transform: uppercase;


### PR DESCRIPTION
Adds support for displaying video headers in Artsy Vanguard. Related to https://artsyproduct.atlassian.net/browse/GROW-1425