### PR TITLE
Don't tie `yalc` publishing to `yarn watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:watch": "jest --watch --runInBand",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "type-check": "tsc --pretty --noEmit",
-    "watch": "concurrently --raw --kill-others 'yarn relay --watch' 'yarn compile -w' 'yarn emit-types --watch' 'node scripts/publish-on-change.js'"
+    "watch": "concurrently --raw --kill-others 'yarn relay --watch' 'yarn compile -w' 'yarn emit-types --watch'"
   },
   "resolutions": {
     "@types/react": "16.8.7",

--- a/scripts/quicklink-to-project.sh
+++ b/scripts/quicklink-to-project.sh
@@ -43,4 +43,4 @@ fi
 
 echo ""
 echo "Beginning integration..."
-yarn concurrently --kill-others --names "$CURRENT_NAME,$PROJECT_NAME" "yarn watch" "cd $PROJECT && ./scripts/quicklink.sh @artsy/reaction"
+yarn concurrently --kill-others --names "$CURRENT_NAME,$CURRENT_NAME,$PROJECT_NAME" "yarn watch" "node scripts/publish-on-change.js" "cd $PROJECT && ./scripts/quicklink.sh @artsy/reaction"


### PR DESCRIPTION
The publishing mechanism for `yalc` was tied directly into `yarn watch` for simplicity when designing that workflow. That said, `yarn link` or just local development in reaction is slowed down by having that publishing step backed into `yarn watch`, so this pulls them apart. 

Thanks @damassi for the recommendation!