### PR TITLE
PURCHASE-1433: Refactor carousel to use explicit height instead of 60vh

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -54,7 +54,7 @@ export class LargeArtworkImageBrowser extends React.Component<
           showArrows={hasMultipleImages}
           options={options}
           oneSlideVisible
-          height="60vh"
+          height="auto"
           setCarouselRef={setCarouselRef}
           data={carouselImages}
           renderLeftArrow={({ flickity }) => (
@@ -81,6 +81,7 @@ export class LargeArtworkImageBrowser extends React.Component<
                 width="100%"
                 px={hasMultipleImages ? [2, 2, 0] : 0}
                 height="60vh"
+                maxHeight="660px"
               >
                 <Lightbox
                   imageAlt={imageAlt}
@@ -89,6 +90,7 @@ export class LargeArtworkImageBrowser extends React.Component<
                   isDefault={image.is_default}
                   src={image.uri}
                   initialHeight="60vh"
+                  maxHeight="660px"
                 />
               </Flex>
             )
@@ -137,6 +139,7 @@ export class SmallArtworkImageBrowser extends React.Component<
                   isDefault={image.is_default}
                   src={image.uri}
                   initialHeight="45vh"
+                  maxHeight="388px"
                 />
               </Flex>
             )


### PR DESCRIPTION
[PURCHASE-1433]

https://artsyproduct.atlassian.net/browse/PURCHASE-1420 brought up the issue that Artwork images are being incorrectly rendered by google. The image carousel is currently using `60vh` to render the height of the image. We need to adjust the carousel height to use a height without using `vh`.

I chose to keep the view-height heights and just add a max height as well. This way the images can still resize dynamically, but only until they hit a certain size. I believe this will solve the problem, but we will need to wait for this to be released before we can verify in google search console.



[PURCHASE-1433]: https://artsyproduct.atlassian.net/browse/PURCHASE-1433