### PR TITLE
Revert "Update dep @artsy/palette from 4.17.3 to v4.17.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "1.0.1",
-    "@artsy/palette": "4.17.4",
+    "@artsy/palette": "4.17.3",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.3.4",
     "@babel/plugin-proposal-class-properties": "7.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.0.5.tgz#abf85959f8567816babec6f582b744f58c98b726"
   integrity sha512-axgW5YuqSpPzHb27yo2jmPHz/N9eN2hh2E+Mub5BKuu/jHZI+iDTdw0OZ3I+z7Z9WKBh+FPVx4gpza5w7slJNA==
 
-"@artsy/palette@4.17.4":
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.17.4.tgz#c4c824f3fea4b4895b7dacb416960b12a5b1c833"
-  integrity sha512-pCM/VzZWzLw2rpXt7hMx7H3HIYouyvYSGStSeApRatQ6CQL7saj8YFJKHVwunQt2JidNaJPUcsxId6ytYLAq2g==
+"@artsy/palette@4.17.3":
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.17.3.tgz#ba106cb74647fd58ed2e85600cef0e0ebd10ee38"
+  integrity sha512-QZ5k1NvqTOLNXEElEenQh5sMbqQolZxxyJU2/kJY/3aUKUk6kX8ebBJrmKVs8p7+O8A2nTQkO7VJg8qmzF95Jw==
   dependencies:
     babel-plugin-styled-components "^1.10.0"
     d3-interpolate "^1.3.2"


### PR DESCRIPTION
Reverts artsy/reaction#2808

One of the `Button`s on the order page is broken and stopping publishing of reaction, 
```
src/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx:54:7 - error TS4041: Return type of public getter 'submitButton' from exported class has or is using name 'WebButtonProps' from external module "/home/circleci/project/node_modules/@artsy/palette/dist/elements/Button/Button" but cannot be named.

54   get submitButton() {
```

https://circleci.com/gh/artsy/reaction/43658?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification