### PR TITLE
Add STRIPE_PUBISHABLE_KEY to .env.oss

### DIFF
--- a/.env.oss
+++ b/.env.oss
@@ -1,11 +1,14 @@
 NODE_ENV=development
 WEBPACK_DEVTOOL=cheap-module-eval-source-map
 
+# ENV variables to be sourced from artsy/force
+# Use `$ hokusai staging env get` in your local checkout of artsy/force.
 APP_URL=https://staging.artsy.net
 CMS_URL=https://cms-staging.artsy.net
 GEMINI_CLOUDFRONT_URL=https://d7hftxdivxxvm.cloudfront.net
 GENOME_URL=https://helix.artsy.net
 METAPHYSICS_ENDPOINT=https://metaphysics-staging.artsy.net
+STRIPE_PUBISHABLE_KEY=
 
 # Grab these values by:
 # 1. signing in on staging.artsy.net
@@ -13,6 +16,3 @@ METAPHYSICS_ENDPOINT=https://metaphysics-staging.artsy.net
 # 3. and get the values `sd.CURRENT_USER.id` and `sd.CURRENT_USER.accessToken`
 USER_ID=
 USER_ACCESS_TOKEN=
-
-# `cd path/to/force && hokusai staging env get | grep -i stripe`
-STRIPE_PUBISHABLE_KEY=

--- a/.env.oss
+++ b/.env.oss
@@ -14,3 +14,5 @@ METAPHYSICS_ENDPOINT=https://metaphysics-staging.artsy.net
 USER_ID=
 USER_ACCESS_TOKEN=
 
+# `cd path/to/force && hokusai staging env get | grep -i stripe`
+STRIPE_PUBISHABLE_KEY=

--- a/src/__stories__/config.js
+++ b/src/__stories__/config.js
@@ -31,4 +31,3 @@ Events.onEvent(data => {
 if (!window.sd || !(typeof window.sd === "object")) {
   window.sd = {}
 }
-window.sd.STRIPE_PUBLISHABLE_KEY = "pk_test_R4eRJrMVtXTZxbSPK8mTeluc"


### PR DESCRIPTION
Problem

Some app, particularly the new Auction app, requires a meaningful
STRIPE_PUBISHABLE_KEY for `yarn start` to start storybooks correctly.

It's kind of hard to know this though as there's no explicit call out
of this.

Solution:

- Add entry for `STRIPE_PUBISHABLE_KEY` to .env.oss
- Add instructions on how to get this from Force