### PR TITLE
Fix ArtistCollectionsRail's fetching of collections' artworks

### DIFF
--- a/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionEntity.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionEntity.tsx
@@ -30,14 +30,15 @@ export class ArtistCollectionEntity extends React.Component<CollectionProps> {
 
   render() {
     const {
-      artworks: { hits },
       headerImage,
       price_guidance,
       slug,
       title,
+      artworks: { artworks_connection },
     } = this.props.collection
+    const artworks = artworks_connection.edges.map(({ node }) => node)
     const formattedTitle = (title && title.split(": ")[1]) || title
-    const bgImages = compact(hits.map(hit => hit.image && hit.image.url))
+    const bgImages = compact(artworks.map(({ image }) => image && image.url))
     const imageSize =
       bgImages.length === 1 ? 265 : bgImages.length === 2 ? 131 : 85
 
@@ -50,9 +51,9 @@ export class ArtistCollectionEntity extends React.Component<CollectionProps> {
           <ImgWrapper pb={1}>
             {bgImages.length ? (
               bgImages.map((url, i) => {
-                const artistName = get(hits[i].artist, a => a.name)
+                const artistName = get(artworks[i].artist, a => a.name)
                 const alt = `${artistName ? artistName + ", " : ""}${
-                  hits[i].title
+                  artworks[i].title
                 }`
                 return (
                   <SingleImgContainer key={i}>
@@ -150,14 +151,18 @@ export const ArtistCollectionEntityFragmentContainer = createFragmentContainer(
         slug
         title
         price_guidance
-        artworks(size: 3, sort: "-decayed_merch") {
-          hits {
-            artist {
-              name
-            }
-            title
-            image {
-              url(version: "small")
+        artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
+          artworks_connection(first: 3) {
+            edges {
+              node {
+                artist {
+                  name
+                }
+                title
+                image {
+                  url(version: "small")
+                }
+              }
             }
           }
         }

--- a/src/Apps/Artist/Components/ArtistCollectionsRail/__tests__/ArtistCollectionEntity.test.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/__tests__/ArtistCollectionEntity.test.tsx
@@ -36,10 +36,12 @@ describe("ArtistCollectionEntity", () => {
       collection: {
         ...collection,
         artworks: {
-          hits: [
-            props.collection.artworks.hits[0],
-            props.collection.artworks.hits[1],
-          ],
+          artworks_connection: {
+            edges: [
+              props.collection.artworks.artworks_connection.edges[0],
+              props.collection.artworks.artworks_connection.edges[1],
+            ],
+          },
         },
       },
     }
@@ -62,14 +64,19 @@ describe("ArtistCollectionEntity", () => {
       collection: {
         ...collection,
         artworks: {
-          hits: [
-            {
-              ...props.collection.artworks.hits[0],
-              image: null,
-            },
-            props.collection.artworks.hits[1],
-            props.collection.artworks.hits[2],
-          ],
+          artworks_connection: {
+            edges: [
+              {
+                node: {
+                  ...props.collection.artworks.artworks_connection.edges[0]
+                    .node,
+                  image: null,
+                },
+              },
+              props.collection.artworks.artworks_connection.edges[1],
+              props.collection.artworks.artworks_connection.edges[2],
+            ],
+          },
         },
       },
     }
@@ -92,7 +99,7 @@ describe("ArtistCollectionEntity", () => {
       collection: {
         ...collection,
         artworks: {
-          hits: [],
+          artworks_connection: { edges: [] },
         },
       },
     }

--- a/src/Apps/Artist/Components/ArtistCollectionsRail/__tests__/ArtistCollectionsRail.test.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/__tests__/ArtistCollectionsRail.test.tsx
@@ -74,38 +74,46 @@ describe("CollectionsRail", () => {
         title: "Jasper Johns: Flags Part 2",
         price_guidance: 1000,
         artworks: {
-          hits: [
-            {
-              artist: {
-                name: "Jasper Johns",
+          artworks_connection: {
+            edges: [
+              {
+                node: {
+                  artist: {
+                    name: "Jasper Johns",
+                  },
+                  title: "Flag",
+                  image: {
+                    url:
+                      "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                  },
+                },
               },
-              title: "Flag",
-              image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+              {
+                node: {
+                  artist: {
+                    name: "Jasper Johns",
+                  },
+                  title: "Flag (Moratorium)",
+                  image: {
+                    url:
+                      "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+                  },
+                },
               },
-            },
-            {
-              artist: {
-                name: "Jasper Johns",
+              {
+                node: {
+                  artist: {
+                    name: "Jasper Johns",
+                  },
+                  title: "Flag I",
+                  image: {
+                    url:
+                      "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+                  },
+                },
               },
-              title: "Flag (Moratorium)",
-              image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
-              },
-            },
-            {
-              artist: {
-                name: "Jasper Johns",
-              },
-              title: "Flag I",
-              image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
-              },
-            },
-          ],
+            ],
+          },
         },
       })
       const updatedCollections = { collections: collectionsCopy }

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -19,8 +19,15 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
   member,
   itemNumber,
 }) => {
-  const { headerImage, artworks, price_guidance, slug, title } = member
-  const bgImages = artworks!.hits!.map(hit => hit!.image!.url)
+  const {
+    headerImage,
+    artworks: { artworks_connection },
+    price_guidance,
+    slug,
+    title,
+  } = member
+  const artworks = artworks_connection.edges.map(({ node }) => node)
+  const bgImages = artworks.map(({ image }) => image && image.url)
   const imageSize =
     bgImages!.length === 1 ? 221 : bgImages!.length === 2 ? 109 : 72
 
@@ -43,7 +50,7 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
         <ImgWrapper>
           {bgImages!.length
             ? bgImages.map((url, i) => {
-                const hit = artworks!.hits![i]
+                const hit = artworks![i]
                 const artistName = get(hit!.artist, a => a!.name)
                 const alt = `${artistName ? artistName + ", " : ""}${
                   hit!.title
@@ -148,14 +155,19 @@ export const ArtistSeriesRailContainer = createFragmentContainer(
         thumbnail
         title
         price_guidance
-        artworks(size: 3, sort: "-decayed_merch") {
-          hits {
-            artist {
-              name
-            }
-            title
-            image {
-              url(version: "small")
+
+        artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
+          artworks_connection(first: 3) {
+            edges {
+              node {
+                artist {
+                  name
+                }
+                title
+                image {
+                  url(version: "small")
+                }
+              }
             }
           }
         }

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesEntity.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesEntity.test.tsx
@@ -59,7 +59,7 @@ describe("ArtistSeriesEntity", () => {
   })
 
   it("uses medium image width when there are only 2 hits", () => {
-    props.member.artworks.hits.pop()
+    props.member.artworks.artworks_connection.edges.pop()
     const component = mount(<ArtistSeriesEntity {...props} />)
     expect(component.find(ArtworkImage).length).toBe(2)
     expect(
@@ -71,7 +71,7 @@ describe("ArtistSeriesEntity", () => {
   })
 
   it("uses large image width when there is exactly 1 hit", () => {
-    props.member.artworks.hits.pop()
+    props.member.artworks.artworks_connection.edges.pop()
     const component = mount(<ArtistSeriesEntity {...props} />)
     expect(component.find(ArtworkImage).length).toBe(1)
     expect(
@@ -93,7 +93,8 @@ describe("ArtistSeriesEntity", () => {
   })
 
   it("uses the artist name and title for alt text if there is an artist", () => {
-    props.member.artworks.hits[0].artist.name = "Jasper Johns"
+    props.member.artworks.artworks_connection.edges[0].node.artist.name =
+      "Jasper Johns"
     const component = mount(<ArtistSeriesEntity {...props} />)
     expect(
       component

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
@@ -27,18 +27,22 @@ describe("ArtistSeriesRail", () => {
       title: "1787 keyboard",
       price_guidance: 10000,
       artworks: {
-        hits: [
-          {
-            artist: {
-              name: "Jasper Johns",
+        artworks_connection: {
+          edges: [
+            {
+              node: {
+                artist: {
+                  name: "Jasper Johns",
+                },
+                title: "keyborad",
+                image: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                },
+              },
             },
-            title: "keyborad",
-            image: {
-              url:
-                "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
-            },
-          },
-        ],
+          ],
+        },
       },
     }
   }

--- a/src/Apps/__tests__/Fixtures/Collections.ts
+++ b/src/Apps/__tests__/Fixtures/Collections.ts
@@ -43,38 +43,46 @@ export const CollectionsRailFixture = [
     title: "Jasper Johns: Flags",
     price_guidance: 1000,
     artworks: {
-      hits: [
-        {
-          artist: {
-            name: "Jasper Johns",
+      artworks_connection: {
+        edges: [
+          {
+            node: {
+              artist: {
+                name: "Jasper Johns",
+              },
+              title: "Flag",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+              },
+            },
           },
-          title: "Flag",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+          {
+            node: {
+              artist: {
+                name: "Jasper Johns",
+              },
+              title: "Flag (Moratorium)",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+              },
+            },
           },
-        },
-        {
-          artist: {
-            name: "Jasper Johns",
+          {
+            node: {
+              artist: {
+                name: "Jasper Johns",
+              },
+              title: "Flag I",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+              },
+            },
           },
-          title: "Flag (Moratorium)",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
-          },
-        },
-        {
-          artist: {
-            name: "Jasper Johns",
-          },
-          title: "Flag I",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
-          },
-        },
-      ],
+        ],
+      },
     },
   },
   {
@@ -83,38 +91,46 @@ export const CollectionsRailFixture = [
     title: "Street Art Now",
     price_guidance: 200,
     artworks: {
-      hits: [
-        {
-          artist: {
-            name: "Alec Monopoly",
+      artworks_connection: {
+        edges: [
+          {
+            node: {
+              artist: {
+                name: "Alec Monopoly",
+              },
+              title: "Community Chest: Go To Jail",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/DSa-4s-zRJEwW6mZRgDoxQ/small.jpg",
+              },
+            },
           },
-          title: "Community Chest: Go To Jail",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/DSa-4s-zRJEwW6mZRgDoxQ/small.jpg",
+          {
+            node: {
+              artist: {
+                name: "Alec Monopoly",
+              },
+              title: "DJ Monopoly",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/L0wx7i69h96MUFq9EgOpBQ/small.jpg",
+              },
+            },
           },
-        },
-        {
-          artist: {
-            name: "Alec Monopoly",
+          {
+            node: {
+              artist: {
+                name: "Keith Haring",
+              },
+              title: "Keith Haring 1982 Dolphin lithograph",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/ZZodXz8Y7v7h0VWlQnZQCw/small.jpg",
+              },
+            },
           },
-          title: "DJ Monopoly",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/L0wx7i69h96MUFq9EgOpBQ/small.jpg",
-          },
-        },
-        {
-          artist: {
-            name: "Keith Haring",
-          },
-          title: "Keith Haring 1982 Dolphin lithograph",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/ZZodXz8Y7v7h0VWlQnZQCw/small.jpg",
-          },
-        },
-      ],
+        ],
+      },
     },
   },
   {
@@ -124,38 +140,46 @@ export const CollectionsRailFixture = [
     title: "Contemporary Limited Editions",
     price_guidance: 1000,
     artworks: {
-      hits: [
-        {
-          artist: {
-            name: "Kiki Smith",
+      artworks_connection: {
+        edges: [
+          {
+            node: {
+              artist: {
+                name: "Kiki Smith",
+              },
+              title: "Untitled",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/VzteQ4joB2Iwjek9kPUrGg/small.jpg",
+              },
+            },
           },
-          title: "Untitled",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/VzteQ4joB2Iwjek9kPUrGg/small.jpg",
+          {
+            node: {
+              artist: {
+                name: "Gerhard Richter",
+              },
+              title: "P8",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/ZN_qyzZgvHz-DRMFW-Wrcw/small.jpg",
+              },
+            },
           },
-        },
-        {
-          artist: {
-            name: "Gerhard Richter",
+          {
+            node: {
+              artist: {
+                name: "Robert Longo",
+              },
+              title: "Monsters",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/0vJm9FeXzxzZJpBC-A-4ig/small.jpg",
+              },
+            },
           },
-          title: "P8",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/ZN_qyzZgvHz-DRMFW-Wrcw/small.jpg",
-          },
-        },
-        {
-          artist: {
-            name: "Robert Longo",
-          },
-          title: "Monsters",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/0vJm9FeXzxzZJpBC-A-4ig/small.jpg",
-          },
-        },
-      ],
+        ],
+      },
     },
   },
   {
@@ -164,38 +188,46 @@ export const CollectionsRailFixture = [
     title: "Timeless Modern Prints",
     price_guidance: 2500,
     artworks: {
-      hits: [
-        {
-          artist: {
-            name: "Joan Miró",
+      artworks_connection: {
+        edges: [
+          {
+            node: {
+              artist: {
+                name: "Joan Miró",
+              },
+              title: "Migratory Bird I",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/_67k2lYpopsd-UK6LOD61g/small.jpg",
+              },
+            },
           },
-          title: "Migratory Bird I",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/_67k2lYpopsd-UK6LOD61g/small.jpg",
+          {
+            node: {
+              artist: {
+                name: "Pablo Picasso",
+              },
+              title: "Bacchanale",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/mepJj80_m4NiWUJviymyBw/small.jpg",
+              },
+            },
           },
-        },
-        {
-          artist: {
-            name: "Pablo Picasso",
+          {
+            node: {
+              artist: {
+                name: "Josef Albers",
+              },
+              title: "Mitered Squares-Apricot ",
+              image: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/CbgUJdNK5lWvhKzziYgx7w/small.jpg",
+              },
+            },
           },
-          title: "Bacchanale",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/mepJj80_m4NiWUJviymyBw/small.jpg",
-          },
-        },
-        {
-          artist: {
-            name: "Josef Albers",
-          },
-          title: "Mitered Squares-Apricot ",
-          image: {
-            url:
-              "https://d32dm0rphc51dk.cloudfront.net/CbgUJdNK5lWvhKzziYgx7w/small.jpg",
-          },
-        },
-      ],
+        ],
+      },
     },
   },
 ]
@@ -283,38 +315,46 @@ export const CollectionsHubLinkedCollections = {
           title: "Flags unique collections",
           price_guidance: 1000,
           artworks: {
-            hits: [
-              {
-                artist: {
-                  // null
+            artworks_connection: {
+              edges: [
+                {
+                  node: {
+                    artist: {
+                      // null
+                    },
+                    title: "A great flag from Jasper",
+                    image: {
+                      url:
+                        "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                    },
+                  },
                 },
-                title: "A great flag from Jasper",
-                image: {
-                  url:
-                    "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                {
+                  node: {
+                    artist: {
+                      name: "Jasper Johns",
+                    },
+                    title: "Back to 2046",
+                    image: {
+                      url:
+                        "https://d32dm0rp11hc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                    },
+                  },
                 },
-              },
-              {
-                artist: {
-                  name: "Jasper Johns",
+                {
+                  node: {
+                    artist: {
+                      name: "Andy Warhol",
+                    },
+                    title: "An Apple",
+                    image: {
+                      url:
+                        "https://d32142dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                    },
+                  },
                 },
-                title: "Back to 2046",
-                image: {
-                  url:
-                    "https://d32dm0rp11hc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
-                },
-              },
-              {
-                artist: {
-                  name: "Andy Warhol",
-                },
-                title: "An Apple",
-                image: {
-                  url:
-                    "https://d32142dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
-                },
-              },
-            ],
+              ],
+            },
           },
         },
       ],

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -3,7 +3,7 @@ import { RelatedCollectionEntity_collection } from "__generated__/RelatedCollect
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import currency from "currency.js"
-import { map } from "lodash"
+import { compact } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -29,13 +29,14 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
 
   render() {
     const {
-      artworks: { hits },
+      artworks: { artworks_connection },
       headerImage,
       price_guidance,
       slug,
       title,
     } = this.props.collection
-    const bgImages = map(hits, "image.url")
+    const artworks = artworks_connection.edges.map(({ node }) => node)
+    const bgImages = compact(artworks.map(({ image }) => image && image.url))
     const imageSize =
       bgImages.length === 1 ? 265 : bgImages.length === 2 ? 131 : 85
 
@@ -45,12 +46,13 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
           href={`${sd.APP_URL}/collection/${slug}`}
           onClick={this.onLinkClick.bind(this)}
         >
+          Hey!
           <ImgWrapper pb={1}>
             {bgImages.length ? (
               bgImages.map((url, i) => {
-                const artistName = get(hits[i].artist, a => a.name)
+                const artistName = get(artworks[i].artist, a => a.name)
                 const alt = `${artistName ? artistName + ", " : ""}${
-                  hits[i].title
+                  artworks[i].title
                 }`
                 return (
                   <SingleImgContainer key={i}>
@@ -68,7 +70,6 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
               <ArtworkImage src={headerImage} width={265} />
             )}
           </ImgWrapper>
-
           <CollectionTitle size="3">{title}</CollectionTitle>
           {price_guidance && (
             <Sans size="2" color="black60">
@@ -142,14 +143,18 @@ export const RelatedCollectionEntityFragmentContainer = createFragmentContainer(
         slug
         title
         price_guidance
-        artworks(size: 3, sort: "-decayed_merch") {
-          hits {
-            artist {
-              name
-            }
-            title
-            image {
-              url(version: "small")
+        artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
+          artworks_connection(first: 3) {
+            edges {
+              node {
+                artist {
+                  name
+                }
+                title
+                image {
+                  url(version: "small")
+                }
+              }
             }
           }
         }

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -46,7 +46,6 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
           href={`${sd.APP_URL}/collection/${slug}`}
           onClick={this.onLinkClick.bind(this)}
         >
-          Hey!
           <ImgWrapper pb={1}>
             {bgImages.length ? (
               bgImages.map((url, i) => {

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionEntity.test.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionEntity.test.tsx
@@ -38,7 +38,7 @@ describe("RelatedCollectionEntity", () => {
   })
 
   it("Returns proper image size if 2 artworks returned", () => {
-    props.collection.artworks.hits.pop()
+    props.collection.artworks.artworks_connection.edges.pop()
     const component = mount(<RelatedCollectionEntity {...props} />)
     const artworkImage = component
       .find(ArtworkImage)
@@ -50,7 +50,7 @@ describe("RelatedCollectionEntity", () => {
   })
 
   it("Renders a backup image if no artworks returned", () => {
-    props.collection.artworks.hits = []
+    props.collection.artworks.artworks_connection.edges = []
     const component = mount(<RelatedCollectionEntity {...props} />)
     const artworkImage = component
       .find(ArtworkImage)

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.test.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.test.tsx
@@ -75,38 +75,46 @@ describe("CollectionsRail", () => {
         title: "Jasper Johns: Flags Part 2",
         price_guidance: 1000,
         artworks: {
-          hits: [
-            {
-              artist: {
-                name: "Jasper Johns",
+          artworks_connection: {
+            edges: [
+              {
+                node: {
+                  artist: {
+                    name: "Jasper Johns",
+                  },
+                  title: "Flag",
+                  image: {
+                    url:
+                      "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                  },
+                },
               },
-              title: "Flag",
-              image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+              {
+                node: {
+                  artist: {
+                    name: "Jasper Johns",
+                  },
+                  title: "Flag (Moratorium)",
+                  image: {
+                    url:
+                      "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+                  },
+                },
               },
-            },
-            {
-              artist: {
-                name: "Jasper Johns",
+              {
+                node: {
+                  artist: {
+                    name: "Jasper Johns",
+                  },
+                  title: "Flag I",
+                  image: {
+                    url:
+                      "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+                  },
+                },
               },
-              title: "Flag (Moratorium)",
-              image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
-              },
-            },
-            {
-              artist: {
-                name: "Jasper Johns",
-              },
-              title: "Flag I",
-              image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
-              },
-            },
-          ],
+            ],
+          },
         },
       })
 

--- a/src/__generated__/ArtistCollectionEntity_collection.graphql.ts
+++ b/src/__generated__/ArtistCollectionEntity_collection.graphql.ts
@@ -9,15 +9,19 @@ export type ArtistCollectionEntity_collection = {
     readonly title: string;
     readonly price_guidance: number | null;
     readonly artworks: ({
-        readonly hits: ReadonlyArray<({
-            readonly artist: ({
-                readonly name: string | null;
-            }) | null;
-            readonly title: string | null;
-            readonly image: ({
-                readonly url: string | null;
-            }) | null;
-        }) | null> | null;
+        readonly artworks_connection: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly artist: ({
+                        readonly name: string | null;
+                    }) | null;
+                    readonly title: string | null;
+                    readonly image: ({
+                        readonly url: string | null;
+                    }) | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
     }) | null;
     readonly " $refType": ArtistCollectionEntity_collection$ref;
 };
@@ -79,13 +83,15 @@ return {
       "kind": "LinkedField",
       "alias": null,
       "name": "artworks",
-      "storageKey": "artworks(size:3,sort:\"-decayed_merch\")",
+      "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
       "args": [
         {
           "kind": "Literal",
-          "name": "size",
-          "value": 3,
-          "type": "Int"
+          "name": "aggregations",
+          "value": [
+            "TOTAL"
+          ],
+          "type": "[ArtworkAggregation]"
         },
         {
           "kind": "Literal",
@@ -100,59 +106,88 @@ return {
         {
           "kind": "LinkedField",
           "alias": null,
-          "name": "hits",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "Artwork",
-          "plural": true,
+          "name": "artworks_connection",
+          "storageKey": "artworks_connection(first:3)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 3,
+              "type": "Int"
+            }
+          ],
+          "concreteType": "ArtworkConnection",
+          "plural": false,
           "selections": [
             {
               "kind": "LinkedField",
               "alias": null,
-              "name": "artist",
+              "name": "edges",
               "storageKey": null,
               "args": null,
-              "concreteType": "Artist",
-              "plural": false,
+              "concreteType": "ArtworkEdge",
+              "plural": true,
               "selections": [
                 {
-                  "kind": "ScalarField",
+                  "kind": "LinkedField",
                   "alias": null,
-                  "name": "name",
+                  "name": "node",
+                  "storageKey": null,
                   "args": null,
-                  "storageKey": null
-                },
-                v1
-              ]
-            },
-            v0,
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "image",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "Image",
-              "plural": false,
-              "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "url",
-                  "args": [
+                  "concreteType": "Artwork",
+                  "plural": false,
+                  "selections": [
                     {
-                      "kind": "Literal",
-                      "name": "version",
-                      "value": "small",
-                      "type": "[String]"
-                    }
-                  ],
-                  "storageKey": "url(version:\"small\")"
-                },
-                v2
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "artist",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Artist",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "name",
+                          "args": null,
+                          "storageKey": null
+                        },
+                        v1
+                      ]
+                    },
+                    v0,
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "image",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "url",
+                          "args": [
+                            {
+                              "kind": "Literal",
+                              "name": "version",
+                              "value": "small",
+                              "type": "[String]"
+                            }
+                          ],
+                          "storageKey": "url(version:\"small\")"
+                        },
+                        v2
+                      ]
+                    },
+                    v1
+                  ]
+                }
               ]
-            },
-            v1
+            }
           ]
         },
         v1
@@ -162,5 +197,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '457be8470973167da1f503b33d78a395';
+(node as any).hash = '288b038a5e57b8a4730f120cb06796ef';
 export default node;

--- a/src/__generated__/ArtistCollectionsRailQuery.graphql.ts
+++ b/src/__generated__/ArtistCollectionsRailQuery.graphql.ts
@@ -41,18 +41,22 @@ fragment ArtistCollectionEntity_collection on MarketingCollection {
   slug
   title
   price_guidance
-  artworks(size: 3, sort: "-decayed_merch") {
-    hits {
-      artist {
-        name
-        __id
+  artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
+    artworks_connection(first: 3) {
+      edges {
+        node {
+          artist {
+            name
+            __id
+          }
+          title
+          image {
+            url(version: "small")
+            __id: id
+          }
+          __id
+        }
       }
-      title
-      image {
-        url(version: "small")
-        __id: id
-      }
-      __id
     }
     __id
   }
@@ -127,7 +131,7 @@ return {
   "operationKind": "query",
   "name": "ArtistCollectionsRailQuery",
   "id": null,
-  "text": "query ArtistCollectionsRailQuery(\n  $isFeaturedArtistContent: Boolean\n  $size: Int\n  $artistID: String\n) {\n  collections: marketingCollections(isFeaturedArtistContent: $isFeaturedArtistContent, size: $size, artistID: $artistID) {\n    ...ArtistCollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n  __id: id\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(size: 3, sort: \"-decayed_merch\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n        __id: id\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query ArtistCollectionsRailQuery(\n  $isFeaturedArtistContent: Boolean\n  $size: Int\n  $artistID: String\n) {\n  collections: marketingCollections(isFeaturedArtistContent: $isFeaturedArtistContent, size: $size, artistID: $artistID) {\n    ...ArtistCollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n  __id: id\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            url(version: \"small\")\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -195,13 +199,15 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "artworks",
-            "storageKey": "artworks(size:3,sort:\"-decayed_merch\")",
+            "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
             "args": [
               {
                 "kind": "Literal",
-                "name": "size",
-                "value": 3,
-                "type": "Int"
+                "name": "aggregations",
+                "value": [
+                  "TOTAL"
+                ],
+                "type": "[ArtworkAggregation]"
               },
               {
                 "kind": "Literal",
@@ -216,59 +222,88 @@ return {
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "hits",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Artwork",
-                "plural": true,
+                "name": "artworks_connection",
+                "storageKey": "artworks_connection(first:3)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 3,
+                    "type": "Int"
+                  }
+                ],
+                "concreteType": "ArtworkConnection",
+                "plural": false,
                 "selections": [
                   {
                     "kind": "LinkedField",
                     "alias": null,
-                    "name": "artist",
+                    "name": "edges",
                     "storageKey": null,
                     "args": null,
-                    "concreteType": "Artist",
-                    "plural": false,
+                    "concreteType": "ArtworkEdge",
+                    "plural": true,
                     "selections": [
                       {
-                        "kind": "ScalarField",
+                        "kind": "LinkedField",
                         "alias": null,
-                        "name": "name",
+                        "name": "node",
+                        "storageKey": null,
                         "args": null,
-                        "storageKey": null
-                      },
-                      v4
-                    ]
-                  },
-                  v3,
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "image",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "Image",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "url",
-                        "args": [
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
                           {
-                            "kind": "Literal",
-                            "name": "version",
-                            "value": "small",
-                            "type": "[String]"
-                          }
-                        ],
-                        "storageKey": "url(version:\"small\")"
-                      },
-                      v2
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "artist",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "name",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              v4
+                            ]
+                          },
+                          v3,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "small",
+                                    "type": "[String]"
+                                  }
+                                ],
+                                "storageKey": "url(version:\"small\")"
+                              },
+                              v2
+                            ]
+                          },
+                          v4
+                        ]
+                      }
                     ]
-                  },
-                  v4
+                  }
                 ]
               },
               v4

--- a/src/__generated__/ArtistSeriesEntity_member.graphql.ts
+++ b/src/__generated__/ArtistSeriesEntity_member.graphql.ts
@@ -10,15 +10,19 @@ export type ArtistSeriesEntity_member = {
     readonly title: string;
     readonly price_guidance: number | null;
     readonly artworks: ({
-        readonly hits: ReadonlyArray<({
-            readonly artist: ({
-                readonly name: string | null;
-            }) | null;
-            readonly title: string | null;
-            readonly image: ({
-                readonly url: string | null;
-            }) | null;
-        }) | null> | null;
+        readonly artworks_connection: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly artist: ({
+                        readonly name: string | null;
+                    }) | null;
+                    readonly title: string | null;
+                    readonly image: ({
+                        readonly url: string | null;
+                    }) | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
     }) | null;
     readonly " $refType": ArtistSeriesEntity_member$ref;
 };
@@ -87,13 +91,15 @@ return {
       "kind": "LinkedField",
       "alias": null,
       "name": "artworks",
-      "storageKey": "artworks(size:3,sort:\"-decayed_merch\")",
+      "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
       "args": [
         {
           "kind": "Literal",
-          "name": "size",
-          "value": 3,
-          "type": "Int"
+          "name": "aggregations",
+          "value": [
+            "TOTAL"
+          ],
+          "type": "[ArtworkAggregation]"
         },
         {
           "kind": "Literal",
@@ -108,59 +114,88 @@ return {
         {
           "kind": "LinkedField",
           "alias": null,
-          "name": "hits",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "Artwork",
-          "plural": true,
+          "name": "artworks_connection",
+          "storageKey": "artworks_connection(first:3)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 3,
+              "type": "Int"
+            }
+          ],
+          "concreteType": "ArtworkConnection",
+          "plural": false,
           "selections": [
             {
               "kind": "LinkedField",
               "alias": null,
-              "name": "artist",
+              "name": "edges",
               "storageKey": null,
               "args": null,
-              "concreteType": "Artist",
-              "plural": false,
+              "concreteType": "ArtworkEdge",
+              "plural": true,
               "selections": [
                 {
-                  "kind": "ScalarField",
+                  "kind": "LinkedField",
                   "alias": null,
-                  "name": "name",
+                  "name": "node",
+                  "storageKey": null,
                   "args": null,
-                  "storageKey": null
-                },
-                v1
-              ]
-            },
-            v0,
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "image",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "Image",
-              "plural": false,
-              "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "url",
-                  "args": [
+                  "concreteType": "Artwork",
+                  "plural": false,
+                  "selections": [
                     {
-                      "kind": "Literal",
-                      "name": "version",
-                      "value": "small",
-                      "type": "[String]"
-                    }
-                  ],
-                  "storageKey": "url(version:\"small\")"
-                },
-                v2
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "artist",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Artist",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "name",
+                          "args": null,
+                          "storageKey": null
+                        },
+                        v1
+                      ]
+                    },
+                    v0,
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "image",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "url",
+                          "args": [
+                            {
+                              "kind": "Literal",
+                              "name": "version",
+                              "value": "small",
+                              "type": "[String]"
+                            }
+                          ],
+                          "storageKey": "url(version:\"small\")"
+                        },
+                        v2
+                      ]
+                    },
+                    v1
+                  ]
+                }
               ]
-            },
-            v1
+            }
           ]
         },
         v1
@@ -170,5 +205,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'f0796074d0cd80d143104b3f1751e201';
+(node as any).hash = '37c70de561375cea9b334ff8d670fdc7';
 export default node;

--- a/src/__generated__/CollectionRefetch2Query.graphql.ts
+++ b/src/__generated__/CollectionRefetch2Query.graphql.ts
@@ -425,18 +425,22 @@ fragment ArtistSeriesEntity_member on MarketingCollection {
   thumbnail
   title
   price_guidance
-  artworks(size: 3, sort: "-decayed_merch") {
-    hits {
-      artist {
-        name
-        __id
+  artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
+    artworks_connection(first: 3) {
+      edges {
+        node {
+          artist {
+            name
+            __id
+          }
+          title
+          image {
+            url(version: "small")
+            __id: id
+          }
+          __id
+        }
       }
-      title
-      image {
-        url(version: "small")
-        __id: id
-      }
-      __id
     }
     __id
   }
@@ -455,18 +459,22 @@ fragment RelatedCollectionEntity_collection on MarketingCollection {
   slug
   title
   price_guidance
-  artworks(size: 3, sort: "-decayed_merch") {
-    hits {
-      artist {
-        name
-        __id
+  artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
+    artworks_connection(first: 3) {
+      edges {
+        node {
+          artist {
+            name
+            __id
+          }
+          title
+          image {
+            url(version: "small")
+            __id: id
+          }
+          __id
+        }
       }
-      title
-      image {
-        url(version: "small")
-        __id: id
-      }
-      __id
     }
     __id
   }
@@ -664,13 +672,15 @@ v14 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "artworks",
-  "storageKey": "artworks(size:3,sort:\"-decayed_merch\")",
+  "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
   "args": [
     {
       "kind": "Literal",
-      "name": "size",
-      "value": 3,
-      "type": "Int"
+      "name": "aggregations",
+      "value": [
+        "TOTAL"
+      ],
+      "type": "[ArtworkAggregation]"
     },
     v10
   ],
@@ -680,50 +690,79 @@ v14 = {
     {
       "kind": "LinkedField",
       "alias": null,
-      "name": "hits",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "Artwork",
-      "plural": true,
+      "name": "artworks_connection",
+      "storageKey": "artworks_connection(first:3)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 3,
+          "type": "Int"
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "plural": false,
       "selections": [
         {
           "kind": "LinkedField",
           "alias": null,
-          "name": "artist",
+          "name": "edges",
           "storageKey": null,
           "args": null,
-          "concreteType": "Artist",
-          "plural": false,
-          "selections": v13
-        },
-        v3,
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "image",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "Image",
-          "plural": false,
+          "concreteType": "ArtworkEdge",
+          "plural": true,
           "selections": [
             {
-              "kind": "ScalarField",
+              "kind": "LinkedField",
               "alias": null,
-              "name": "url",
-              "args": [
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "plural": false,
+              "selections": [
                 {
-                  "kind": "Literal",
-                  "name": "version",
-                  "value": "small",
-                  "type": "[String]"
-                }
-              ],
-              "storageKey": "url(version:\"small\")"
-            },
-            v2
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "artist",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Artist",
+                  "plural": false,
+                  "selections": v13
+                },
+                v3,
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "image",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "url",
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "version",
+                          "value": "small",
+                          "type": "[String]"
+                        }
+                      ],
+                      "storageKey": "url(version:\"small\")"
+                    },
+                    v2
+                  ]
+                },
+                v12
+              ]
+            }
           ]
-        },
-        v12
+        }
       ]
     },
     v12
@@ -908,7 +947,7 @@ return {
   "operationKind": "query",
   "name": "CollectionRefetch2Query",
   "id": null,
-  "text": "query CollectionRefetch2Query(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $at_auction: Boolean\n  $color: String\n  $for_sale: Boolean\n  $height: String\n  $inquireable_only: Boolean\n  $major_periods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $price_range: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  viewer: marketingCollection(slug: $slug) {\n    ...Collection_viewer_2aBr8l\n    __id: id\n  }\n}\n\nfragment Collection_viewer_2aBr8l on MarketingCollection {\n  category\n  credit\n  description\n  headerImage\n  id\n  slug\n  title\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    __id: id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworks(aggregations: $aggregations, include_medium_filter_in_aggregation: true, size: 12, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  filtered_artworks: artworks(acquireable: $acquireable, aggregations: $aggregations, at_auction: $at_auction, color: $color, for_sale: $for_sale, height: $height, inquireable_only: $inquireable_only, major_periods: $major_periods, medium: $medium, offerable: $offerable, page: $page, price_range: $price_range, size: 0, sort: $sort, width: $width) {\n    __id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n  __id: id\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  __id: id\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Header_artworks on FilterArtworks {\n  ...DefaultHeader_headerArtworks\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworks {\n  __id\n  aggregations {\n    slice\n    counts {\n      id\n      name\n      count\n      __id\n    }\n  }\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __id\n      }\n    }\n    ...ArtworkGrid_artworks\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworks {\n  hits {\n    href\n    id\n    image {\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n      large: resized(height: 220) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  name\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    id\n    slug\n    title\n    description\n    price_guidance\n    thumbnail\n    __id: id\n  }\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  members {\n    ...ArtistSeriesEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance\n  artworks(size: 3, sort: \"-decayed_merch\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n        __id: id\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n  __id: id\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(size: 3, sort: \"-decayed_merch\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n        __id: id\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query CollectionRefetch2Query(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $at_auction: Boolean\n  $color: String\n  $for_sale: Boolean\n  $height: String\n  $inquireable_only: Boolean\n  $major_periods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $price_range: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  viewer: marketingCollection(slug: $slug) {\n    ...Collection_viewer_2aBr8l\n    __id: id\n  }\n}\n\nfragment Collection_viewer_2aBr8l on MarketingCollection {\n  category\n  credit\n  description\n  headerImage\n  id\n  slug\n  title\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    __id: id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworks(aggregations: $aggregations, include_medium_filter_in_aggregation: true, size: 12, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  filtered_artworks: artworks(acquireable: $acquireable, aggregations: $aggregations, at_auction: $at_auction, color: $color, for_sale: $for_sale, height: $height, inquireable_only: $inquireable_only, major_periods: $major_periods, medium: $medium, offerable: $offerable, page: $page, price_range: $price_range, size: 0, sort: $sort, width: $width) {\n    __id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n  __id: id\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  __id: id\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Header_artworks on FilterArtworks {\n  ...DefaultHeader_headerArtworks\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworks {\n  __id\n  aggregations {\n    slice\n    counts {\n      id\n      name\n      count\n      __id\n    }\n  }\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __id\n      }\n    }\n    ...ArtworkGrid_artworks\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworks {\n  hits {\n    href\n    id\n    image {\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n      large: resized(height: 220) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  name\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    id\n    slug\n    title\n    description\n    price_guidance\n    thumbnail\n    __id: id\n  }\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  members {\n    ...ArtistSeriesEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            url(version: \"small\")\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n  __id: id\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            url(version: \"small\")\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",

--- a/src/__generated__/CollectionsHubRailsStoryQuery.graphql.ts
+++ b/src/__generated__/CollectionsHubRailsStoryQuery.graphql.ts
@@ -75,18 +75,22 @@ fragment ArtistSeriesEntity_member on MarketingCollection {
   thumbnail
   title
   price_guidance
-  artworks(size: 3, sort: "-decayed_merch") {
-    hits {
-      artist {
-        name
-        __id
+  artworks(aggregations: [TOTAL], sort: "-decayed_merch") {
+    artworks_connection(first: 3) {
+      edges {
+        node {
+          artist {
+            name
+            __id
+          }
+          title
+          image {
+            url(version: "small")
+            __id: id
+          }
+          __id
+        }
       }
-      title
-      image {
-        url(version: "small")
-        __id: id
-      }
-      __id
     }
     __id
   }
@@ -151,7 +155,7 @@ return {
   "operationKind": "query",
   "name": "CollectionsHubRailsStoryQuery",
   "id": null,
-  "text": "query CollectionsHubRailsStoryQuery(\n  $collectionID: String!\n) {\n  marketingCollection(slug: $collectionID) {\n    linkedCollections {\n      ...CollectionsHubRails_linkedCollections\n    }\n    __id: id\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    id\n    slug\n    title\n    description\n    price_guidance\n    thumbnail\n    __id: id\n  }\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  members {\n    ...ArtistSeriesEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance\n  artworks(size: 3, sort: \"-decayed_merch\") {\n    hits {\n      artist {\n        name\n        __id\n      }\n      title\n      image {\n        url(version: \"small\")\n        __id: id\n      }\n      __id\n    }\n    __id\n  }\n  __id: id\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n  __id: id\n}\n",
+  "text": "query CollectionsHubRailsStoryQuery(\n  $collectionID: String!\n) {\n  marketingCollection(slug: $collectionID) {\n    linkedCollections {\n      ...CollectionsHubRails_linkedCollections\n    }\n    __id: id\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    id\n    slug\n    title\n    description\n    price_guidance\n    thumbnail\n    __id: id\n  }\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  members {\n    ...ArtistSeriesEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            url(version: \"small\")\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -278,13 +282,15 @@ return {
                     "kind": "LinkedField",
                     "alias": null,
                     "name": "artworks",
-                    "storageKey": "artworks(size:3,sort:\"-decayed_merch\")",
+                    "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
                     "args": [
                       {
                         "kind": "Literal",
-                        "name": "size",
-                        "value": 3,
-                        "type": "Int"
+                        "name": "aggregations",
+                        "value": [
+                          "TOTAL"
+                        ],
+                        "type": "[ArtworkAggregation]"
                       },
                       {
                         "kind": "Literal",
@@ -299,53 +305,82 @@ return {
                       {
                         "kind": "LinkedField",
                         "alias": null,
-                        "name": "hits",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "plural": true,
+                        "name": "artworks_connection",
+                        "storageKey": "artworks_connection(first:3)",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 3,
+                            "type": "Int"
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
                         "selections": [
                           {
                             "kind": "LinkedField",
                             "alias": null,
-                            "name": "artist",
+                            "name": "edges",
                             "storageKey": null,
                             "args": null,
-                            "concreteType": "Artist",
-                            "plural": false,
-                            "selections": [
-                              v3,
-                              v5
-                            ]
-                          },
-                          v4,
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "image",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
                             "selections": [
                               {
-                                "kind": "ScalarField",
+                                "kind": "LinkedField",
                                 "alias": null,
-                                "name": "url",
-                                "args": [
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
                                   {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "small",
-                                    "type": "[String]"
-                                  }
-                                ],
-                                "storageKey": "url(version:\"small\")"
-                              },
-                              v2
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "artist",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Artist",
+                                    "plural": false,
+                                    "selections": [
+                                      v3,
+                                      v5
+                                    ]
+                                  },
+                                  v4,
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "url",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": "small",
+                                            "type": "[String]"
+                                          }
+                                        ],
+                                        "storageKey": "url(version:\"small\")"
+                                      },
+                                      v2
+                                    ]
+                                  },
+                                  v5
+                                ]
+                              }
                             ]
-                          },
-                          v5
+                          }
                         ]
                       },
                       v5

--- a/src/__generated__/RelatedCollectionEntity_collection.graphql.ts
+++ b/src/__generated__/RelatedCollectionEntity_collection.graphql.ts
@@ -9,15 +9,19 @@ export type RelatedCollectionEntity_collection = {
     readonly title: string;
     readonly price_guidance: number | null;
     readonly artworks: ({
-        readonly hits: ReadonlyArray<({
-            readonly artist: ({
-                readonly name: string | null;
-            }) | null;
-            readonly title: string | null;
-            readonly image: ({
-                readonly url: string | null;
-            }) | null;
-        }) | null> | null;
+        readonly artworks_connection: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly artist: ({
+                        readonly name: string | null;
+                    }) | null;
+                    readonly title: string | null;
+                    readonly image: ({
+                        readonly url: string | null;
+                    }) | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
     }) | null;
     readonly " $refType": RelatedCollectionEntity_collection$ref;
 };
@@ -79,13 +83,15 @@ return {
       "kind": "LinkedField",
       "alias": null,
       "name": "artworks",
-      "storageKey": "artworks(size:3,sort:\"-decayed_merch\")",
+      "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
       "args": [
         {
           "kind": "Literal",
-          "name": "size",
-          "value": 3,
-          "type": "Int"
+          "name": "aggregations",
+          "value": [
+            "TOTAL"
+          ],
+          "type": "[ArtworkAggregation]"
         },
         {
           "kind": "Literal",
@@ -100,59 +106,88 @@ return {
         {
           "kind": "LinkedField",
           "alias": null,
-          "name": "hits",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "Artwork",
-          "plural": true,
+          "name": "artworks_connection",
+          "storageKey": "artworks_connection(first:3)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 3,
+              "type": "Int"
+            }
+          ],
+          "concreteType": "ArtworkConnection",
+          "plural": false,
           "selections": [
             {
               "kind": "LinkedField",
               "alias": null,
-              "name": "artist",
+              "name": "edges",
               "storageKey": null,
               "args": null,
-              "concreteType": "Artist",
-              "plural": false,
+              "concreteType": "ArtworkEdge",
+              "plural": true,
               "selections": [
                 {
-                  "kind": "ScalarField",
+                  "kind": "LinkedField",
                   "alias": null,
-                  "name": "name",
+                  "name": "node",
+                  "storageKey": null,
                   "args": null,
-                  "storageKey": null
-                },
-                v1
-              ]
-            },
-            v0,
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "image",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "Image",
-              "plural": false,
-              "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "url",
-                  "args": [
+                  "concreteType": "Artwork",
+                  "plural": false,
+                  "selections": [
                     {
-                      "kind": "Literal",
-                      "name": "version",
-                      "value": "small",
-                      "type": "[String]"
-                    }
-                  ],
-                  "storageKey": "url(version:\"small\")"
-                },
-                v2
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "artist",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Artist",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "name",
+                          "args": null,
+                          "storageKey": null
+                        },
+                        v1
+                      ]
+                    },
+                    v0,
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "image",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "url",
+                          "args": [
+                            {
+                              "kind": "Literal",
+                              "name": "version",
+                              "value": "small",
+                              "type": "[String]"
+                            }
+                          ],
+                          "storageKey": "url(version:\"small\")"
+                        },
+                        v2
+                      ]
+                    },
+                    v1
+                  ]
+                }
               ]
-            },
-            v1
+            }
           ]
         },
         v1
@@ -162,5 +197,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '5999447fc717a7fc54772016d68e6cb2';
+(node as any).hash = 'd83ff6b1bae5fd0f0cc405596b3c2e2d';
 export default node;


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-1533
Addresses  https://artsyproduct.atlassian.net/browse/GROW-1541

### Problem

The `ArtistCollectionsRail` that  appears on the artist page — the one that shows a few triplets of thumbnails  — was breaking in two ways:

- erroring as it tried to display (non-existent) thumbnails for deleted works (GROW-1533)
- showing incorrect thumbnails unrelated to the given artist (GROW-1541)

### Background

There are currently two ways of accessing a collection's artworks via MP:

1. `marketingCollection.artworks.hits`
2. `marketingCollection.artworks.artworks_collection`

My investigation showed that method 1 was broken and ignoring input parameters in a way that explained both 1533 and 1541.

This turned out to be due to underlying bug in Gravity that @mzikherman diagnosed and fixed (https://github.com/artsy/gravity/pull/12588 and https://github.com/artsy/gravity/pull/12590)

That actually fixed the immediate issue and took the heat off of these tickets. _But…_

- we decided to convert `ArtistCollectionsRail` from method 1 to method 2 in any case, since using a connection is a better pattern for this use case in general, _and_ this gets us closer to the kind of usage we will want to have in MPv2

- doing so also entailed fixing a couple of other rails, since they relied on shared fixture data

### Solution

This simply updates three collection-related rails to use the `artwork_connection` field instead of the `hits` field — 

- `ArtistCollectionsRail`, where the problems were initially noticed a923a4ebb
- `ArtistSeriesRail`, a new rail that appears on hub pages 2eef5b331
- `RelatedCollectionsRail`, another rail that appears on collection pages 0f959f82f