### PR TITLE
@eessex => [Error Handling] Only serve non 2XX pages on principalField errors

### DIFF
--- a/src/Artsy/Relay/middleware/metaphysicsErrorHandlerMiddleware.ts
+++ b/src/Artsy/Relay/middleware/metaphysicsErrorHandlerMiddleware.ts
@@ -1,0 +1,18 @@
+import { NetworkError } from "Utils/errors"
+
+export function metaphysicsErrorHandlerMiddleware({
+  checkStatus,
+}: {
+  checkStatus: boolean
+}) {
+  return next => async req => {
+    const response = await next(req)
+    if (!checkStatus || (response.status >= 200 && response.status < 300)) {
+      return response
+    } else {
+      const error = new NetworkError(response.statusText)
+      error.response = response
+      throw error
+    }
+  }
+}

--- a/src/Artsy/Relay/middleware/principalFieldErrorHandlerMiddleware.ts
+++ b/src/Artsy/Relay/middleware/principalFieldErrorHandlerMiddleware.ts
@@ -1,0 +1,18 @@
+import { HttpError } from "found"
+import { get } from "Utils/get"
+
+export function principalFieldErrorHandlerMiddleware() {
+  return next => async req => {
+    const res = await next(req)
+    const statusCode = get(
+      res,
+      r => r.json.extensions.principalField.httpStatusCode
+    )
+
+    if (statusCode) {
+      throw new HttpError(statusCode)
+    } else {
+      return res
+    }
+  }
+}

--- a/src/Artsy/Relay/middleware/searchBarImmediateResolveMiddleware.ts
+++ b/src/Artsy/Relay/middleware/searchBarImmediateResolveMiddleware.ts
@@ -1,0 +1,10 @@
+// TODO: Better introspection around if this is a SearchBar query,
+// or further refactoring to extract `addMiddlewareToEnvironment(environment)`,
+// to be used in the SearchBar QueryRenderer (for example).
+export function searchBarImmediateResolveMiddleware() {
+  return next => req => {
+    if (req.id === "SearchBarSuggestQuery" && req.variables.term === "")
+      return Promise.resolve({ data: { viewer: {} } })
+    return next(req)
+  }
+}

--- a/src/Artsy/Router/Utils/Route.tsx
+++ b/src/Artsy/Router/Utils/Route.tsx
@@ -7,7 +7,6 @@ import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
 import { HttpError } from "found"
 import BaseRoute from "found/lib/Route"
 import React from "react"
-import { get } from "Utils/get"
 
 type FetchIndicator = "spinner" | "overlay"
 
@@ -28,33 +27,8 @@ function createRender({
 }: CreateRenderProps) {
   return (renderArgs: RenderArgProps) => {
     const { Component, props, error } = renderArgs
-    let status: number
-    let message: string
-    if (error) {
-      if (error instanceof HttpError) {
-        throw error
-      } else if (error.name === "RRNLRequestError") {
-        // TODO: Better error typing.
-        // @ts-ignore
-        const firstError = get(error, e => e.res.errors[0])
-        const statusCodes = get(
-          firstError,
-          e => e.extensions.httpStatusCodes,
-          []
-        )
-        if (statusCodes.length === 1) {
-          status = statusCodes[0]
-          message = firstError.message
-        }
-      } else {
-        status = 500
-        message = error.message
-      }
-
-      // TODO: Need upstream fix type in found as it complains about missing
-      // second argument.
-      // @ts-ignore
-      throw new HttpError(status, message)
+    if (error && error instanceof HttpError) {
+      throw error
     }
 
     if (render) {


### PR DESCRIPTION
aka unleash partial renders.

Doing some testing of this locally, and it seems to do what we want!

I ran Reaction linked with Force, pointing to local Metaphysics.

I then went into the resolvers for some of the leafs used in the artwork page, and intentionally threw errors there (to mimic an upstream service/fetch failing).

Intentionally threw an error when fetching some of the grids in 'Other Works', threw an error when fetching sale data and threw an error when fetching Vortex price histogram data.

In all cases without this change, a 500 was served. With this change, the page rendered with a 200, and at least in these specific examples, there didn't seem to be any negative affect on UI/layout.

Some info was just missing, an entire artwork grid in 'Other Works' was gone, but the page seemed pretty happy to me! There were no null/exist-y related crashes.

I let this as a [HOLD] b/c this unleashes partial renders.

 