### PR TITLE
[GROW-1501]: fixes word wrapping in ie

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -88,4 +88,5 @@ export const ThumbnailImage = styled(ResponsiveImage)`
 
 const TitleContainer = styled(Serif)`
   width: max-content;
+  white-space: nowrap;
 `


### PR DESCRIPTION
Addresses: [GROW-1501](https://artsyproduct.atlassian.net/browse/GROW-1501)

[`max-context`](https://caniuse.com/#search=max-content) is not supported in internet explorer so to prevent word-wrapping we use `white-space: nowrap`.

![Screen Shot 2019-09-12 at 6 18 34 PM](https://user-images.githubusercontent.com/5201004/64825350-f4c0f400-d58a-11e9-8d43-ba0a35d0d441.png)
