### PR TITLE
Mark components with clear artsy/palette equivalents as deprecated

### DIFF
--- a/src/Components/Checkbox.tsx
+++ b/src/Components/Checkbox.tsx
@@ -11,6 +11,10 @@ export interface CheckboxState {
 
 export type CheckboxProps = ExtractProps<typeof CheckboxInput>
 
+/**
+ * @deprecated in favor of our Design System Checkbox component in @artsy/palette
+ * https://palette.artsy.net/elements/inputs/checkbox
+ */
 export class Checkbox extends Component<CheckboxProps, CheckboxState> {
   constructor(props) {
     super(props)

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -15,9 +15,8 @@ export interface InputProps extends React.HTMLProps<HTMLInputElement> {
 }
 
 /**
- * Standard input field.
- * The `title` and `description` props are rendered above the input.
- *
+ * @deprecated in favor of our Design System Input component in @artsy/palette
+ * https://palette.artsy.net/elements/inputs/input
  */
 export const Input: React.ExoticComponent<InputProps> = React.forwardRef(
   ({ error, title, description, ...rest }, ref) => {

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -19,6 +19,10 @@ export interface ModalProps extends React.HTMLProps<Modal> {
   title?: string
 }
 
+/**
+ * @deprecated in favor of our Design System Modal component in @artsy/palette
+ * https://palette.artsy.net/elements/dialogs/modal
+ */
 export class Modal extends React.Component<ModalProps> {
   static defaultProps = {
     show: false,

--- a/src/Components/ProgressIndicator.tsx
+++ b/src/Components/ProgressIndicator.tsx
@@ -7,6 +7,10 @@ interface Props {
   percentComplete: number
 }
 
+/**
+ * @deprecated in favor of our Design System ProgressBar component in @artsy/palette
+ * https://palette.artsy.net/elements/loaders/progressbar
+ */
 export class ProgressIndicator extends React.Component<Props, null> {
   static defaultProps = {
     percentComplete: 0,

--- a/src/Components/Publishing/ReadMore/ReadMoreButton.tsx
+++ b/src/Components/Publishing/ReadMore/ReadMoreButton.tsx
@@ -13,6 +13,10 @@ interface ReadMoreProps {
   referrer: string
 }
 
+/**
+ * @deprecated in favor of our Design System ReadMore component in @artsy/palette
+ * https://palette.artsy.net/elements/layout/readmore
+ */
 @track({
   context_module: Schema.ContextModule.ReadMore,
   subject: Schema.Subject.ReadMore,

--- a/src/Components/Publishing/ReadMore/ReadMoreWrapper.tsx
+++ b/src/Components/Publishing/ReadMore/ReadMoreWrapper.tsx
@@ -11,6 +11,10 @@ interface ReadMoreWrapperState {
   truncationHeight: number | string
 }
 
+/**
+ * @deprecated in favor of our Design System ReadMore component in @artsy/palette
+ * https://palette.artsy.net/elements/layout/readmore
+ */
 export class ReadMoreWrapper extends React.Component<
   ReadMoreWrapperProps,
   ReadMoreWrapperState

--- a/src/Components/Spinner.tsx
+++ b/src/Components/Spinner.tsx
@@ -8,6 +8,10 @@ interface Props extends React.HTMLProps<Spinner> {
   spinnerSize?: "small" | "medium" | "large"
 }
 
+/**
+ * @deprecated in favor of our Design System Spinner component in @artsy/palette
+ * https://palette.artsy.net/elements/loaders/spinner
+ */
 export class Spinner extends React.Component<Props> {
   render() {
     return <div className={this.props.className} />

--- a/src/Components/Text.tsx
+++ b/src/Components/Text.tsx
@@ -46,6 +46,10 @@ const RawText: React.SFC<TextProps> = (props: TextProps) => {
   return <p {...remainderProps}>{props.children}</p>
 }
 
+/**
+ * @deprecated in favor of our Design System Typography components in @artsy/palette
+ * https://palette.artsy.net/tokens/typography
+ */
 const Text = styled(RawText)`
   ${props => textStyleNameToCss[props.textStyle]};
   font-size: ${props => TextStyleToTextSize[props.textStyle][props.textSize]};

--- a/src/Components/TextArea.tsx
+++ b/src/Components/TextArea.tsx
@@ -8,6 +8,10 @@ interface TextAreaProps extends React.HTMLProps<HTMLTextAreaElement> {
   block?: boolean
 }
 
+/**
+ * @deprecated in favor of our Design System TextArea component in @artsy/palette
+ * https://palette.artsy.net/elements/inputs/textarea
+ */
 const TextArea: React.SFC<TextAreaProps> = props => {
   const newProps = { ...props }
   delete newProps.block

--- a/src/Components/TextLink.tsx
+++ b/src/Components/TextLink.tsx
@@ -12,6 +12,10 @@ export interface LinkProps
   target?: string
 }
 
+/**
+ * @deprecated in favor of our Design System Link component in @artsy/palette
+ * https://palette.artsy.net/elements/buttons/link
+ */
 export class TextLink extends React.Component<LinkProps, null> {
   public static defaultProps: LinkProps = {
     target: "_self",

--- a/src/Components/Title.tsx
+++ b/src/Components/Title.tsx
@@ -19,6 +19,10 @@ const titleSizes = {
   xlarge: "s50",
 }
 
+/**
+ * @deprecated in favor of our Design System Typography components in @artsy/palette
+ * https://palette.artsy.net/tokens/typography
+ */
 const Title: React.SFC<TitleProps> = props => {
   const newProps: TitleProps = { ...props }
   delete newProps.titleSize

--- a/src/Components/Tooltip.tsx
+++ b/src/Components/Tooltip.tsx
@@ -71,6 +71,10 @@ const TooltipContainer = Div`
   }
 `
 
+/**
+ * @deprecated in favor of our Design System Tooltip component in @artsy/palette
+ * https://palette.artsy.net/elements/inputs/tooltip
+ */
 export class Tooltip extends React.Component<Props, null> {
   render() {
     return (


### PR DESCRIPTION
Use JSDoc deprecation notices to encourage use of artsy/palette components when available.

cc/ @pepopowitz 