### PR TITLE
Update Targeting Data in Ad Server

### DIFF
--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -12,6 +12,7 @@ export interface DisplayAdProps extends FlexProps {
     is_testing: boolean
     page_type: string
     post_id: string
+    tags: string
   }
   isSeries?: boolean
   isStandard?: boolean
@@ -28,6 +29,7 @@ GPT.syncCorrelator(true)
 
 export const DisplayAd: SFC<DisplayAdProps> = props => {
   const { adDimension, adUnit, targetingData, ...otherProps } = props
+  console.log("TCL: targetingData", targetingData)
 
   const [width, height] = adDimension.split("x").map(a => parseInt(a))
   const [isAdEmpty, setAdEmpty] = useState(null)

--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -29,8 +29,6 @@ GPT.syncCorrelator(true)
 
 export const DisplayAd: SFC<DisplayAdProps> = props => {
   const { adDimension, adUnit, targetingData, ...otherProps } = props
-  console.log("TCL: targetingData", targetingData)
-
   const [width, height] = adDimension.split("x").map(a => parseInt(a))
   const [isAdEmpty, setAdEmpty] = useState(null)
   const isMobileLeaderboardAd = is300x50AdUnit(adDimension)

--- a/src/Components/Publishing/Display/DisplayTargeting.tsx
+++ b/src/Components/Publishing/Display/DisplayTargeting.tsx
@@ -2,25 +2,21 @@ import { ArticleData } from "Components/Publishing/Typings"
 import { data as sd } from "sharify"
 import { get } from "Utils/get"
 
-export const targetingData = (
-  id: string,
-  pageType: string,
-  verticalTag: string
-) => {
+export const targetingData = (article: ArticleData, pageType: string) => {
   const isTesting = sd.DEPLOY_ENV === "production" ? false : true
 
   return {
-    tags: verticalTag,
     is_testing: isTesting,
     page_type: pageType,
-    post_id: id,
+    post_id: article.id,
+    tags: verticalTag(article),
   }
+}
+
+const verticalTag = (article: ArticleData) => {
+  return get(article, a => a.vertical.name, "")
 }
 
 export const is300x50AdUnit = (unit: string): boolean => {
   return unit.slice(-3) === "x50"
-}
-
-export const getVerticalTag = (article: ArticleData) => {
-  return get(article, a => a.vertical.name, "")
 }

--- a/src/Components/Publishing/Display/DisplayTargeting.tsx
+++ b/src/Components/Publishing/Display/DisplayTargeting.tsx
@@ -1,9 +1,16 @@
+import { ArticleData } from "Components/Publishing/Typings"
 import { data as sd } from "sharify"
+import { get } from "Utils/get"
 
-export const targetingData = (id: string, pageType: string) => {
+export const targetingData = (
+  id: string,
+  pageType: string,
+  verticalTag: string
+) => {
   const isTesting = sd.DEPLOY_ENV === "production" ? false : true
 
   return {
+    tags: verticalTag,
     is_testing: isTesting,
     page_type: pageType,
     post_id: id,
@@ -12,4 +19,8 @@ export const targetingData = (id: string, pageType: string) => {
 
 export const is300x50AdUnit = (unit: string): boolean => {
   return unit.slice(-3) === "x50"
+}
+
+export const getVerticalTag = (article: ArticleData) => {
+  return get(article, a => a.vertical.name, "")
 }

--- a/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
@@ -17,11 +17,7 @@ it("renders the new canvas in standard layout", () => {
       <DisplayAd
         adDimension={AdData.adDimension}
         adUnit={AdData.adUnit}
-        targetingData={targetingData(
-          StandardArticle.id,
-          "article",
-          StandardArticle.vertical.name
-        )}
+        targetingData={targetingData(StandardArticle, "article")}
       />
     )
     .toJSON()
@@ -33,11 +29,7 @@ it("renders the component with the correct data and properties in standard layou
     <DisplayAd
       adDimension={AdData.adDimension}
       adUnit={AdData.adUnit}
-      targetingData={targetingData(
-        StandardArticle.id,
-        "article",
-        StandardArticle.vertical.name
-      )}
+      targetingData={targetingData(StandardArticle, "article")}
     />
   )
 
@@ -52,11 +44,7 @@ it("renders GPT with the correct properties in standard layout articles", () => 
     <DisplayAd
       adDimension={AdData.adDimension}
       adUnit={AdData.adUnit}
-      targetingData={targetingData(
-        StandardArticle.id,
-        "article",
-        StandardArticle.vertical.name
-      )}
+      targetingData={targetingData(StandardArticle, "article")}
     />
   )
 

--- a/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
@@ -17,7 +17,11 @@ it("renders the new canvas in standard layout", () => {
       <DisplayAd
         adDimension={AdData.adDimension}
         adUnit={AdData.adUnit}
-        targetingData={targetingData(StandardArticle.id, "article")}
+        targetingData={targetingData(
+          StandardArticle.id,
+          "article",
+          StandardArticle.vertical.name
+        )}
       />
     )
     .toJSON()
@@ -29,7 +33,11 @@ it("renders the component with the correct data and properties in standard layou
     <DisplayAd
       adDimension={AdData.adDimension}
       adUnit={AdData.adUnit}
-      targetingData={targetingData(StandardArticle.id, "article")}
+      targetingData={targetingData(
+        StandardArticle.id,
+        "article",
+        StandardArticle.vertical.name
+      )}
     />
   )
 
@@ -44,7 +52,11 @@ it("renders GPT with the correct properties in standard layout articles", () => 
     <DisplayAd
       adDimension={AdData.adDimension}
       adUnit={AdData.adUnit}
-      targetingData={targetingData(StandardArticle.id, "article")}
+      targetingData={targetingData(
+        StandardArticle.id,
+        "article",
+        StandardArticle.vertical.name
+      )}
     />
   )
 
@@ -55,6 +67,7 @@ it("renders GPT with the correct properties in standard layout articles", () => 
     is_testing: true,
     page_type: "article",
     post_id: "594a7e2254c37f00177c0ea9",
+    tags: "Art Market",
   })
   expect(gptProps.slotSize).toEqual([970, 250])
 })

--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -1389,6 +1389,10 @@ export const NewsArticle: ArticleData = {
     id: "50f4367051e7956b6e00045d",
     name: "Artsy Editorial",
   },
+  vertical: {
+    name: "News",
+    id: "12345",
+  },
   published_at: "2018-07-19T17:19:55.909Z",
   authors: [
     {

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -196,6 +196,7 @@ export const StandardArticleHostedAdPanel: DisplayAdProps = {
     is_testing: true,
     page_type: "article",
     post_id: "123",
+    tags: "Art Market",
   },
 }
 
@@ -206,6 +207,7 @@ export const StandardArticleHostedAdCanvas: DisplayAdProps = {
     is_testing: true,
     page_type: "article",
     post_id: "123",
+    tags: "Art Market",
   },
 }
 

--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -1,6 +1,9 @@
 import { color } from "@artsy/palette"
 import { unica } from "Assets/Fonts"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  getVerticalTag,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { once } from "lodash"
 import React, { Component } from "react"
 import track, { TrackingProp } from "react-tracking"
@@ -110,6 +113,7 @@ export class NewsLayout extends Component<Props, State> {
       showCollectionsRail,
       shouldAdRender,
     } = this.props
+    const verticalTag = getVerticalTag(article)
     const adUnit = this.getAdUnit()
     const adDimension = isMobile
       ? AdDimension.Mobile_NewsLanding_InContent1
@@ -121,7 +125,11 @@ export class NewsLayout extends Component<Props, State> {
           <DisplayAd
             adUnit={adUnit}
             adDimension={adDimension}
-            targetingData={targetingData(article.id, "newslanding")}
+            targetingData={targetingData(
+              article.id,
+              "newslanding",
+              verticalTag
+            )}
           />
         )}
         {relatedArticlesForCanvas && (

--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -1,9 +1,6 @@
 import { color } from "@artsy/palette"
 import { unica } from "Assets/Fonts"
-import {
-  getVerticalTag,
-  targetingData,
-} from "Components/Publishing/Display/DisplayTargeting"
+import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
 import { once } from "lodash"
 import React, { Component } from "react"
 import track, { TrackingProp } from "react-tracking"
@@ -113,7 +110,6 @@ export class NewsLayout extends Component<Props, State> {
       showCollectionsRail,
       shouldAdRender,
     } = this.props
-    const verticalTag = getVerticalTag(article)
     const adUnit = this.getAdUnit()
     const adDimension = isMobile
       ? AdDimension.Mobile_NewsLanding_InContent1
@@ -125,11 +121,7 @@ export class NewsLayout extends Component<Props, State> {
           <DisplayAd
             adUnit={adUnit}
             adDimension={adDimension}
-            targetingData={targetingData(
-              article.id,
-              "newslanding",
-              verticalTag
-            )}
+            targetingData={targetingData(article, "newslanding")}
           />
         )}
         {relatedArticlesForCanvas && (

--- a/src/Components/Publishing/Layouts/SeriesLayout.tsx
+++ b/src/Components/Publishing/Layouts/SeriesLayout.tsx
@@ -1,5 +1,8 @@
 import { Box, color } from "@artsy/palette"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  getVerticalTag,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { Nav } from "Components/Publishing/Nav/Nav"
 import { ArticleCards } from "Components/Publishing/RelatedArticles/ArticleCards/ArticleCards"
 import { FixedBackground } from "Components/Publishing/Series/FixedBackground"
@@ -29,6 +32,7 @@ export class SeriesLayout extends Component<Props, null> {
     const { article, backgroundColor, relatedArticles, isMobile } = this.props
 
     const { hero_section, sponsor } = article
+    const verticalTag = getVerticalTag(article)
     const isSponsored = isEditorialSponsored(sponsor)
     const backgroundUrl =
       hero_section && hero_section.url ? hero_section.url : ""
@@ -71,7 +75,8 @@ export class SeriesLayout extends Component<Props, null> {
           adDimension={adDimension}
           targetingData={targetingData(
             article.id,
-            isSponsored ? "sponsorlanding" : "standardseries"
+            isSponsored ? "sponsorlanding" : "standardseries",
+            verticalTag
           )}
           isSeries
         />

--- a/src/Components/Publishing/Layouts/SeriesLayout.tsx
+++ b/src/Components/Publishing/Layouts/SeriesLayout.tsx
@@ -1,8 +1,5 @@
 import { Box, color } from "@artsy/palette"
-import {
-  getVerticalTag,
-  targetingData,
-} from "Components/Publishing/Display/DisplayTargeting"
+import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
 import { Nav } from "Components/Publishing/Nav/Nav"
 import { ArticleCards } from "Components/Publishing/RelatedArticles/ArticleCards/ArticleCards"
 import { FixedBackground } from "Components/Publishing/Series/FixedBackground"
@@ -32,7 +29,6 @@ export class SeriesLayout extends Component<Props, null> {
     const { article, backgroundColor, relatedArticles, isMobile } = this.props
 
     const { hero_section, sponsor } = article
-    const verticalTag = getVerticalTag(article)
     const isSponsored = isEditorialSponsored(sponsor)
     const backgroundUrl =
       hero_section && hero_section.url ? hero_section.url : ""
@@ -74,9 +70,8 @@ export class SeriesLayout extends Component<Props, null> {
           }
           adDimension={adDimension}
           targetingData={targetingData(
-            article.id,
-            isSponsored ? "sponsorlanding" : "standardseries",
-            verticalTag
+            article,
+            isSponsored ? "sponsorlanding" : "standardseries"
           )}
           isSeries
         />

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -3,10 +3,7 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { getEditorialHref } from "Components/Publishing/Constants"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
-import {
-  getVerticalTag,
-  targetingData,
-} from "Components/Publishing/Display/DisplayTargeting"
+import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
@@ -66,7 +63,7 @@ export class StandardLayout extends React.Component<
     this.setState({ isTruncated: false })
   }
 
-  renderSideRailDisplayAd(isMobileAd: boolean, verticalTag: string) {
+  renderSideRailDisplayAd(isMobileAd: boolean) {
     const { article, isSuper } = this.props
 
     if (isSuper) {
@@ -83,12 +80,12 @@ export class StandardLayout extends React.Component<
             ? AdDimension.Mobile_InContentMR1
             : AdDimension.Desktop_RightRail1
         }
-        targetingData={targetingData(article.id, "article", verticalTag)}
+        targetingData={targetingData(article, "article")}
       />
     )
   }
 
-  renderTopRailDisplayAd(isMobileAd: boolean, verticalTag: string) {
+  renderTopRailDisplayAd(isMobileAd: boolean) {
     const { article, isSuper } = this.props
     const adDimension = isMobileAd
       ? AdDimension.Mobile_InContentMR1
@@ -106,7 +103,7 @@ export class StandardLayout extends React.Component<
             : AdUnit.Desktop_TopLeaderboard
         }
         adDimension={adDimension}
-        targetingData={targetingData(article.id, "article", verticalTag)}
+        targetingData={targetingData(article, "article")}
       />
     )
   }
@@ -127,19 +124,18 @@ export class StandardLayout extends React.Component<
     const { isTruncated } = this.state
     const { seriesArticle } = article
     const seriesOrSuper = isSuper || seriesArticle
-    const verticalTag = getVerticalTag(article)
 
     return (
       <Responsive>
         {({ xs, sm, md }) => {
           const isMobileAd = Boolean(isMobile || xs || sm || md)
           const sideRailDisplayAd = () => (
-            <>{this.renderSideRailDisplayAd(isMobileAd, verticalTag)}</>
+            <>{this.renderSideRailDisplayAd(isMobileAd)}</>
           )
 
           return (
             <ArticleWrapper isInfiniteScroll={this.props.isTruncated}>
-              {this.renderTopRailDisplayAd(isMobileAd, verticalTag)}
+              {this.renderTopRailDisplayAd(isMobileAd)}
 
               <ReadMoreWrapper
                 isTruncated={isTruncated}

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -3,7 +3,10 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { getEditorialHref } from "Components/Publishing/Constants"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  getVerticalTag,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
@@ -63,7 +66,7 @@ export class StandardLayout extends React.Component<
     this.setState({ isTruncated: false })
   }
 
-  renderSideRailDisplayAd(isMobileAd: boolean) {
+  renderSideRailDisplayAd(isMobileAd: boolean, verticalTag: string) {
     const { article, isSuper } = this.props
 
     if (isSuper) {
@@ -80,12 +83,12 @@ export class StandardLayout extends React.Component<
             ? AdDimension.Mobile_InContentMR1
             : AdDimension.Desktop_RightRail1
         }
-        targetingData={targetingData(article.id, "article")}
+        targetingData={targetingData(article.id, "article", verticalTag)}
       />
     )
   }
 
-  renderTopRailDisplayAd(isMobileAd: boolean) {
+  renderTopRailDisplayAd(isMobileAd: boolean, verticalTag: string) {
     const { article, isSuper } = this.props
     const adDimension = isMobileAd
       ? AdDimension.Mobile_InContentMR1
@@ -103,7 +106,7 @@ export class StandardLayout extends React.Component<
             : AdUnit.Desktop_TopLeaderboard
         }
         adDimension={adDimension}
-        targetingData={targetingData(article.id, "article")}
+        targetingData={targetingData(article.id, "article", verticalTag)}
       />
     )
   }
@@ -124,18 +127,19 @@ export class StandardLayout extends React.Component<
     const { isTruncated } = this.state
     const { seriesArticle } = article
     const seriesOrSuper = isSuper || seriesArticle
+    const verticalTag = getVerticalTag(article)
 
     return (
       <Responsive>
         {({ xs, sm, md }) => {
           const isMobileAd = Boolean(isMobile || xs || sm || md)
           const sideRailDisplayAd = () => (
-            <>{this.renderSideRailDisplayAd(isMobileAd)}</>
+            <>{this.renderSideRailDisplayAd(isMobileAd, verticalTag)}</>
           )
 
           return (
             <ArticleWrapper isInfiniteScroll={this.props.isTruncated}>
-              {this.renderTopRailDisplayAd(isMobileAd)}
+              {this.renderTopRailDisplayAd(isMobileAd, verticalTag)}
 
               <ReadMoreWrapper
                 isTruncated={isTruncated}

--- a/src/Components/Publishing/Layouts/VideoLayout.tsx
+++ b/src/Components/Publishing/Layouts/VideoLayout.tsx
@@ -1,7 +1,10 @@
 import { Box } from "@artsy/palette"
 import { getEditorialHref } from "Components/Publishing/Constants"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  getVerticalTag,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { Nav, NavContainer } from "Components/Publishing/Nav/Nav"
 import { ArticleCardsBlock } from "Components/Publishing/RelatedArticles/ArticleCards/Block"
 import { AdDimension, AdUnit, ArticleData } from "Components/Publishing/Typings"
@@ -79,6 +82,7 @@ export class VideoLayout extends Component<Props, State> {
   render() {
     const { article, isMobile, relatedArticles } = this.props
     const { media, seriesArticle } = article
+    const verticalTag = getVerticalTag(article)
     const sponsor = seriesArticle ? seriesArticle.sponsor : article.sponsor
     const isSponsored = isEditorialSponsored(sponsor)
     const seriesLink =
@@ -129,7 +133,8 @@ export class VideoLayout extends Component<Props, State> {
           adDimension={adDimension}
           targetingData={targetingData(
             article.id,
-            isSponsored ? "sponsorfeature" : "video"
+            isSponsored ? "sponsorfeature" : "video",
+            verticalTag
           )}
           isSeries
         />

--- a/src/Components/Publishing/Layouts/VideoLayout.tsx
+++ b/src/Components/Publishing/Layouts/VideoLayout.tsx
@@ -1,10 +1,7 @@
 import { Box } from "@artsy/palette"
 import { getEditorialHref } from "Components/Publishing/Constants"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
-import {
-  getVerticalTag,
-  targetingData,
-} from "Components/Publishing/Display/DisplayTargeting"
+import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
 import { Nav, NavContainer } from "Components/Publishing/Nav/Nav"
 import { ArticleCardsBlock } from "Components/Publishing/RelatedArticles/ArticleCards/Block"
 import { AdDimension, AdUnit, ArticleData } from "Components/Publishing/Typings"
@@ -82,7 +79,6 @@ export class VideoLayout extends Component<Props, State> {
   render() {
     const { article, isMobile, relatedArticles } = this.props
     const { media, seriesArticle } = article
-    const verticalTag = getVerticalTag(article)
     const sponsor = seriesArticle ? seriesArticle.sponsor : article.sponsor
     const isSponsored = isEditorialSponsored(sponsor)
     const seriesLink =
@@ -132,9 +128,8 @@ export class VideoLayout extends Component<Props, State> {
           }
           adDimension={adDimension}
           targetingData={targetingData(
-            article.id,
-            isSponsored ? "sponsorfeature" : "video",
-            verticalTag
+            article,
+            isSponsored ? "sponsorfeature" : "video"
           )}
           isSeries
         />

--- a/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.tsx
@@ -163,6 +163,7 @@ describe("News Layout with display ads", () => {
       is_testing: true,
       page_type: "newslanding",
       post_id: "594a7e2254c37f00177c0ea9",
+      tags: "News",
     })
   })
 
@@ -181,6 +182,7 @@ describe("News Layout with display ads", () => {
       is_testing: true,
       page_type: "newslanding",
       post_id: "594a7e2254c37f00177c0ea9",
+      tags: "News",
     })
   })
 

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -174,11 +174,7 @@ describe("standard article ad data", () => {
       <DisplayAd
         adDimension={AdDimension.Desktop_TopLeaderboard}
         adUnit={AdUnit.Desktop_TopLeaderboard}
-        targetingData={targetingData(
-          StandardArticle.id,
-          "article",
-          StandardArticle.vertical.name
-        )}
+        targetingData={targetingData(StandardArticle, "article")}
       />
     )
 
@@ -198,11 +194,7 @@ describe("standard article ad data", () => {
       <DisplayAd
         adDimension={AdDimension.Desktop_RightRail1}
         adUnit={AdUnit.Desktop_RightRail1}
-        targetingData={targetingData(
-          StandardArticle.id,
-          "article",
-          StandardArticle.vertical.name
-        )}
+        targetingData={targetingData(StandardArticle, "article")}
       />
     )
 
@@ -222,11 +214,7 @@ describe("standard article ad data", () => {
       <DisplayAd
         adDimension={AdDimension.Mobile_InContentMR1}
         adUnit={AdUnit.Mobile_InContentMR1}
-        targetingData={targetingData(
-          StandardArticle.id,
-          "article",
-          StandardArticle.vertical.name
-        )}
+        targetingData={targetingData(StandardArticle, "article")}
       />
     )
 
@@ -246,11 +234,7 @@ describe("standard article ad data", () => {
       <DisplayAd
         adDimension={AdDimension.Mobile_TopLeaderboard}
         adUnit={AdUnit.Mobile_TopLeaderboard}
-        targetingData={targetingData(
-          StandardArticle.id,
-          "article",
-          StandardArticle.vertical.name
-        )}
+        targetingData={targetingData(StandardArticle, "article")}
       />
     )
 

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -174,7 +174,11 @@ describe("standard article ad data", () => {
       <DisplayAd
         adDimension={AdDimension.Desktop_TopLeaderboard}
         adUnit={AdUnit.Desktop_TopLeaderboard}
-        targetingData={targetingData(StandardArticle.id, "article")}
+        targetingData={targetingData(
+          StandardArticle.id,
+          "article",
+          StandardArticle.vertical.name
+        )}
       />
     )
 
@@ -184,6 +188,7 @@ describe("standard article ad data", () => {
       is_testing: true,
       page_type: "article",
       post_id: "594a7e2254c37f00177c0ea9",
+      tags: "Art Market",
     })
     expect(ad).toHaveLength(1)
   })
@@ -193,7 +198,11 @@ describe("standard article ad data", () => {
       <DisplayAd
         adDimension={AdDimension.Desktop_RightRail1}
         adUnit={AdUnit.Desktop_RightRail1}
-        targetingData={targetingData(StandardArticle.id, "article")}
+        targetingData={targetingData(
+          StandardArticle.id,
+          "article",
+          StandardArticle.vertical.name
+        )}
       />
     )
 
@@ -203,6 +212,7 @@ describe("standard article ad data", () => {
       is_testing: true,
       page_type: "article",
       post_id: "594a7e2254c37f00177c0ea9",
+      tags: "Art Market",
     })
     expect(ad).toHaveLength(1)
   })
@@ -212,7 +222,11 @@ describe("standard article ad data", () => {
       <DisplayAd
         adDimension={AdDimension.Mobile_InContentMR1}
         adUnit={AdUnit.Mobile_InContentMR1}
-        targetingData={targetingData(StandardArticle.id, "article")}
+        targetingData={targetingData(
+          StandardArticle.id,
+          "article",
+          StandardArticle.vertical.name
+        )}
       />
     )
 
@@ -222,6 +236,7 @@ describe("standard article ad data", () => {
       is_testing: true,
       page_type: "article",
       post_id: "594a7e2254c37f00177c0ea9",
+      tags: "Art Market",
     })
     expect(ad).toHaveLength(1)
   })
@@ -231,7 +246,11 @@ describe("standard article ad data", () => {
       <DisplayAd
         adDimension={AdDimension.Mobile_TopLeaderboard}
         adUnit={AdUnit.Mobile_TopLeaderboard}
-        targetingData={targetingData(StandardArticle.id, "article")}
+        targetingData={targetingData(
+          StandardArticle.id,
+          "article",
+          StandardArticle.vertical.name
+        )}
       />
     )
 
@@ -241,6 +260,7 @@ describe("standard article ad data", () => {
       is_testing: true,
       page_type: "article",
       post_id: "594a7e2254c37f00177c0ea9",
+      tags: "Art Market",
     })
     expect(ad).toHaveLength(1)
   })

--- a/src/Components/Publishing/Layouts/__tests__/VideoLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/VideoLayout.test.tsx
@@ -130,9 +130,8 @@ describe("display ad data on video series", () => {
         }
         isSeries
         targetingData={targetingData(
-          VideoArticleSponsored.id,
-          isSponsored ? "sponsorlanding" : "video",
-          VideoArticleSponsored.vertical.name
+          VideoArticleSponsored,
+          isSponsored ? "sponsorlanding" : "video"
         )}
       />
     )
@@ -158,9 +157,8 @@ describe("display ad data on video series", () => {
         }
         isSeries
         targetingData={targetingData(
-          VideoArticleFixture.id,
-          isSponsored ? "sponsorlanding" : "video",
-          VideoArticleSponsored.vertical.name
+          VideoArticleFixture,
+          isSponsored ? "sponsorlanding" : "video"
         )}
       />
     )
@@ -186,9 +184,8 @@ describe("display ad data on video series", () => {
         }
         isSeries
         targetingData={targetingData(
-          VideoArticleFixture.id,
-          isSponsored ? "sponsorlanding" : "video",
-          VideoArticleSponsored.vertical.name
+          VideoArticleFixture,
+          isSponsored ? "sponsorlanding" : "video"
         )}
       />
     )
@@ -207,11 +204,7 @@ describe("display ad data on video series", () => {
         }
         adUnit={AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom}
         isSeries
-        targetingData={targetingData(
-          VideoArticleFixture.id,
-          "sponsorlanding",
-          VideoArticleSponsored.vertical.name
-        )}
+        targetingData={targetingData(VideoArticleFixture, "sponsorlanding")}
       />
     )
 

--- a/src/Components/Publishing/Layouts/__tests__/VideoLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/VideoLayout.test.tsx
@@ -131,7 +131,8 @@ describe("display ad data on video series", () => {
         isSeries
         targetingData={targetingData(
           VideoArticleSponsored.id,
-          isSponsored ? "sponsorlanding" : "video"
+          isSponsored ? "sponsorlanding" : "video",
+          VideoArticleSponsored.vertical.name
         )}
       />
     )
@@ -140,6 +141,7 @@ describe("display ad data on video series", () => {
       is_testing: true,
       page_type: "sponsorlanding",
       post_id: "597b9f652d35b80017a2a6a7",
+      tags: "Art Market",
     })
   })
 
@@ -157,7 +159,8 @@ describe("display ad data on video series", () => {
         isSeries
         targetingData={targetingData(
           VideoArticleFixture.id,
-          isSponsored ? "sponsorlanding" : "video"
+          isSponsored ? "sponsorlanding" : "video",
+          VideoArticleSponsored.vertical.name
         )}
       />
     )
@@ -166,6 +169,7 @@ describe("display ad data on video series", () => {
       is_testing: true,
       page_type: "video",
       post_id: "597b9f652d35b80017a2a6a7",
+      tags: "Art Market",
     })
   })
 
@@ -183,7 +187,8 @@ describe("display ad data on video series", () => {
         isSeries
         targetingData={targetingData(
           VideoArticleFixture.id,
-          isSponsored ? "sponsorlanding" : "video"
+          isSponsored ? "sponsorlanding" : "video",
+          VideoArticleSponsored.vertical.name
         )}
       />
     )
@@ -202,7 +207,11 @@ describe("display ad data on video series", () => {
         }
         adUnit={AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom}
         isSeries
-        targetingData={targetingData(VideoArticleFixture.id, "sponsorlanding")}
+        targetingData={targetingData(
+          VideoArticleFixture.id,
+          "sponsorlanding",
+          VideoArticleSponsored.vertical.name
+        )}
       />
     )
 

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -1,5 +1,8 @@
 import { Box } from "@artsy/palette"
-import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
+import {
+  getVerticalTag,
+  targetingData,
+} from "Components/Publishing/Display/DisplayTargeting"
 import { getSlideshowImagesFromArticle } from "Components/Publishing/Layouts/ArticleWithFullScreen"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import { clone, compact, findLastIndex, get, once } from "lodash"
@@ -254,6 +257,7 @@ export class Sections extends Component<Props, State> {
       hideAds,
     } = this.props
     const { shouldInjectMobileDisplay } = this.state
+    const verticalTag = getVerticalTag(article)
     let quantityOfAdsRendered = 0
     let firstAdInjected = false
     let placementCount = 1
@@ -315,7 +319,8 @@ export class Sections extends Component<Props, State> {
               adDimension={adDimension}
               targetingData={targetingData(
                 article.id,
-                isSponsored ? "sponsorfeature" : "feature"
+                isSponsored ? "sponsorfeature" : "feature",
+                verticalTag
               )}
             />
           </AdWrapper>

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -1,8 +1,5 @@
 import { Box } from "@artsy/palette"
-import {
-  getVerticalTag,
-  targetingData,
-} from "Components/Publishing/Display/DisplayTargeting"
+import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
 import { getSlideshowImagesFromArticle } from "Components/Publishing/Layouts/ArticleWithFullScreen"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import { clone, compact, findLastIndex, get, once } from "lodash"
@@ -257,7 +254,6 @@ export class Sections extends Component<Props, State> {
       hideAds,
     } = this.props
     const { shouldInjectMobileDisplay } = this.state
-    const verticalTag = getVerticalTag(article)
     let quantityOfAdsRendered = 0
     let firstAdInjected = false
     let placementCount = 1
@@ -318,9 +314,8 @@ export class Sections extends Component<Props, State> {
               adUnit={this.getAdUnit(placementCount, indexAtFirstAd)}
               adDimension={adDimension}
               targetingData={targetingData(
-                article.id,
-                isSponsored ? "sponsorfeature" : "feature",
-                verticalTag
+                article,
+                isSponsored ? "sponsorfeature" : "feature"
               )}
             />
           </AdWrapper>

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
@@ -182,6 +182,7 @@ describe("Sections", () => {
         is_testing: true,
         page_type: "feature",
         post_id: "594a7e2254c37f00177c0ea9",
+        tags: "Creativity",
       })
     })
 
@@ -200,6 +201,7 @@ describe("Sections", () => {
         is_testing: true,
         page_type: "sponsorfeature",
         post_id: "594a7e2254c37f00177c0ea9",
+        tags: "Creativity",
       })
     })
 


### PR DESCRIPTION
This PR adds article vertical data to the targeting data sent to the 3rd party ad server.

[Link to Slack discussion for context](https://artsy.slack.com/archives/GK7Q3BZ6K/p1565272756001100)


[Links to GROW-1459](https://artsyproduct.atlassian.net/browse/GROW-1459)