### PR TITLE
Handle caption color on static images in expanded mode in mobile

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/ArtistWrapper.tsx
@@ -270,7 +270,8 @@ const ArtistContainer = styled(Box)<TextProps>`
     p {
       mix-blend-mode: ${p => (p.isMobile ? "normal" : "difference")};
       will-change: color;
-      color: ${p => (p.isMobile ? color("black100") : color("white100"))};
+      color: ${p =>
+        p.isMobile && !p.isExpanded ? color("black100") : color("white100")};
     }
 
     a {


### PR DESCRIPTION
[Links to GROW-1525](https://artsyproduct.atlassian.net/browse/GROW-1525)

<img width="381" alt="Screen Shot 2019-09-12 at 4 12 39 PM" src="https://user-images.githubusercontent.com/10385964/64791790-82471880-d578-11e9-8e79-a65f6815e57d.png">
