### PR TITLE
PURCHASE-1476: If work can only ship domestically, the shipping form only displays the artwork's origin country

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1,3 +1,5 @@
+directive @principalField on FIELD
+
 input AddAssetToConsignmentSubmissionInput {
   # The type of the asset
   asset_type: String!
@@ -1385,15 +1387,25 @@ type Artwork implements Node & Searchable & Sellable {
   listPrice: ListPrice
   price_currency: String
   priceIncludesTax: Boolean
+  priceIncludesTaxDisplay: String
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean
+    @deprecated(
+      reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"
+    )
+
+  # Is this work only available for shipping domestically?
+  onlyShipsDomestically: Boolean
 
   # The string that describes domestic and international shipping.
   shippingInfo: String
 
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
+
+  # The country an artwork will be shipped from.
+  shippingCountry: String
   provenance(format: Format): String
   publisher(format: Format): String
   related(size: Int): [Artwork]
@@ -2415,15 +2427,25 @@ type ArtworkItem implements Node & Searchable & Sellable {
   listPrice: ListPrice
   price_currency: String
   priceIncludesTax: Boolean
+  priceIncludesTaxDisplay: String
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean
+    @deprecated(
+      reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"
+    )
+
+  # Is this work only available for shipping domestically?
+  onlyShipsDomestically: Boolean
 
   # The string that describes domestic and international shipping.
   shippingInfo: String
 
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
+
+  # The country an artwork will be shipped from.
+  shippingCountry: String
   provenance(format: Format): String
   publisher(format: Format): String
   related(size: Int): [Artwork]
@@ -4640,6 +4662,7 @@ type CommerceSubmitOrderPayload {
 input CommerceSubmitOrderWithOfferInput {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+  confirmedSetupIntentId: String
   offerId: ID!
 }
 

--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -36,7 +36,8 @@ export interface AddressFormProps {
   onChange: AddressChangeHandler
   value?: Partial<Address>
   billing?: boolean
-  continentalUsOnly?: boolean
+  domesticOnly?: boolean
+  shippingCountry?: string
   errors: AddressErrors
   touched: AddressTouched
 }
@@ -83,7 +84,7 @@ export class AddressForm extends React.Component<
   }
 
   render() {
-    const lockCountryToUS = !this.props.billing && this.props.continentalUsOnly
+    const lockCountryToOrigin = !this.props.billing && this.props.domesticOnly
     return (
       <Join separator={<Spacer mb={2} />}>
         <Flex flexDirection="column">
@@ -106,15 +107,19 @@ export class AddressForm extends React.Component<
               Country
             </Serif>
             <CountrySelect
-              selected={lockCountryToUS ? "US" : this.state.address.country}
+              selected={
+                lockCountryToOrigin
+                  ? this.props.shippingCountry
+                  : this.state.address.country
+              }
               onSelect={this.changeValueHandler("country")}
-              disabled={lockCountryToUS}
+              disabled={lockCountryToOrigin}
             />
-            {lockCountryToUS && (
+            {lockCountryToOrigin && (
               <>
                 <Spacer m={0.5} />
                 <Sans size="2" color="black60">
-                  Ships to continental US only
+                  Domestic shipping only.
                 </Sans>
               </>
             )}

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -335,7 +335,8 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                     errors={addressErrors}
                     touched={addressTouched}
                     onChange={this.onAddressChange}
-                    continentalUsOnly={artwork.shipsToContinentalUSOnly}
+                    domesticOnly={artwork.onlyShipsDomestically}
+                    shippingCountry={artwork.shippingCountry}
                   />
                 </Collapse>
 
@@ -405,7 +406,8 @@ export const ShippingFragmentContainer = createFragmentContainer(
               artwork {
                 id
                 pickup_available
-                shipsToContinentalUSOnly
+                onlyShipsDomestically
+                shippingCountry
               }
             }
           }

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -80,11 +80,11 @@ describe("Shipping", () => {
     expect(page.find(RadioGroup).length).toEqual(0)
   })
 
-  it("disables country select when shipsToContinentalUSOnly is true", async () => {
-    const continentalUSOnlyOrder = cloneDeep(testOrder) as any
-    continentalUSOnlyOrder.lineItems.edges[0].node.artwork.shipsToContinentalUSOnly = true
+  it("disables country select when onlyShipsDomestically is true", async () => {
+    const domesticShippingOnlyOrder = cloneDeep(testOrder) as any
+    domesticShippingOnlyOrder.lineItems.edges[0].node.artwork.onlyShipsDomestically = true
     const page = await buildPage({
-      mockData: { order: continentalUSOnlyOrder },
+      mockData: { order: domesticShippingOnlyOrder },
     })
     expect(page.find(CountrySelect).props().disabled).toBe(true)
   })

--- a/src/Apps/__tests__/Fixtures/Order.ts
+++ b/src/Apps/__tests__/Fixtures/Order.ts
@@ -63,7 +63,8 @@ export const UntouchedOrder = {
             date: "2016",
             shippingOrigin: "New York, NY",
             medium: "Oil and pencil on panel",
-            shipsToContinentalUSOnly: false,
+            onlyShipsDomestically: false,
+            shippingCountry: "US",
             is_acquireable: true,
             is_offerable: false,
             dimensions: {

--- a/src/__generated__/ReviewSubmitOfferOrderMutation.graphql.ts
+++ b/src/__generated__/ReviewSubmitOfferOrderMutation.graphql.ts
@@ -4,6 +4,7 @@ import { ConcreteRequest } from "relay-runtime";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
 export type CommerceSubmitOrderWithOfferInput = {
     readonly clientMutationId?: string | null;
+    readonly confirmedSetupIntentId?: string | null;
     readonly offerId: string;
 };
 export type ReviewSubmitOfferOrderMutationVariables = {

--- a/src/__generated__/ShippingTestQuery.graphql.ts
+++ b/src/__generated__/ShippingTestQuery.graphql.ts
@@ -47,7 +47,8 @@ fragment Shipping_order on CommerceOrder {
         artwork {
           id
           pickup_available
-          shipsToContinentalUSOnly
+          onlyShipsDomestically
+          shippingCountry
           __id
         }
         __id: id
@@ -275,7 +276,7 @@ return {
   "operationKind": "query",
   "name": "ShippingTestQuery",
   "id": null,
-  "text": "query ShippingTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  id\n  mode\n  state\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          shipsToContinentalUSOnly\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n",
+  "text": "query ShippingTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  id\n  mode\n  state\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          onlyShipsDomestically\n          shippingCountry\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -441,7 +442,14 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "shipsToContinentalUSOnly",
+                            "name": "onlyShipsDomestically",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "shippingCountry",
                             "args": null,
                             "storageKey": null
                           },

--- a/src/__generated__/Shipping_order.graphql.ts
+++ b/src/__generated__/Shipping_order.graphql.ts
@@ -32,7 +32,8 @@ export type Shipping_order = {
                 readonly artwork: ({
                     readonly id: string;
                     readonly pickup_available: boolean | null;
-                    readonly shipsToContinentalUSOnly: boolean | null;
+                    readonly onlyShipsDomestically: boolean | null;
+                    readonly shippingCountry: string | null;
                 }) | null;
             }) | null;
         }) | null> | null;
@@ -207,7 +208,14 @@ return {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "shipsToContinentalUSOnly",
+                      "name": "onlyShipsDomestically",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "shippingCountry",
                       "args": null,
                       "storageKey": null
                     },
@@ -241,5 +249,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '014b1825a797aad9654920cb221e1aae';
+(node as any).hash = '7ae2c5fc71b9b498d4207c3533662985';
 export default node;

--- a/src/__generated__/routes_ShippingQuery.graphql.ts
+++ b/src/__generated__/routes_ShippingQuery.graphql.ts
@@ -51,7 +51,8 @@ fragment Shipping_order on CommerceOrder {
         artwork {
           id
           pickup_available
-          shipsToContinentalUSOnly
+          onlyShipsDomestically
+          shippingCountry
           __id
         }
         __id: id
@@ -287,7 +288,7 @@ return {
   "operationKind": "query",
   "name": "routes_ShippingQuery",
   "id": null,
-  "text": "query routes_ShippingQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  id\n  mode\n  state\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          shipsToContinentalUSOnly\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n",
+  "text": "query routes_ShippingQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Shipping_order\n    __id: id\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  id\n  mode\n  state\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          id\n          pickup_available\n          onlyShipsDomestically\n          shippingCountry\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  __id: id\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __id\n    }\n    ... on User {\n      __id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n        __id: id\n      }\n    }\n  }\n  __id: id\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n    myLastOffer {\n      id\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      __id: id\n    }\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -453,7 +454,14 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "shipsToContinentalUSOnly",
+                            "name": "onlyShipsDomestically",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "shippingCountry",
                             "args": null,
                             "storageKey": null
                           },


### PR DESCRIPTION
# PURCHASE-1476

If I'm buying a work that can only be shipped domestically, when I enter my shipping information, the shipping form has the artwork's origin country selected, and I cannot select any other country.

Previously, this only happened for US works and the copy said "continental US" instead of "domestic".

<img width="397" alt="Screen Shot 2019-09-11 at 11 10 14 AM" src="https://user-images.githubusercontent.com/5643895/64711040-015c2400-d487-11e9-9191-b0cbe89c1f97.png">
