### PR TITLE
Adds prop to hide ads from feature articles for vanguard development

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -90,7 +90,7 @@ export class VanguardArtistWrapper extends React.Component<
           </Box>
 
           {/** TODO: Sections may need to be customized to handle expansion */}
-          <Sections article={article} />
+          <Sections hideAds article={article} />
 
           <ReadMoreButton
             size="5"

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -26,6 +26,7 @@ interface Props {
   isSponsored?: boolean
   isSuper?: boolean
   customWidth?: number
+  hideAds?: boolean
 }
 
 interface State {
@@ -232,7 +233,14 @@ export class Sections extends Component<Props, State> {
   }
 
   renderSections() {
-    const { article, customWidth, isMobile, isSponsored, isSuper } = this.props
+    const {
+      article,
+      customWidth,
+      isMobile,
+      isSponsored,
+      isSuper,
+      hideAds,
+    } = this.props
     const { shouldInjectMobileDisplay } = this.state
     let quantityOfAdsRendered = 0
     let firstAdInjected = false
@@ -258,7 +266,8 @@ export class Sections extends Component<Props, State> {
         (sectionItem.type === "image_collection" ||
           sectionItem.type === "image_set") &&
         !firstAdInjected &&
-        !isSuper
+        !isSuper &&
+        !hideAds
 
       if (firstAdInjected) {
         placementCount++

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
@@ -158,6 +158,14 @@ describe("Sections", () => {
       expect(wrapper.find(DisplayAd).length).toBe(2)
     })
 
+    it("it does not inject display ads on features if hideAd props is passed", () => {
+      props.article = FeatureArticle
+      props.isMobile = false
+      props.hideAds = true
+      const wrapper = mountWrapper(props)
+      expect(wrapper.find(DisplayAd).length).toBe(0)
+    })
+
     it("it injects display ads with correct targeting data if not sponsored feature", () => {
       props.article = NonSponsoredFeatureArticle
       props.isMobile = false


### PR DESCRIPTION
Currently, we are not expecting to render ads on the 2019 Artsy Vanguard article series.

This PR adds a boolean property we can use to render/hide display ads.