### PR TITLE
Add Reponsiveness to Primary and Subseries SVG Videos 

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "react-tracking": "^7.0.1",
     "react-transition-group": "^2.3.0",
     "react-url-query": "^1.1.4",
+    "react-use-dimensions": "^1.2.1",
     "react-waypoint": "^7.3.3",
     "relay-mock-network-layer": "^2.0.0",
     "relay-runtime": "https://github.com/artsy/relay/releases/download/v1.5.0-artsy.3/relay-runtime-1.5.0-artsy.3.tgz",

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
@@ -1,10 +1,10 @@
 import { Box, Flex, Sans, Serif } from "@artsy/palette"
 import { Byline, BylineContainer } from "Components/Publishing/Byline/Byline"
-import { VanguardVideoPrimarySeries } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground"
 import { Text } from "Components/Publishing/Sections/Text"
 import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
+import { VanguardVideoPrimarySeries } from "./VanguardVideoPrimarySeries"
 
 export const VanguardIntroduction: React.SFC<{
   article: ArticleData

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Sans, Serif } from "@artsy/palette"
 import { Byline, BylineContainer } from "Components/Publishing/Byline/Byline"
-import { VanguardVideoBackground } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground"
+import { VanguardVideoPrimarySeries } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground"
 import { Text } from "Components/Publishing/Sections/Text"
 import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
@@ -18,9 +18,7 @@ export const VanguardIntroduction: React.SFC<{
     <IntroContainer>
       <Box minHeight="calc(100vh - 50px)" mb={150} pt={50}>
         <VideoWrapper>
-          {isVideo && (
-            <VanguardVideoBackground id="#clip-svg-intro" url={url} />
-          )}
+          {isVideo && <VanguardVideoPrimarySeries url={url} />}
         </VideoWrapper>
         <HeaderText pt={70} size="8" textAlign="center">
           The Artsy

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Sans, Serif } from "@artsy/palette"
 import { Share } from "Components/Publishing/Byline/Share"
 import { getFullEditorialHref } from "Components/Publishing/Constants"
-import { VanguardVideoBackground } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground"
+import { VanguardVideoSubSeries } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground"
 import { ArticleData } from "Components/Publishing/Typings"
 import { times } from "lodash"
 import React from "react"
