### PR TITLE
Host new registration form on `/auction-registration`

### DIFF
--- a/src/Apps/Auction/Routes/__stories__/Register.story.tsx
+++ b/src/Apps/Auction/Routes/__stories__/Register.story.tsx
@@ -7,7 +7,7 @@ storiesOf("Apps/Auction/Routes", module).add("Register", () => {
   return (
     <MockRouter
       routes={auctionRoutes}
-      initialRoute="/auction-registration2/shared-live-mocktion-k8s"
+      initialRoute="/auction-registration/shared-live-mocktion-k8s"
     />
   )
 })

--- a/src/Apps/Auction/__tests__/redirects.test.ts
+++ b/src/Apps/Auction/__tests__/redirects.test.ts
@@ -33,7 +33,7 @@ describe("Auction/redirects", () => {
 
   it("does not redirect if a sale is found", async () => {
     const { redirect } = await render(
-      `/auction-registration2/${Fixture.sale.id}`,
+      `/auction-registration/${Fixture.sale.id}`,
       mockResolver(Fixture)
     )
     expect(redirect).toBeUndefined
@@ -41,7 +41,7 @@ describe("Auction/redirects", () => {
 
   it("redirects to the auction registration modal if the user has a qualified credit card", async () => {
     const { redirect } = await render(
-      `/auction-registration2/${Fixture.sale.id}`,
+      `/auction-registration/${Fixture.sale.id}`,
       mockResolver({
         ...Fixture,
         me: {
@@ -56,7 +56,7 @@ describe("Auction/redirects", () => {
 
   it("redirects back to the auction if the registration window has closed", async () => {
     const { redirect } = await render(
-      `/auction-registration2/${Fixture.sale.id}`,
+      `/auction-registration/${Fixture.sale.id}`,
       mockResolver({
         ...Fixture,
         sale: {
@@ -71,7 +71,7 @@ describe("Auction/redirects", () => {
 
   it("redirects to the auction confirm registration route if bidder has already registered", async () => {
     const { redirect } = await render(
-      `/auction-registration2/${Fixture.sale.id}`,
+      `/auction-registration/${Fixture.sale.id}`,
       mockResolver({
         ...Fixture,
         sale: {

--- a/src/Apps/Auction/__tests__/routes.test.ts
+++ b/src/Apps/Auction/__tests__/routes.test.ts
@@ -32,11 +32,22 @@ describe("Auction/routes", () => {
   })
 
   it("does not redirect if a sale is found", async () => {
-    const { redirect } = await render(
+    const { redirect, status } = await render(
       `/auction-registration/${Fixture.sale.id}`,
       mockResolver(Fixture)
     )
+
+    expect(status).toBe(200)
     expect(redirect).toBeUndefined
+  })
+
+  it("also responds to auction-registration2 route", async () => {
+    const { status } = await render(
+      `/auction-registration2/${Fixture.sale.id}`,
+      mockResolver(Fixture)
+    )
+
+    expect(status).toBe(200)
   })
 
   it("redirects to the auction registration modal if the user has a qualified credit card", async () => {

--- a/src/Apps/Auction/__tests__/routes.test.ts
+++ b/src/Apps/Auction/__tests__/routes.test.ts
@@ -9,7 +9,7 @@ import {
   RegisterQueryResponseFixture as Fixture,
 } from "../../__tests__/Fixtures/Auction/Routes/Register"
 
-describe("Auction/redirects", () => {
+describe("Auction/routes", () => {
   async function render(url, mockData) {
     const network = createMockNetworkLayer2({ mockData })
     const source = new RecordSource()

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -18,7 +18,7 @@ type Me = routes_RegisterQueryResponse["me"]
 
 export const routes: RouteConfig[] = [
   {
-    path: "/auction-registration2/:saleID",
+    path: "/auction-registration/:saleID",
     Component: RegisterRouteFragmentContainer,
     render: ({ Component, props }) => {
       if (Component && props) {

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -18,7 +18,7 @@ type Me = routes_RegisterQueryResponse["me"]
 
 export const routes: RouteConfig[] = [
   {
-    path: "/auction-registration/:saleID",
+    path: "/auction-registration(2)?/:saleID",
     Component: RegisterRouteFragmentContainer,
     render: ({ Component, props }) => {
       if (Component && props) {


### PR DESCRIPTION
Prepares us for a Force change that'll look for the Reaction component
on /auction-registration

Co-authored-by: Daniel Levenson <dleve123@gmail.com>