### PR TITLE
Auction post-registration modal (migrating from force)

### DIFF
--- a/src/Components/Auction/PostRegistrationModal.tsx
+++ b/src/Components/Auction/PostRegistrationModal.tsx
@@ -1,0 +1,111 @@
+import { Box, Button, CheckCircleIcon, Modal, Serif } from "@artsy/palette"
+import React, { useEffect, useState } from "react"
+
+export type ContentKey =
+  | "registrationConfirmed"
+  | "registrationPending"
+  | "bidPending"
+
+interface Props {
+  onClose: () => void
+  contentKey: ContentKey
+}
+
+type ModalContent = React.ComponentType<{ onClick: () => void }>
+
+const BidPending: ModalContent = ({ onClick }) => {
+  return (
+    <>
+      <RegistrationPendingHeader />
+      <Serif my={3} size="3t">
+        We're sorry, your bid could not be placed.
+      </Serif>
+      <ReviewingRegistrationContent />
+      <ViewWorksButton onClick={onClick} />
+    </>
+  )
+}
+
+const RegistrationPending: ModalContent = ({ onClick }) => {
+  return (
+    <>
+      <RegistrationPendingHeader />
+      <ReviewingRegistrationContent />
+      <ViewWorksButton onClick={onClick} />
+    </>
+  )
+}
+const RegistrationComplete: ModalContent = ({ onClick }) => {
+  return (
+    <>
+      <Serif size="6">Registration complete</Serif>
+      <CheckCircleIcon mt={2} height="28px" width="28px" fill="green100" />
+      <Serif mt={2} mb={3} size="3t">
+        Thank you for registering.
+        <br />
+        You’re now eligible to bid on lots in this sale.
+      </Serif>
+      <Button width="100%" onClick={onClick}>
+        Start bidding
+      </Button>
+    </>
+  )
+}
+
+const contentFor: { [key in ContentKey]: ModalContent } = {
+  registrationConfirmed: RegistrationComplete,
+  registrationPending: RegistrationPending,
+  bidPending: BidPending,
+}
+
+export const PostRegistrationModal: React.FC<Props> = ({
+  onClose,
+  contentKey,
+}) => {
+  const [show, setShow] = useState(true)
+
+  function closeModal() {
+    setShow(false)
+  }
+
+  useEffect(() => {
+    if (!show) {
+      onClose()
+    }
+  }, [show])
+
+  const Content = contentFor[contentKey]
+
+  return (
+    <Modal show={show} onClose={closeModal}>
+      <Box pt={[3, 0]} textAlign="center">
+        <Content onClick={closeModal} />
+      </Box>
+    </Modal>
+  )
+}
+
+const ReviewingRegistrationContent = () => {
+  return (
+    <Serif my={3} size="3t">
+      Artsy is reviewing your registration and you will receive an email when it
+      has been confirmed. Please email specialist@artsy.net with any questions.
+      <br />
+      <br />
+      In the meantime, you can still view works and watch lots you’re interested
+      in.
+    </Serif>
+  )
+}
+
+const RegistrationPendingHeader = () => {
+  return <Serif size="6">Registration pending</Serif>
+}
+
+const ViewWorksButton = props => {
+  return (
+    <Button width="100%" onClick={props.onClick}>
+      View works in this sale
+    </Button>
+  )
+}

--- a/src/Components/Auction/__stories__/AuctionRegistrationModal.story.tsx
+++ b/src/Components/Auction/__stories__/AuctionRegistrationModal.story.tsx
@@ -8,17 +8,14 @@ const submitHandler = submitUtils => {
     alert("Your Submission Callback Here")
   }, 1000)
 }
-storiesOf("Components/AuctionRegistrationModal", module).add(
-  "AuctionRegistrationModal",
-  () => {
-    return (
-      <>
-        <AuctionRegistrationModal
-          onSubmit={submitHandler}
-          onClose={() => null}
-          auction={{ name: "Big Time Sale" }}
-        />
-      </>
-    )
-  }
-)
+storiesOf("Components/Auction", module).add("AuctionRegistrationModal", () => {
+  return (
+    <>
+      <AuctionRegistrationModal
+        onSubmit={submitHandler}
+        onClose={() => null}
+        auction={{ name: "Big Time Sale" }}
+      />
+    </>
+  )
+})

