### PR TITLE
Add "Select a country" no value placeholder to CountrySelect

### DIFF
--- a/src/Components/v2/CountrySelect.tsx
+++ b/src/Components/v2/CountrySelect.tsx
@@ -13,6 +13,7 @@ export const CountrySelect = (props: CountrySelectProps) => {
 }
 
 const COUNTRY_SELECT_OPTIONS = [
+  { text: "Select a country", value: "" },
   { text: "Afghanistan", value: "AF" },
   { text: "Åland Islands", value: "AX" },
   { text: "Albania", value: "AL" },


### PR DESCRIPTION
Instead of showing the first country in the list and no value selected internally, show a no value placeholder prompting a selection.

![screenshot 1565979365](https://user-images.githubusercontent.com/123595/63188961-d40b8a00-c030-11e9-9989-b46f5aab3a7f.png)
