### PR TITLE
Update fake hubs data with more accurate fake images

### DIFF
--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -1,7 +1,7 @@
 import { CSSGrid } from "@artsy/palette"
 import { Serif } from "@artsy/palette"
 import { CollectionsHubsHomepageNav_marketingCollections } from "__generated__/CollectionsHubsHomepageNav_marketingCollections.graphql"
-import { placeholderImage } from "Components/v2/CollectionsHubsNav"
+import { placeholderImages } from "Components/v2/CollectionsHubsNav"
 import React, { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ImageLink } from "./ImageLink"
@@ -26,7 +26,7 @@ export const CollectionsHubsHomepageNav: FC<
       {props.marketingCollections.map((hub, index) => (
         <ImageLink
           to={`/collection/${hub.slug}`}
-          src={placeholderImage}
+          src={placeholderImages[index]}
           ratio={[0.49]}
           title={<Serif size={["3", "4"]}>{hub.title}</Serif>}
           subtitle={<Serif size="2">{subtitleFor(hub.title, index)}</Serif>}

--- a/src/Components/v2/CollectionsHubsNav.tsx
+++ b/src/Components/v2/CollectionsHubsNav.tsx
@@ -21,10 +21,10 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
       ]}
       gridGap={20}
     >
-      {props.marketingCollections.map(hub => (
+      {props.marketingCollections.map((hub, i) => (
         <ImageLink
           to={`/collection/${hub.slug}`}
-          src={placeholderImage}
+          src={placeholderImages[i]}
           ratio={[0.49]}
           title={<Serif size="4t">{hub.title}</Serif>}
           key={hub.id}
@@ -34,9 +34,15 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
   )
 }
 
-// This is a temporary image URL until we get real data.
-export const placeholderImage =
-  "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeF_qAORql7lSnD2BwbFOYg%2Flarge.jpg"
+// These are temporary image URLs until we get real data.
+export const placeholderImages = [
+  "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAqIUxe69SL6dNmFSF7XgDg%2Flarge.jpg",
+  "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Faes0eLUVKs0oksAzap8NNw%2Flarge.jpg",
+  "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FxsGtXP5r6O6DkfUcBIjprQ%2Flarge.jpg",
+  "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWtPYZyT08x5_vMCy77bmWw%2Flarge.jpg",
+  "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FMK--4uZxx3BPS6ychTsW8A%2Flarge.jpg",
+  "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fill&width=357&height=175&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F8gwEs3lxHBSpvaITesYRXw%2Flarge.jpg",
+]
 
 export const CollectionsHubsNavFragmentContainer = createFragmentContainer(
   CollectionsHubsNav,


### PR DESCRIPTION
This PR updates the images for the fake hubs tiles to something less jarring, and hopefully less likely to prompt inquiries into whether the rail is broken.

The tiles look like this: 

![image](https://user-images.githubusercontent.com/1627089/65257167-68e92380-dac6-11e9-85bb-4f9d3478d04f.png)
 
It's still all temporary/fake data...until we can figure out how to get genes fully automated for the 6 hubs.