### PR TITLE
[Vanguard] SectionsList can accommodate custom widths

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -47,7 +47,7 @@ export class VanguardArtistWrapper extends React.Component<
           )}
         </Box>
         {/** TODO: Sections may need to be customized to handle expansion */}
-        <Sections article={article} />
+        <Sections article={article} customWidth={900} />
 
         <ReadMoreButton
           size="5"

--- a/src/Components/Publishing/Sections/ImageCollection.tsx
+++ b/src/Components/Publishing/Sections/ImageCollection.tsx
@@ -9,7 +9,7 @@ import { ArticleLayout, SectionLayout } from "../Typings"
 import { Artwork } from "./Artwork"
 import { Image } from "./Image"
 
-interface ImageCollectionProps {
+export interface ImageCollectionProps {
   color?: string
   images: any
   targetHeight?: number

--- a/src/Components/Publishing/Sections/SectionContainer.tsx
+++ b/src/Components/Publishing/Sections/SectionContainer.tsx
@@ -9,14 +9,16 @@ const Fillwidth = "100%"
 const OverflowWidth = "780px"
 const OverflowWidthClassic = "1100px"
 
-export const SectionContainer = styled.div.attrs<{
+export const SectionContainer = styled.div<{
   section?: SectionData
   articleLayout?: ArticleLayout
-}>({})`
+  customWidth?: number
+}>`
   box-sizing: border-box;
   margin: auto;
   margin-bottom: 40px;
-  width: ${props => getSectionWidth(props.section, props.articleLayout)};
+  width: ${props =>
+    getSectionWidth(props.section, props.articleLayout, props.customWidth)};
   max-width: 100%;
 
   ${props => pMedia.xl`
@@ -24,20 +26,27 @@ export const SectionContainer = styled.div.attrs<{
       `
       width: ${ColumnWidth}
     `}
-  `} ${props => pMedia.md`
+  `};
+
+  ${props => pMedia.md`
     padding: ${getSectionMobilePadding(props.section)};
   `};
 `
 
 export const getSectionWidth = (
   section?: SectionData,
-  articleLayout?: ArticleLayout
+  articleLayout?: ArticleLayout,
+  customWidth?: number
 ) => {
   const layout = (section && section.layout) || "column_width"
   const maybeOverflow =
     layout === "overflow_fillwidth" ? OverflowWidth : ColumnWidth
   const isText = section && section.type === "text"
   const isBlockquote = isText && section.body.includes("<blockquote>")
+
+  if (customWidth) {
+    return `${customWidth}px`
+  }
 
   switch (articleLayout) {
     case "standard": {

--- a/src/Components/Publishing/Sections/SectionContainer.tsx
+++ b/src/Components/Publishing/Sections/SectionContainer.tsx
@@ -1,6 +1,6 @@
+import { pMedia } from "Components/Helpers"
+import { ArticleLayout, SectionData } from "Components/Publishing/Typings"
 import styled from "styled-components"
-import { pMedia } from "../../Helpers"
-import { ArticleLayout, SectionData } from "../Typings"
 
 const BlockquoteWidth = "900px"
 const ColumnWidth = "680px"

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -150,8 +150,9 @@ export class Sections extends Component<Props, State> {
   }
 
   getSection(section, index) {
-    const { article, color, showTooltips } = this.props
-
+    const { article, color, customWidth, showTooltips } = this.props
+    const targetHeight = customWidth && customWidth > 750 ? 750 : 500
+    const size = customWidth && { width: customWidth }
     const sections = {
       image_collection: (
         <ImageCollection
@@ -159,8 +160,9 @@ export class Sections extends Component<Props, State> {
           sectionLayout={section.layout}
           articleLayout={article.layout}
           images={section.images}
-          targetHeight={500}
+          targetHeight={targetHeight}
           gutter={10}
+          size={size}
         />
       ),
       image_set: <ImageSetPreview section={section} color={color} />,

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -25,6 +25,7 @@ interface Props {
   showTooltips?: boolean
   isSponsored?: boolean
   isSuper?: boolean
+  customWidth?: number
 }
 
 interface State {
@@ -229,7 +230,7 @@ export class Sections extends Component<Props, State> {
   }
 
   renderSections() {
-    const { article, isMobile, isSponsored, isSuper } = this.props
+    const { article, customWidth, isMobile, isSponsored, isSuper } = this.props
     const { shouldInjectMobileDisplay } = this.state
     let quantityOfAdsRendered = 0
     let firstAdInjected = false
@@ -315,6 +316,7 @@ export class Sections extends Component<Props, State> {
             key={index}
             articleLayout={article.layout}
             section={section}
+            customWidth={customWidth}
           >
             {child}
             {ad}

--- a/src/Components/Publishing/Sections/__tests__/SectionContainer.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/SectionContainer.test.tsx
@@ -25,6 +25,10 @@ describe("SectionContainer", () => {
       expect(getSectionWidth()).toBe("680px")
     })
 
+    it("returns a custom width if prop provided", () => {
+      expect(getSectionWidth(section, "feature", 900)).toBe("900px")
+    })
+
     describe("classic layout", () => {
       const articleLayout = "classic"
 

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
@@ -6,6 +6,10 @@ import {
   StandardArticle,
 } from "Components/Publishing/Fixtures/Articles"
 import { WrapperWithFullscreenContext } from "Components/Publishing/Fixtures/Helpers"
+import {
+  ImageCollection,
+  ImageCollectionProps,
+} from "Components/Publishing/Sections/ImageCollection"
 import { SectionData } from "Components/Publishing/Typings"
 import { mount } from "enzyme"
 import "jest-styled-components"
@@ -240,6 +244,33 @@ describe("Sections", () => {
       ad = ads.at(1).props()
       expect(ad.adUnit).toBe("Mobile_InContentLB2")
       expect(ad.adDimension).toBe("300x250")
+    })
+  })
+
+  describe("Images targetHeight", () => {
+    it("Returns default targetHeight and size", () => {
+      props.article = FeatureArticle
+
+      const wrapper = mountWrapper(props)
+      const imageProps = wrapper
+        .find(ImageCollection)
+        .at(0)
+        .props() as ImageCollectionProps
+      expect(imageProps.targetHeight).toBe(500)
+      expect(imageProps.size.width).toBe(680)
+    })
+
+    it("Increases image targetHeight and size if a wide customWidth is passed", () => {
+      props.article = FeatureArticle
+      props.customWidth = 900
+
+      const wrapper = mountWrapper(props)
+      const imageProps = wrapper
+        .find(ImageCollection)
+        .at(0)
+        .props() as ImageCollectionProps
+      expect(imageProps.targetHeight).toBe(750)
+      expect(imageProps.size.width).toBe(900)
     })
   })
 

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -51,67 +51,6 @@ exports[`Sections snapshots tests renders properly 1`] = `
   line-height: 26px;
 }
 
-.c45 {
-  font-family: artsy-icons;
-  color: black;
-  font-size: 24px;
-  margin: 0 5px;
-  display: inline-block;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  position: relative;
-  color: black;
-}
-
-.c40 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-bottom: 20px;
-  color: black;
-}
-
-.c40 a {
-  color: black;
-}
-
-.c42 {
-  margin-right: 20px;
-}
-
-.c43 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.c43 .c44 {
-  vertical-align: middle;
-  margin: 0;
-}
-
-.c39 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c24 {
-  width: 100%;
-  height: 1000px;
-}
-
 .c19 {
   margin-right: 30px;
 }
@@ -285,6 +224,67 @@ exports[`Sections snapshots tests renders properly 1`] = `
 .c26 {
   margin-right: 0px;
   width: 222px;
+}
+
+.c45 {
+  font-family: artsy-icons;
+  color: black;
+  font-size: 24px;
+  margin: 0 5px;
+  display: inline-block;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  position: relative;
+  color: black;
+}
+
+.c40 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 20px;
+  color: black;
+}
+
+.c40 a {
+  color: black;
+}
+
+.c42 {
+  margin-right: 20px;
+}
+
+.c43 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.c43 .c44 {
+  vertical-align: middle;
+  margin: 0;
+}
+
+.c39 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c24 {
+  width: 100%;
+  height: 1000px;
 }
 
 .c36 {
@@ -639,13 +639,6 @@ exports[`Sections snapshots tests renders properly 1`] = `
   }
 }
 
-@media (max-width:720px) {
-  .c24 {
-    height: 1300px;
-    width: 100%;
-  }
-}
-
 @media (max-width:600px) {
   .c17 {
     padding: 0 10px;
@@ -717,6 +710,13 @@ exports[`Sections snapshots tests renders properly 1`] = `
 @media (max-width:600px) {
   .c26 {
     margin-bottom: 10px;
+  }
+}
+
+@media (max-width:720px) {
+  .c24 {
+    height: 1300px;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Related to https://artsyproduct.atlassian.net/browse/GROW-1432

Updates `Sections` and related components to accommodate a `customWidth` prop, which overrides widths based on `article.layout`.  This also updates the image sizes passed down to image sections.