### PR TITLE
Rename "Credit card number*" to "Credit card" to fix scan cc on mobile

### DIFF
--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -64,7 +64,7 @@ const InnerForm: React.FC<FormikProps<FormValues>> = props => {
 
         <Box mb={2}>
           <Serif size="3t" mb={0.5}>
-            Credit card number*
+            Credit card
           </Serif>
           <CreditCardInput
             error={{ message: errors.creditCard } as stripe.Error}


### PR DESCRIPTION
Problem:

On mobile safari the registration form was asking the user to scan their
credit card for _all_ form elements and was placing the credit card
number on the first billing info line for reasons unknown to human kind.

Solution:

Rename "Credit card number*" to "Credit card". This is more consistent
with our BN/MO flows as well.

Jira: https://artsyproduct.atlassian.net/browse/AUCT-596