### PR TITLE
Create Collection Hubs entrypoint nav component for homepage

### DIFF
--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -28,7 +28,7 @@ export const CollectionsHubsHomepageNav: FC<
           to={`/collection/${hub.slug}`}
           src={placeholderImage}
           ratio={[0.49]}
-          title={<Serif size="4t">{hub.title}</Serif>}
+          title={<Serif size={["3", "4"]}>{hub.title}</Serif>}
           subtitle={<Serif size="2">{subtitleFor(hub.title)}</Serif>}
           key={hub.id}
         />

--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -1,16 +1,18 @@
 import { CSSGrid } from "@artsy/palette"
-import { CollectionsHubsNav_marketingCollections } from "__generated__/CollectionsHubsNav_marketingCollections.graphql"
+import { Serif } from "@artsy/palette"
+import { CollectionsHubsHomepageNav_marketingCollections } from "__generated__/CollectionsHubsHomepageNav_marketingCollections.graphql"
+import { placeholderImage } from "Components/v2/CollectionsHubsNav"
 import React, { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-
-import { Serif } from "@artsy/palette"
 import { ImageLink } from "./ImageLink"
 
-interface CollectionsHubsNavProps {
-  marketingCollections: CollectionsHubsNav_marketingCollections
+interface CollectionsHubsHomepageNavProps {
+  marketingCollections: CollectionsHubsHomepageNav_marketingCollections
 }
 
-export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
+export const CollectionsHubsHomepageNav: FC<
+  CollectionsHubsHomepageNavProps
+> = props => {
   return (
     <CSSGrid
       as="aside"
@@ -35,15 +37,11 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
   )
 }
 
-// This is a temporary image URL until we get real data.
-export const placeholderImage =
-  "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeF_qAORql7lSnD2BwbFOYg%2Flarge.jpg"
-
-export const CollectionsHubsNavFragmentContainer = createFragmentContainer(
-  CollectionsHubsNav,
+export const CollectionsHubsHomepageNavFragmentContainer = createFragmentContainer(
+  CollectionsHubsHomepageNav,
   {
     marketingCollections: graphql`
-      fragment CollectionsHubsNav_marketingCollections on MarketingCollection
+      fragment CollectionsHubsHomepageNav_marketingCollections on MarketingCollection
         @relay(plural: true) {
         id
         slug

--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -25,9 +25,9 @@ export const CollectionsHubsHomepageNav: FC<
     >
       {props.marketingCollections.map(hub => (
         <ImageLink
-          href={`/collection/${hub.slug}`}
+          to={`/collection/${hub.slug}`}
           src={placeholderImage}
-          alt={hub.title}
+          ratio={[0.49]}
           title={<Serif size="4t">{hub.title}</Serif>}
           subtitle={<Serif size="2">{subtitleFor(hub.title)}</Serif>}
           key={hub.id}

--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -18,8 +18,8 @@ export const CollectionsHubsHomepageNav: FC<
       as="aside"
       gridTemplateColumns={[
         "repeat(2, 1fr)",
+        "repeat(2, 1fr)",
         "repeat(3, 1fr)",
-        "repeat(6, 1fr)",
       ]}
       gridGap={20}
     >
@@ -29,7 +29,7 @@ export const CollectionsHubsHomepageNav: FC<
           src={placeholderImage}
           alt={hub.title}
           title={<Serif size="4t">{hub.title}</Serif>}
-          // subtitle={subtitle && <Serif size="2">{hub.subtitle}</Serif>}
+          subtitle={<Serif size="2">{subtitleFor(hub.title)}</Serif>}
           key={hub.id}
         />
       ))}
@@ -51,3 +51,30 @@ export const CollectionsHubsHomepageNavFragmentContainer = createFragmentContain
     `,
   }
 )
+
+/*
+ * This is a customization just for the homepage entry-points use case.
+ *
+ * Valid hub collections will have a subtitle defined here, rather than in KAWS.
+ * This mapping therefore will need to kept in sync as hubs are rotated
+ * in/out of the entrypoint.
+ *
+ * TODO: remove (or replace with safer) placeholder once we have real data.
+ */
+
+const subtitlesMapping = {
+  Contemporary: "Today’s leading artists and emerging talents",
+  "Post-War": "From Abstract Expressionism to Pop Art",
+  "Impressionist & Modern": "The birth of abstraction, Surrealism, and Dada",
+  "Pre-20th Century": "Ancient Rome, the Renaissance, Baroque, and more",
+  Photography: "Through the lens—from daguerreotypes to digital",
+  "Street Art": "The rise of graffiti, vinyl toys, and skate culture",
+}
+
+const subtitleFor = (title: string) => {
+  return (
+    subtitlesMapping[title] ||
+    /* placeholder */
+    Object.values(subtitlesMapping)[Math.floor(6 * Math.random())]
+  )
+}

--- a/src/Components/v2/CollectionsHubsNav.tsx
+++ b/src/Components/v2/CollectionsHubsNav.tsx
@@ -27,7 +27,6 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
           src={placeholderImage}
           ratio={[0.49]}
           title={<Serif size="4t">{hub.title}</Serif>}
-          // subtitle={subtitle && <Serif size="2">{hub.subtitle}</Serif>}
           key={hub.id}
         />
       ))}

