### PR TITLE
Grow 1498 fix the broken scrolling in small size

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -63,7 +63,6 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
           wrapAround: sd.IS_MOBILE ? true : false,
           cellAlign: "left",
           pageDots: false,
-          draggable: xs || sm ? true : false,
           contain: true,
         }}
         data={members}

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -18,7 +18,7 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
 }) => {
   const { name, members } = collectionGroup
   const { trackEvent } = useTracking()
-  const { xs, sm, md } = useMedia()
+  const { sm, md } = useMedia()
 
   useEffect(() => {
     trackEvent({
@@ -53,7 +53,6 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
           cellAlign: "left",
           wrapAround: sd.IS_MOBILE ? true : false,
           pageDots: false,
-          draggable: xs || sm ? true : false,
           contain: true,
         }}
         data={members}


### PR DESCRIPTION
Address [Grow 1498](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1498)


![smallSizeS](https://user-images.githubusercontent.com/45926410/64820852-4bc0cc00-d57f-11e9-979a-d2a8e1c40496.gif)

To fix the broken scrolling in small size. This PR is going to remove the condition check on "draggable". Then it going to use its default value, which is true.
The condition check should be work, but it doesn't. There will be another ticket to investigate. 
