### PR TITLE
PURCHASE-1470: Reuse SetupIntent for make offer

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -4640,6 +4640,7 @@ type CommerceSubmitOrderPayload {
 input CommerceSubmitOrderWithOfferInput {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+  confirmedSetupIntentId: String
   offerId: ID!
 }
 

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -80,12 +80,13 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
       },
     ],
   }))
-  async onSubmit() {
+  async onSubmit(setupIntentId: null) {
     try {
       const orderOrError =
         this.props.order.mode === "BUY"
           ? (await this.submitBuyOrder()).commerceSubmitOrder.orderOrError
-          : (await this.submitOffer()).commerceSubmitOrderWithOffer.orderOrError
+          : (await this.submitOffer(setupIntentId)).commerceSubmitOrderWithOffer
+              .orderOrError
 
       if (orderOrError.error) {
         this.handleSubmitError(orderOrError.error)
@@ -105,7 +106,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               })
               return
             } else {
-              this.onSubmit()
+              this.onSubmit(setupIntentId)
             }
           })
       } else if (
@@ -123,7 +124,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               })
               return
             } else {
-              this.onSubmit()
+              this.onSubmit(result.setupIntent.id)
             }
           })
       } else {
@@ -170,11 +171,12 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
     })
   }
 
-  submitOffer() {
+  submitOffer(setupIntentId) {
     return this.props.commitMutation<ReviewSubmitOfferOrderMutation>({
       variables: {
         input: {
           offerId: this.props.order.myLastOffer.id,
+          confirmedSetupIntentId: setupIntentId,
         },
       },
       mutation: graphql`

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -106,7 +106,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
               })
               return
             } else {
-              this.onSubmit(setupIntentId)
+              this.onSubmit()
             }
           })
       } else if (

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -171,7 +171,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
     })
   }
 
-  submitOffer(setupIntentId) {
+  submitOffer(setupIntentId: string | null) {
     return this.props.commitMutation<ReviewSubmitOfferOrderMutation>({
       variables: {
         input: {

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -80,7 +80,7 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
       },
     ],
   }))
-  async onSubmit(setupIntentId: null) {
+  async onSubmit(setupIntentId?: null) {
     try {
       const orderOrError =
         this.props.order.mode === "BUY"

--- a/src/Apps/Order/Routes/__tests__/Review.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.test.tsx
@@ -38,10 +38,12 @@ class ReviewTestPage extends OrderAppTestPage {
 }
 
 const handleCardAction = jest.fn()
+const handleCardSetup = jest.fn()
+
 describe("Review", () => {
   beforeAll(() => {
     window.Stripe = () => {
-      return { handleCardAction } as any
+      return { handleCardAction, handleCardSetup } as any
     }
 
     window.sd = { STRIPE_PUBLISHABLE_KEY: "" }
@@ -155,7 +157,6 @@ describe("Review", () => {
       )
       expect(window.location.assign).toBeCalledWith("/artist/artistId")
     })
-
     it("shows SCA modal when required", async () => {
       mutations.useResultsOnce(submitOrderWithActionRequired)
 
@@ -254,7 +255,7 @@ describe("Review", () => {
       mutations.useResultsOnce(submitOfferOrderWithActionRequired)
 
       await page.clickSubmit()
-      expect(handleCardAction).toBeCalledWith("client-secret")
+      expect(handleCardSetup).toBeCalledWith("client-secret")
     })
   })
 

--- a/src/__generated__/ReviewSubmitOfferOrderMutation.graphql.ts
+++ b/src/__generated__/ReviewSubmitOfferOrderMutation.graphql.ts
@@ -4,6 +4,7 @@ import { ConcreteRequest } from "relay-runtime";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
 export type CommerceSubmitOrderWithOfferInput = {
     readonly clientMutationId?: string | null;
+    readonly confirmedSetupIntentId?: string | null;
     readonly offerId: string;
 };
 export type ReviewSubmitOfferOrderMutationVariables = {


### PR DESCRIPTION
[PURCHASE-1470]

Reaction should pass confirmedSetupIntentId so that the same confirmed setup intent is used when the order is submitted a second time

[PURCHASE-1470]: https://artsyproduct.atlassian.net/browse/PURCHASE-1470