--- a/src/Components/Auction/__stories__/PostRegistrationModal.story.tsx
+++ b/src/Components/Auction/__stories__/PostRegistrationModal.story.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { PostRegistrationModal } from "../PostRegistrationModal"
+
+storiesOf("Components/Auction", module)
+  .add("PostRegistrationModal - Confirmed", () => {
+    return (
+      <>
+        <PostRegistrationModal
+          contentKey="registrationConfirmed"
+          onClose={() => null}
+        />
+      </>
+    )
+  })
+  .add("PostRegistrationModal - Registration Pending", () => {
+    return (
+      <>
+        <PostRegistrationModal
+          contentKey="registrationPending"
+          onClose={() => null}
+        />
+      </>
+    )
+  })
+  .add("PostRegistrationModal - Bid Pending", () => {
+    return (
+      <>
+        <PostRegistrationModal contentKey="bidPending" onClose={() => null} />
+      </>
+    )
+  })

--- a/src/Components/Auction/__tests__/PostRegistrationModal.test.tsx
+++ b/src/Components/Auction/__tests__/PostRegistrationModal.test.tsx
@@ -1,0 +1,61 @@
+import { Modal } from "@artsy/palette"
+import { mount } from "enzyme"
+import React from "react"
+import { flushPromiseQueue } from "Utils/flushPromiseQueue"
+import { ContentKey, PostRegistrationModal } from "../PostRegistrationModal"
+
+const closeMock = jest.fn()
+const defaultProps = {
+  onClose: closeMock,
+}
+
+describe("AuctionRegistrationModal", () => {
+  const mountModal = async (key: ContentKey) => {
+    const wrapper = mount(
+      <PostRegistrationModal onClose={closeMock} contentKey={key} />
+    )
+
+    // We need to await the promises to let this wrapper render
+    await flushPromiseQueue()
+    wrapper.update()
+    return wrapper
+  }
+
+  beforeEach(jest.resetAllMocks)
+
+  it("renders a registration confirmation modal", async () => {
+    const wrapper = await mountModal("registrationConfirmed")
+
+    expect(wrapper.find(Modal).text()).toMatch(
+      "Thank you for registering.You’re now eligible to bid on lots in this sale."
+    )
+  })
+
+  it("renders a registration pending modal", async () => {
+    const wrapper = await mountModal("registrationPending")
+
+    expect(wrapper.find(Modal).text()).toMatch(
+      "Registration pendingArtsy is reviewing your registration"
+    )
+  })
+
+  it("renders a bid pending modal", async () => {
+    const wrapper = await mountModal("bidPending")
+
+    expect(wrapper.find(Modal).text()).toMatch(
+      "We're sorry, your bid could not be placed."
+    )
+  })
+
+  it("calls the onClose prop AFTER the modal show prop turns false", async () => {
+    const wrapper = await mountModal("registrationConfirmed")
+    expect(wrapper.find(Modal).prop("show")).toEqual(true)
+
+    defaultProps.onClose.mockImplementationOnce(() => {
+      expect(wrapper.find(Modal).prop("show")).toEqual(false)
+    })
+    wrapper.find("CloseIcon").simulate("click")
+    await flushPromiseQueue()
+    expect(defaultProps.onClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Tracked in https://artsyproduct.atlassian.net/browse/AUCT-571

This PR moves the confirm registration modal from force [here](https://github.com/artsy/force/blob/329ce6874381f6e5574c11333c7b06df875c97b1/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx) to reaction to be alongside its sibling modal, the AuctionRegistrationModal. This allows a better consolidation of styles and modal rendering/unmounting logic in a single place and also updates the modal to use the new hotness, the palette modal.

![2019-08-19 18 17 32](https://user-images.githubusercontent.com/9088720/63303382-b1d27000-c2ad-11e9-84f9-36771d044cea.gif)

