### PR TITLE
Collection hub title

### DIFF
--- a/src/Apps/Collect2/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect2/Components/Collection/Header/index.tsx
@@ -228,7 +228,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                   />
                 )}
                 <MetaContainer mb={2} mt={[0, imageHeightSizes.sm + space(3)]}>
-                  <BreadcrumbContainer size={["2", "3"]}>
+                  <BreadcrumbContainer size={["2", "3"]} mt={[2, 0]}>
                     <Link to="/collect">All works</Link> /{" "}
                     <Link to={categoryTarget}>{collection.category}</Link>
                   </BreadcrumbContainer>

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -121,7 +121,7 @@ const SingleImgContainer = styled(Box)`
 `
 
 const CollectionTitle = styled(Serif)`
-  width: max-content;
+  width: 100%;
 `
 
 export const ImgWrapper = styled(Flex)`


### PR DESCRIPTION
Addresses: [GROW-1499 ](https://artsyproduct.atlassian.net/browse/GROW-1499) & [GROW-1500](https://artsyproduct.atlassian.net/browse/GROW-1500)

- This PR adds space in between the header and breadcrumb in mobile.
- Line breaks long titles.

**BREADCRUMB**
<img width="283" alt="Screen Shot 2019-09-10 at 1 06 39 PM" src="https://user-images.githubusercontent.com/5201004/64634703-e4aee600-d3cb-11e9-9583-ba4a2eecb77a.png">

**WRAPPED TITLE**
<img width="1192" alt="Screen Shot 2019-09-10 at 12 51 54 PM" src="https://user-images.githubusercontent.com/5201004/64634184-acf36e80-d3ca-11e9-866f-aa9fc86393aa.png">
