### PR TITLE
PURCHASE-1428: Get failed payment flow working with case where payment intent of a already confirmed setupintent fails when seller accepts offer

### DIFF
--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -110,19 +110,18 @@ export class NewPaymentRoute extends Component<
         orderOrError.actionData &&
         orderOrError.actionData.clientSecret
       ) {
-        this.state.stripe
-          .handleCardAction(orderOrError.actionData.clientSecret)
-          .then(scaResult => {
-            if (scaResult.error) {
-              this.props.dialog.showErrorDialog({
-                title: "An error occurred",
-                message: scaResult.error.message,
-              })
-              return
-            } else {
-              this.onContinue()
-            }
+        const scaResult = await this.state.stripe.handleCardAction(
+          orderOrError.actionData.clientSecret
+        )
+        if (scaResult.error) {
+          this.props.dialog.showErrorDialog({
+            title: "An error occurred",
+            message: scaResult.error.message,
           })
+          return
+        } else {
+          this.onContinue()
+        }
       } else {
         this.props.router.push(`/orders/${this.props.order.id}/status`)
       }

--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -13,6 +13,7 @@ import { RouteConfig, Router } from "found"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql, RelayRefetchProp } from "react-relay"
 import { ReactStripeElements } from "react-stripe-elements"
+import { data as sd } from "sharify"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 
@@ -48,6 +49,7 @@ export interface NewPaymentProps
 
 interface NewPaymentState {
   isGettingCreditCardId: boolean
+  stripe: stripe.Stripe
 }
 
 const logger = createLogger("Order/Routes/NewPayment/index.tsx")
@@ -60,6 +62,21 @@ export class NewPaymentRoute extends Component<
   paymentPicker = React.createRef<PaymentPicker>()
   state = {
     isGettingCreditCardId: false,
+    stripe: null,
+  }
+  componentDidMount() {
+    if (window.Stripe) {
+      this.setState({
+        stripe: window.Stripe(sd.STRIPE_PUBLISHABLE_KEY),
+      })
+    } else {
+      document.querySelector("#stripe-js").addEventListener("load", () => {
+        // Create Stripe instance once Stripe.js loads
+        this.setState({
+          stripe: window.Stripe(sd.STRIPE_PUBLISHABLE_KEY),
+        })
+      })
+    }
   }
 
   onContinue = async () => {
@@ -89,6 +106,25 @@ export class NewPaymentRoute extends Component<
       if (orderOrError.error) {
         this.handleFixFailedPaymentError(orderOrError.error.code)
         return
+      } else if (
+        orderOrError.actionData &&
+        orderOrError.actionData.clientSecret
+      ) {
+        this.state.stripe
+          .handleCardAction(orderOrError.actionData.clientSecret)
+          .then(scaResult => {
+            if (scaResult.error) {
+              this.props.dialog.showErrorDialog({
+                title: "An error occurred",
+                message: scaResult.error.message,
+              })
+              return
+            } else {
+              this.onContinue()
+            }
+          })
+      } else {
+        this.props.router.push(`/orders/${this.props.order.id}/status`)
       }
 
       this.props.router.push(`/orders/${this.props.order.id}/status`)
@@ -200,6 +236,11 @@ export class NewPaymentRoute extends Component<
                   ... on CommerceOfferOrder {
                     awaitingResponseFrom
                   }
+                }
+              }
+              ... on CommerceOrderRequiresAction {
+                actionData {
+                  clientSecret
                 }
               }
               ... on CommerceOrderWithMutationFailure {

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/fixFailedPayment.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/fixFailedPayment.ts
@@ -33,3 +33,14 @@ export const fixFailedPaymentInsufficientInventoryFailure = {
     },
   },
 }
+
+export const fixFailedPaymentWithActionRequired = {
+  commerceFixFailedPayment: {
+    orderOrError: {
+      __typename: "CommerceOrderRequiresAction",
+      actionData: {
+        clientSecret: "client-secret",
+      },
+    },
+  },
+}

--- a/src/__generated__/NewPaymentRouteSetOrderPaymentMutation.graphql.ts
+++ b/src/__generated__/NewPaymentRouteSetOrderPaymentMutation.graphql.ts
@@ -28,6 +28,9 @@ export type NewPaymentRouteSetOrderPaymentMutationResponse = {
                 }) | null;
                 readonly awaitingResponseFrom?: CommerceOrderParticipantEnum | null;
             };
