### PR TITLE
[TRIVIAL] Put back super article related_articles

### DIFF
--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -1221,7 +1221,7 @@ export const SuperArticle = extend(cloneDeep(FeatureArticle), {
     partner_logo:
       "https://artsy-media-uploads.s3.amazonaws.com/PUn-n_Zn0VHfyDKofWeLeQ%2FUBS_Black.png",
     partner_logo_link: "https://www.ubs.com/microsites/planet-art/home.html",
-    related_article_ids: [
+    related_articles: [
       "5846e12cc137140011634710",
       "5846e1fdc137140011634711",
       "58459e56104093001189a7d1",


### PR DESCRIPTION
Changed the `SuperArticle` fixture incorrectly, it does indeed use `related_articles` and not the newer `related_article_ids` (https://github.com/artsy/reaction/pull/2694/files), breaking Force tests.