### PR TITLE
[GROW-1355]: Address OtherCollectionsRail QA items

### DIFF
--- a/src/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -159,6 +159,11 @@ const FeaturedCollectionsContainer = styled(Box)`
 
 const Container = styled(Box)`
   border: 1px solid ${color("black10")};
+  border-radius: 2px;
+  &:hover {
+    text-decoration: none;
+    border: 1px solid ${color("black60")};
+  }
 `
 
 const ExtendedSerif = styled(Serif)`
@@ -198,9 +203,5 @@ export const StyledLink = styled(Link)`
 
   &:hover {
     text-decoration: none;
-
-    ${CollectionTitle} {
-      text-decoration: underline;
-    }
   }
 `

--- a/src/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -15,7 +15,12 @@ export const StyledLink = styled(Link)`
   text-decoration: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   border: 1px solid ${color("black10")};
+  border-radius: 2px;
   margin-right: 10px;
+  &:hover {
+    text-decoration: none;
+    border: 1px solid ${color("black60")};
+  }
 `
 
 export const ImageContainer = styled(Box)`
@@ -25,6 +30,7 @@ export const ImageContainer = styled(Box)`
 
 export const ThumbnailImage = styled(ResponsiveImage)`
   background-size: cover;
+  border-radius: 2px 1px 1px 2px;
 `
 
 const TitleContainer = styled(Serif)`

--- a/src/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -52,6 +52,7 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
           wrapAround: sd.IS_MOBILE ? true : false,
           pageDots: false,
           draggable: sd.IS_MOBILE ? true : false,
+          contain: true,
         }}
         data={members}
         render={slide => {


### PR DESCRIPTION
Addresses: [GROW-1355](https://artsyproduct.atlassian.net/browse/GROW-1355)

Addresses the follow QA items:
- Only show the remaining items in the carousel when there is an odd number (prevents showing whitespace)
- Ensure the component tiles have a 2px radius border
- Change the border color from black-10 to black-60 on hover

![Screen Shot 2019-08-14 at 1 29 07 PM](https://user-images.githubusercontent.com/5201004/63042264-9f17ff80-be97-11e9-92ff-2c9c7d8ce02d.png)

![Screen Shot 2019-08-14 at 1 29 16 PM](https://user-images.githubusercontent.com/5201004/63042267-a3441d00-be97-11e9-9795-031b62f05e67.png)


