### PR TITLE
Bump react to 16.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "prettier": "1.16.4",
     "raf": "3.4.0",
     "raw-loader": "0.5.1",
-    "react": "16.8.2",
+    "react": "16.8.4",
     "react-addons-test-utils": "16.0.0-alpha.3",
     "react-docgen-typescript-loader": "2.1.0",
     "react-dom": "16.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12811,15 +12811,15 @@ react-waypoint@^7.3.3:
     consolidated-events "^1.1.0"
     prop-types "^15.0.0"
 
-react@16.8.2:
-  version "16.8.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.2.tgz#83064596feaa98d9c2857c4deae1848b542c9c0c"
-  integrity sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==
+react@16.8.4:
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.4.tgz#fdf7bd9ae53f03a9c4cd1a371432c206be1c4768"
+  integrity sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.2"
+    scheduler "^0.13.4"
 
 react@^16.8.3:
   version "16.8.6"


### PR DESCRIPTION
Bumps `react` version to match `react-dom` and versions used in force, in an attempt to mitigate Force testing issues.