+            readonly actionData?: {
+                readonly clientSecret: string;
+            };
             readonly error?: {
                 readonly type: string;
                 readonly code: string;
@@ -69,6 +72,11 @@ mutation NewPaymentRouteSetOrderPaymentMutation(
             awaitingResponseFrom
           }
           __id: id
+        }
+      }
+      ... on CommerceOrderRequiresAction {
+        actionData {
+          clientSecret
         }
       }
       ... on CommerceOrderWithMutationFailure {
@@ -139,13 +147,37 @@ v2 = {
   ]
 },
 v3 = {
+  "kind": "InlineFragment",
+  "type": "CommerceOrderRequiresAction",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "actionData",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CommerceOrderActionData",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "clientSecret",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
+},
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "state",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "creditCard",
@@ -189,7 +221,7 @@ v4 = {
       "args": null,
       "storageKey": null
     },
-    v3,
+    v4,
     {
       "kind": "ScalarField",
       "alias": null,
@@ -213,14 +245,14 @@ v4 = {
     }
   ]
 },
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "InlineFragment",
   "type": "CommerceOfferOrder",
   "selections": [
@@ -233,7 +265,7 @@ v6 = {
     }
   ]
 },
-v7 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
@@ -245,7 +277,7 @@ return {
   "operationKind": "mutation",
   "name": "NewPaymentRouteSetOrderPaymentMutation",
   "id": null,
-  "text": "mutation NewPaymentRouteSetOrderPaymentMutation(\n  $input: CommerceFixFailedPaymentInput!\n) {\n  commerceFixFailedPayment(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          __typename\n          state\n          creditCard {\n            id\n            name\n            street1\n            street2\n            city\n            state\n            country\n            postal_code\n            __id\n          }\n          ... on CommerceOfferOrder {\n            awaitingResponseFrom\n          }\n          __id: id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
+  "text": "mutation NewPaymentRouteSetOrderPaymentMutation(\n  $input: CommerceFixFailedPaymentInput!\n) {\n  commerceFixFailedPayment(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          __typename\n          state\n          creditCard {\n            id\n            name\n            street1\n            street2\n            city\n            state\n            country\n            postal_code\n            __id\n          }\n          ... on CommerceOfferOrder {\n            awaitingResponseFrom\n          }\n          __id: id\n        }\n      }\n      ... on CommerceOrderRequiresAction {\n        actionData {\n          clientSecret\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -273,6 +305,7 @@ return {
             "plural": false,
             "selections": [
               v2,
+              v3,
               {
                 "kind": "InlineFragment",
                 "type": "CommerceOrderWithMutationSuccess",
@@ -286,10 +319,10 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      v3,
                       v4,
                       v5,
-                      v6
+                      v6,
+                      v7
                     ]
                   }
                 ]
@@ -323,8 +356,9 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              v7,
+              v8,
               v2,
+              v3,
               {
                 "kind": "InlineFragment",
                 "type": "CommerceOrderWithMutationSuccess",
@@ -338,11 +372,11 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      v7,
-                      v3,
+                      v8,
                       v4,
                       v5,
-                      v6
+                      v6,
+                      v7
                     ]
                   }
                 ]
@@ -355,5 +389,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'dc95d92d55f7e60f9122eb79f8d9dedf';
+(node as any).hash = '32baca22a4e80acb3aed8485dac30a8b';
 export default node;

--- a/src/__generated__/StatusQuery.graphql.ts
+++ b/src/__generated__/StatusQuery.graphql.ts
@@ -48,7 +48,6 @@ fragment Status_order on CommerceOrder {
   lineItems {
     edges {
       node {
-        ...ItemReview_lineItem
         fulfillments {
           edges {
             node {
@@ -58,11 +57,6 @@ fragment Status_order on CommerceOrder {
               __id: id
             }
           }
-        }
-        artwork {
-          id
-          is_acquireable
-          __id
         }
         __id: id
       }
@@ -193,40 +187,6 @@ fragment CreditCardSummaryItem_order on CommerceOrder {
   __id: id
 }
 
-fragment ItemReview_lineItem on CommerceLineItem {
-  artwork {
-    artist_names
-    title
-    date
-    medium
-    dimensions {
-      in
-      cm
-    }
-    attribution_class {
-      shortDescription
-      __id
-    }
-    image {
-      resized(width: 185) {
-        url
-      }
-      __id: id
-    }
-    edition_sets {
-      id
-      dimensions {
-        in
-        cm
-      }
-      __id
-    }
-    __id
-  }
-  editionSetId
-  __id: id
-}
-
 fragment ShippingAddress_ship on CommerceShip {
   name
   addressLine1
@@ -276,48 +236,14 @@ v4 = {
   "args": null,
   "storageKey": null
 },
-v5 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "url",
-    "args": null,
-    "storageKey": null
-  }
-],
-v6 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "dimensions",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "dimensions",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "in",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "cm",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
-v7 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v8 = [
+v6 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -325,44 +251,44 @@ v8 = [
     "type": "Int"
   }
 ],
-v9 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v8,
+  "args": v6,
   "storageKey": "shippingTotal(precision:2)"
 },
-v10 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v8,
+  "args": v6,
   "storageKey": "taxTotal(precision:2)"
 },
-v12 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotalCents",
   "args": null,
   "storageKey": null
 },
-v13 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v8,
+  "args": v6,
   "storageKey": "buyerTotal(precision:2)"
 },
-v14 = [
-  v12,
-  v7,
+v12 = [
+  v10,
+  v5,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -370,17 +296,17 @@ v14 = [
     "args": null,
     "storageKey": null
   },
+  v7,
+  v8,
   v9,
-  v10,
-  v11,
   {
     "kind": "ScalarField",
     "alias": null,
     "name": "amount",
-    "args": v8,
+    "args": v6,
     "storageKey": "amount(precision:2)"
   },
-  v13,
+  v11,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -409,7 +335,7 @@ return {
   "operationKind": "query",
   "name": "StatusQuery",
   "id": null,
-  "text": "query StatusQuery {\n  order: commerceOrder(id: \"42\") {\n    __typename\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on CommerceOrder {\n  __typename\n  id\n  code\n  state\n  mode\n  stateReason\n  stateExpiresAt(format: \"MMM D\")\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              __id: id\n            }\n          }\n        }\n        artwork {\n          id\n          is_acquireable\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    artist_names\n    title\n    date\n    medium\n    dimensions {\n      in\n      cm\n    }\n    attribution_class {\n      shortDescription\n      __id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n      __id: id\n    }\n    edition_sets {\n      id\n      dimensions {\n        in\n        cm\n      }\n      __id\n    }\n    __id\n  }\n  editionSetId\n  __id: id\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query StatusQuery {\n  order: commerceOrder(id: \"42\") {\n    __typename\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on CommerceOrder {\n  __typename\n  id\n  code\n  state\n  mode\n  stateReason\n  stateExpiresAt(format: \"MMM D\")\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              __id: id\n            }\n          }\n        }\n        __id: id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -622,14 +548,14 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "medium",
+                            "name": "artist_names",
                             "args": null,
                             "storageKey": null
                           },
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "artist_names",
+                            "name": "title",
                             "args": null,
                             "storageKey": null
                           },
@@ -671,88 +597,23 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v5
-                              },
-                              v1,
-                              {
-                                "kind": "LinkedField",
-                                "alias": null,
-                                "name": "resized",
-                                "storageKey": "resized(width:185)",
-                                "args": [
+                                "selections": [
                                   {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 185,
-                                    "type": "Int"
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "url",
+                                    "args": null,
+                                    "storageKey": null
                                   }
-                                ],
-                                "concreteType": "ResizedImageUrl",
-                                "plural": false,
-                                "selections": v5
-                              }
-                            ]
-                          },
-                          v4,
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "title",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          v6,
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "attribution_class",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "AttributionClass",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "shortDescription",
-                                "args": null,
-                                "storageKey": null
+                                ]
                               },
-                              v4
+                              v1
                             ]
                           },
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "edition_sets",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "EditionSet",
-                            "plural": true,
-                            "selections": [
-                              v7,
-                              v6,
-                              v4
-                            ]
-                          },
-                          v7,
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "is_acquireable",
-                            "args": null,
-                            "storageKey": null
-                          }
+                          v4
                         ]
                       },
                       v1,
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "editionSetId",
-                        "args": null,
-                        "storageKey": null
-                      },
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -821,26 +682,26 @@ return {
               }
             ]
           },
+          v5,
           v7,
+          v8,
           v9,
           v10,
-          v11,
-          v12,
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v8,
+            "args": v6,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v8,
+            "args": v6,
             "storageKey": "totalListPrice(precision:2)"
           },
-          v13,
+          v11,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -893,7 +754,7 @@ return {
                 "args": null,
                 "concreteType": "CommerceOffer",
                 "plural": false,
-                "selections": v14
+                "selections": v12
               },
               {
                 "kind": "LinkedField",
@@ -903,7 +764,7 @@ return {
                 "args": null,
                 "concreteType": "CommerceOffer",
                 "plural": false,
-                "selections": v14
+                "selections": v12
               }
             ]
           }

