### PR TITLE
Call modal onClose only after show has been set to false

### DIFF
--- a/src/Components/Auction/AuctionRegistrationModal.tsx
+++ b/src/Components/Auction/AuctionRegistrationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 
 import { Box, Button, Flex, Sans, Serif } from "@artsy/palette"
 import { Modal } from "@artsy/palette"
@@ -37,8 +37,13 @@ export const AuctionRegistrationModal: React.FC<Props> = ({
 
   function closeModal() {
     setShow(false)
-    onClose()
   }
+
+  useEffect(() => {
+    if (!show) {
+      onClose()
+    }
+  }, [show])
 
   function validate() {
     if (acceptedConditions) {

--- a/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
+++ b/src/Components/Auction/__tests__/AuctionRegistrationModal.test.tsx
@@ -46,8 +46,14 @@ describe("AuctionRegistrationModal", () => {
     expect(defaultProps.onSubmit).toHaveBeenCalled()
   })
 
-  it("calls the onClose prop when the modal closes", async () => {
+  it("calls the onClose prop AFTER the modal show prop turns false", async () => {
+    expect(wrapper.find(Modal).prop("show")).toEqual(true)
+
+    defaultProps.onClose.mockImplementationOnce(() => {
+      expect(wrapper.find(Modal).prop("show")).toEqual(false)
+    })
     wrapper.find("CloseIcon").simulate("click")
+    await flushPromiseQueue()
     expect(defaultProps.onClose).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
This PR fixes the same issue that we found in https://github.com/artsy/force/pull/4411.

~🚧 WIP 🚧 : As shown in the gif below the palette modal is showing scrollbars. I'm going to hold off on this until we have a clear path forward on that. _Fixed in artsy/palette#565 so just need that to get merged into reaction and this will be unblocked_~

Once merged, that force PR will need to be updated to include this change.

In short both changes are the same. We had a modal close handler that looked like this:
```
handleClose(){
  setModalVisible(false)  // state hook
  setReduxModalType(null)  redux handler passed in as a prop
}
```
Because they were called next to each other, the changes were batched together.
Because they were batched together, the second change (in a parent component, force's auction `Layout.js`) causes the modal be removed from the component tree completely.
Because the modal is removed from the tree, react doesn't bother with the first change (passing `false` into the `Modal` wrapper's `show` prop)
Because the `show` prop never changes to false, the wrapper Modal component never [undoes the scroll lock it applied to the body element](https://github.com/artsy/palette/blob/master/packages/palette/src/elements/Modal/Modal.tsx#L89-L104)

This pr fixes it.

Opening and closing the modal, linked to force, and seeing the scroll behavior preserved:
![2019-08-15 12 22 30](https://user-images.githubusercontent.com/9088720/63109532-76573f00-bf57-11e9-8933-aca7b5d84047.gif)
