### PR TITLE
Add bottom margin to viewports > XS on bidder registration form

### DIFF
--- a/src/Apps/Auction/Routes/Register/index.tsx
+++ b/src/Apps/Auction/Routes/Register/index.tsx
@@ -169,7 +169,7 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
   return (
     <AppContainer>
       <Title>Auction Registration</Title>
-      <Box maxWidth={550} px={[2, 0]} mx="auto" my={[1, 0]}>
+      <Box maxWidth={550} px={[2, 0]} mx="auto" mt={[1, 0]} mb={[1, 100]}>
         <Serif size="10">Register to Bid on Artsy</Serif>
         <Separator mt={1} mb={2} />
 


### PR DESCRIPTION
Matches the 100px bottom margin configured for the current registration form: https://github.com/artsy/force/blob/f5a63c987af9b10b3644400bd91c08919f5282a0/src/desktop/apps/auction_support/stylesheets/index.styl#L19

**Before**

> ![screenshot 1567624006](https://user-images.githubusercontent.com/123595/64283542-a88c0900-cf25-11e9-94f7-d073d75e0b43.png)

---

**After**

> ![screenshot 1567623986](https://user-images.githubusercontent.com/123595/64283555-ae81ea00-cf25-11e9-8238-ba87c00becfb.png)