--- a/src/__generated__/Status_order.graphql.ts
+++ b/src/__generated__/Status_order.graphql.ts
@@ -3,7 +3,6 @@
 import { ConcreteFragment } from "relay-runtime";
 import { ArtworkSummaryItem_order$ref } from "./ArtworkSummaryItem_order.graphql";
 import { CreditCardSummaryItem_order$ref } from "./CreditCardSummaryItem_order.graphql";
-import { ItemReview_lineItem$ref } from "./ItemReview_lineItem.graphql";
 import { ShippingSummaryItem_order$ref } from "./ShippingSummaryItem_order.graphql";
 import { TransactionDetailsSummaryItem_order$ref } from "./TransactionDetailsSummaryItem_order.graphql";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
@@ -37,11 +36,6 @@ export type Status_order = {
                         }) | null;
                     }) | null> | null;
                 }) | null;
-                readonly artwork: ({
-                    readonly id: string;
-                    readonly is_acquireable: boolean | null;
-                }) | null;
-                readonly " $fragmentRefs": ItemReview_lineItem$ref;
             }) | null;
         }) | null> | null;
     }) | null;
@@ -213,11 +207,6 @@ return {
               "plural": false,
               "selections": [
                 {
-                  "kind": "FragmentSpread",
-                  "name": "ItemReview_lineItem",
-                  "args": null
-                },
-                {
                   "kind": "LinkedField",
                   "alias": null,
                   "name": "fulfillments",
@@ -276,32 +265,6 @@ return {
                           ]
                         }
                       ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "LinkedField",
-                  "alias": null,
-                  "name": "artwork",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "Artwork",
-                  "plural": false,
-                  "selections": [
-                    v2,
-                    {
-                      "kind": "ScalarField",
-                      "alias": null,
-                      "name": "is_acquireable",
-                      "args": null,
-                      "storageKey": null
-                    },
-                    {
-                      "kind": "ScalarField",
-                      "alias": null,
-                      "name": "__id",
-                      "args": null,
-                      "storageKey": null
                     }
                   ]
                 },
@@ -377,5 +340,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '5b2c1fde3aa98f22666e0244a934893e';
+(node as any).hash = 'dc527973941511a05bed5036e544a6e5';
 export default node;

--- a/src/__generated__/routes_StatusQuery.graphql.ts
+++ b/src/__generated__/routes_StatusQuery.graphql.ts
@@ -52,7 +52,6 @@ fragment Status_order on CommerceOrder {
   lineItems {
     edges {
       node {
-        ...ItemReview_lineItem
         fulfillments {
           edges {
             node {
@@ -62,11 +61,6 @@ fragment Status_order on CommerceOrder {
               __id: id
             }
           }
-        }
-        artwork {
-          id
-          is_acquireable
-          __id
         }
         __id: id
       }
@@ -197,40 +191,6 @@ fragment CreditCardSummaryItem_order on CommerceOrder {
   __id: id
 }
 
-fragment ItemReview_lineItem on CommerceLineItem {
-  artwork {
-    artist_names
-    title
-    date
-    medium
-    dimensions {
-      in
-      cm
-    }
-    attribution_class {
-      shortDescription
-      __id
-    }
-    image {
-      resized(width: 185) {
-        url
-      }
-      __id: id
-    }
-    edition_sets {
-      id
-      dimensions {
-        in
-        cm
-      }
-      __id
-    }
-    __id
-  }
-  editionSetId
-  __id: id
-}
-
 fragment ShippingAddress_ship on CommerceShip {
   name
   addressLine1
@@ -288,48 +248,14 @@ v5 = {
   "args": null,
   "storageKey": null
 },
-v6 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "url",
-    "args": null,
-    "storageKey": null
-  }
-],
-v7 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "dimensions",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "dimensions",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "in",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "cm",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
-v8 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v9 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -337,44 +263,44 @@ v9 = [
     "type": "Int"
   }
 ],
-v10 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotal",
-  "args": v9,
+  "args": v7,
   "storageKey": "shippingTotal(precision:2)"
 },
-v11 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "shippingTotalCents",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotal",
-  "args": v9,
+  "args": v7,
   "storageKey": "taxTotal(precision:2)"
 },
-v13 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "taxTotalCents",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "buyerTotal",
-  "args": v9,
+  "args": v7,
   "storageKey": "buyerTotal(precision:2)"
 },
