### PR TITLE
refactor to use responsive media component

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -1,6 +1,7 @@
 import { CollectionHubFixture } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton } from "Components/v2/Carousel"
+import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
@@ -12,13 +13,6 @@ import {
 } from "../index"
 
 jest.mock("Artsy/Analytics/useTracking")
-jest.mock("Utils/Hooks/useMedia", () => ({
-  useMedia: () => ({
-    xs: false,
-    sm: false,
-    xl: true,
-  }),
-}))
 
 jest.mock("found", () => ({
   Link: ({ children, ...props }) => <div {...props}>{children}</div>,
@@ -60,7 +54,11 @@ describe("FeaturedCollectionsRails", () => {
   })
 
   it("Renders no arrows when there are less than 5 collections", () => {
-    const component = mount(<FeaturedCollectionsRails {...props} />)
+    const component = mount(
+      <MockBoot>
+        <FeaturedCollectionsRails {...props} />
+      </MockBoot>
+    )
     expect(component.find(ArrowButton).length).toBe(1)
   })
 
@@ -73,7 +71,11 @@ describe("FeaturedCollectionsRails", () => {
       memberData(),
     ]
 
-    const component = mount(<FeaturedCollectionsRails {...props} />)
+    const component = mount(
+      <MockBoot>
+        <FeaturedCollectionsRails {...props} />
+      </MockBoot>
+    )
     expect(component.find(ArrowButton).length).toBe(2)
   })
 

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -17,7 +17,7 @@ import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
-import { useMedia } from "Utils/Hooks/useMedia"
+import { Media } from "Utils/Responsive"
 
 interface Props {
   collectionGroup: FeaturedCollectionsRails_collectionGroup
@@ -28,8 +28,6 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
 }) => {
   const { members, name } = collectionGroup
   const { trackEvent } = useTracking()
-  const { xs, sm, xl } = useMedia()
-  const carouselHeight = xs || sm ? "430px" : "500px"
 
   useEffect(() => {
     trackEvent({
@@ -51,13 +49,10 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
     })
   }
 
-  return (
-    <FeaturedCollectionsContainer>
-      <Serif size="5" mt={3}>
-        {name}
-      </Serif>
+  const renderCarousel = ({ xs, sm, xl }) => {
+    return (
       <Carousel
-        height={carouselHeight}
+        height={xs || sm ? "430px" : "500px"}
         options={{
           groupCells: xs || sm ? 1 : 2,
           wrapAround: sd.IS_MOBILE ? true : false,
@@ -92,6 +87,26 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
         }}
         onArrowClick={() => trackArrowClick()}
       />
+    )
+  }
+
+  return (
+    <FeaturedCollectionsContainer>
+      <Serif size="5" mt={3}>
+        {name}
+      </Serif>
+      <Media lessThan="md">
+        {renderCarousel({ xs: true, sm: true, xl: false })}
+      </Media>
+      <Media at="md">
+        {renderCarousel({ xs: false, sm: false, xl: false })}
+      </Media>
+      <Media at="lg">
+        {renderCarousel({ xs: false, sm: false, xl: false })}
+      </Media>
+      <Media greaterThanOrEqual="xl">
+        {renderCarousel({ xs: false, sm: false, xl: true })}
+      </Media>
       <Spacer pb={2} />
     </FeaturedCollectionsContainer>
   )
@@ -107,7 +122,6 @@ export const FeaturedCollectionEntity: React.FC<
 > = ({ itemNumber, member }) => {
   const { description, price_guidance, slug, thumbnail, title } = member
   const { trackEvent } = useTracking()
-  const { xs, sm } = useMedia()
   const hasLongTitle = title.length > 31
 
   const handleClick = () => {
@@ -122,30 +136,45 @@ export const FeaturedCollectionEntity: React.FC<
     })
   }
 
+  const renderReadMore = (isSmallerScreen: boolean) => {
+    return (
+      <ReadMore
+        disabled
+        maxChars={hasLongTitle && isSmallerScreen ? 50 : 100}
+        content={
+          <>
+            {description && (
+              <span dangerouslySetInnerHTML={{ __html: description }} />
+            )}
+          </>
+        }
+      />
+    )
+  }
+
   return (
     <Container p={2} m={1} width={["261px", "261px", "355px", "355px"]}>
       <StyledLink to={`/collection/${slug}`} onClick={handleClick}>
         <Flex height={["190px", "190px", "280px", "280px"]}>
           <FeaturedImage src={thumbnail} />
         </Flex>
-        <CollectionTitle size="4" mt={1} isSmallerScreen={xs || sm}>
-          {title}
-        </CollectionTitle>
+        <Media lessThan="md">
+          <Serif size="4" mt={1} maxWidth="246px">
+            {title}
+          </Serif>
+        </Media>
+        <Media greaterThanOrEqual="md">
+          <Serif size="4" mt={1} maxWidth="100%">
+            {title}
+          </Serif>
+        </Media>
+
         {price_guidance && (
           <Sans size="2" color="black60">{`From $${price_guidance}`}</Sans>
         )}
         <ExtendedSerif size="3" mt={1}>
-          <ReadMore
-            disabled
-            maxChars={hasLongTitle && (xs || sm) ? 50 : 100}
-            content={
-              <>
-                {description && (
-                  <span dangerouslySetInnerHTML={{ __html: description }} />
-                )}
-              </>
-            }
-          />
+          <Media lessThan="md">{renderReadMore(true)}</Media>
+          <Media greaterThan="sm">{renderReadMore(false)}</Media>
         </ExtendedSerif>
       </StyledLink>
     </Container>
@@ -210,10 +239,6 @@ export const ArrowContainer = styled(Box)`
   ${ArrowButton} {
     height: 100%;
   }
-`
-
-const CollectionTitle = styled(Serif)<{ isSmallerScreen: boolean }>`
-  width: ${props => (props.isSmallerScreen ? "246px" : "max-content")};
 `
 
 export const StyledLink = styled(RouterLink)`

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -49,12 +49,12 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
     })
   }
 
-  const renderCarousel = ({ xs, sm, xl }) => {
+  const renderCarousel = breakpoints => {
     return (
       <Carousel
-        height={xs || sm ? "430px" : "500px"}
+        height={breakpoints.xs || breakpoints.sm ? "430px" : "500px"}
         options={{
-          groupCells: xs || sm ? 1 : 2,
+          groupCells: breakpoints.xs || breakpoints.sm ? 1 : 2,
           wrapAround: sd.IS_MOBILE ? true : false,
           cellAlign: "left",
           pageDots: false,
@@ -74,7 +74,7 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
           )
         }}
         renderRightArrow={({ Arrow }) => {
-          const shouldDisplayArrow = !xl && members.length > 2
+          const shouldDisplayArrow = !breakpoints.xl && members.length > 2
           return (
             <ArrowContainer>
               {members.length > 3 ? (
@@ -95,18 +95,10 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
       <Serif size="5" mt={3}>
         {name}
       </Serif>
-      <Media lessThan="md">
-        {renderCarousel({ xs: true, sm: true, xl: false })}
-      </Media>
-      <Media at="md">
-        {renderCarousel({ xs: false, sm: false, xl: false })}
-      </Media>
-      <Media at="lg">
-        {renderCarousel({ xs: false, sm: false, xl: false })}
-      </Media>
-      <Media greaterThanOrEqual="xl">
-        {renderCarousel({ xs: false, sm: false, xl: true })}
-      </Media>
+      <Media lessThan="md">{renderCarousel({ xs: true, sm: true })}</Media>
+      <Media at="md">{renderCarousel({})}</Media>
+      <Media at="lg">{renderCarousel({})}</Media>
+      <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
       <Spacer pb={2} />
     </FeaturedCollectionsContainer>
   )
@@ -158,17 +150,9 @@ export const FeaturedCollectionEntity: React.FC<
         <Flex height={["190px", "190px", "280px", "280px"]}>
           <FeaturedImage src={thumbnail} />
         </Flex>
-        <Media lessThan="md">
-          <Serif size="4" mt={1} maxWidth="246px">
-            {title}
-          </Serif>
-        </Media>
-        <Media greaterThanOrEqual="md">
-          <Serif size="4" mt={1} maxWidth="100%">
-            {title}
-          </Serif>
-        </Media>
-
+        <Serif size="4" mt={1} maxWidth={["246px", "100%"]}>
+          {title}
+        </Serif>
         {price_guidance && (
           <Sans size="2" color="black60">{`From $${price_guidance}`}</Sans>
         )}

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -49,7 +49,13 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
     })
   }
 
-  const renderCarousel = breakpoints => {
+  interface Breakpoints {
+    xs?: boolean
+    sm?: boolean
+    xl?: boolean
+  }
+
+  const renderCarousel = (breakpoints: Breakpoints = {}) => {
     return (
       <Carousel
         height={breakpoints.xs || breakpoints.sm ? "430px" : "500px"}
@@ -96,8 +102,8 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
         {name}
       </Serif>
       <Media lessThan="md">{renderCarousel({ xs: true, sm: true })}</Media>
-      <Media at="md">{renderCarousel({})}</Media>
-      <Media at="lg">{renderCarousel({})}</Media>
+      <Media at="md">{renderCarousel()}</Media>
+      <Media at="lg">{renderCarousel()}</Media>
       <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
       <Spacer pb={2} />
     </FeaturedCollectionsContainer>


### PR DESCRIPTION
This `useMedia` hook shouldn't be used on this server so this PR refactors the featured collections rail to use the `<Media>` component instead.