### PR TITLE
@zephraph => [Error Handling] Present downstream 404s as 404s when possible instead of 500s

### DIFF
--- a/src/Artsy/Router/Utils/Route.tsx
+++ b/src/Artsy/Router/Utils/Route.tsx
@@ -7,6 +7,7 @@ import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
 import { HttpError } from "found"
 import BaseRoute from "found/lib/Route"
 import React from "react"
+import { get } from "Utils/get"
 
 type FetchIndicator = "spinner" | "overlay"
 
@@ -27,12 +28,27 @@ function createRender({
 }: CreateRenderProps) {
   return (renderArgs: RenderArgProps) => {
     const { Component, props, error } = renderArgs
-
+    let status: number
+    let message: string
     if (error) {
+      if (error.name === "RRNLRequestError") {
+        // TODO: Better error typing.
+        // @ts-ignore
+        const firstError = get(error, e => e.res.errors[0])
+        const statusCodes = get(firstError, e => e.extensions.httpStatusCodes)
+        if (statusCodes.length === 1) {
+          status = statusCodes[0]
+          message = firstError.message
+        }
+      } else {
+        status = 500
+        message = error.message
+      }
+
       // TODO: Need upstream fix type in found as it complains about missing
       // second argument.
-      // @ts-ignore;
-      throw new HttpError(500, error.message)
+      // @ts-ignore
+      throw new HttpError(status, message)
     }
 
     if (render) {


### PR DESCRIPTION
Slack discussion: https://artsy.slack.com/archives/C02BC3HEJ/p1566936132153300

Basically, with https://github.com/artsy/reaction/pull/2719 , we had Reaction rendering error pages and sending those down as normal renders, instead of just throwing an error (which Force would catch: https://github.com/artsy/force/blob/240518cf4de48df519233ef7aa6571baaa42bdef/src/desktop/apps/artwork/server.tsx#L88

So, this means that things that should have been caught and coerced into 404s in this way, are presented as 500s. This isn't ideal as the steady stream of these will overwhelm logs and Sentry reporting/alerting.

Since we now have the newfangled error'ing status codes stuff from Metaphysics, instead of doing a similar pattern match against `/Artist Not Found/` and the like, we can actually get the correct relevant code.