### PR TITLE
Update ImageLink to use a fixed aspect ratio and avoid jitter

### DIFF
--- a/src/Components/v2/CollectionsHubsNav.tsx
+++ b/src/Components/v2/CollectionsHubsNav.tsx
@@ -25,7 +25,7 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
         <ImageLink
           href={`/collection/${hub.slug}`}
           src={placeholderImage}
-          alt={hub.title}
+          ratio={[0.49]}
           title={<Serif size="4t">{hub.title}</Serif>}
           // subtitle={subtitle && <Serif size="2">{hub.subtitle}</Serif>}
           key={hub.id}

--- a/src/Components/v2/CollectionsHubsNav.tsx
+++ b/src/Components/v2/CollectionsHubsNav.tsx
@@ -23,7 +23,7 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
     >
       {props.marketingCollections.map(hub => (
         <ImageLink
-          href={`/collection/${hub.slug}`}
+          to={`/collection/${hub.slug}`}
           src={placeholderImage}
           ratio={[0.49]}
           title={<Serif size="4t">{hub.title}</Serif>}

--- a/src/Components/v2/ImageLink.tsx
+++ b/src/Components/v2/ImageLink.tsx
@@ -50,7 +50,7 @@ interface ImageLinkProps {
   src: string
 
   /** Destination for the hyperlink */
-  href: string
+  to: string
 
   /** Primary text that appears below the image */
   title: React.ReactElement<SerifProps & { className?: string }>
@@ -63,14 +63,14 @@ interface ImageLinkProps {
 }
 
 export const ImageLink: FC<ImageLinkProps> = ({
-  href,
+  to,
   src,
   title,
   subtitle,
   ratio,
 }) => {
   return (
-    <OuterLink to={href}>
+    <OuterLink to={to}>
       <ImageContainer>
         <ImageOverlay>
           <HubImage src={src} width="100%" ratio={ratio} />

--- a/src/Components/v2/ImageLink.tsx
+++ b/src/Components/v2/ImageLink.tsx
@@ -1,4 +1,4 @@
-import { Box, Image, SerifProps } from "@artsy/palette"
+import { Box, ResponsiveImage, SerifProps } from "@artsy/palette"
 import { RouterLink } from "Artsy/Router/RouterLink"
 import React, { FC } from "react"
 import styled from "styled-components"
@@ -9,7 +9,7 @@ const ImageContainer = styled(Box)`
   position: relative;
 `
 
-const HubImage = styled(Image)`
+const HubImage = styled(ResponsiveImage)`
   vertical-align: middle;
 `
 
@@ -46,25 +46,34 @@ const OuterLink = styled(RouterLink)`
 `
 
 interface ImageLinkProps {
+  /** Source url for the image */
   src: string
+
+  /** Destination for the hyperlink */
   href: string
-  alt: string
+
+  /** Primary text that appears below the image */
   title: React.ReactElement<SerifProps & { className?: string }>
+
+  /** Secondary text that (optionally) appears below the title */
   subtitle?: React.ReactElement<SerifProps>
+
+  /** A number corresponding to the ratio of height/width (inverted from the usual width/height aspect ratio) */
+  ratio: number | number[]
 }
 
 export const ImageLink: FC<ImageLinkProps> = ({
   href,
   src,
-  alt,
   title,
   subtitle,
+  ratio,
 }) => {
   return (
     <OuterLink to={href}>
       <ImageContainer>
         <ImageOverlay>
-          <HubImage src={src} width="100%" alt={alt} />
+          <HubImage src={src} width="100%" ratio={ratio} />
         </ImageOverlay>
       </ImageContainer>
       {React.cloneElement(title, {

--- a/src/Components/v2/__stories__/ImageLink.story.tsx
+++ b/src/Components/v2/__stories__/ImageLink.story.tsx
@@ -10,7 +10,7 @@ storiesOf("Components/ImageLink", module)
   .add("with specific dimensions", () => (
     <Box width={300}>
       <ImageLink
-        href="http://example.com"
+        to="http://example.com"
         src={imageSample}
         ratio={0.49}
         title={<Serif size="4t">Photography</Serif>}
@@ -20,7 +20,7 @@ storiesOf("Components/ImageLink", module)
   .add("with variable dimensions", () => (
     <Box width="30%">
       <ImageLink
-        href="http://example.com"
+        to="http://example.com"
         src={imageSample}
         ratio={0.49}
         title={<Serif size="4t">Street Art</Serif>}
@@ -30,7 +30,7 @@ storiesOf("Components/ImageLink", module)
   .add("with a long text", () => (
     <Box width={300}>
       <ImageLink
-        href="http://example.com"
+        to="http://example.com"
         src={imageSample}
         ratio={0.49}
         title={
@@ -44,7 +44,7 @@ storiesOf("Components/ImageLink", module)
   .add("with title and subtitle", () => (
     <Box width="30%">
       <ImageLink
-        href="http://example.com"
+        to="http://example.com"
         src={imageSample}
         ratio={0.49}
         title={<Serif size="4t">Photography</Serif>}

--- a/src/Components/v2/__stories__/ImageLink.story.tsx
+++ b/src/Components/v2/__stories__/ImageLink.story.tsx
@@ -12,7 +12,7 @@ storiesOf("Components/ImageLink", module)
       <ImageLink
         href="http://example.com"
         src={imageSample}
-        alt="Photography"
+        ratio={0.49}
         title={<Serif size="4t">Photography</Serif>}
       />
     </Box>
@@ -22,7 +22,7 @@ storiesOf("Components/ImageLink", module)
       <ImageLink
         href="http://example.com"
         src={imageSample}
-        alt="Street Art"
+        ratio={0.49}
         title={<Serif size="4t">Street Art</Serif>}
       />
     </Box>
@@ -32,7 +32,7 @@ storiesOf("Components/ImageLink", module)
       <ImageLink
         href="http://example.com"
         src={imageSample}
-        alt="Impressionist and Modern Art and Other Things People Like"
+        ratio={0.49}
         title={
           <Serif size="4t">
             Impressionist and Modern Art and Other Things People Like
@@ -46,7 +46,7 @@ storiesOf("Components/ImageLink", module)
       <ImageLink
         href="http://example.com"
         src={imageSample}
-        alt="Photography"
+        ratio={0.49}
         title={<Serif size="4t">Photography</Serif>}
         subtitle={
           <Serif size="2">Today’s leading artists and emerging talents</Serif>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1481

The hubs entrypoint nav for /collect was causing the layout to stutter as images were loaded.

Following @damassi's tip, the solution here is to use Palette's `ResponsiveImage`, which fills its containing element's available space, and takes an aspect ratio so that it can reserve a fixed-height space in the layout before the image is loaded.

---

## Before

![deelay](https://user-images.githubusercontent.com/140521/63895881-6b23fa80-c9be-11e9-84fa-724654f4782b.gif)

---
## After

And here it is with fixed height images.

![responsive](https://user-images.githubusercontent.com/140521/63895839-50ea1c80-c9be-11e9-8d66-abe287d099c9.gif)