### PR TITLE
Handle case for payment_method_confirmation_failed

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -260,6 +260,14 @@ export class ReviewRoute extends Component<ReviewProps, ReviewState> {
         }
         break
       }
+      case "payment_method_confirmation_failed": {
+        await this.props.dialog.showErrorDialog({
+          title: "Your card was declined",
+          message:
+            "We couldn't authorize your credit card. Please enter another payment method or contact your bank for more information.",
+        })
+        break
+      }
       case "artwork_version_mismatch": {
         await this.props.dialog.showErrorDialog({
           title: "Work has been updated",

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/submitOfferOrder.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/submitOfferOrder.ts
@@ -12,6 +12,19 @@ export const submitOfferOrderWithFailure = {
   },
 }
 
+export const submitOfferOrderFailedConfirmation = {
+  commerceSubmitOrderWithOffer: {
+    orderOrError: {
+      __typename: "CommerceOrderWithMutationFailure",
+      error: {
+        type: "processing",
+        code: "payment_method_confirmation_failed",
+        data: null,
+      },
+    },
+  },
+}
+
 export const submitOfferOrderWithVersionMismatchFailure = {
   commerceSubmitOrderWithOffer: {
     orderOrError: {

--- a/src/Apps/Order/Routes/__tests__/Review.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.test.tsx
@@ -9,6 +9,7 @@ import { createTestEnv } from "DevTools/createTestEnv"
 import { expectOne } from "DevTools/RootTestPage"
 import { graphql } from "react-relay"
 import {
+  submitOfferOrderFailedConfirmation,
   submitOfferOrderSuccess,
   submitOfferOrderWithActionRequired,
   submitOfferOrderWithFailure,
@@ -240,6 +241,19 @@ describe("Review", () => {
         "Something about the work changed since you started checkout. Please review the work before submitting your order."
       )
       expect(window.location.assign).toBeCalledWith("/artwork/artworkId")
+    })
+
+    it("shows a modal if there is a payment_method_confirmation_failed", async () => {
+      window.location.assign = jest.fn()
+
+      mutations.useResultsOnce(submitOfferOrderFailedConfirmation)
+
+      await page.clickSubmit()
+
+      await page.expectAndDismissErrorDialogMatching(
+        "Your card was declined",
+        "We couldn't authorize your credit card. Please enter another payment method or contact your bank for more information."
+      )
     })
 
     it("shows a modal that redirects to the artist page if there is an insufficient inventory", async () => {


### PR DESCRIPTION
# Change
This is a follow up on https://github.com/artsy/exchange/pull/508 where we introduced new `payment_method_confirmation_failed` processing error which is the case where payment method confirmation fails on Stripe end and show proper new message.

more discussions about copy: https://artsy.slack.com/archives/C9YNS4X32/p1568669811033800