### PR TITLE
Extract tooltip provider from fullscreen logic

### DIFF
--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -2,6 +2,7 @@ import { Theme } from "@artsy/palette"
 import React from "react"
 
 import { EditorialFeature } from "Components/Publishing/EditorialFeature/EditorialFeature"
+import { TooltipsDataProvider } from "Components/Publishing/ToolTip/TooltipsDataProvider"
 import { Bling as GPT } from "react-gpt"
 import track, { TrackingProp } from "react-tracking"
 import { MediaContextProvider } from "Utils/Responsive"
@@ -120,15 +121,20 @@ export class Article extends React.Component<ArticleProps> {
     return (
       <MediaContextProvider>
         <Theme>
-          <FullScreenProvider>
-            {this.getArticleLayout()}
-            {trackingCode && (
-              <PixelTracker unit={trackingCode} date={this.props.renderTime} />
-            )}
-            {this.shouldRenderSignUpCta() && (
-              <BannerWrapper article={article} />
-            )}
-          </FullScreenProvider>
+          <TooltipsDataProvider {...this.props}>
+            <FullScreenProvider>
+              {this.getArticleLayout()}
+              {trackingCode && (
+                <PixelTracker
+                  unit={trackingCode}
+                  date={this.props.renderTime}
+                />
+              )}
+              {this.shouldRenderSignUpCta() && (
+                <BannerWrapper article={article} />
+              )}
+            </FullScreenProvider>
+          </TooltipsDataProvider>
         </Theme>
       </MediaContextProvider>
     )

--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -162,12 +162,14 @@ export const getArtsySlugsFromArticle = (
   article: ArticleData
 ): SlugsFromArticle => {
   const articleBody = article.sections
-    .map(section => {
-      if (section.type === "text") {
-        return section.body
-      }
-    })
-    .join()
+    ? article.sections
+        .map(section => {
+          if (section.type === "text") {
+            return section.body
+          }
+        })
+        .join()
+    : ""
 
   const artists = uniq(getArtsySlugsFromHTML(articleBody, "artist"))
   const genes = uniq(getArtsySlugsFromHTML(articleBody, "gene"))

--- a/src/Components/Publishing/Layouts/ArticleWithFullScreen.tsx
+++ b/src/Components/Publishing/Layouts/ArticleWithFullScreen.tsx
@@ -5,7 +5,6 @@ import track from "react-tracking"
 import { ArticleProps } from "../Article"
 import { FullscreenViewer } from "../Sections/FullscreenViewer/FullscreenViewer"
 import { withFullScreen } from "../Sections/FullscreenViewer/withFullScreen"
-import { TooltipsData } from "../ToolTip/TooltipsDataLoader"
 import { ArticleData } from "../Typings"
 import { FeatureLayout } from "./FeatureLayout"
 import { StandardLayout } from "./StandardLayout"
@@ -66,17 +65,12 @@ export class ArticleWithFullScreen extends React.Component<
       customEditorial,
       slideIndex,
       viewerIsOpen,
-      onOpenAuthModal,
     } = this.props
 
     const articleProps = extend(cloneDeep(this.props), { article, slideIndex })
 
     return (
-      <TooltipsData
-        article={article}
-        shouldFetchData={this.props.showTooltips}
-        onOpenAuthModal={onOpenAuthModal}
-      >
+      <div>
         {customEditorial ? (
           <EditorialFeature {...articleProps} />
         ) : article.layout === "feature" ? (
@@ -90,7 +84,7 @@ export class ArticleWithFullScreen extends React.Component<
           slideIndex={slideIndex}
           images={fullscreenImages}
         />
-      </TooltipsData>
+      </div>
     )
   }
 }

--- a/src/Components/Publishing/ToolTip/TooltipsDataProvider.tsx
+++ b/src/Components/Publishing/ToolTip/TooltipsDataProvider.tsx
@@ -2,18 +2,16 @@ import { ArticleProps } from "Components/Publishing/Article"
 import React from "react"
 import { TooltipsData } from "./TooltipsDataLoader"
 
-export class TooltipsDataProvider extends React.Component<ArticleProps> {
-  render() {
-    const { article, onOpenAuthModal, showTooltips } = this.props
+export const TooltipsDataProvider: React.SFC<ArticleProps> = props => {
+  const { article, onOpenAuthModal, showTooltips } = props
 
-    return (
-      <TooltipsData
-        article={article}
-        shouldFetchData={showTooltips}
-        onOpenAuthModal={onOpenAuthModal}
-      >
-        {this.props.children}
-      </TooltipsData>
-    )
-  }
+  return (
+    <TooltipsData
+      article={article}
+      shouldFetchData={showTooltips}
+      onOpenAuthModal={onOpenAuthModal}
+    >
+      {props.children}
+    </TooltipsData>
+  )
 }

--- a/src/Components/Publishing/ToolTip/TooltipsDataProvider.tsx
+++ b/src/Components/Publishing/ToolTip/TooltipsDataProvider.tsx
@@ -1,0 +1,19 @@
+import { ArticleProps } from "Components/Publishing/Article"
+import React from "react"
+import { TooltipsData } from "./TooltipsDataLoader"
+
+export class TooltipsDataProvider extends React.Component<ArticleProps> {
+  render() {
+    const { article, onOpenAuthModal, showTooltips } = this.props
+
+    return (
+      <TooltipsData
+        article={article}
+        shouldFetchData={showTooltips}
+        onOpenAuthModal={onOpenAuthModal}
+      >
+        {this.props.children}
+      </TooltipsData>
+    )
+  }
+}

--- a/src/Components/Publishing/__tests__/Constants.test.ts
+++ b/src/Components/Publishing/__tests__/Constants.test.ts
@@ -7,7 +7,11 @@ import {
   getFullEditorialHref,
   getMediaDate,
 } from "../Constants"
-import { FeatureArticle, VideoArticle } from "../Fixtures/Articles"
+import {
+  FeatureArticle,
+  SeriesArticle,
+  VideoArticle,
+} from "../Fixtures/Articles"
 
 describe("getMediaDate", () => {
   let article
@@ -112,7 +116,10 @@ describe("getFullEditorialHref", () => {
 })
 
 describe("getArtsySlugs", () => {
-  const article = cloneDeep(FeatureArticle)
+  let article
+  beforeEach(() => {
+    article = cloneDeep(FeatureArticle)
+  })
 
   it("#getArtsySlugsFromArticle returns object with arrays of artsy ids by model", () => {
     article.sections.push({
@@ -125,6 +132,14 @@ describe("getArtsySlugs", () => {
     expect(slugs.artists.length).toBe(6)
     expect(slugs.genes.length).toBe(1)
     expect(slugs.genes[0]).toBe("capitalist-realism")
+  })
+
+  it("#getArtsySlugsFromArticle can handle articles without sections", () => {
+    article = cloneDeep(SeriesArticle)
+    const slugs = getArtsySlugsFromArticle(article)
+
+    expect(slugs.artists.length).toBe(0)
+    expect(slugs.genes.length).toBe(0)
   })
 
   it("#getArtsySlugsFromHTML can return linked artists from html", () => {


### PR DESCRIPTION
Our `FullscreenProvider` was doing double duty, because it also contained logic related to fetching Tooltip data -- this PR separates the tooltip logic into its own component, `TooltipsDataProvider`. 

I ran into issues with the co-location when working on changes to slideshows in the Vanguard project, this should unblock that work.