### PR TITLE
[WIP] Stub out new API for collection hub nav item

### DIFF
--- a/src/Components/v2/CollectionsHubsNavItem.tsx
+++ b/src/Components/v2/CollectionsHubsNavItem.tsx
@@ -1,6 +1,6 @@
-import { Box, Image, Serif } from "@artsy/palette"
+import { Box, Image, Serif, SerifProps } from "@artsy/palette"
 import { RouterLink } from "Artsy/Router/RouterLink"
-import React from "react"
+import React, { FC } from "react"
 import styled from "styled-components"
 import { space, SpaceProps } from "styled-system"
 
@@ -71,3 +71,132 @@ const OuterLink = styled(RouterLink)`
 
   ${space}
 `
+
+// ------------------------------------
+// two ways I can think of to allow the caller to specify what the
+//   title and optional subtitle will look like, below. Both satisfy:
+// - Caller can choose whether there is a subtitle
+// - Caller can specify size or padding, or use the default. (Different entry points will use different values for these.)
+// - Lots of things are decided for the caller; it's basically just filling in text, with a little bit of overrideable text styling.
+
+// ------------------------------------
+
+// Method 1: pass title and subtitle as props.
+// Drawbacks:
+// 1. have to figure out how to pass ${Title} into OuterLink on line 61, or else
+//    we lose the "hover" effect of underlining the text.
+//   (it's a dynamic element, passed into the component. Not sure how to reference that
+//    with styled-components.)
+// 2. caller has to specify the type & size of text element for title & subtitle.
+//    (see CollectionsHubsNavItem.story.tsx ln 40 & 48)
+
+interface ImageLinkProps {
+  src: string
+  href: string
+  alt: string
+  title: React.ReactElement<SerifProps>
+  subtitle?: React.ReactElement<SerifProps>
+}
+
+export const ImageLink: FC<ImageLinkProps> = ({
+  href,
+  src,
+  alt,
+  title,
+  subtitle,
+}) => {
+  return (
+    <OuterLink to={href}>
+      <ImageContainer>
+        <ImageOverlay>
+          <HubImage src={src} width="100%" alt={alt} />
+        </ImageOverlay>
+      </ImageContainer>
+      {React.cloneElement(title, {
+        // kind of like "default props" for a cloned element.
+        element: title.props.element || "h3",
+        p: title.props.p || "1",
+        textAlign: "center",
+      })}
+
+      {subtitle &&
+        React.cloneElement(subtitle, {
+          // kind of like "default props" for a cloned element.
+          element: title.props.element || "h4",
+          p: title.props.p || "1",
+          textAlign: "center",
+        })}
+    </OuterLink>
+  )
+}
+
+// ------------------------------------
+
+// Method 2: pass title and subtitle as children.
+// Advantages:
+// 1. I like it more from a readability standpoint.
+// 2. We'd still have to figure out how to get the hover effect of underlining the text,
+//    but I think with IL2Title and IL2SubTitle being declared components, that will be easier.
+// Drawbacks:
+// 1. New element types (IL2Title and IL2SubTitle). I'm not sure if I dislike this or not.
+// 2. Discoverability. With props, it's easy to see what to fill in. With children, you have to know more what you're looking for.
+//    This _might_ be fixed if I could get the types to actually restrict to only allow IL2Title and IL2SubTitle for children
+
+interface ImageLink2Props {
+  src: string
+  href: string
+  alt: string
+  // You'd _think_ this would restrict the children to being of a certain type,
+  //   but it doesn't.
+  children:
+    | React.ReactElement<OptionalSerifProps>
+    | Array<React.ReactElement<OptionalSerifProps>>
+}
+
+export const ImageLink2: FC<ImageLink2Props> = ({
+  href,
+  src,
+  alt,
+  children,
+}) => {
+  return (
+    <OuterLink to={href}>
+      <>
+        <ImageContainer>
+          <ImageOverlay>
+            <HubImage src={src} width="100%" alt={alt} />
+          </ImageOverlay>
+        </ImageContainer>
+        {children}
+      </>
+    </OuterLink>
+  )
+}
+
+// There's probably a better way to do this, but I want to say
+//    "it can have any serif prop, but all are optional."
+type OptionalSerifProps = { [P in keyof SerifProps]?: SerifProps[P] }
+
+export const IL2Title: FC<OptionalSerifProps> = ({
+  children,
+  size = "4",
+  p = 1,
+}) => {
+  return (
+    <Serif size={size} textAlign="center" p={p}>
+      {children}
+    </Serif>
+  )
+}
+
+export const IL2SubTitle: FC<OptionalSerifProps> = ({
+  children,
+  size = "3",
+  p = 1,
+}) => {
+  return (
+    <Serif size={size} textAlign="center" p={p}>
+      {children}
+    </Serif>
+  )
+}

--- a/src/Components/v2/__stories__/CollectionsHubsNavItem.story.tsx
+++ b/src/Components/v2/__stories__/CollectionsHubsNavItem.story.tsx
@@ -1,7 +1,13 @@
-import { Box } from "@artsy/palette"
+import { Box, Separator, Serif } from "@artsy/palette"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
-import { CollectionsHubsNavItem } from "../CollectionsHubsNavItem"
+import {
+  CollectionsHubsNavItem,
+  IL2SubTitle,
+  IL2Title,
+  ImageLink,
+  ImageLink2,
+} from "../CollectionsHubsNavItem"
 
 const imageSample =
   "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeF_qAORql7lSnD2BwbFOYg%2Flarge.jpg"
@@ -27,4 +33,38 @@ storiesOf("Components/CollectionsHubsNavItem", module)
         Impressionist and Modern Art and Other Things People Like
       </CollectionsHubsNavItem>
     </Box>
+  ))
+  .add("ImageLink", () => (
+    <>
+      <Box width={300}>
+        <Serif element="h2" size="6" p="2">
+          Method 1: pass title and subtitle as props
+        </Serif>
+        <ImageLink
+          href="google.com"
+          src="http://placekitten.com/300/200"
+          alt="kitty kitty meow meow"
+          title={
+            <Serif size="5" element="h4">
+              I miss my little kitty kat
+            </Serif>
+          }
+          subtitle={<Serif size="3">And his little baby fur feet</Serif>}
+        />
+      </Box>
+      <Separator />
+      <Box width={300}>
+        <Serif element="h2" size="6" p="2">
+          Method 2: pass title and subtitle as children
+        </Serif>
+        <ImageLink2
+          href="google.com"
+          src="http://placekitten.com/300/200"
+          alt="kitty kitty meow meow"
+        >
+          <IL2Title>I miss my little kitty kat</IL2Title>
+          <IL2SubTitle size="5">And his little baby fur feet</IL2SubTitle>
+        </ImageLink2>
+      </Box>
+    </>
   ))


### PR DESCRIPTION
@anandaroop As part of putting collection hubs on the home page (https://artsyproduct.atlassian.net/browse/GROW-1360), we need to figure out how to make the CollectionsHubsNavItem more dynamic. Different entry points will use different font sizes, and some have titles while others have titles _and_ subtitles. 

This PR explores two ways to do that. Neither is fully fleshed out, but both are started. Take a look and let me know what you think! I've documented the pros & cons of each, as I see them, in the code. I don't think I feel a strong allegiance to either.

There is also a new story to demonstrate the usage of each.