### PR TITLE
Vanguard QA--moves credits to end of article series on mobile

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/SeriesWrapper.tsx
@@ -1,6 +1,5 @@
 import { Box, color, Flex, Sans, Serif } from "@artsy/palette"
 import { Share } from "Components/Publishing/Byline/Share"
-import { VanguardCredits } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardCredits"
 import { VanguardVideoHeader } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VideoHeader"
 import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
@@ -76,7 +75,6 @@ export const VanguardSeriesWrapper: React.SFC<{
             onSlideshowStateChange={onSlideshowStateChange}
           />
         ))}
-      {isMobile && <VanguardCredits isMobile={isMobile} />}
     </Box>
   )
 }

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/index.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/index.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@artsy/palette"
+import { VanguardCredits } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardCredits"
 import { EditorialFeaturesProps } from "Components/Publishing/EditorialFeature/EditorialFeature"
 import { Nav, NavContainer } from "Components/Publishing/Nav/Nav"
 import { last } from "lodash"
@@ -108,6 +109,9 @@ export class Vanguard2019 extends React.Component<
               onSlideshowStateChange={this.onFullScreenProviderStateChange}
             />
           ))}
+
+        {/** display credits at end of article series on mobile */}
+        {isMobile && <VanguardCredits isMobile={isMobile} />}
       </VanguardWrapper>
     )
   }


### PR DESCRIPTION
Previously the credits on mobile were rendering at the end of each series, this moves them to the 
After:
<img width="378" alt="Screen Shot 2019-09-13 at 12 14 13 PM" src="https://user-images.githubusercontent.com/10385964/64855467-38b20880-d620-11e9-9034-a4ac9c300161.png">
end of the entire article series.

Before:
<img width="318" alt="Screen Shot 2019-09-13 at 12 15 21 PM" src="https://user-images.githubusercontent.com/10385964/64855475-41a2da00-d620-11e9-95f2-cda507406502.png">
<img width="325" alt="Screen Shot 2019-09-13 at 12 15 27 PM" src="https://user-images.githubusercontent.com/10385964/64855476-41a2da00-d620-11e9-8af5-005be69d85e6.png">
<img width="340" alt="Screen Shot 2019-09-13 at 12 15 37 PM" src="https://user-images.githubusercontent.com/10385964/64855477-41a2da00-d620-11e9-83cc-92b6a02ea0cf.png">
