### PR TITLE
Collect2 app passes strict null checks

### DIFF
--- a/src/Apps/Collect2/Components/SeoProductsForArtworks.tsx
+++ b/src/Apps/Collect2/Components/SeoProductsForArtworks.tsx
@@ -29,108 +29,83 @@ export class SeoProducts extends React.Component<SeoProductsProps> {
     // here the filtering is necessary so we can re-use the artwork list shown in the page (could include
     // non-acquireable artworks) without making an extra request. Also, seller image is a required field
     // so excluding those that don't have `partner.profile.icon.url`.
-
-    const edges = artworks_connection && artworks_connection.edges
-    const artworksForSeoProduct =
-      edges &&
-      edges.filter(edge => {
-        return get(edge, e => {
-          const node = e && e.node !== null && e.node
-
-          if (node) {
-            const { is_acquireable, partner } = node
-            const iconUrl =
-              partner &&
-              partner.profile &&
-              partner.profile.icon &&
-              partner.profile.icon.url
-            return is_acquireable && iconUrl
-          } else {
-            return false
-          }
-        })
+    const artworksForSeoProduct = artworks_connection!.edges!.filter(edge => {
+      return get(edge, e => {
+        return e!.node!.is_acquireable && e!.node!.partner!.profile!.icon!.url
       })
+    })
 
-    return (
-      artworksForSeoProduct &&
-      artworksForSeoProduct.map(a => {
-        if (a && a.node !== null) {
-          const { node } = a
-          const {
-            artists,
-            availability,
-            image,
-            is_price_range,
-            partner,
-            price,
-          } = node
-          const location = partner && partner.locations && partner.locations[0]
-          const artistsName = artists
-            ? toSentence(artists.map(artist => artist && artist.name))
-            : null
-          const isInstitution = partner && partner.type === "Institution"
-          const iconUrl =
-            partner &&
-            partner.profile &&
-            partner.profile.icon &&
-            partner.profile.icon.url
+    return artworksForSeoProduct!.map(a => {
+      if (a!.node !== null) {
+        const node = a!.node
+        const {
+          artists,
+          availability,
+          image,
+          is_price_range,
+          partner,
+          price,
+        } = node
+        const location = partner!.locations && partner!.locations[0]
+        const artistsName = artists
+          ? toSentence(artists.map(artist => artist!.name))
+          : null
+        const isInstitution = partner!.type === "Institution"
 
-          return (
-            <Product
-              key={node.__id}
-              data={{
-                name: node.title,
-                image: image && image.url,
-                description: node.meta && node.meta.description,
-                url: `${APP_URL}${node.href}`,
-                brand: {
-                  "@type": "Person",
-                  name: artistsName,
-                },
-                ...(isInstitution
-                  ? {}
-                  : {
-                      category: node.category,
-                      productionDate: node.date,
-                      offers: {
-                        "@type": "Offer",
-                        price: !is_price_range
-                          ? formatCurrency(price)
-                          : {
-                              minPrice:
-                                price && formatCurrency(price.split("-")[0]),
-                              maxPrice:
-                                price && formatCurrency(price.split("-")[1]),
-                            },
-                        priceCurrency: node.price_currency,
-                        availability:
-                          availability && AVAILABILITY[availability],
-                        seller: {
-                          "@type": "ArtGallery",
-                          name: partner && partner.name,
-                          image: iconUrl,
-                          address: location
-                            ? [
-                                location.address,
-                                location.address_2,
-                                location.city,
-                                location.state,
-                                location.country,
-                                location.postal_code,
-                              ]
-                                .filter(Boolean)
-                                .join(", ")
-                            : null,
-                          telephone: location ? location.phone : null,
-                        },
+        return (
+          <Product
+            key={node.__id}
+            data={{
+              name: node.title,
+              image: image!.url,
+              description: node.meta!.description,
+              url: `${APP_URL}${node.href}`,
+              brand: {
+                "@type": "Person",
+                name: artistsName,
+              },
+              ...(isInstitution
+                ? {}
+                : {
+                    category: node.category,
+                    productionDate: node.date,
+                    offers: {
+                      "@type": "Offer",
+                      price: !is_price_range
+                        ? formatCurrency(price)
+                        : {
+                            minPrice:
+                              price && formatCurrency(price.split("-")[0]),
+                            maxPrice:
+                              price && formatCurrency(price.split("-")[1]),
+                          },
+                      priceCurrency: node.price_currency,
+                      availability: availability && AVAILABILITY[availability],
+                      seller: {
+                        "@type": "ArtGallery",
+                        name: partner!.name,
+                        image: partner!.profile!.icon!.url,
+                        address: location
+                          ? [
+                              location.address,
+                              location.address_2,
+                              location.city,
+                              location.state,
+                              location.country,
+                              location.postal_code,
+                            ]
+                              .filter(Boolean)
+                              .join(", ")
+                          : null,
+                        telephone: location!.phone,
                       },
-                    }),
-              }}
-            />
-          )
-        }
-      })
-    )
+                    },
+                  }),
+            }}
+          />
+        )
+      }
+    })
   }
 }
 

--- a/src/Apps/Collect2/Components/SeoProductsForArtworks.tsx
+++ b/src/Apps/Collect2/Components/SeoProductsForArtworks.tsx
@@ -29,72 +29,108 @@ export class SeoProducts extends React.Component<SeoProductsProps> {
     // here the filtering is necessary so we can re-use the artwork list shown in the page (could include
     // non-acquireable artworks) without making an extra request. Also, seller image is a required field
     // so excluding those that don't have `partner.profile.icon.url`.
-    const artworksForSeoProduct = artworks_connection.edges.filter(edge => {
-      return get(
-        edge,
-        e => e.node.is_acquireable && e.node.partner.profile.icon.url
-      )
-    })
 
-    return artworksForSeoProduct.map(({ node }, index) => {
-      const { artists, is_price_range, partner, price } = node
-      const location = partner.locations && partner.locations[0]
-      const artistsName = artists
-        ? toSentence(node.artists.map(({ name }) => name))
-        : null
-      const isInstitution = partner.type === "Institution"
+    const edges = artworks_connection && artworks_connection.edges
+    const artworksForSeoProduct =
+      edges &&
+      edges.filter(edge => {
+        return get(edge, e => {
+          const node = e && e.node !== null && e.node
 
-      return (
-        <Product
-          key={node.__id}
-          data={{
-            name: node.title,
-            image: node.image.url,
-            description: node.meta && node.meta.description,
-            url: `${APP_URL}${node.href}`,
-            brand: {
-              "@type": "Person",
-              name: artistsName,
-            },
-            ...(isInstitution
-              ? {}
-              : {
-                  category: node.category,
-                  productionDate: node.date,
-                  offers: {
-                    "@type": "Offer",
-                    price: !is_price_range
-                      ? formatCurrency(price)
-                      : {
-                          minPrice: formatCurrency(price.split("-")[0]),
-                          maxPrice: formatCurrency(price.split("-")[1]),
+          if (node) {
+            const { is_acquireable, partner } = node
+            const iconUrl =
+              partner &&
+              partner.profile &&
+              partner.profile.icon &&
+              partner.profile.icon.url
+            return is_acquireable && iconUrl
+          } else {
+            return false
+          }
+        })
+      })
+
+    return (
+      artworksForSeoProduct &&
+      artworksForSeoProduct.map(a => {
+        if (a && a.node !== null) {
+          const { node } = a
+          const {
+            artists,
+            availability,
+            image,
+            is_price_range,
+            partner,
+            price,
+          } = node
+          const location = partner && partner.locations && partner.locations[0]
+          const artistsName = artists
+            ? toSentence(artists.map(artist => artist && artist.name))
+            : null
+          const isInstitution = partner && partner.type === "Institution"
+          const iconUrl =
+            partner &&
+            partner.profile &&
+            partner.profile.icon &&
+            partner.profile.icon.url
+
+          return (
+            <Product
+              key={node.__id}
+              data={{
+                name: node.title,
+                image: image && image.url,
+                description: node.meta && node.meta.description,
+                url: `${APP_URL}${node.href}`,
+                brand: {
+                  "@type": "Person",
+                  name: artistsName,
+                },
+                ...(isInstitution
+                  ? {}
+                  : {
+                      category: node.category,
+                      productionDate: node.date,
+                      offers: {
+                        "@type": "Offer",
+                        price: !is_price_range
+                          ? formatCurrency(price)
+                          : {
+                              minPrice:
+                                price && formatCurrency(price.split("-")[0]),
+                              maxPrice:
+                                price && formatCurrency(price.split("-")[1]),
+                            },
+                        priceCurrency: node.price_currency,
+                        availability:
+                          availability && AVAILABILITY[availability],
+                        seller: {
+                          "@type": "ArtGallery",
+                          name: partner && partner.name,
+                          image: iconUrl,
+                          address: location
+                            ? [
+                                location.address,
+                                location.address_2,
+                                location.city,
+                                location.state,
+                                location.country,
+                                location.postal_code,
+                              ]
+                                .filter(Boolean)
+                                .join(", ")
+                            : null,
+                          telephone: location ? location.phone : null,
                         },
-                    priceCurrency: node.price_currency,
-                    availability: AVAILABILITY[node.availability],
-                    seller: {
-                      "@type": "ArtGallery",
-                      name: partner.name,
-                      image: partner.profile.icon.url,
-                      address: location
-                        ? [
-                            location.address,
-                            location.address_2,
-                            location.city,
-                            location.state,
-                            location.country,
-                            location.postal_code,
-                          ]
-                            .filter(Boolean)
-                            .join(", ")
-                        : null,
-                      telephone: location ? location.phone : null,
-                    },
-                  },
-                }),
-          }}
-        />
-      )
-    })
+                      },
+                    }),
+              }}
+            />
+          )
+        }
+      })
+    )
   }
 }
 

--- a/src/Apps/Collect2/Routes/Collect/index.tsx
+++ b/src/Apps/Collect2/Routes/Collect/index.tsx
@@ -50,6 +50,15 @@ export const CollectApp = track({
   const showCollectionHubs =
     sd.COLLECTION_HUBS === "experiment" ||
     props.COLLECTION_HUBS === "experiment"
+  const { filterArtworks } = props
+
+  const items = [{ path: "/collect", name: "Collect" }]
+  if (medium) {
+    items.push({
+      path: `/collect/${medium}`,
+      name: breadcrumbTitle,
+    })
+  }
 
   return (
     <AppContainer>
@@ -65,17 +74,9 @@ export const CollectApp = track({
         <Meta property="twitter:description" content={description} />
         <Link rel="canonical" href={canonicalHref} />
 
-        <BreadCrumbList
-          items={[
-            { path: "/collect", name: "Collect" },
-            medium && {
-              path: `/collect/${medium}`,
-              name: breadcrumbTitle,
-            },
-          ].filter(Boolean)}
-        />
+        <BreadCrumbList items={items} />
 
-        <SeoProductsForArtworks artworks={props.filterArtworks} />
+        {filterArtworks && <SeoProductsForArtworks artworks={filterArtworks} />}
 
         <Box mt={3}>
           <Serif size="8">

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -20,14 +20,9 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
   itemNumber,
 }) => {
   const { headerImage, artworks, price_guidance, slug, title } = member
-  const hits = artworks && artworks.hits
-  const bgImages = hits && hits.map(hit => hit && hit.image && hit.image.url)
+  const bgImages = artworks!.hits!.map(hit => hit!.image!.url)
   const imageSize =
-    bgImages && bgImages.length === 1
-      ? 221
-      : bgImages && bgImages.length === 2
-      ? 109
-      : 72
+    bgImages!.length === 1 ? 221 : bgImages!.length === 2 ? 109 : 72
 
   const { trackEvent } = useTracking()
 
@@ -46,12 +41,13 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
     <Container px={2} pt={2} pb={2} m={1}>
       <StyledLink to={`/collection/${slug}`} onClick={handleLinkClick}>
         <ImgWrapper>
-          {bgImages && bgImages.length
+          {bgImages!.length
             ? bgImages.map((url, i) => {
-                const hit = hits && hits.length && hits[i] !== null && hits[i]
-                const artistName = get(hit && hit.artist, a => a && a.name)
-                const alt = `${artistName ? artistName + ", " : ""}${hit &&
-                  hit.title}`
+                const hit = artworks!.hits![i]
+                const artistName = get(hit!.artist, a => a!.name)
+                const alt = `${artistName ? artistName + ", " : ""}${
+                  hit!.title
+                }`
                 return (
                   <SingleImgContainer key={i}>
                     <ImgOverlay width={imageSize} />

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -19,16 +19,15 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
   member,
   itemNumber,
 }) => {
-  const {
-    headerImage,
-    artworks: { hits },
-    price_guidance,
-    slug,
-    title,
-  } = member
-  const bgImages = hits.map(hit => hit.image.url)
+  const { headerImage, artworks, price_guidance, slug, title } = member
+  const hits = artworks && artworks.hits
+  const bgImages = hits && hits.map(hit => hit && hit.image && hit.image.url)
   const imageSize =
-    bgImages.length === 1 ? 221 : bgImages.length === 2 ? 109 : 72
+    bgImages && bgImages.length === 1
+      ? 221
+      : bgImages && bgImages.length === 2
+      ? 109
+      : 72
 
   const { trackEvent } = useTracking()
 
@@ -47,22 +46,27 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
     <Container px={2} pt={2} pb={2} m={1}>
       <StyledLink to={`/collection/${slug}`} onClick={handleLinkClick}>
         <ImgWrapper>
-          {bgImages.length ? (
-            bgImages.map((url, i) => {
-              const artistName = get(hits[i].artist, a => a.name)
-              const alt = `${artistName ? artistName + ", " : ""}${
-                hits[i].title
-              }`
-              return (
-                <SingleImgContainer key={i}>
-                  <ImgOverlay width={imageSize} />
-                  <ArtworkImage key={i} src={url} width={imageSize} alt={alt} />
-                </SingleImgContainer>
-              )
-            })
-          ) : (
-            <ArtworkImage src={headerImage} width={221} />
-          )}
+          {bgImages && bgImages.length
+            ? bgImages.map((url, i) => {
+                const hit = hits && hits.length && hits[i] !== null && hits[i]
+                const artistName = get(hit && hit.artist, a => a && a.name)
+                const alt = `${artistName ? artistName + ", " : ""}${hit &&
+                  hit.title}`
+                return (
+                  <SingleImgContainer key={i}>
+                    <ImgOverlay width={imageSize} />
+                    {url && (
+                      <ArtworkImage
+                        key={i}
+                        src={url}
+                        width={imageSize}
+                        alt={alt}
+                      />
+                    )}
+                  </SingleImgContainer>
+                )
+              })
+            : headerImage && <ArtworkImage src={headerImage} width={221} />}
         </ImgWrapper>
         {
           <CollectionTitle pt={1} pb={0.5} size="3">
@@ -105,6 +109,7 @@ const ImgOverlay = styled(Box)<{ width: number }>`
 export const Container = styled(Box)`
   border: 1px solid ${color("black10")};
   border-radius: 2px;
+
   &:hover {
     text-decoration: none;
     border: 1px solid ${color("black60")};

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
@@ -106,6 +106,7 @@ const Content = styled(Box)`
 
 export const ArrowContainer = styled(Box)`
   align-self: flex-start;
+
   ${ArrowButton} {
     height: 85%;
   }

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -128,7 +128,7 @@ export const FeaturedCollectionEntity: React.FC<
         <Flex height={["190px", "190px", "280px", "280px"]}>
           <FeaturedImage src={thumbnail} />
         </Flex>
-        <CollectionTitle size="4" mt={1} isSmallerScreen={xs || sm}>
+        <CollectionTitle size="4" mt={1} isSmallerScreen={xs || sm || false}>
           {title}
         </CollectionTitle>
         {price_guidance && (
@@ -182,10 +182,21 @@ const Container = styled(Box)`
   }
 `
 
+export const ArrowContainer = styled(Box)`
+  align-self: flex-start;
+
+  ${ArrowButton} {
+    height: 100%;
+  }
+`
+
 const FeaturedCollectionsContainer = styled(Box)`
   border-top: 1px solid ${color("black10")};
-  ${Container}:first-of-type {
-    margin-left: 2px;
+
+  ${Container} {
+    &:first-of-type {
+      margin-left: 2px;
+    }
   }
 `
 
@@ -202,14 +213,6 @@ const ExtendedSerif = styled(Serif)`
 `
 export const FeaturedImage = styled(ResponsiveImage)`
   background-position: top;
-`
-
-export const ArrowContainer = styled(Box)`
-  align-self: flex-start;
-
-  ${ArrowButton} {
-    height: 100%;
-  }
 `
 
 const CollectionTitle = styled(Serif)<{ isSmallerScreen: boolean }>`

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/DefaultHeader.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/DefaultHeader.tsx
@@ -97,10 +97,10 @@ export const getHeaderArtworks = (
   isSmallViewport: boolean
 ) => {
   let artworkWidths = 0
-  const headerArtworks = []
+  const headerArtworks: any[] = []
 
   if (artworksArray.length < 1) {
-    return []
+    return [] as any[]
   }
 
   /**

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/Header.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/Header.test.tsx
@@ -84,7 +84,7 @@ describe("collections header", () => {
         {}
       )
 
-      expect(results && results.length).toEqual(1)
+      expect(results!.length).toEqual(1)
     })
 
     it("passes correct arguments featuredArtistsEntityCollection", () => {
@@ -154,7 +154,7 @@ describe("collections header", () => {
           const component = mountComponent(props)
 
           const readMore = component.find("ReadMore")
-          expect(readMore && readMore.length).toEqual(1)
+          expect(readMore!.length).toEqual(1)
           expect(readMore.text()).toEqual("")
         })
       })

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/Header.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/Header.test.tsx
@@ -1,5 +1,4 @@
 import { EntityHeader } from "@artsy/palette"
-import { FollowArtistButton_artist$ref } from "__generated__/FollowArtistButton_artist.graphql"
 import {
   collectionHeaderArtworks,
   defaultCollectionHeaderArtworks,
@@ -61,7 +60,7 @@ describe("collections header", () => {
   }
 
   it("renders the default collections header when there is no header image", () => {
-    props.collection.headerImage = null
+    props.collection.headerImage = ""
     props.artworks = defaultCollectionHeaderArtworks as any
     const component = mountComponent(props)
 
@@ -85,7 +84,7 @@ describe("collections header", () => {
         {}
       )
 
-      expect(results.length).toEqual(1)
+      expect(results && results.length).toEqual(1)
     })
 
     it("passes correct arguments featuredArtistsEntityCollection", () => {
@@ -155,7 +154,7 @@ describe("collections header", () => {
           const component = mountComponent(props)
 
           const readMore = component.find("ReadMore")
-          expect(readMore.length).toEqual(1)
+          expect(readMore && readMore.length).toEqual(1)
           expect(readMore.text()).toEqual("")
         })
       })
@@ -200,7 +199,7 @@ describe("collections header", () => {
         " $refType": null,
         " $fragmentRefs": null,
         merchandisable_artists: [],
-      }
+      } as any
       const component = mountComponent(props, "lg")
       const entities = component.find(EntityHeader)
 
@@ -217,7 +216,7 @@ describe("collections header", () => {
           "https://d32dm0rphc51dk.cloudfront.net/npEmyaOeaPzkfEHX5VsmQg/square.jpg",
         birthday: "",
         nationality: "",
-        " $fragmentRefs": null as FollowArtistButton_artist$ref,
+        " $fragmentRefs": null,
       }
     }
 
@@ -250,7 +249,7 @@ describe("collections header", () => {
           anArtist(),
           anArtist(),
         ],
-      }
+      } as any
 
       const component = mountComponent(props, "sm")
       const entityHeaders = component.find(EntityHeader)
@@ -275,7 +274,7 @@ describe("collections header", () => {
           anArtist(),
           anArtist(),
         ],
-      }
+      } as any
 
       const component = mountComponent(props, "md")
       const entityHeaders = component.find(EntityHeader)
@@ -302,7 +301,7 @@ describe("collections header", () => {
           anArtist(),
           anArtist(),
         ],
-      }
+      } as any
 
       const component = mountComponent(props, "lg")
       const entityHeaders = component.find(EntityHeader)
@@ -326,7 +325,7 @@ describe("collections header", () => {
           anArtist(),
           anArtist(),
         ],
-      }
+      } as any
 
       const component = mountComponent(props, "xs")
       const entityHeaders = component.find(EntityHeader)

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
@@ -98,7 +98,7 @@ export const featuredArtistsEntityCollection: (
           meta={
             hasArtistMetaData
               ? `${artist.nationality}, b. ${artist.birthday}`
-              : null
+              : undefined
           }
           href={`/artist/${artist.id}`}
           FollowButton={
@@ -192,12 +192,19 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
           mediator,
           user
         )
+        const resizedHeaderImage =
+          collection.headerImage &&
+          resize(collection.headerImage, {
+            width: imageWidth * (xs ? 2 : 1),
+            height: imageHeight * (xs ? 2 : 1),
+            quality: 80,
+          })
 
         return (
           <header>
             <Flex flexDirection="column">
               <Box mt={[0, "-12px"]}>
-                {collection.headerImage ? (
+                {resizedHeaderImage ? (
                   <CollectionSingleImageHeader
                     position={["relative", "absolute"]}
                     left={["auto", 0]}
@@ -205,11 +212,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     p={2}
                     mt={0}
                     mb={3}
-                    headerImageUrl={resize(collection.headerImage, {
-                      width: imageWidth * (xs ? 2 : 1),
-                      height: imageHeight * (xs ? 2 : 1),
-                      quality: 80,
-                    })}
+                    headerImageUrl={resizedHeaderImage}
                     height={imageHeight}
                   >
                     <Overlay />
@@ -243,7 +246,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                           {smallerScreen ? (
                             <ReadMore
                               maxChars={chars}
-                              content={htmlUnsafeDescription}
+                              content={htmlUnsafeDescription || ""}
                             />
                           ) : (
                             htmlUnsafeDescription
@@ -253,11 +256,13 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                       </Flex>
                     </Col>
                     <Col sm={12} md={12}>
-                      <FeaturedArtists
-                        breakpointSize={size}
-                        featuredArtists={featuredArtists}
-                        hasMultipleArtists={hasMultipleArtists}
-                      />
+                      {featuredArtists && hasMultipleArtists && (
+                        <FeaturedArtists
+                          breakpointSize={size}
+                          featuredArtists={featuredArtists}
+                          hasMultipleArtists={hasMultipleArtists}
+                        />
+                      )}
                     </Col>
                   </Row>
                 </Grid>

--- a/src/Apps/Collect2/Routes/Collection/Components/__stories__/CollectionsHubRails.story.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/__stories__/CollectionsHubRails.story.tsx
@@ -29,30 +29,34 @@ export const CollectionHubRailsQueryRenderer: React.FC<Props> = ({
   collectionID,
 }) => {
   const { relayEnvironment } = useContext(SystemContext)
-  return (
-    // tslint:disable-next-line:relay-operation-generics
-    <QueryRenderer
-      environment={relayEnvironment}
-      variables={{
-        collectionID,
-      }}
-      query={graphql`
-        query CollectionsHubRailsStoryQuery($collectionID: String!) {
-          marketingCollection(slug: $collectionID) {
-            linkedCollections {
-              ...CollectionsHubRails_linkedCollections
+  if (relayEnvironment) {
+    return (
+      // tslint:disable-next-line:relay-operation-generics
+      <QueryRenderer
+        environment={relayEnvironment}
+        variables={{
+          collectionID,
+        }}
+        query={graphql`
+          query CollectionsHubRailsStoryQuery($collectionID: String!) {
+            marketingCollection(slug: $collectionID) {
+              linkedCollections {
+                ...CollectionsHubRails_linkedCollections
+              }
             }
           }
-        }
-      `}
-      render={({ props }) => {
-        if (props) {
-          const { linkedCollections } = props.marketingCollection
-          return <CollectionsHubRails linkedCollections={linkedCollections} />
-        } else {
-          return null
-        }
-      }}
-    />
-  )
+        `}
+        render={({ props }) => {
+          if (props) {
+            const { linkedCollections } = props.marketingCollection
+            return <CollectionsHubRails linkedCollections={linkedCollections} />
+          } else {
+            return null
+          }
+        }}
+      />
+    )
+  } else {
+    return null
+  }
 }

--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -62,7 +62,8 @@ export class CollectionApp extends Component<CollectionAppProps> {
 
     const showCollectionHubs =
       viewer.linkedCollections.length > 0 && userIsAdmin(user)
-
+    const aggregations =
+      viewer && viewer.artworks && viewer.artworks.aggregations
     return (
       <AppContainer>
         <FrameWithRecentlyViewed>
@@ -79,8 +80,11 @@ export class CollectionApp extends Component<CollectionAppProps> {
               { path: `/collection/${slug}`, name: title },
             ]}
           />
-          <SeoProductsForArtworks artworks={artworks} />
-          <CollectionHeader collection={viewer} artworks={artworks as any} />
+          {artworks && <SeoProductsForArtworks artworks={artworks} />}
+          <CollectionHeader
+            collection={viewer as any}
+            artworks={artworks as any}
+          />
           {showCollectionHubs && (
             <CollectionsHubRails linkedCollections={viewer.linkedCollections} />
           )}
@@ -95,8 +99,7 @@ export class CollectionApp extends Component<CollectionAppProps> {
                 { value: "year", text: "Artwork year (asc.)" },
               ]}
               aggregations={
-                this.props.viewer.artworks
-                  .aggregations as SharedArtworkFilterContextProps["aggregations"]
+                aggregations as SharedArtworkFilterContextProps["aggregations"]
               }
               onChange={updateUrl}
               onFilterClick={(key, value, filterState) => {

--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -62,8 +62,7 @@ export class CollectionApp extends Component<CollectionAppProps> {
 
     const showCollectionHubs =
       viewer.linkedCollections.length > 0 && userIsAdmin(user)
-    const aggregations =
-      viewer && viewer.artworks && viewer.artworks.aggregations
+
     return (
       <AppContainer>
         <FrameWithRecentlyViewed>
@@ -99,7 +98,8 @@ export class CollectionApp extends Component<CollectionAppProps> {
                 { value: "year", text: "Artwork year (asc.)" },
               ]}
               aggregations={
-                aggregations as SharedArtworkFilterContextProps["aggregations"]
+                viewer!.artworks!
+                  .aggregations as SharedArtworkFilterContextProps["aggregations"]
               }
               onChange={updateUrl}
               onFilterClick={(key, value, filterState) => {

--- a/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
+++ b/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
@@ -31,7 +31,7 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
     const hasShortRow = collections.length % 3 !== 0 // Preserve left align
 
     return (
-      <Box pb={80} id={slugify(name)}>
+      <Box pb={80} id={name && slugify(name)}>
         <Sans size="3" weight="medium" pb={15}>
           {name}
         </Sans>
@@ -59,7 +59,7 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
                   <EntityHeader
                     py={2}
                     href={`/collection/${collection.slug}`}
-                    imageUrl={imageUrl}
+                    imageUrl={imageUrl || undefined}
                     name={collection.title}
                     onClick={event => {
                       event.preventDefault()


### PR DESCRIPTION
An experiment related to https://artsyproduct.atlassian.net/browse/PLATFORM-1780

Turned on strict null checking for typescript, and converted the `Apps/Collect2` directory to pass all checks. I've disabled strict null checking for the moment so there is a chance these changes could be accidentally removed. 

Next steps: 
- implement a strategy to turn on type-checking selectively by path.
- Develop list of apps that have greatest need for checking so we can prioritize these changes.