-v15 = [
-  v13,
-  v8,
+v13 = [
+  v11,
+  v6,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -382,17 +308,17 @@ v15 = [
     "args": null,
     "storageKey": null
   },
+  v8,
+  v9,
   v10,
-  v11,
-  v12,
   {
     "kind": "ScalarField",
     "alias": null,
     "name": "amount",
-    "args": v9,
+    "args": v7,
     "storageKey": "amount(precision:2)"
   },
-  v14,
+  v12,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -421,7 +347,7 @@ return {
   "operationKind": "query",
   "name": "routes_StatusQuery",
   "id": null,
-  "text": "query routes_StatusQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on CommerceOrder {\n  __typename\n  id\n  code\n  state\n  mode\n  stateReason\n  stateExpiresAt(format: \"MMM D\")\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              __id: id\n            }\n          }\n        }\n        artwork {\n          id\n          is_acquireable\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    artist_names\n    title\n    date\n    medium\n    dimensions {\n      in\n      cm\n    }\n    attribution_class {\n      shortDescription\n      __id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n      __id: id\n    }\n    edition_sets {\n      id\n      dimensions {\n        in\n        cm\n      }\n      __id\n    }\n    __id\n  }\n  editionSetId\n  __id: id\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
+  "text": "query routes_StatusQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Status_order\n    __id: id\n  }\n}\n\nfragment Status_order on CommerceOrder {\n  __typename\n  id\n  code\n  state\n  mode\n  stateReason\n  stateExpiresAt(format: \"MMM D\")\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              __id: id\n            }\n          }\n        }\n        __id: id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    last_digits\n    expiration_year\n    expiration_month\n    __id\n  }\n  __id: id\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -634,14 +560,14 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "medium",
+                            "name": "artist_names",
                             "args": null,
                             "storageKey": null
                           },
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "artist_names",
+                            "name": "title",
                             "args": null,
                             "storageKey": null
                           },
@@ -683,88 +609,23 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": v6
-                              },
-                              v2,
-                              {
-                                "kind": "LinkedField",
-                                "alias": null,
-                                "name": "resized",
-                                "storageKey": "resized(width:185)",
-                                "args": [
+                                "selections": [
                                   {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 185,
-                                    "type": "Int"
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "url",
+                                    "args": null,
+                                    "storageKey": null
                                   }
-                                ],
-                                "concreteType": "ResizedImageUrl",
-                                "plural": false,
-                                "selections": v6
-                              }
-                            ]
-                          },
-                          v5,
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "title",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          v7,
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "attribution_class",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "AttributionClass",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "shortDescription",
-                                "args": null,
-                                "storageKey": null
+                                ]
                               },
-                              v5
+                              v2
                             ]
                           },
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "edition_sets",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "EditionSet",
-                            "plural": true,
-                            "selections": [
-                              v8,
-                              v7,
-                              v5
-                            ]
-                          },
-                          v8,
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "is_acquireable",
-                            "args": null,
-                            "storageKey": null
-                          }
+                          v5
                         ]
                       },
                       v2,
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "editionSetId",
-                        "args": null,
-                        "storageKey": null
-                      },
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -833,26 +694,26 @@ return {
               }
             ]
           },
+          v6,
           v8,
+          v9,
           v10,
           v11,
-          v12,
-          v13,
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "itemsTotal",
-            "args": v9,
+            "args": v7,
             "storageKey": "itemsTotal(precision:2)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "totalListPrice",
-            "args": v9,
+            "args": v7,
             "storageKey": "totalListPrice(precision:2)"
           },
-          v14,
+          v12,
           {
             "kind": "LinkedField",
             "alias": null,
@@ -905,7 +766,7 @@ return {
                 "args": null,
                 "concreteType": "CommerceOffer",
                 "plural": false,
-                "selections": v15
+                "selections": v13
               },
               {
                 "kind": "LinkedField",
@@ -915,7 +776,7 @@ return {
                 "args": null,
                 "concreteType": "CommerceOffer",
                 "plural": false,
-                "selections": v15
+                "selections": v13
               }
             ]
           }


### PR DESCRIPTION
# [PURCHASE-1428] Get failed payment flow working with case where payment intent of a already confirmed setupintent fails when seller accepts offer

current failed payment flow works when a seller accepts an offer and payment doesn't go through, we send email to buyer about the failed payment and they fix their issue.
we need to make sure this works also for the case were we confirmed setupintent and later when seller accepts offer we tried to process off-session payment intent but that fails

# Problem
The NewPayment page is not currently set up to handle SCA authentication, so payments requiring SCA will always fail.

# Solution
I updated the NewPayment page with similar logic to what already exists in the Review page so it will display the SCA modal if authentication is required.

[PURCHASE-1428]: https://artsyproduct.atlassian.net/browse/PURCHASE-1428