### PR TITLE
[Router] Add ErrorPage handler

### DIFF
--- a/src/Apps/Collect2/Routes/Collections/index.tsx
+++ b/src/Apps/Collect2/Routes/Collections/index.tsx
@@ -51,6 +51,7 @@ export class CollectionsApp extends Component<CollectionsAppProps> {
               <Box pb={0.3}>
                 <Sans size="3" weight="medium">
                   <Link to="/collect">View works</Link>
+                  <Link to="/collect/foo-error">View error</Link>
                 </Sans>
               </Box>
             </Flex>

--- a/src/Artsy/Router/Utils/RenderStatus.tsx
+++ b/src/Artsy/Router/Utils/RenderStatus.tsx
@@ -2,7 +2,13 @@ import React from "react"
 import StaticContainer from "react-static-container"
 
 import { Box } from "@artsy/palette"
+import { ErrorPage } from "Components/ErrorPage"
 import ElementsRenderer from "found/lib/ElementsRenderer"
+import { data as sd } from "sharify"
+import styled from "styled-components"
+import createLogger from "Utils/logger"
+
+const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
 export const RenderPending: React.FC = props => {
   /**
@@ -12,19 +18,7 @@ export const RenderPending: React.FC = props => {
   return (
     <>
       <Renderer>{null}</Renderer>
-      <Box
-        style={{
-          position: "fixed",
-          top: 0,
-          right: 0,
-          bottom: 0,
-          left: 0,
-          background: "white",
-          opacity: 0.5,
-          zIndex: 10,
-          height: "100vh",
-        }}
-      />
+      <LoadingOverlay />
     </>
   )
 }
@@ -38,6 +32,32 @@ export const RenderReady: React.FC<{
     </Renderer>
   )
 }
+
+export const RenderError: React.FC<{
+  error: { status?: number; data?: any }
+}> = props => {
+  logger.error(props.error.data)
+
+  const message =
+    (process.env.NODE_ENV || sd.NODE_ENV) === "development"
+      ? String(props.error.data)
+      : "Internal error"
+
+  // TODO: Make error code more granular. See:
+  // https://artsyproduct.atlassian.net/browse/PLATFORM-1343
+  // https://github.com/artsy/reaction/pull/1855
+  return <ErrorPage code={props.error.status} message={message} />
+}
+
+const LoadingOverlay = styled(Box)`
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  background: rgba(255, 255, 255, 0.5);
+  z-index: 10;
+  height: 100vh;
+`
 
 /**
  * Define a container component so that we don't run into reconciliation issues

--- a/src/Artsy/Router/Utils/Route.tsx
+++ b/src/Artsy/Router/Utils/Route.tsx
@@ -4,6 +4,7 @@
  */
 
 import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
+import { HttpError } from "found"
 import BaseRoute from "found/lib/Route"
 import React from "react"
 
@@ -28,7 +29,10 @@ function createRender({
     const { Component, props, error } = renderArgs
 
     if (error) {
-      throw error
+      // TODO: Need upstream fix type in found as it complains about missing
+      // second argument.
+      // @ts-ignore;
+      throw new HttpError(500, error.message)
     }
 
     if (render) {

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -20,7 +20,7 @@ import { Boot } from "Artsy/Router/Boot"
 
 import { RouterConfig } from "./"
 
-import { RenderPending, RenderReady } from "./Utils/RenderStatus"
+import { RenderError, RenderPending, RenderReady } from "./Utils/RenderStatus"
 
 interface Resolve {
   ClientApp: ComponentType<any>
@@ -70,6 +70,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
       const render = createRender({
         renderPending: RenderPending,
         renderReady: RenderReady,
+        renderError: RenderError,
       })
 
       const Router = await createInitialFarceRouter({

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -21,7 +21,7 @@ import { createRouteConfig } from "./Utils/createRouteConfig"
 import { matchingMediaQueriesForUserAgent } from "./Utils/matchingMediaQueriesForUserAgent"
 
 import { RouterConfig } from "./"
-import { RenderPending, RenderReady } from "./Utils/RenderStatus"
+import { RenderError, RenderPending, RenderReady } from "./Utils/RenderStatus"
 
 interface Resolve {
   bodyHTML?: string
@@ -58,9 +58,11 @@ export function buildServerApp(config: ServerRouterConfig): Promise<Resolve> {
           }),
         ]
         const resolver = new Resolver(relayEnvironment)
+
         const render = createRender({
           renderPending: RenderPending,
           renderReady: RenderReady,
+          renderError: RenderError,
         })
 
         const { redirect, status, element } = await trace(


### PR DESCRIPTION
Adds a redirect to an error page if an error is encountered from MP. Currently we've just been throwing, which we've needed to fix for a while.

Right now, because we don't have consistent error's that we can parse from MP, I'm passing a generic 404, which I think is less alarming than a 500. 

Note that this routing stuff is still something of a moving target and will likely change in minor ways over the next few weeks. Once it's stable will update test coverage where missing. 

![error](https://user-images.githubusercontent.com/236943/63298834-48406a80-c289-11e9-8898-37ab0903b2a6.gif)
