### PR TITLE
Handle collections header flicker

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/Header/DefaultHeader.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/DefaultHeader.tsx
@@ -58,7 +58,7 @@ export const CollectionDefaultHeader: FC<Props> = ({
             return (
               <a
                 href={artwork.href}
-                key={i}
+                key={artwork.href}
                 onClick={() => {
                   trackEvent({
                     action_type: AnalyticsSchema.ActionType.Click,

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
@@ -214,6 +214,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     mb={3}
                     headerImageUrl={resizedHeaderImage}
                     height={imageHeight}
+                    key="singleImageHeader"
                   >
                     <Overlay />
                     {collection.credit && (
@@ -228,6 +229,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     defaultHeaderImageHeight={defaultHeaderImageHeight[size]}
                     collection_id={collection.id}
                     collection_slug={collection.slug}
+                    key="defaultHeader"
                   />
                 )}
                 <MetaContainer mb={2} mt={[0, imageHeightSizes.sm + space(3)]}>


### PR DESCRIPTION
This PR attempts to address the flickering effect when navigating between various collection hubs (the header switches on initial page load). 

[Links to GROW-1506](https://artsyproduct.atlassian.net/browse/GROW-1506)

![Kapture 2019-09-20 at 12 46 38](https://user-images.githubusercontent.com/10385964/65344171-f0a55f80-dba4-11e9-9410-e4383adb477b.gif)
 