### PR TITLE
PURCHASE-1091: Buyer receives a more friendly, informative error when their card is declined in checkout

### DIFF
--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -91,7 +91,9 @@ export class NewPaymentRoute extends Component<
 
       if (result.type === "error") {
         this.props.dialog.showErrorDialog({
-          message: result.error,
+          title: "Your card was declined",
+          message:
+            "Please enter another payment method or contact your bank for more information.",
         })
         return
       }

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -74,7 +74,9 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
 
       if (result.type === "error") {
         this.props.dialog.showErrorDialog({
-          message: result.error,
+          title: "Your card was declined",
+          message:
+            "Please enter another payment method or contact your bank for more information.",
         })
         return
       }

--- a/src/Apps/Order/Routes/__tests__/NewPayment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/NewPayment.test.tsx
@@ -175,8 +175,8 @@ describe("Payment", () => {
     const page = await buildPage()
     await page.clickSubmit()
     await page.expectAndDismissErrorDialogMatching(
-      "An error occurred",
-      "This is the description of an error."
+      "Your card was declined",
+      "Please enter another payment method or contact your bank for more information."
     )
   })
 

--- a/src/Apps/Order/Routes/__tests__/Payment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.test.tsx
@@ -99,8 +99,8 @@ describe("Payment", () => {
     const page = await buildPage()
     await page.clickSubmit()
     await page.expectAndDismissErrorDialogMatching(
-      "An error occurred",
-      "This is the description of an error."
+      "Your card was declined",
+      "Please enter another payment method or contact your bank for more information."
     )
   })
 


### PR DESCRIPTION
[PURCHASE-1091]
Desired Behavior:
Heading: Your card was declined
Body: Please enter another payment method or contact your bank for more information.
CTA: Continue

__Before:__
<img width="312" alt="Screen Shot 2019-09-20 at 1 42 13 PM" src="https://user-images.githubusercontent.com/5643895/65347590-50a00400-dbad-11e9-8051-9cee031ce7d6.png">

__After:__
<img width="332" alt="Screen Shot 2019-09-20 at 1 39 37 PM" src="https://user-images.githubusercontent.com/5643895/65347597-55fd4e80-dbad-11e9-9d7c-a20fbd1ae284.png">


[PURCHASE-1091]: https://artsyproduct.atlassian.net/browse/PURCHASE-1091