### PR TITLE
Defensively access images' aspect ratio in Recently Viewed rail

### DIFF
--- a/src/Components/v2/RecentlyViewed.tsx
+++ b/src/Components/v2/RecentlyViewed.tsx
@@ -11,6 +11,7 @@ import React, { useContext } from "react"
 import { QueryRenderer } from "react-relay"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
+import { get } from "Utils/get"
 
 export interface RecentlyViewedProps {
   me: RecentlyViewed_me
@@ -48,11 +49,11 @@ export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
                 <Carousel
                   data={me.recentlyViewedArtworks.edges as object[]}
                   render={artwork => {
-                    const {
-                      node: {
-                        image: { aspect_ratio },
-                      },
-                    } = artwork
+                    const aspect_ratio = get(
+                      artwork,
+                      w => w.node.image.aspect_ratio,
+                      1
+                    )
 
                     return (
                       <FillwidthItem


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/GROW-1496

This fixes the white screen of death some users were [experiencing](https://cl.ly/10c5211b1b55) after they had viewed certain pathological artworks that were missing images altogether. (Missing whyyyy 😱  — follow-up ticket at https://artsyproduct.atlassian.net/browse/GALL-2132)

When those artworks were subsequently displayed in the Recently Viewed rail, scrolling down to that rail would trigger a lazy load, which in turn would result in trying to reference an `aspect_ratio` on a null image.

The solution is simply to use the well-established Force convention for safe access of nested properties, so that `aspect_ratio` will have a fallback value of `1` in the pathological case.