### PR TITLE
PURCHASE-1432: Improve error messaging for generic declines on the payment page

### DIFF
--- a/src/Apps/Order/Components/PaymentPicker.tsx
+++ b/src/Apps/Order/Components/PaymentPicker.tsx
@@ -108,6 +108,7 @@ export class PaymentPicker extends React.Component<
 
   getCreditCardId: () => Promise<
     | { type: "error"; error: string | undefined }
+    | { type: "internal_error"; error: string | undefined }
     | { type: "invalid_form" }
     | { type: "success"; creditCardId: string }
   > = async () => {
@@ -142,10 +143,21 @@ export class PaymentPicker extends React.Component<
       },
     })).createCreditCard.creditCardOrError
 
-    if (creditCardOrError.mutationError) {
+    if (
+      creditCardOrError.mutationError &&
+      creditCardOrError.mutationError.detail
+    ) {
       return { type: "error", error: creditCardOrError.mutationError.detail }
-    }
-    return { type: "success", creditCardId: creditCardOrError.creditCard.id }
+    } else if (
+      creditCardOrError.mutationError &&
+      creditCardOrError.mutationError.message
+    ) {
+      return {
+        type: "internal_error",
+        error: creditCardOrError.mutationError.message,
+      }
+    } else
+      return { type: "success", creditCardId: creditCardOrError.creditCard.id }
   }
 
   @track((props: PaymentPickerProps, state, args) => {

--- a/src/Apps/Order/Components/__mocks__/PaymentPicker.tsx
+++ b/src/Apps/Order/Components/__mocks__/PaymentPicker.tsx
@@ -31,6 +31,14 @@ export const useErrorResult = () => {
   PaymentPickerMock.getCreditCardId.mockResolvedValue(errorResult)
 }
 
+const internalErrorResult: CreditCardIdResult = {
+  type: "internal_error",
+  error: "This is the description of an internal error.",
+}
+export const useInternalErrorResult = () => {
+  PaymentPickerMock.getCreditCardId.mockResolvedValue(internalErrorResult)
+}
+
 export const useThrownError = () => {
   PaymentPickerMock.getCreditCardId.mockRejectedValue(new Error("Actual error"))
 }

--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -79,6 +79,14 @@ export class NewPaymentRoute extends Component<
         return
       }
 
+      if (result.type === "internal_error") {
+        this.props.dialog.showErrorDialog({
+          title: "An internal error occurred",
+        })
+        logger.error(result.error)
+        return
+      }
+
       const orderOrError = (await this.fixFailedPayment({
         input: {
           creditCardId: result.creditCardId,

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -71,6 +71,14 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
         return
       }
 
+      if (result.type === "internal_error") {
+        this.props.dialog.showErrorDialog({
+          title: "An internal error occurred",
+        })
+        logger.error(result.error)
+        return
+      }
+
       const orderOrError = (await this.setOrderPayment({
         input: {
           creditCardId: result.creditCardId,

--- a/src/Apps/Order/Routes/__tests__/NewPayment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/NewPayment.test.tsx
@@ -171,6 +171,16 @@ describe("Payment", () => {
     )
   })
 
+  it("shows an error modal with the title 'An internal error occurred' and the default message when the payment picker returns an error with the type 'internal_error'", async () => {
+    paymentPickerMock.useInternalErrorResult()
+    const page = await buildPage()
+    await page.clickSubmit()
+    await page.expectAndDismissErrorDialogMatching(
+      "An internal error occurred",
+      "Please try again or contact orders@artsy.net."
+    )
+  })
+
   it("shows an error modal when fixing the failed payment fails", async () => {
     const page = await buildPage()
     mutations.useResultsOnce(fixFailedPaymentFailure)

--- a/src/Apps/Order/Routes/__tests__/Payment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.test.tsx
@@ -101,6 +101,16 @@ describe("Payment", () => {
     )
   })
 
+  it("shows an error modal with the title 'An internal error occurred' and the default message when the payment picker returns an error with the type 'internal_error'", async () => {
+    paymentPickerMock.useInternalErrorResult()
+    const page = await buildPage()
+    await page.clickSubmit()
+    await page.expectAndDismissErrorDialogMatching(
+      "An internal error occurred",
+      "Please try again or contact orders@artsy.net."
+    )
+  })
+
   it("commits setOrderPayment mutation with the credit card id", async () => {
     const page = await buildPage()
     await page.clickSubmit()


### PR DESCRIPTION
# PURCHASE-1432

# Problem
A new user received a generic error message when attempting to add a card on the payment page. We should be displaying the error message in the dialog, or a custom message based on the decline code.

https://artsy.slack.com/archives/CB110C6LE/p1566571791008000
https://exchange.artsy.net/admin/orders/db831680-b90c-46e2-96a2-09fe8d440025

# Solution
While I was unable to reproduce the error in the same as the customer received it, I figured out that that a blank error modal displays when the error detail is null. I was able to trigger a different error where detail was null and added a new error type "internal error" for these types of errors. The  error dialog message is the default error contact message and the title is 'An internal error occurred' so we can differentiate between these errors and other errors also using the default message. I also log these errors to sentry.