### PR TITLE
replace up/down arrows with underline on read more button

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -186,7 +186,6 @@ export class VanguardArtistWrapper extends React.Component<
                 isExpanded={isExpanded}
               >
                 {isExpanded ? "Close" : "Read More"}
-                <Sans size="8">{isExpanded ? "\u2191" : "\u2193"}</Sans>
               </ReadMoreButton>
             </ArtistContainer>
           </ArticleWithFullScreen>
@@ -214,6 +213,7 @@ const ArtistTitle = styled(InvertedSerif)`
 `
 
 const ReadMoreButton = styled(InvertedSans)<{ onClick: () => void }>`
+  text-decoration: underline;
   text-transform: uppercase;
   cursor: pointer;
   color: ${p =>

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -185,7 +185,9 @@ export class VanguardArtistWrapper extends React.Component<
                 isMobile={isMobile}
                 isExpanded={isExpanded}
               >
-                {isExpanded ? "Close" : "Read More"}
+                <ReadMoreText>
+                  {isExpanded ? "Close" : "Read More"}
+                </ReadMoreText>
               </ReadMoreButton>
             </ArtistContainer>
           </ArticleWithFullScreen>
@@ -212,8 +214,12 @@ const ArtistTitle = styled(InvertedSerif)`
   line-height: 1em;
 `
 
+const ReadMoreText = styled(Box)`
+  display: inline-flex;
+  border-bottom: solid;
+  line-height: normal;
+`
 const ReadMoreButton = styled(InvertedSans)<{ onClick: () => void }>`
-  text-decoration: underline;
   text-transform: uppercase;
   cursor: pointer;
   color: ${p =>


### PR DESCRIPTION
[Links to GROW-1516](https://artsyproduct.atlassian.net/browse/GROW-1516)

<img width="1375" alt="Screen Shot 2019-09-11 at 7 58 03 PM" src="https://user-images.githubusercontent.com/10385964/64722355-98000380-d4ce-11e9-92b6-8a25c828011f.png">
