### PR TITLE
[Router] Fix zIndex #trivial

### DIFF
--- a/src/Apps/Collect2/Components/Base/CollectArtworkGrid.tsx
+++ b/src/Apps/Collect2/Components/Base/CollectArtworkGrid.tsx
@@ -63,12 +63,9 @@ class CollectArtworkGrid extends Component<Props, LoadingAreaState> {
   }
 
   toggleLoading = isLoading => {
-    this.setState(
-      {
-        isLoading,
-      },
-      () => window.scrollTo(0, 0)
-    )
+    this.setState({
+      isLoading,
+    })
   }
 
   render() {

--- a/src/Apps/Collect2/Components/Base/CollectFilterContainer.tsx
+++ b/src/Apps/Collect2/Components/Base/CollectFilterContainer.tsx
@@ -4,6 +4,7 @@ import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { CollectRefetchContainer } from "./CollectRefetch"
 
+import { Box } from "@artsy/palette"
 import { FilterState } from "Apps/Collect2/Routes/Collect/FilterState"
 import { FilterContainer } from "../Filters"
 
@@ -18,14 +19,17 @@ export class CollectFilterContainer extends Component<
       <SystemContextConsumer>
         {({ user }) => {
           return (
-            <FilterContainer user={user}>
-              {(filters: FilterState) => (
-                <CollectRefetchContainer
-                  viewer={this.props.viewer}
-                  filtersState={filters.state}
-                />
-              )}
-            </FilterContainer>
+            <>
+              <Box id="jump--collectArtworkGrid" />
+              <FilterContainer user={user}>
+                {(filters: FilterState) => (
+                  <CollectRefetchContainer
+                    viewer={this.props.viewer}
+                    filtersState={filters.state}
+                  />
+                )}
+              </FilterContainer>
+            </>
           )
         }}
       </SystemContextConsumer>

--- a/src/Artsy/Router/Utils/RenderStatus.tsx
+++ b/src/Artsy/Router/Utils/RenderStatus.tsx
@@ -14,14 +14,14 @@ export const RenderPending: React.FC = props => {
       <Renderer>{null}</Renderer>
       <Box
         style={{
-          position: "absolute",
+          position: "fixed",
           top: 0,
           right: 0,
           bottom: 0,
           left: 0,
           background: "white",
           opacity: 0.5,
-          zIndex: 1000,
+          zIndex: 10,
           height: "100vh",
         }}
       />


### PR DESCRIPTION
Fixes zIndex of loader overlay so that it doesn't cover top nav. 

Also fixes issue on /collection/id where window would scroll to the top on pagination change and confuse focus, vs scrolling to the top of the grid where content updates. 

#trivial 