### PR TITLE
Refactor ConditionsOfSaleCheckbox to use palette checkbox

### DIFF
--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Input, Serif } from "@artsy/palette"
+import { Box, Button, Flex, Input, Sans, Serif } from "@artsy/palette"
 import { AuctionApp_sale } from "__generated__/AuctionApp_sale.graphql"
 import { RegistrationFormCreateBidderMutation } from "__generated__/RegistrationFormCreateBidderMutation.graphql"
 import { RegistrationFormCreateCreditCardMutation } from "__generated__/RegistrationFormCreateCreditCardMutation.graphql"
@@ -40,6 +40,8 @@ const InnerForm = (props: FormikProps<FormValues>) => {
     isSubmitting,
     handleChange,
     values,
+    setFieldValue,
+    setFieldTouched,
   } = props
 
   return (
@@ -128,14 +130,22 @@ const InnerForm = (props: FormikProps<FormValues>) => {
         </Box>
       </Box>
 
-      <Flex mt={4} mb={2} justifyContent="center">
-        <ConditionsOfSaleCheckbox
-          error={touched.agree_to_terms && errors.agree_to_terms}
-          value={values.agree_to_terms}
-          name="agree_to_terms"
-          onChange={handleChange}
-          onBlur={handleBlur}
-        />
+      <Flex mt={4} mb={2} flexDirection="column" justifyContent="center">
+        <Box mx="auto">
+          <ConditionsOfSaleCheckbox
+            selected={values.agree_to_terms}
+            onSelect={value => {
+              setFieldValue("agree_to_terms", value)
+              setFieldTouched("agree_to_terms")
+            }}
+          />
+        </Box>
+
+        {touched.agree_to_terms && errors.agree_to_terms && (
+          <Sans mt={1} color="red100" size="2" textAlign="center">
+            {errors.agree_to_terms}
+          </Sans>
+        )}
       </Flex>
 
       <Button mt={1} size="large" width="100%" loading={isSubmitting}>

--- a/src/Components/Auction/AuctionRegistrationModal.tsx
+++ b/src/Components/Auction/AuctionRegistrationModal.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react"
 
-import { Box, Button, Flex, Serif } from "@artsy/palette"
+import { Box, Button, Flex, Sans, Serif } from "@artsy/palette"
 import { Modal } from "@artsy/palette"
-import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
+import { ConditionsOfSaleCheckbox } from "./ConditionsOfSaleCheckbox"
 
 // For convenience even though sale is for now a single value
 interface Sale {
@@ -69,16 +69,18 @@ export const AuctionRegistrationModal: React.FC<Props> = ({
           Welcome back. To complete your registration, please confirm that you
           agree to the Conditions of Sale.
         </Serif>
-        <Flex my={4} justifyContent="center">
-          <ConditionsOfSaleCheckbox
-            name="accept_cos"
-            value={acceptedConditions}
-            onChange={e => {
-              setAcceptedConditions(e.target.checked)
-            }}
-            onBlur={() => null}
-            error={error}
-          />
+        <Flex my={4} flexDirection="column" justifyContent="center">
+          <Box mx="auto">
+            <ConditionsOfSaleCheckbox
+              selected={acceptedConditions}
+              onSelect={value => setAcceptedConditions(value)}
+            />
+          </Box>
+          {error && (
+            <Sans mt={1} color="red100" size="2">
+              {error}
+            </Sans>
+          )}
         </Flex>
         <Button
           block

--- a/src/Components/Auction/ConditionsOfSaleCheckbox.tsx
+++ b/src/Components/Auction/ConditionsOfSaleCheckbox.tsx
@@ -1,52 +1,23 @@
-import { Box, Link, Sans, Serif } from "@artsy/palette"
-import Checkbox from "Components/Checkbox"
+import { Checkbox, CheckboxProps, Link, Serif } from "@artsy/palette"
 import React from "react"
 import { data as sd } from "sharify"
-import styled from "styled-components"
 
-interface Props {
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
-  name: string
-  error?: string
-  onBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void
-  value: boolean
-}
-
-export const ConditionsOfSaleCheckbox: React.FC<Props> = ({
-  error,
-  name,
-  onChange,
-  onBlur,
-  value,
-  ...props
-}) => {
+export const ConditionsOfSaleCheckbox: React.FC<CheckboxProps> = props => {
   return (
-    <Box mx="auto">
-      <StyledCheckbox {...{ checked: value, error, onChange, onBlur, name }}>
-        <Serif display="inline" color="black60" size="3t" ml={0.5}>
-          {"Agree to "}
-          <Serif display="inline" color="black100" size="3t">
-            <Link
-              color="black100"
-              href={`${sd.APP_URL}/conditions-of-sale`}
-              target="_blank"
-            >
-              Conditions of Sale
-            </Link>
-          </Serif>
-          .
+    <Checkbox {...props}>
+      <Serif display="inline" color="black60" size="3t" ml={0.5}>
+        {"Agree to "}
+        <Serif display="inline" color="black100" size="3t">
+          <Link
+            color="black100"
+            href={`${sd.APP_URL}/conditions-of-sale`}
+            target="_blank"
+          >
+            Conditions of Sale
+          </Link>
         </Serif>
-      </StyledCheckbox>
-      {error && (
-        <Sans mt={1} color="red100" size="2">
-          {error}
-        </Sans>
-      )}
-    </Box>
+        .
+      </Serif>
+    </Checkbox>
   )
 }
-
-const StyledCheckbox = styled(Checkbox)`
-  margin: 5px 0;
-  align-items: flex-start;
-`

--- a/src/Components/Auction/ConditionsOfSaleCheckbox.tsx
+++ b/src/Components/Auction/ConditionsOfSaleCheckbox.tsx
@@ -16,7 +16,6 @@ export const ConditionsOfSaleCheckbox: React.FC<CheckboxProps> = props => {
             Conditions of Sale
           </Link>
         </Serif>
-        .
       </Serif>
     </Checkbox>
   )

--- a/src/Components/Auction/ConditionsOfSaleCheckbox.tsx
+++ b/src/Components/Auction/ConditionsOfSaleCheckbox.tsx
@@ -2,9 +2,12 @@ import { Checkbox, CheckboxProps, Link, Serif } from "@artsy/palette"
 import React from "react"
 import { data as sd } from "sharify"
 
-export const ConditionsOfSaleCheckbox: React.FC<CheckboxProps> = props => {
+export const ConditionsOfSaleCheckbox: React.FC<CheckboxProps> = ({
+  selected,
+  onSelect,
+}) => {
   return (
-    <Checkbox {...props}>
+    <Checkbox selected={selected} onSelect={onSelect}>
       <Serif display="inline" color="black60" size="3t" ml={0.5}>
         {"Agree to "}
         <Serif display="inline" color="black100" size="3t">

--- a/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
+++ b/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
@@ -1,9 +1,8 @@
-import { Modal } from "@artsy/palette"
+import { Button, Checkbox, Modal } from "@artsy/palette"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
-
-import { Button } from "@artsy/palette"
+import { act } from "react-dom/test-utils"
 import { flushPromiseQueue } from "Utils/flushPromiseQueue"
 import { AuctionRegistrationModal } from "../AuctionRegistrationModal"
 
@@ -37,9 +36,10 @@ describe("AuctionRegistrationModal", () => {
   })
 
   it("calls the onSubmit prop when trying to submit after accepting terms", async () => {
-    wrapper
-      .find('input[type="checkbox"]')
-      .simulate("change", { target: { checked: true } })
+    act(() => {
+      wrapper.find(Checkbox).prop("onSelect")(true)
+    })
+
     await flushPromiseQueue()
     wrapper.find(Button).simulate("click")
     expect(wrapper.text()).not.toMatch("You must agree to our terms.")


### PR DESCRIPTION
This PR updates the Auction registration conditions of sale checkbox (used in both registration form and modal) to use the palette checkbox, which has more consistent performance and avoids a breaking issue on touch interfaces.

Paired with @dblandin 

![2019-08-12 16 49 13](https://user-images.githubusercontent.com/9088720/62897388-255e0580-bd21-11e9-95ad-3fc037738031.gif)

![2019-08-12 17 03 25](https://user-images.githubusercontent.com/9088720/62898292-27c15f00-bd23-11e9-95b8-28eb1d9f0bee.gif)
