### PR TITLE
[CollectionHubs] adds item_number to analytics tracking

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -139,7 +139,9 @@ describe("FeaturedCollectionEntity", () => {
 
   it("Tracks collection entity click", () => {
     const { members } = props.collectionGroup
-    const component = mount(<FeaturedCollectionEntity member={members[0]} />)
+    const component = mount(
+      <FeaturedCollectionEntity member={members[0]} itemNumber={0} />
+    )
     component
       .find(StyledLink)
       .at(0)
@@ -150,8 +152,9 @@ describe("FeaturedCollectionEntity", () => {
       context_page: "Collection",
       context_module: "FeaturedCollectionsRail",
       context_page_owner_type: "Collection",
-      type: "Link",
+      type: "thumbnail",
       destination_path: "undefined/collection/art-inspired-by-cartoons",
+      item_number: 0,
     })
   })
 })

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -63,8 +63,10 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
           draggable: sd.IS_MOBILE ? true : false,
         }}
         data={members}
-        render={slide => {
-          return <FeaturedCollectionEntity member={slide} />
+        render={(slide, slideIndex) => {
+          return (
+            <FeaturedCollectionEntity member={slide} itemNumber={slideIndex} />
+          )
         }}
         renderLeftArrow={({ Arrow }) => {
           return (
@@ -87,28 +89,30 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
 
 interface FeaturedCollectionEntityProps {
   member: any
+  itemNumber: number
 }
 
 export const FeaturedCollectionEntity: React.FC<
   FeaturedCollectionEntityProps
-> = ({ member }) => {
+> = ({ itemNumber, member }) => {
   const { description, price_guidance, slug, thumbnail, title } = member
   const { trackEvent } = useTracking()
 
-  const onClickLink = () => {
+  const handleClick = () => {
     trackEvent({
       action_type: Schema.ActionType.Click,
       context_page: Schema.PageName.CollectionPage,
       context_module: Schema.ContextModule.FeaturedCollectionsRail,
       context_page_owner_type: Schema.OwnerType.Collection,
-      type: Schema.Type.Link,
+      type: Schema.Type.Thumbnail,
       destination_path: `${sd.APP_URL}/collection/${slug}`,
+      item_number: itemNumber,
     })
   }
 
   return (
     <Container p={2} m={1} width={sd.IS_MOBILE ? "261px" : "355px"}>
-      <StyledLink to={`/collection/${slug}`} onClick={onClickLink}>
+      <StyledLink to={`/collection/${slug}`} onClick={handleClick}>
         <Flex height={sd.IS_MOBILE ? "190px" : "280px"}>
           <FeaturedImage src={thumbnail} />
         </Flex>

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -10,27 +10,30 @@ import styled from "styled-components"
 
 export interface CollectionProps {
   member: OtherCollectionEntity_member
+  itemNumber: number
 }
 
 export const OtherCollectionEntity: React.FC<CollectionProps> = ({
+  itemNumber,
   member,
 }) => {
   const { slug, thumbnail, title } = member
   const { trackEvent } = useTracking()
 
-  const onClickLink = () => {
+  const handleClick = () => {
     trackEvent({
       action_type: Schema.ActionType.Click,
       context_page: Schema.PageName.CollectionPage,
       context_module: Schema.ContextModule.OtherCollectionsRail,
       context_page_owner_type: Schema.OwnerType.Collection,
-      type: Schema.Type.Link,
+      type: Schema.Type.Thumbnail,
       destination_path: `${sd.APP_URL}/collection/${slug}`,
+      item_number: itemNumber,
     })
   }
 
   return (
-    <StyledLink to={`/collection/${slug}`} onClick={onClickLink}>
+    <StyledLink to={`/collection/${slug}`} onClick={handleClick}>
       <Flex alignItems="center">
         {thumbnail && (
           <ImageContainer>

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionEntity.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionEntity.test.tsx
@@ -60,7 +60,9 @@ describe("OtherCollectionEntity", () => {
 
   describe("Tracking", () => {
     it("Tracks collection click", () => {
-      const component = mount(<OtherCollectionEntity {...props} />)
+      const component = mount(
+        <OtherCollectionEntity {...props} itemNumber={0} />
+      )
 
       component.at(0).simulate("click")
 
@@ -69,8 +71,9 @@ describe("OtherCollectionEntity", () => {
         context_page: "Collection",
         context_module: "OtherCollectionsRail",
         context_page_owner_type: "Collection",
-        type: "Link",
+        type: "thumbnail",
         destination_path: "undefined/collection/artist-posters",
+        item_number: 0,
       })
     })
   })

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -55,8 +55,10 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
           contain: true,
         }}
         data={members}
-        render={slide => {
-          return <OtherCollectionEntity member={slide} />
+        render={(slide, slideIndex) => {
+          return (
+            <OtherCollectionEntity member={slide} itemNumber={slideIndex} />
+          )
         }}
         renderLeftArrow={({ Arrow }) => {
           return (

--- a/src/Artsy/Analytics/Schema/index.ts
+++ b/src/Artsy/Analytics/Schema/index.ts
@@ -23,6 +23,7 @@ interface Uncategorized {
   item_type: any
   item_id: any
   query: any
+  item_number: number
 }
 
 export type Trackables =


### PR DESCRIPTION
I closed https://github.com/artsy/reaction/pull/2712 in favor of this PR that has the relocated CollectionHubsRail component. This adds the `item_number` to the analytics tracking data and renames the `onClickLink` -> `handleClick`.