@@ -19,16 +19,6 @@ export const VanguardSeriesWrapper: React.SFC<{
   const { hero_section } = props.article
   const url = ((hero_section && hero_section.url) || "") as string
   const isVideo = url.includes("mp4")
-  const getVideoID = section => {
-    switch (section) {
-      case "newly-established":
-        return "#clip-svg-newly-established"
-      case "emerging":
-        return "#clip-svg-emerging"
-      case "getting-their-due":
-        return "#clip-svg-getting-their-due"
-    }
-  }
 
   return (
     <Box id={slugifiedTitle}>
@@ -37,9 +27,7 @@ export const VanguardSeriesWrapper: React.SFC<{
         // prevents overlapping nav on jump-link
       />
       <Box height="95vh" mb={80}>
-        {isVideo && (
-          <VanguardVideoBackground id={getVideoID(slugifiedTitle)} url={url} />
-        )}
+        {isVideo && <VanguardVideoSubSeries svg={slugifiedTitle} url={url} />}
         <Box mx="auto" maxWidth={1400} px={4}>
           <Numeral size="12">{times(index + 1, () => "I")}</Numeral>
           <Title size="16" textAlign="center" element="h2">

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Sans, Serif } from "@artsy/palette"
 import { Share } from "Components/Publishing/Byline/Share"
 import { getFullEditorialHref } from "Components/Publishing/Constants"
-import { VanguardVideoSubSeries } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground"
+import { VanguardVideoSubSeries } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoSubseries"
 import { ArticleData } from "Components/Publishing/Typings"
 import { times } from "lodash"
 import React from "react"

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground.tsx
@@ -1,11 +1,6 @@
-import { Box, color } from "@artsy/palette"
+import { Box, color, Flex } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
-
-// interface SVGVideoBackgroundProps {
-//   id?: string
-//   url?: string
-// }
 
 export const VanguardVideoPrimarySeries = props => (
   <VideoSVGWrapper>
@@ -22,27 +17,62 @@ export const VanguardVideoPrimarySeries = props => (
 )
 
 export const VanguardVideoSubSeries = props => (
-  <VideoSVGWrapperSubseries>
-    <svg
-      viewBox="0 0 1600 900"
-      xmlns="http://www.w3.org/2000/svg"
-      fill={color("white100")}
-      // stroke={color("white100")}
-      // strokeWidth="25"
-      {...props}
-    >
-      {getSVGPath(props.svg)}
-    </svg>
-    <VanguardVideoSubseries {...props} />
-  </VideoSVGWrapperSubseries>
+  <WholeWrapper>
+    <SVGWrapper>
+      <svg
+        viewBox="0 0 1600 900"
+        xmlns="http://www.w3.org/2000/svg"
+        fill={color("white100")}
+        height="inherit"
+        {...props}
+      >
+        {getSVGPath(props.svg)}
+      </svg>
+      <VideoWrapperSubseries>
+        <Video
+          autoPlay
+          loop
+          muted
+          playsInline
+          controls={false}
+          src={props.url}
+        />
+      </VideoWrapperSubseries>
+    </SVGWrapper>
+  </WholeWrapper>
 )
 
+// const VideoSubseries = styled.video`
+//   max-height: 96%;
+// `
+
+const WholeWrapper = styled(Flex)`
+  flex-direction: row;
+  position: relative;
+  min-height: 110vh;
+  margin-right: 5vw;
+`
+
+const SVGWrapper = styled(Box)`
+  position: absolute;
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+`
+
+const VideoWrapperSubseries = styled(Box)`
+  z-index: -1;
+  position: absolute;
+  top: 0;
+`
+
 const getSVGPath = svg => {
-  console.log("TCL: svg", svg)
   switch (svg) {
     case "emerging":
       return (
-        <path d="M0,0V900H1600V0ZM1489.83,896.43,146.61,805.5,47.2,182.84,320,4.17l874.07,86,360.06,148Z" />
+        <>
+          <path d="M0,0V900H1600V0ZM1489.83,896.43,146.61,805.5,47.2,182.84,320,4.17l874.07,86,360.06,148Z" />
+        </>
       )
     case "getting-their-due":
       return (
@@ -61,19 +91,6 @@ const VanguardVideo = props => (
   </VideoWrapper>
 )
 
-const VanguardVideoSubseries = props => (
-  <VideoWrapperSubseries>
-    <VideoSubseries
-      autoPlay
-      loop
-      muted
-      playsInline
-      controls={false}
-      src={props.url}
-    />
-  </VideoWrapperSubseries>
-)
-
 const VideoWrapper = styled(Box)`
   height: 100%;
   max-width: 100vw;
@@ -87,26 +104,6 @@ const Video = styled.video`
 `
 
 const VideoSVGWrapper = styled(Box)`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  overflow: hidden;
-`
-
-const VideoWrapperSubseries = styled(Box)`
-  height: 100%;
-  max-width: 100vw;
-  position: absolute;
-  top: 0;
-  z-index: -1;
-`
-
-const VideoSubseries = styled.video`
-  max-height: 98%;
-`
-
-const VideoSVGWrapperSubseries = styled(Box)`
   position: absolute;
   top: 0;
   left: 0;

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground.tsx
@@ -1,84 +1,115 @@
-import { Box } from "@artsy/palette"
+import { Box, color } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 
-interface SVGVideoBackgroundProps {
-  id?: string
-  url?: string
-}
+// interface SVGVideoBackgroundProps {
+//   id?: string
+//   url?: string
+// }
 
-export const VanguardVideoBackground = props => (
-  <VideoBackgroundWrapper>
+export const VanguardVideoPrimarySeries = props => (
+  <VideoSVGWrapper>
     <svg
-      height="0"
-      width="0"
       viewBox="0 0 1600 900"
       xmlns="http://www.w3.org/2000/svg"
-      preserveAspectRatio="xMinYMin meet"
-      clipPathUnits="objectBoundingBox"
+      fill={color("white100")}
       {...props}
     >
-      <defs>{getSVGClipPath(props.id)}</defs>
+      <path d="M0,0V900H1600V0ZM1117.25,859.16c-321.9,34.84-538.72,61.19-699.67-12s-244.75-34.58-297.95-94.44S61.14,621.06,47.84,566.53-2.66,374.1,61.31,242.72c40.62-83.44,50.38-148.4,146.69-183,72.79-26.07,208.29,0,296.08,4,35.91,1.64,149-21.28,207.51-39.9s176.91-16,248.74,0,186.22-1.33,262,1.33,275.35,5.32,283.33,234.11-20,235.44,0,359.14S1439.15,824.32,1117.25,859.16Z" />
     </svg>
     <VanguardVideo {...props} />
-  </VideoBackgroundWrapper>
+  </VideoSVGWrapper>
 )
 
-const getSVGClipPath = id => {
-  switch (id) {
-    case "#clip-svg-intro":
+export const VanguardVideoSubSeries = props => (
+  <VideoSVGWrapperSubseries>
+    <svg
+      viewBox="0 0 1600 900"
+      xmlns="http://www.w3.org/2000/svg"
+      fill={color("white100")}
+      // stroke={color("white100")}
+      // strokeWidth="25"
+      {...props}
+    >
+      {getSVGPath(props.svg)}
+    </svg>
+    <VanguardVideoSubseries {...props} />
+  </VideoSVGWrapperSubseries>
+)
+
+const getSVGPath = svg => {
+  console.log("TCL: svg", svg)
+  switch (svg) {
+    case "emerging":
       return (
-        <clipPath id={id.slice(1)}>
-          <path d="M504.08 63.72c35.91 1.64 149-21.28 207.51-39.9s176.91-16 248.74 0 186.22-1.33 262 1.33 275.35 5.32 283.33 234.11-20 235.44 0 359.14-66.51 205.92-388.41 240.76-538.72 61.19-699.67-12-244.75-34.58-297.95-94.44-58.49-131.66-71.79-186.19-50.5-192.43 13.47-323.81c40.62-83.44 50.38-148.4 146.69-183 72.79-26.07 208.29.01 296.08 4z" />
-        </clipPath>
+        <path d="M0,0V900H1600V0ZM1489.83,896.43,146.61,805.5,47.2,182.84,320,4.17l874.07,86,360.06,148Z" />
       )
-    case "#clip-svg-emerging":
+    case "getting-their-due":
       return (
-        <clipPath id={id.slice(1)}>
-          <path d="M319.96 4.17L47.2 182.84l99.41 622.66 1343.22 90.93 64.26-658.28-360.06-147.99L319.96 4.17z" />
-        </clipPath>
+        <path d="M0,0V900H1600V0ZM113.08,888.27,65.88,87.92,1488.94,4h0l47.19,800.35Z" />
       )
-    case "#clip-svg-getting-their-due":
+    case "newly-established":
       return (
-        <clipPath id={id.slice(1)}>
-          <path d="M1488.94 4L65.88 87.92l47.2 800.35 1423.07-83.92L1488.96 4h-.02z" />
-        </clipPath>
-      )
-    case "#clip-svg-newly-established":
-      return (
-        <clipPath id={id.slice(1)}>
-          <path d="M103.9 84.75a631.43 631.43 0 0195.48-21.84c56.68-8.43 113.86-9.53 171-12.3q72.95-2.7 145.49-11.07Q583.17 30.78 650.6 23c51.28-5.2 103.25-9.27 154.82-9.33 56-.05 111.88 5.93 167.63 10.71 67.17 5.76 134.18 35.8 201.61 37.05 23.86 0 47.71-13.15 71.56-12.31 25.79 1.88 51-4.07 75.48 4.34 40.51 12.77 80.73 30.95 117.85 51.75 22.73 12.74 43.63 26.54 60.68 46.63 13.57 16 24.59 34.74 35.61 52.58q11.06 18.33 21.74 36.87a199.56 199.56 0 0120.92 42.12c14.72 45.82 2.3 93-5 138.87-9.83 62.06-6.47 128.19-29 187.64a281.32 281.32 0 01-49.61 82.79l-32.41 30.52c-33.51 26.21-58 60-96.63 77.77-57.73 25.72-133.38 57.1-195.88 63.95q-60.6 4.67-121.34 6.67-76.32 6.38-152.58 13.26c-65.83 5-132.21 10.43-198.11 3.31-61.12-6.6-122.78-19.64-181.87-36.52C468 837.92 420.34 823 377.46 796.45q-40.68-28.23-81.08-56.86-35-24-70.7-47c-23.26-14.9-50.81-27.78-71-47.18-18.86-18.11-34.77-73-46.11-96.52l-10.55-26.38q-12-34-24.84-67.8a353.7 353.7 0 01-17.6-101.19C54 302.39 58.53 250 64.36 199.22c2.28-19.87 5-40.17 10.39-59.47 4.08-14.44 11.47-26.14 17.48-39.24.82-1.78 1.62-3.59 2.38-5.44 0 0 2.19-8.1 9.29-10.32" />
-        </clipPath>
+        <path d="M0,0V900H1600V0ZM1573.5,422.28c-9.83,62.06-6.47,128.19-29,187.64a281.24,281.24,0,0,1-49.61,82.79l-32.41,30.52c-33.51,26.21-58,60-96.63,77.77-57.73,25.72-133.38,57.1-195.88,64q-60.6,4.66-121.34,6.67Q972.31,878,896.05,884.88c-65.83,5-132.21,10.43-198.11,3.31-61.12-6.6-122.78-19.64-181.87-36.52C468,837.92,420.34,823,377.46,796.45q-40.68-28.23-81.08-56.86-35-24-70.7-47c-23.26-14.9-50.81-27.78-71-47.18-18.86-18.11-34.77-73-46.11-96.52q-5.28-13.2-10.55-26.38-12-34-24.84-67.8a353.55,353.55,0,0,1-17.6-101.19c-1.58-51.13,3-103.52,8.78-154.3,2.28-19.87,5-40.17,10.39-59.47,4.08-14.44,11.47-26.14,17.48-39.24.82-1.78,1.62-3.59,2.38-5.44,0,0,2.19-8.1,9.29-10.32a632,632,0,0,1,95.48-21.84c56.68-8.43,113.86-9.53,171-12.3q72.94-2.7,145.49-11.07Q583.17,30.78,650.6,23c51.28-5.2,103.25-9.27,154.82-9.33,56-.05,111.88,5.93,167.63,10.71,67.17,5.76,134.18,35.8,201.61,37.05,23.86,0,47.71-13.15,71.56-12.31,25.79,1.88,51-4.07,75.48,4.34,40.51,12.77,80.73,30.95,117.85,51.75,22.73,12.74,43.63,26.54,60.68,46.63,13.57,16,24.59,34.74,35.61,52.58q11.06,18.33,21.74,36.87a199.55,199.55,0,0,1,20.92,42.12C1593.22,329.23,1580.8,376.41,1573.5,422.28Z" />
       )
   }
 }
 
 const VanguardVideo = props => (
   <VideoWrapper>
-    <Video
+    <Video autoPlay loop muted playsInline controls={false} src={props.url} />
+  </VideoWrapper>
+)
+
+const VanguardVideoSubseries = props => (
+  <VideoWrapperSubseries>
+    <VideoSubseries
       autoPlay
       loop
       muted
       playsInline
       controls={false}
       src={props.url}
-      {...props}
     />
-  </VideoWrapper>
+  </VideoWrapperSubseries>
 )
 
 const VideoWrapper = styled(Box)`
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  max-width: 100vw;
+  position: absolute;
+  top: 0;
+  z-index: -1;
+`
+
+const Video = styled.video`
+  max-height: 98%;
+`
+
+const VideoSVGWrapper = styled(Box)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
   overflow: hidden;
 `
-const VideoBackgroundWrapper = styled(Box)`
-  height: 100vw;
-  width: 100vw;
+
+const VideoWrapperSubseries = styled(Box)`
+  height: 100%;
+  max-width: 100vw;
   position: absolute;
-  overflow-x: hidden;
-`
-const Video = styled.video<SVGVideoBackgroundProps>`
+  top: 0;
   z-index: -1;
-  clip-path: url(${props => props.id});
+`
+
+const VideoSubseries = styled.video`
+  max-height: 98%;
+`
+
+const VideoSVGWrapperSubseries = styled(Box)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  overflow: hidden;
 `

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoBackground.tsx
@@ -1,9 +1,14 @@
-import { Box, color, Flex } from "@artsy/palette"
+import { Box, color, Flex, FlexProps } from "@artsy/palette"
 import React from "react"
+import useDimensions from "react-use-dimensions"
 import styled from "styled-components"
 
+interface VanguardSubseriesVideoProps extends FlexProps {
+  svgHeight?: number
+}
+
 export const VanguardVideoPrimarySeries = props => (
-  <VideoSVGWrapper>
+  <PrimarySeriesWrapper>
     <svg
       viewBox="0 0 1600 900"
       xmlns="http://www.w3.org/2000/svg"
@@ -12,55 +17,89 @@ export const VanguardVideoPrimarySeries = props => (
     >
       <path d="M0,0V900H1600V0ZM1117.25,859.16c-321.9,34.84-538.72,61.19-699.67-12s-244.75-34.58-297.95-94.44S61.14,621.06,47.84,566.53-2.66,374.1,61.31,242.72c40.62-83.44,50.38-148.4,146.69-183,72.79-26.07,208.29,0,296.08,4,35.91,1.64,149-21.28,207.51-39.9s176.91-16,248.74,0,186.22-1.33,262,1.33,275.35,5.32,283.33,234.11-20,235.44,0,359.14S1439.15,824.32,1117.25,859.16Z" />
     </svg>
-    <VanguardVideo {...props} />
-  </VideoSVGWrapper>
+    <VanguardIntroVideoWrapper>
+      <VanguardIntroVideo
+        autoPlay
+        loop
+        muted
+        playsInline
+        controls={false}
+        src={props.url}
+      />
+      {...props}
+    </VanguardIntroVideoWrapper>
+  </PrimarySeriesWrapper>
 )
+const VanguardIntroVideoWrapper = styled(Box)`
+  height: 100%;
+  max-width: 100vw;
+  position: absolute;
+  top: 0;
+  z-index: -1;
+`
 
-export const VanguardVideoSubSeries = props => (
-  <WholeWrapper>
-    <SVGWrapper>
-      <svg
-        viewBox="0 0 1600 900"
-        xmlns="http://www.w3.org/2000/svg"
-        fill={color("white100")}
-        height="inherit"
-        {...props}
-      >
-        {getSVGPath(props.svg)}
-      </svg>
-      <VideoWrapperSubseries>
-        <Video
-          autoPlay
-          loop
-          muted
-          playsInline
-          controls={false}
-          src={props.url}
-        />
-      </VideoWrapperSubseries>
-    </SVGWrapper>
-  </WholeWrapper>
-)
+const VanguardIntroVideo = styled.video`
+  max-height: 98%;
+`
 
-// const VideoSubseries = styled.video`
-//   max-height: 96%;
-// `
+const PrimarySeriesWrapper = styled(Box)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  overflow: hidden;
+`
 
-const WholeWrapper = styled(Flex)`
+export const VanguardVideoSubSeries = props => {
+  const [ref, { height: svgHeight }] = useDimensions()
+
+  return (
+    <SubseriesWrapper>
+      <SubseriesSVGWrapper>
+        <svg
+          ref={ref}
+          viewBox="0 0 1600 900"
+          xmlns="http://www.w3.org/2000/svg"
+          fill={color("white100")}
+          width="100vw"
+          {...props}
+        >
+          {getSVGPath(props.svg)}
+        </svg>
+        <VanguardSubseriesVideoWrapper>
+          <VanguardSubseriesVideo
+            autoPlay
+            loop
+            muted
+            playsInline
+            controls={false}
+            src={props.url}
+            svgHeight={svgHeight}
+          />
+        </VanguardSubseriesVideoWrapper>
+      </SubseriesSVGWrapper>
+    </SubseriesWrapper>
+  )
+}
+
+const VanguardSubseriesVideo = styled.video<VanguardSubseriesVideoProps>`
+  max-height: ${props => props.svgHeight}px;
+`
+
+const SubseriesWrapper = styled(Flex)`
   flex-direction: row;
   position: relative;
   min-height: 110vh;
-  margin-right: 5vw;
 `
 
-const SVGWrapper = styled(Box)`
+const SubseriesSVGWrapper = styled(Box)`
   position: absolute;
   overflow: hidden;
   height: 100%;
   width: 100%;
 `
 
-const VideoWrapperSubseries = styled(Box)`
+const VanguardSubseriesVideoWrapper = styled(Box)`
   z-index: -1;
   position: absolute;
   top: 0;
@@ -70,9 +109,7 @@ const getSVGPath = svg => {
   switch (svg) {
     case "emerging":
       return (
-        <>
-          <path d="M0,0V900H1600V0ZM1489.83,896.43,146.61,805.5,47.2,182.84,320,4.17l874.07,86,360.06,148Z" />
-        </>
+        <path d="M0,0V900H1600V0ZM1489.83,896.43,146.61,805.5,47.2,182.84,320,4.17l874.07,86,360.06,148Z" />
       )
     case "getting-their-due":
       return (
@@ -84,29 +121,3 @@ const getSVGPath = svg => {
       )
   }
 }
-
-const VanguardVideo = props => (
-  <VideoWrapper>
-    <Video autoPlay loop muted playsInline controls={false} src={props.url} />
-  </VideoWrapper>
-)
-
-const VideoWrapper = styled(Box)`
-  height: 100%;
-  max-width: 100vw;
-  position: absolute;
-  top: 0;
-  z-index: -1;
-`
-
-const Video = styled.video`
-  max-height: 98%;
-`
-
-const VideoSVGWrapper = styled(Box)`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  overflow: hidden;
-`

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoPrimarySeries.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoPrimarySeries.tsx
@@ -1,0 +1,52 @@
+import { Box, color } from "@artsy/palette"
+import React from "react"
+import styled from "styled-components"
+
+interface Props {
+  url: string
+}
+
+export const VanguardVideoPrimarySeries: React.SFC<Props> = props => {
+  return (
+    <PrimarySeriesWrapper>
+      <svg
+        viewBox="0 0 1600 900"
+        xmlns="http://www.w3.org/2000/svg"
+        fill={color("white100")}
+        {...props}
+      >
+        <path d="M0,0V900H1600V0ZM1117.25,859.16c-321.9,34.84-538.72,61.19-699.67-12s-244.75-34.58-297.95-94.44S61.14,621.06,47.84,566.53-2.66,374.1,61.31,242.72c40.62-83.44,50.38-148.4,146.69-183,72.79-26.07,208.29,0,296.08,4,35.91,1.64,149-21.28,207.51-39.9s176.91-16,248.74,0,186.22-1.33,262,1.33,275.35,5.32,283.33,234.11-20,235.44,0,359.14S1439.15,824.32,1117.25,859.16Z" />
+      </svg>
+      <VanguardIntroVideoWrapper>
+        <VanguardIntroVideo
+          autoPlay
+          loop
+          muted
+          playsInline
+          controls={false}
+          src={props.url}
+        />
+      </VanguardIntroVideoWrapper>
+    </PrimarySeriesWrapper>
+  )
+}
+
+const VanguardIntroVideoWrapper = styled(Box)`
+  height: 100%;
+  max-width: 100vw;
+  position: absolute;
+  top: 0;
+  z-index: -1;
+`
+
+const VanguardIntroVideo = styled.video`
+  max-height: 98%;
+`
+
+const PrimarySeriesWrapper = styled(Box)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  overflow: hidden;
+`

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoSubseries.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardVideoSubseries.tsx
@@ -4,53 +4,15 @@ import useDimensions from "react-use-dimensions"
 import styled from "styled-components"
 
 interface VanguardSubseriesVideoProps extends FlexProps {
-  svgHeight?: number
+  svgHeight: number
 }
 
-export const VanguardVideoPrimarySeries = props => (
-  <PrimarySeriesWrapper>
-    <svg
-      viewBox="0 0 1600 900"
-      xmlns="http://www.w3.org/2000/svg"
-      fill={color("white100")}
-      {...props}
-    >
-      <path d="M0,0V900H1600V0ZM1117.25,859.16c-321.9,34.84-538.72,61.19-699.67-12s-244.75-34.58-297.95-94.44S61.14,621.06,47.84,566.53-2.66,374.1,61.31,242.72c40.62-83.44,50.38-148.4,146.69-183,72.79-26.07,208.29,0,296.08,4,35.91,1.64,149-21.28,207.51-39.9s176.91-16,248.74,0,186.22-1.33,262,1.33,275.35,5.32,283.33,234.11-20,235.44,0,359.14S1439.15,824.32,1117.25,859.16Z" />
-    </svg>
-    <VanguardIntroVideoWrapper>
-      <VanguardIntroVideo
-        autoPlay
-        loop
-        muted
-        playsInline
-        controls={false}
-        src={props.url}
-      />
-      {...props}
-    </VanguardIntroVideoWrapper>
-  </PrimarySeriesWrapper>
-)
-const VanguardIntroVideoWrapper = styled(Box)`
-  height: 100%;
-  max-width: 100vw;
-  position: absolute;
-  top: 0;
-  z-index: -1;
-`
+interface Props {
+  url: string
+  svg: string
+}
 
-const VanguardIntroVideo = styled.video`
-  max-height: 98%;
-`
-
-const PrimarySeriesWrapper = styled(Box)`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  overflow: hidden;
-`
-
-export const VanguardVideoSubSeries = props => {
+export const VanguardVideoSubSeries: React.SFC<Props> = props => {
   const [ref, { height: svgHeight }] = useDimensions()
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -12899,6 +12899,11 @@ react-url-query@^1.1.4:
     prop-types "^15.5.9"
     query-string "^4.2.3"
 
+react-use-dimensions@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-use-dimensions/-/react-use-dimensions-1.2.1.tgz#eb1561db7b06c393209d2bffa449931dd93f7870"
+  integrity sha512-XL+Rup9Hosxx3Ap9xpyQMbVwuUa4BSqiOjfBb2zDuGs4uv2FesFV+m8Z/huRx2BNptMd9ARPqFuSNA62zhCozg==
+
 react-waypoint@^7.3.3:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/react-waypoint/-/react-waypoint-7.3.4.tgz#6f4a167ca71c0877576699d6980089f001137f90"


### PR DESCRIPTION
Handles responsiveness and resizing issues on the Video in SVG Blobs.
[Links to GROW-1469](https://artsyproduct.atlassian.net/browse/GROW-1469)

![Kapture 2019-08-23 at 14 31 43](https://user-images.githubusercontent.com/10385964/63615198-c31fc300-c5b2-11e9-94d4-7b4763c933e2.gif)
![Kapture 2019-08-23 at 14 26 40](https://user-images.githubusercontent.com/10385964/63614929-307f2400-c5b2-11e9-8b9e-4fb46b1cb55b.gif)
![Kapture 2019-08-23 at 14 28 28](https://user-images.githubusercontent.com/10385964/63615038-6a502a80-c5b2-11e9-9978-b824bde1da49.gif)
![Kapture 2019-08-23 at 14 30 09](https://user-images.githubusercontent.com/10385964/63615159-ab483f00-c5b2-11e9-9172-6099d4b30c58.gif)


