### PR TITLE
Vanguard qa

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -133,10 +133,11 @@ export class VanguardArtistWrapper extends React.Component<
 
                 <Media lessThan="xl">
                   <InvertedSerif
-                    size={["10", "12", "12"]}
+                    size={["8", "10", "12", "12"]}
                     element="h3"
                     isMobile={isMobile}
                     isExpanded={isExpanded}
+                    lineHeight="1.1em"
                   >
                     {title}
                   </InvertedSerif>
@@ -145,10 +146,11 @@ export class VanguardArtistWrapper extends React.Component<
                 <Box position="relative">
                   {hero_section && (
                     <InvertedSans
-                      size="4"
+                      size={["3", "4", "4", "4"]}
                       weight="medium"
                       isMobile={isMobile}
                       isExpanded={isExpanded}
+                      lineHeight="1.1em"
                     >
                       {hero_section.deck}
                     </InvertedSans>

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -1,6 +1,5 @@
 import { Box, color, Flex, FlexProps, Sans, Serif } from "@artsy/palette"
 import { Share, ShareContainer } from "Components/Publishing/Byline/Share"
-import { getFullEditorialHref } from "Components/Publishing/Constants"
 import { Emerging } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Blobs/Emerging"
 import { GettingTheirDue } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Blobs/GettingTheirDue"
 import { NewlyEstablished } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Blobs/NewlyEstablished"
@@ -16,6 +15,7 @@ import { StyledText } from "Components/Publishing/Sections/StyledText"
 import { ArticleData } from "Components/Publishing/Typings"
 import { random } from "lodash"
 import React from "react"
+import { data as sd } from "sharify"
 import styled from "styled-components"
 import { slugify } from "underscore.string"
 import { Media } from "Utils/Responsive"
@@ -94,7 +94,7 @@ export class VanguardArtistWrapper extends React.Component<
 
   render() {
     const { article, section, isMobile, onSlideshowStateChange } = this.props
-    const { hero_section, layout, slug, title } = article
+    const { hero_section, title } = article
     const { isExpanded } = this.state
 
     const background = this.getSVGBackground(
@@ -102,6 +102,7 @@ export class VanguardArtistWrapper extends React.Component<
       section
     )
     const backgroundColor = isExpanded ? color("black100") : color("white100")
+    const slugifiedTitle = slugify(article.title)
 
     return (
       <FullScreenProvider onSlideshowStateChange={onSlideshowStateChange}>
@@ -109,7 +110,7 @@ export class VanguardArtistWrapper extends React.Component<
           background={backgroundColor}
           pt={50}
           mb={isExpanded && 100}
-          id={slugify(article.title)}
+          id={slugifiedTitle}
           ref={artistWrapper => (this.artistWrapper = artistWrapper)}
         >
           <BackgroundContainer backgroundColor={backgroundColor}>
@@ -158,9 +159,10 @@ export class VanguardArtistWrapper extends React.Component<
                   <Flex justifyContent={["center", "flex-start"]}>
                     <Box position={["relative", "absolute"]} top={0}>
                       <Share
-                        // TODO: We may need to use custom urls for in-page routing
-                        url={getFullEditorialHref(layout, slug)}
-                        title={title}
+                        url={`${
+                          sd.APP_URL
+                        }/artsy-vanguard-2019/${slugifiedTitle}`}
+                        title={`Artsy Vanguard 2019: ${title}`}
                         color={color("white100")}
                       />
                     </Box>

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/FrameText.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/FrameText.tsx
@@ -57,6 +57,7 @@ const FrameTextLeft = styled(FrameText)<{ isSlideOpen?: boolean }>`
   left: 0;
   transform: rotate(-90deg);
   transform-origin: 30% 136%;
+
   &&& {
     z-index: ${p => (p.isSlideOpen ? 0 : 2)};
   }
@@ -66,6 +67,7 @@ const FrameTextRight = styled(FrameText)<{ isSlideOpen?: boolean }>`
   right: 0;
   transform: rotate(90deg);
   transform-origin: 60% 60%;
+
   &&& {
     z-index: ${p => (p.isSlideOpen ? 0 : 2)};
   }
@@ -75,7 +77,7 @@ const MobileFrame = styled(Flex)`
   position: fixed;
   flex-direction: column;
   top: 65px;
-  left: 0;
+  left: -10px;
   height: calc(100vh - 150px);
   width: 60px;
   justify-content: space-between;

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
@@ -1,9 +1,9 @@
 import { Box, color, Flex, Sans, Serif } from "@artsy/palette"
 import { Share } from "Components/Publishing/Byline/Share"
-import { getFullEditorialHref } from "Components/Publishing/Constants"
 import { VanguardVideoHeader } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VideoHeader"
 import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
+import { data as sd } from "sharify"
 import styled from "styled-components"
 import { slugify } from "underscore.string"
 import { VanguardArtistWrapper } from "./ArtistWrapper"
@@ -15,7 +15,7 @@ export const VanguardSeriesWrapper: React.SFC<{
   onSlideshowStateChange?: (state: boolean) => void
 }> = props => {
   const { article, isMobile, onSlideshowStateChange } = props
-  const { relatedArticles, title, layout, series, slug } = article
+  const { relatedArticles, title, series } = article
   const slugifiedTitle = slugify(title)
   const { hero_section } = props.article
   const url = ((hero_section && hero_section.url) || "") as string
@@ -58,9 +58,8 @@ export const VanguardSeriesWrapper: React.SFC<{
               </SubTitle>
             )}
             <Share
-              // TODO: We may need to use custom urls here for in-page routing
-              url={getFullEditorialHref(layout, slug)}
-              title={title}
+              url={`${sd.APP_URL}/artsy-vanguard-2019/${slugifiedTitle}`}
+              title={`Artsy Vanguard 2019: ${title}`}
             />
           </Flex>
         </Box>

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
@@ -49,7 +49,7 @@ export const VanguardSeriesWrapper: React.SFC<{
           maxWidth={["90vw", "80vw", "80vw", "65%"]}
           px={4}
           pb={150}
-          pt={80}
+          pt={60}
         >
           <Flex flexDirection="column" alignItems="center">
             {series && (


### PR DESCRIPTION
Addresses:
- Mobile frame text sits closer to left boundary (not yet ticketed)
- Smaller margin on sub-series title https://artsyproduct.atlassian.net/browse/GROW-1519
- Mobile artist title size tweaks https://artsyproduct.atlassian.net/browse/GROW-1521
- Use correct slugs/titles for share links - Using custom image is outstanding and QA for titles are the blocked item left for https://artsyproduct.atlassian.net/browse/GROW-1468 