### PR TITLE
@damassi => [QueryString] When parsing query strings for apps, coerce Ints and Bools

### DIFF
--- a/src/Artsy/Router/Utils/__tests__/queryStringParsing.test.ts
+++ b/src/Artsy/Router/Utils/__tests__/queryStringParsing.test.ts
@@ -1,0 +1,30 @@
+import { queryStringParsing } from "../queryStringParsing"
+
+interface ParsedQuery {
+  acquireable: any
+  page: any
+}
+
+describe(queryStringParsing, () => {
+  it("coerces booleans from the strings 'true' and 'false'", () => {
+    const parsedTrue: Partial<ParsedQuery> = queryStringParsing(
+      "acquireable=true"
+    )
+    expect(parsedTrue.acquireable).toBe(true)
+
+    const parsedFalse: Partial<ParsedQuery> = queryStringParsing(
+      "acquireable=false"
+    )
+    expect(parsedFalse.acquireable).toBe(false)
+  })
+
+  it("coerces ints from strings", () => {
+    const parsedPage: Partial<ParsedQuery> = queryStringParsing("page=4")
+    expect(parsedPage.page).toBe(4)
+  })
+
+  it("passes through strings", () => {
+    const parsedPage: Partial<ParsedQuery> = queryStringParsing("page=blah")
+    expect(parsedPage.page).toBe("blah")
+  })
+})

--- a/src/Artsy/Router/Utils/queryStringParsing.ts
+++ b/src/Artsy/Router/Utils/queryStringParsing.ts
@@ -1,0 +1,29 @@
+import qs from "qs"
+
+const parseValue = value => {
+  let parsedValue = value
+
+  // If this is a string that can be coerced into a number, do it.
+  if (
+    !Number.isNaN(Number(value)) &&
+    (typeof value === "string" && value.trim() !== "")
+  ) {
+    parsedValue = Number(value)
+  } else if (
+    // If this is the case-insensitive string 'true' or 'false'
+    value !== null &&
+    typeof value === "string" &&
+    (value.toLowerCase() === "true" || value.toLowerCase() === "false")
+  ) {
+    parsedValue = value.toLowerCase() === "true"
+  }
+
+  return parsedValue
+}
+
+export const queryStringParsing = (urlStr: string) => {
+  const parsedArgs = qs.parse(urlStr)
+  return Object.entries(parsedArgs).reduce((acc, [field, value]) => {
+    return { ...acc, [field]: parseValue(value) }
+  }, {})
+}

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -14,6 +14,7 @@ import qs from "qs"
 import createLogger from "Utils/logger"
 import { getUser } from "Utils/user"
 import { createRouteConfig } from "./Utils/createRouteConfig"
+import { queryStringParsing } from "./Utils/queryStringParsing"
 
 import { createRelaySSREnvironment } from "Artsy/Relay/createRelaySSREnvironment"
 import { Boot } from "Artsy/Router/Boot"
@@ -61,7 +62,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
 
       const historyMiddlewares = [
         createQueryMiddleware({
-          parse: qs.parse,
+          parse: queryStringParsing,
           stringify: qs.stringify,
         }),
       ]

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -21,6 +21,7 @@ import { createRouteConfig } from "./Utils/createRouteConfig"
 import { matchingMediaQueriesForUserAgent } from "./Utils/matchingMediaQueriesForUserAgent"
 
 import { RouterConfig } from "./"
+import { queryStringParsing } from "./Utils/queryStringParsing"
 import { RenderError, RenderPending, RenderReady } from "./Utils/RenderStatus"
 
 interface Resolve {
@@ -53,7 +54,7 @@ export function buildServerApp(config: ServerRouterConfig): Promise<Resolve> {
         const relayEnvironment = context.relayEnvironment || createRelaySSREnvironment({ user }) // prettier-ignore
         const historyMiddlewares = [
           createQueryMiddleware({
-            parse: qs.parse,
+            parse: queryStringParsing,
             stringify: qs.stringify,
           }),
         ]


### PR DESCRIPTION
Kind of a weird one, lmk what you think!

This is a client-side update for https://github.com/artsy/metaphysics/pull/1939.

Basically, sending a string of "true" or "2" used to work, for boolean and integer inputs in GraphQL, respectively.

Generally this isn't an issue when sending variables (we have type checking, use POSTs). However, we sometimes parse incoming URLs (like someone linking a friend to a filter URL of the form: `/?acquireable=true&page=4`).

There, the query string parsing produces `{"acquireable": "true", "page": "4"}`, and we send that directly to Metaphysics. This modifies the parsing middleware to make sure incoming URLs are parsed. I can't immediately think of a downside to this (although I'm sure there is one!).