--- a/src/Components/v2/__stories__/CollectionsHubsHomepageNav.story.tsx
+++ b/src/Components/v2/__stories__/CollectionsHubsHomepageNav.story.tsx
@@ -1,0 +1,38 @@
+import { Theme } from "@artsy/palette"
+import { CollectionsHubsHomepageNavQuery } from "__generated__/CollectionsHubsHomepageNavQuery.graphql"
+import { useSystemContext } from "Artsy"
+import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { storiesOf } from "storybook/storiesOf"
+import { CollectionsHubsHomepageNavFragmentContainer } from "../CollectionsHubsHomepageNav"
+
+storiesOf("Components/CollectionsHubsHomepageNav", module).add(
+  "default",
+  () => (
+    <Theme>
+      <CollectionsHubsHomepageNavQueryRenderer />
+    </Theme>
+  )
+)
+
+const CollectionsHubsHomepageNavQueryRenderer = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <QueryRenderer<CollectionsHubsHomepageNavQuery>
+      environment={relayEnvironment}
+      variables={{}}
+      query={graphql`
+        query CollectionsHubsHomepageNavQuery {
+          marketingCollections(size: 6) {
+            ...CollectionsHubsHomepageNav_marketingCollections
+          }
+        }
+      `}
+      render={renderWithLoadProgress(
+        CollectionsHubsHomepageNavFragmentContainer
+      )}
+    />
+  )
+}

--- a/src/__generated__/CollectionsHubsHomepageNavQuery.graphql.ts
+++ b/src/__generated__/CollectionsHubsHomepageNavQuery.graphql.ts
@@ -1,0 +1,134 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { CollectionsHubsHomepageNav_marketingCollections$ref } from "./CollectionsHubsHomepageNav_marketingCollections.graphql";
+export type CollectionsHubsHomepageNavQueryVariables = {};
+export type CollectionsHubsHomepageNavQueryResponse = {
+    readonly marketingCollections: ReadonlyArray<{
+        readonly " $fragmentRefs": CollectionsHubsHomepageNav_marketingCollections$ref;
+    }>;
+};
+export type CollectionsHubsHomepageNavQuery = {
+    readonly response: CollectionsHubsHomepageNavQueryResponse;
+    readonly variables: CollectionsHubsHomepageNavQueryVariables;
+};
+
+
+
+/*
+query CollectionsHubsHomepageNavQuery {
+  marketingCollections(size: 6) {
+    ...CollectionsHubsHomepageNav_marketingCollections
+    __id: id
+  }
+}
+
+fragment CollectionsHubsHomepageNav_marketingCollections on MarketingCollection {
+  id
+  slug
+  title
+  thumbnail
+  __id: id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 6,
+    "type": "Int"
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "CollectionsHubsHomepageNavQuery",
+  "id": null,
+  "text": "query CollectionsHubsHomepageNavQuery {\n  marketingCollections(size: 6) {\n    ...CollectionsHubsHomepageNav_marketingCollections\n    __id: id\n  }\n}\n\nfragment CollectionsHubsHomepageNav_marketingCollections on MarketingCollection {\n  id\n  slug\n  title\n  thumbnail\n  __id: id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "CollectionsHubsHomepageNavQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "marketingCollections",
+        "storageKey": "marketingCollections(size:6)",
+        "args": v0,
+        "concreteType": "MarketingCollection",
+        "plural": true,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "CollectionsHubsHomepageNav_marketingCollections",
+            "args": null
+          },
+          v1
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "CollectionsHubsHomepageNavQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "marketingCollections",
+        "storageKey": "marketingCollections(size:6)",
+        "args": v0,
+        "concreteType": "MarketingCollection",
+        "plural": true,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "slug",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "thumbnail",
+            "args": null,
+            "storageKey": null
+          },
+          v1
+        ]
+      }
+    ]
+  }
+};
+})();
+(node as any).hash = '0560202a24b7e2143c54554f18fb1041';
+export default node;

--- a/src/__generated__/CollectionsHubsHomepageNav_marketingCollections.graphql.ts
+++ b/src/__generated__/CollectionsHubsHomepageNav_marketingCollections.graphql.ts
@@ -1,0 +1,63 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+declare const _CollectionsHubsHomepageNav_marketingCollections$ref: unique symbol;
+export type CollectionsHubsHomepageNav_marketingCollections$ref = typeof _CollectionsHubsHomepageNav_marketingCollections$ref;
+export type CollectionsHubsHomepageNav_marketingCollections = ReadonlyArray<{
+    readonly id: string;
+    readonly slug: string;
+    readonly title: string;
+    readonly thumbnail: string | null;
+    readonly " $refType": CollectionsHubsHomepageNav_marketingCollections$ref;
+}>;
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "CollectionsHubsHomepageNav_marketingCollections",
+  "type": "MarketingCollection",
+  "metadata": {
+    "plural": true
+  },
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "title",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "thumbnail",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "__id",
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '57db5beb8e6251df4cb00a9a980ed7f9';
+export default node;


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1360
subtask: https://artsyproduct.atlassian.net/browse/GROW-1485

![hp hubs](https://user-images.githubusercontent.com/140521/63873736-1ff1f380-c98e-11e9-83d2-cc64336796a7.gif)

This creates the component that we will insert into the homepage, to allow direct navigation to our set of initial collection hubs.

Another Force PR will be required to stitch this into place, in the existing Jade template for the homepage.