### PR TITLE
Prevent Side Frame from overlapping with Article Content

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -120,7 +120,7 @@ export class VanguardArtistWrapper extends React.Component<
             <ArtistContainer
               pb={4}
               maxWidth={["100vw", 1000]}
-              px={4}
+              px={["10vw", "10vw", "10vw", "10vw", 4]}
               mx="auto"
               isMobile={isMobile}
               isExpanded={isExpanded}


### PR DESCRIPTION
As a part of Vanguard 2019 QA fixes, this PR prevents article content from expanding beyond container width so that side frame text does not cover it. 

[Links to GROW-1514](https://artsyproduct.atlassian.net/browse/GROW-1514)


![Kapture 2019-09-11 at 16 21 26](https://user-images.githubusercontent.com/10385964/64705459-4779ad80-d4b0-11e9-829c-61b6eb49094f.gif)



<img width="488" alt="Screen Shot 2019-09-11 at 3 12 51 PM" src="https://user-images.githubusercontent.com/10385964/64700498-4a23d500-d4a7-11e9-9102-031eec4cd2da.png">
![Uploadin
<img width="1374" alt="Screen Shot 2019-09-11 at 3 15 31 PM" src="https://user-images.githubusercontent.com/10385964/64700501-4abc6b80-d4a7-11e9-8ef1-cfef6a0cabb4.png">
g Screen Shot 2019-09-11 at 3.13.18 PM.png…]()
<img width="1194" alt="Screen Shot 2019-09-11 at 3 15 22 PM" src="https://user-images.githubusercontent.com/10385964/64700500-4abc6b80-d4a7-11e9-978b-a9ecc7b23325.png">
