### PR TITLE
[ArtworkFilter] Ensure page is reset to 1 on filter change #trivial

### DIFF
--- a/src/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
@@ -16,19 +16,20 @@ export const initialArtworkFilterState = {
 export interface ArtworkFilters {
   acquireable?: boolean
   at_auction?: boolean
+  attribution_class?: string[]
   color?: string
   for_sale?: boolean
-  height: string
+  height?: string
   inquireable_only?: boolean
   keyword?: string
-  major_periods: string[]
+  major_periods?: string[]
   medium?: string
   offerable?: boolean
-  page: number
+  page?: number
   partner_id?: string
-  price_range: string
-  sort: string
-  width: string
+  price_range?: string
+  sort?: string
+  width?: string
 }
 
 interface ArtworkFilterContextProps {
@@ -180,7 +181,7 @@ const artworkFilterReducer = (state, action) => {
     case "SET": {
       const { name, value } = action.payload
 
-      let filterState = {}
+      let filterState: ArtworkFilters = {}
 
       if (name === "attribution_class") {
         filterState = {
@@ -194,6 +195,8 @@ const artworkFilterReducer = (state, action) => {
       }
       if (name === "page") {
         filterState[name] = Number(value)
+      } else {
+        filterState.page = 1 // Always reset page back to 1 on filter change
       }
 
       // String filter types
@@ -224,10 +227,12 @@ const artworkFilterReducer = (state, action) => {
         }
       })
 
-      return {
+      const updatedState = {
         ...state,
         ...filterState,
       }
+
+      return updatedState
     }
 
     /**
@@ -236,7 +241,7 @@ const artworkFilterReducer = (state, action) => {
     case "UNSET": {
       const { name } = action.payload
 
-      let filterState = {}
+      let filterState: ArtworkFilters = {}
 
       if (name === "attribution_class") {
         filterState = {
@@ -273,10 +278,12 @@ const artworkFilterReducer = (state, action) => {
         }
       })
 
-      return {
+      const updatedState = {
         ...state,
         ...filterState,
       }
+
+      return updatedState
     }
 
     /**

--- a/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterContext.test.tsx
+++ b/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterContext.test.tsx
@@ -58,7 +58,7 @@ describe("ArtworkFilterContext", () => {
       expect(context.hasFilters).toBe(false)
       act(() => {
         context.setFilter("page", 10)
-        setTimeout(() => {
+        setImmediate(() => {
           expect(context.hasFilters).toBe(true)
           done()
         })
@@ -79,9 +79,26 @@ describe("ArtworkFilterContext", () => {
       getWrapper()
       act(() => {
         context.setFilter("page", 10)
-        setTimeout(() => {
+        setImmediate(() => {
           expect(context.filters.page).toEqual(10)
           done()
+        })
+      })
+    })
+
+    it("resets page back to zero on filter change", done => {
+      getWrapper()
+      act(() => {
+        context.setFilter("page", 10)
+        setImmediate(() => {
+          expect(context.filters.page).toEqual(10)
+          act(() => {
+            context.setFilter("sort", "-foo")
+            setImmediate(() => {
+              expect(context.filters.page).toEqual(1)
+              done()
+            })
+          })
         })
       })
     })
@@ -90,11 +107,11 @@ describe("ArtworkFilterContext", () => {
       getWrapper()
       act(() => {
         context.setFilter("page", 10)
-        setTimeout(() => {
+        setImmediate(() => {
           expect(context.filters.page).toEqual(10)
           act(() => {
             context.unsetFilter("page", 10)
-            setTimeout(() => {
+            setImmediate(() => {
               expect(context.filters.page).toEqual(1)
               done()
             })
@@ -116,7 +133,7 @@ describe("ArtworkFilterContext", () => {
 
       act(() => {
         context.resetFilters()
-        setTimeout(() => {
+        setImmediate(() => {
           expect(context.filters).toEqual(initialArtworkFilterState)
         })
       })


### PR DESCRIPTION
Noticed a prod bug that we needed to fix in the new filter