### PR TITLE
[CollectionHubsRails] minor UI fixes

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -121,6 +121,17 @@ describe("FeaturedCollectionEntity", () => {
   let props
   const trackEvent = jest.fn()
 
+  const memberDataWithoutPriceGuidance = () => {
+    return {
+      description:
+        "<p>From SpongeBob SquarePants to Snoopy, many beloved childhood cartoons have made an impact on the history of art.</p>",
+      price_guidance: null,
+      slug: "art-inspired-by-cartoons",
+      thumbnail: "http://files.artsy.net/images/cartoons_thumbnail.png",
+      title: "Art Inspired by Cartoons",
+    }
+  }
+
   beforeEach(() => {
     props = {
       collectionGroup: CollectionHubFixture.linkedCollections[1],
@@ -142,6 +153,14 @@ describe("FeaturedCollectionEntity", () => {
     expect(featuredImage.getElement().props.src).toBe(
       "http://files.artsy.net/images/cartoons_thumbnail.png"
     )
+  })
+
+  it("Does not renders price guidance for FeaturedCollectionEntity when it is null", () => {
+    props.collectionGroup.members = [memberDataWithoutPriceGuidance()]
+    const component = mount(<FeaturedCollectionsRails {...props} />)
+    const firstEntity = component.find(FeaturedCollectionEntity).at(0)
+
+    expect(firstEntity.text()).not.toContain("From $")
   })
 
   it("Tracks collection entity click", () => {

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -130,7 +130,9 @@ export const FeaturedCollectionEntity: React.FC<
         <CollectionTitle size="4" mt={1}>
           {title}
         </CollectionTitle>
-        <Sans size="2" color="black60">{`From $${price_guidance}`}</Sans>
+        {price_guidance && (
+          <Sans size="2" color="black60">{`From $${price_guidance}`}</Sans>
+        )}
         <ExtendedSerif size="3" mt={1}>
           <ReadMore
             disabled
@@ -169,10 +171,6 @@ export const FeaturedCollectionsRailsContainer = createFragmentContainer(
   }
 )
 
-const FeaturedCollectionsContainer = styled(Box)`
-  border-top: 1px solid ${color("black10")};
-`
-
 const Container = styled(Box)`
   border: 1px solid ${color("black10")};
   border-radius: 2px;
@@ -180,6 +178,13 @@ const Container = styled(Box)`
   &:hover {
     text-decoration: none;
     border: 1px solid ${color("black60")};
+  }
+`
+
+const FeaturedCollectionsContainer = styled(Box)`
+  border-top: 1px solid ${color("black10")};
+  ${Container}:first-of-type {
+    margin-left: 2px;
   }
 `
 


### PR DESCRIPTION
This PR fixes a spacing issue on FeaturedCollections. This PR conditionally displays price guidance on FeaturedCollections when it's available.

**Before**
<img width="1141" alt="Screen Shot 2019-08-29 at 10 49 01 AM" src="https://user-images.githubusercontent.com/5201004/63950845-bdaaf880-ca4a-11e9-96b7-2c0743f72d2d.png">

<img width="604" alt="Screen Shot 2019-08-29 at 10 53 50 AM" src="https://user-images.githubusercontent.com/5201004/63951243-66595800-ca4b-11e9-9022-a586aacdfd73.png">


<img width="1152" alt="Screen Shot 2019-08-29 at 10 48 00 AM" src="https://user-images.githubusercontent.com/5201004/63950866-c7ccf700-ca4a-11e9-9c91-a4e0449fbab5.png">

<img width="525" alt="Screen Shot 2019-08-29 at 10 54 06 AM" src="https://user-images.githubusercontent.com/5201004/63951314-85f08080-ca4b-11e9-8497-a23447c72f4f.png">
