### PR TITLE
[GROW-1547] increment correctly at smaller breakpoints

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesEntity.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesEntity.test.tsx
@@ -9,10 +9,6 @@ import {
 } from "../ArtistSeriesEntity"
 
 jest.mock("Artsy/Analytics/useTracking")
-jest.mock("Utils/Hooks/useMedia", () => ({
-  useMedia: () => ({}),
-}))
-
 jest.mock("found", () => ({
   Link: ({ children, ...props }) => <div {...props}>{children}</div>,
 }))

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
@@ -1,10 +1,8 @@
 import { CollectionsHubLinkedCollections } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton } from "Components/v2/Carousel"
-import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import "jest-styled-components"
-import { clone } from "lodash"
 import React from "react"
 import { ArtistSeriesRail } from "../index"
 

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
@@ -1,6 +1,7 @@
 import { CollectionsHubLinkedCollections } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton } from "Components/v2/Carousel"
+import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import { clone } from "lodash"
@@ -8,12 +9,6 @@ import React from "react"
 import { ArtistSeriesRail } from "../index"
 
 jest.mock("Artsy/Analytics/useTracking")
-jest.mock("Utils/Hooks/useMedia", () => ({
-  useMedia: () => ({
-    xl: true,
-  }),
-}))
-
 jest.mock("found", () => ({
   Link: props => <div>{props.children}</div>,
 }))
@@ -69,7 +64,11 @@ describe("ArtistSeriesRail", () => {
       singleData(),
       singleData(),
     ]
-    const Component = mount(<ArtistSeriesRail {...newprops} />)
+    const Component = mount(
+      <MockBoot>
+        <ArtistSeriesRail {...newprops} />
+      </MockBoot>
+    )
     expect(Component.find(ArrowButton).length).toBe(0)
   })
 
@@ -84,7 +83,11 @@ describe("ArtistSeriesRail", () => {
       singleData(),
       singleData(),
     ]
-    const Component = mount(<ArtistSeriesRail {...newprops} />)
+    const Component = mount(
+      <MockBoot>
+        <ArtistSeriesRail {...newprops} />
+      </MockBoot>
+    )
     expect(Component.find(ArrowButton).length).toBe(2)
   })
 

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
@@ -56,41 +56,6 @@ describe("ArtistSeriesRail", () => {
     expect(component.text()).toMatch("From $1,000")
   })
 
-  it("Does NOT show arrows when there are exactly 4 collections", () => {
-    const newprops = clone(props)
-    newprops.collectionGroup.members = [
-      singleData(),
-      singleData(),
-      singleData(),
-      singleData(),
-    ]
-    const Component = mount(
-      <MockBoot>
-        <ArtistSeriesRail {...newprops} />
-      </MockBoot>
-    )
-    expect(Component.find(ArrowButton).length).toBe(0)
-  })
-
-  it("Arrows appear when there are more than 5 collections", () => {
-    const newprops = clone(props)
-    newprops.collectionGroup.members = [
-      singleData(),
-      singleData(),
-      singleData(),
-      singleData(),
-      singleData(),
-      singleData(),
-      singleData(),
-    ]
-    const Component = mount(
-      <MockBoot>
-        <ArtistSeriesRail {...newprops} />
-      </MockBoot>
-    )
-    expect(Component.find(ArrowButton).length).toBe(2)
-  })
-
   describe("Tracking", () => {
     it("Tracks impressions", () => {
       mount(<ArtistSeriesRail {...props} />)

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
@@ -7,7 +7,6 @@ import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
-import { Media } from "Utils/Responsive"
 import { ArtistSeriesRailContainer as ArtistSeriesEntity } from "./ArtistSeriesEntity"
 
 export interface ArtistSeriesRailProps {
@@ -39,70 +38,29 @@ export const ArtistSeriesRail: React.FC<ArtistSeriesRailProps> = ({
     })
   }
 
-  interface Breakpoints {
-    xs?: boolean
-    sm?: boolean
-    md?: boolean
-    xl?: boolean
-  }
-
-  const renderCarousel = (breakpoints: Breakpoints = {}) => {
-    return (
-      <Carousel
-        height="250px"
-        options={{
-          groupCells:
-            breakpoints.xs || breakpoints.sm || breakpoints.md ? 1 : 4,
-          wrapAround: sd.IS_MOBILE ? true : false,
-          cellAlign: "left",
-          pageDots: false,
-          contain: true,
-        }}
-        data={members}
-        render={(slide, slideIndex) => {
-          return <ArtistSeriesEntity member={slide} itemNumber={slideIndex} />
-        }}
-        renderLeftArrow={({ Arrow }) => {
-          const showArrowChecker =
-            !breakpoints.xl && members.length <= 4 && !sd.IS_MOBILE
-          return (
-            <ArrowContainer>
-              {members.length > 4 ? (
-                <Arrow />
-              ) : (
-                showArrowChecker && <Arrow showArrow={true} />
-              )}
-            </ArrowContainer>
-          )
-        }}
-        renderRightArrow={({ Arrow }) => {
-          const showArrowChecker =
-            !breakpoints.xl && members.length <= 4 && !sd.IS_MOBILE
-          return (
-            <ArrowContainer>
-              {members.length > 4 ? (
-                <Arrow />
-              ) : (
-                showArrowChecker && <Arrow showArrow={true} />
-              )}
-            </ArrowContainer>
-          )
-        }}
-        onArrowClick={() => trackArrowClick()}
-      />
-    )
-  }
-
   return (
     <Content mt={2} py={3}>
       <Serif size="5" mb={1}>
         Trending Artist Series
       </Serif>
-      <Media lessThan="lg">
-        {renderCarousel({ xs: true, sm: true, md: true })}
-      </Media>
-      <Media at="lg">{renderCarousel()}</Media>
-      <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
+      <Carousel
+        height="250px"
+        options={{
+          wrapAround: sd.IS_MOBILE ? true : false,
+          pageDots: false,
+        }}
+        data={members}
+        render={(slide, slideIndex) => {
+          return (
+            <ArtistSeriesEntity
+              member={slide}
+              itemNumber={slideIndex}
+              key={slide.slug}
+            />
+          )
+        }}
+        onArrowClick={() => trackArrowClick()}
+      />
     </Content>
   )
 }

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
@@ -7,7 +7,7 @@ import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
-import { useMedia } from "Utils/Hooks/useMedia"
+import { Media } from "Utils/Responsive"
 import { ArtistSeriesRailContainer as ArtistSeriesEntity } from "./ArtistSeriesEntity"
 
 export interface ArtistSeriesRailProps {
@@ -17,19 +17,6 @@ export const ArtistSeriesRail: React.FC<ArtistSeriesRailProps> = ({
   collectionGroup,
 }) => {
   const { members } = collectionGroup
-
-  let groupCells: number
-
-  const { xl } = useMedia()
-
-  if (sd.IS_MOBILE) {
-    groupCells = 1
-  } else if (!xl && members.length <= 4) {
-    groupCells = 3
-  } else {
-    groupCells = 4
-  }
-
   const { trackEvent } = useTracking()
 
   useEffect(() => {
@@ -52,15 +39,20 @@ export const ArtistSeriesRail: React.FC<ArtistSeriesRailProps> = ({
     })
   }
 
-  return (
-    <Content mt={2} py={3}>
-      <Serif size="5" mb={1}>
-        Trending Artist Series
-      </Serif>
+  interface Breakpoints {
+    xs?: boolean
+    sm?: boolean
+    md?: boolean
+    xl?: boolean
+  }
+
+  const renderCarousel = (breakpoints: Breakpoints = {}) => {
+    return (
       <Carousel
         height="250px"
         options={{
-          groupCells,
+          groupCells:
+            breakpoints.xs || breakpoints.sm || breakpoints.md ? 1 : 4,
           wrapAround: sd.IS_MOBILE ? true : false,
           cellAlign: "left",
           pageDots: false,
@@ -70,9 +62,9 @@ export const ArtistSeriesRail: React.FC<ArtistSeriesRailProps> = ({
         render={(slide, slideIndex) => {
           return <ArtistSeriesEntity member={slide} itemNumber={slideIndex} />
         }}
-        onArrowClick={() => trackArrowClick()}
         renderLeftArrow={({ Arrow }) => {
-          const showArrowChecker = !xl && members.length <= 4 && !sd.IS_MOBILE
+          const showArrowChecker =
+            !breakpoints.xl && members.length <= 4 && !sd.IS_MOBILE
           return (
             <ArrowContainer>
               {members.length > 4 ? (
@@ -84,7 +76,8 @@ export const ArtistSeriesRail: React.FC<ArtistSeriesRailProps> = ({
           )
         }}
         renderRightArrow={({ Arrow }) => {
-          const showArrowChecker = !xl && members.length <= 4 && !sd.IS_MOBILE
+          const showArrowChecker =
+            !breakpoints.xl && members.length <= 4 && !sd.IS_MOBILE
           return (
             <ArrowContainer>
               {members.length > 4 ? (
@@ -95,7 +88,21 @@ export const ArtistSeriesRail: React.FC<ArtistSeriesRailProps> = ({
             </ArrowContainer>
           )
         }}
+        onArrowClick={() => trackArrowClick()}
       />
+    )
+  }
+
+  return (
+    <Content mt={2} py={3}>
+      <Serif size="5" mb={1}>
+        Trending Artist Series
+      </Serif>
+      <Media lessThan="lg">
+        {renderCarousel({ xs: true, sm: true, md: true })}
+      </Media>
+      <Media at="lg">{renderCarousel()}</Media>
+      <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
     </Content>
   )
 }

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -1,7 +1,7 @@
 import { CollectionHubFixture } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton } from "Components/v2/Carousel"
-import { MockBoot } from "DevTools/MockBoot"
+// import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
@@ -9,6 +9,7 @@ import {
   FeaturedCollectionEntity,
   FeaturedCollectionsRails,
   FeaturedImage,
+  // renderCarousel,
   StyledLink,
 } from "../index"
 
@@ -53,22 +54,18 @@ describe("FeaturedCollectionsRails", () => {
     expect(component.text()).toMatch("Street Art: Superheroes and Villains")
   })
 
-  it("Renders arrows when there are more than 4 featured collections", () => {
-    props.collectionGroup.members = [
-      memberData(),
-      memberData(),
-      memberData(),
-      memberData(),
-      memberData(),
-    ]
+  // it("Renders correct height at smaller breakpoints", () => {
+  //   const component = mount(
+  //     <MockBoot breakpoint="sm">
+  //       <FeaturedCollectionsRails {...props} />
+  //     </MockBoot>
+  //   )
 
-    const component = mount(
-      <MockBoot>
-        <FeaturedCollectionsRails {...props} />
-      </MockBoot>
-    )
-    expect(component.find(ArrowButton).length).toBe(2)
-  })
+  //   console.log("comp", component.props())
+  //   console.log("key", component.key())
+
+  //   expect(renderCarousel).toBeCalledWith("430px")
+  // })
 
   describe("Tracking", () => {
     it("Tracks impressions", () => {

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -1,6 +1,7 @@
 import { CollectionHubFixture } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton } from "Components/v2/Carousel"
+import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
@@ -12,13 +13,6 @@ import {
 } from "../index"
 
 jest.mock("Artsy/Analytics/useTracking")
-jest.mock("Utils/Hooks/useMedia", () => ({
-  useMedia: () => ({
-    xs: false,
-    sm: false,
-    xl: true,
-  }),
-}))
 
 jest.mock("found", () => ({
   Link: ({ children, ...props }) => <div {...props}>{children}</div>,
@@ -60,7 +54,11 @@ describe("FeaturedCollectionsRails", () => {
   })
 
   it("Renders no arrows when there are less than 5 collections", () => {
-    const component = mount(<FeaturedCollectionsRails {...props} />)
+    const component = mount(
+      <MockBoot>
+        <FeaturedCollectionsRails {...props} />
+      </MockBoot>
+    )
     expect(component.find(ArrowButton).length).toBe(1)
   })
 
@@ -73,7 +71,11 @@ describe("FeaturedCollectionsRails", () => {
       memberData(),
     ]
 
-    const component = mount(<FeaturedCollectionsRails {...props} />)
+    const component = mount(
+      <MockBoot>
+        <FeaturedCollectionsRails {...props} />
+      </MockBoot>
+    )
     expect(component.find(ArrowButton).length).toBe(2)
   })
 

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -53,15 +53,6 @@ describe("FeaturedCollectionsRails", () => {
     expect(component.text()).toMatch("Street Art: Superheroes and Villains")
   })
 
-  it("Renders no arrows when there are less than 5 collections", () => {
-    const component = mount(
-      <MockBoot>
-        <FeaturedCollectionsRails {...props} />
-      </MockBoot>
-    )
-    expect(component.find(ArrowButton).length).toBe(1)
-  })
-
   it("Renders arrows when there are more than 4 featured collections", () => {
     props.collectionGroup.members = [
       memberData(),

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -1,7 +1,6 @@
 import { CollectionHubFixture } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton } from "Components/v2/Carousel"
-// import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
@@ -9,7 +8,6 @@ import {
   FeaturedCollectionEntity,
   FeaturedCollectionsRails,
   FeaturedImage,
-  // renderCarousel,
   StyledLink,
 } from "../index"
 
@@ -53,19 +51,6 @@ describe("FeaturedCollectionsRails", () => {
     expect(component.text()).toMatch("Street Art: Celebrity Portraits")
     expect(component.text()).toMatch("Street Art: Superheroes and Villains")
   })
-
-  // it("Renders correct height at smaller breakpoints", () => {
-  //   const component = mount(
-  //     <MockBoot breakpoint="sm">
-  //       <FeaturedCollectionsRails {...props} />
-  //     </MockBoot>
-  //   )
-
-  //   console.log("comp", component.props())
-  //   console.log("key", component.key())
-
-  //   expect(renderCarousel).toBeCalledWith("430px")
-  // })
 
   describe("Tracking", () => {
     it("Tracks impressions", () => {

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -49,12 +49,12 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
     })
   }
 
-  const renderCarousel = ({ xs, sm, xl }) => {
+  const renderCarousel = breakpoints => {
     return (
       <Carousel
-        height={xs || sm ? "430px" : "500px"}
+        height={breakpoints.xs || breakpoints.sm ? "430px" : "500px"}
         options={{
-          groupCells: xs || sm ? 1 : 2,
+          groupCells: breakpoints.xs || breakpoints.sm ? 1 : 2,
           wrapAround: sd.IS_MOBILE ? true : false,
           cellAlign: "left",
           pageDots: false,
@@ -74,7 +74,7 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
           )
         }}
         renderRightArrow={({ Arrow }) => {
-          const shouldDisplayArrow = !xl && members.length > 2
+          const shouldDisplayArrow = !breakpoints.xl && members.length > 2
           return (
             <ArrowContainer>
               {members.length > 3 ? (
@@ -95,18 +95,10 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
       <Serif size="5" mt={3}>
         {name}
       </Serif>
-      <Media lessThan="md">
-        {renderCarousel({ xs: true, sm: true, xl: false })}
-      </Media>
-      <Media at="md">
-        {renderCarousel({ xs: false, sm: false, xl: false })}
-      </Media>
-      <Media at="lg">
-        {renderCarousel({ xs: false, sm: false, xl: false })}
-      </Media>
-      <Media greaterThanOrEqual="xl">
-        {renderCarousel({ xs: false, sm: false, xl: true })}
-      </Media>
+      <Media lessThan="md">{renderCarousel({ xs: true, sm: true })}</Media>
+      <Media at="md">{renderCarousel({})}</Media>
+      <Media at="lg">{renderCarousel({})}</Media>
+      <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
       <Spacer pb={2} />
     </FeaturedCollectionsContainer>
   )

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -49,7 +49,13 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
     })
   }
 
-  const renderCarousel = breakpoints => {
+  interface Breakpoints {
+    xs?: boolean
+    sm?: boolean
+    xl?: boolean
+  }
+
+  const renderCarousel = (breakpoints: Breakpoints = {}) => {
     return (
       <Carousel
         height={breakpoints.xs || breakpoints.sm ? "430px" : "500px"}
@@ -96,8 +102,8 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
         {name}
       </Serif>
       <Media lessThan="md">{renderCarousel({ xs: true, sm: true })}</Media>
-      <Media at="md">{renderCarousel({})}</Media>
-      <Media at="lg">{renderCarousel({})}</Media>
+      <Media at="md">{renderCarousel()}</Media>
+      <Media at="lg">{renderCarousel()}</Media>
       <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
       <Spacer pb={2} />
     </FeaturedCollectionsContainer>

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -17,7 +17,7 @@ import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
-import { useMedia } from "Utils/Hooks/useMedia"
+import { Media } from "Utils/Responsive"
 
 interface Props {
   collectionGroup: FeaturedCollectionsRails_collectionGroup
@@ -28,8 +28,6 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
 }) => {
   const { members, name } = collectionGroup
   const { trackEvent } = useTracking()
-  const { xs, sm, xl } = useMedia()
-  const carouselHeight = xs || sm ? "430px" : "500px"
 
   useEffect(() => {
     trackEvent({
@@ -51,13 +49,10 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
     })
   }
 
-  return (
-    <FeaturedCollectionsContainer>
-      <Serif size="5" mt={3}>
-        {name}
-      </Serif>
+  const renderCarousel = ({ xs, sm, xl }) => {
+    return (
       <Carousel
-        height={carouselHeight}
+        height={xs || sm ? "430px" : "500px"}
         options={{
           groupCells: xs || sm ? 1 : 2,
           wrapAround: sd.IS_MOBILE ? true : false,
@@ -92,6 +87,26 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
         }}
         onArrowClick={() => trackArrowClick()}
       />
+    )
+  }
+
+  return (
+    <FeaturedCollectionsContainer>
+      <Serif size="5" mt={3}>
+        {name}
+      </Serif>
+      <Media lessThan="md">
+        {renderCarousel({ xs: true, sm: true, xl: false })}
+      </Media>
+      <Media at="md">
+        {renderCarousel({ xs: false, sm: false, xl: false })}
+      </Media>
+      <Media at="lg">
+        {renderCarousel({ xs: false, sm: false, xl: false })}
+      </Media>
+      <Media greaterThanOrEqual="xl">
+        {renderCarousel({ xs: false, sm: false, xl: true })}
+      </Media>
       <Spacer pb={2} />
     </FeaturedCollectionsContainer>
   )
@@ -107,7 +122,6 @@ export const FeaturedCollectionEntity: React.FC<
 > = ({ itemNumber, member }) => {
   const { description, price_guidance, slug, thumbnail, title } = member
   const { trackEvent } = useTracking()
-  const { xs, sm } = useMedia()
   const hasLongTitle = title.length > 31
 
   const handleClick = () => {
@@ -122,30 +136,37 @@ export const FeaturedCollectionEntity: React.FC<
     })
   }
 
+  const renderReadMore = (isSmallerScreen: boolean) => {
+    return (
+      <ReadMore
+        disabled
+        maxChars={hasLongTitle && isSmallerScreen ? 50 : 100}
+        content={
+          <>
+            {description && (
+              <span dangerouslySetInnerHTML={{ __html: description }} />
+            )}
+          </>
+        }
+      />
+    )
+  }
+
   return (
     <Container p={2} m={1} width={["261px", "261px", "355px", "355px"]}>
       <StyledLink to={`/collection/${slug}`} onClick={handleClick}>
         <Flex height={["190px", "190px", "280px", "280px"]}>
           <FeaturedImage src={thumbnail} />
         </Flex>
-        <CollectionTitle size="4" mt={1} isSmallerScreen={xs || sm || false}>
+        <Serif size="4" mt={1} maxWidth={["246px", "100%"]}>
           {title}
-        </CollectionTitle>
+        </Serif>
         {price_guidance && (
           <Sans size="2" color="black60">{`From $${price_guidance}`}</Sans>
         )}
         <ExtendedSerif size="3" mt={1}>
-          <ReadMore
-            disabled
-            maxChars={hasLongTitle && (xs || sm) ? 50 : 100}
-            content={
-              <>
-                {description && (
-                  <span dangerouslySetInnerHTML={{ __html: description }} />
-                )}
-              </>
-            }
-          />
+          <Media lessThan="md">{renderReadMore(true)}</Media>
+          <Media greaterThan="sm">{renderReadMore(false)}</Media>
         </ExtendedSerif>
       </StyledLink>
     </Container>
@@ -182,14 +203,6 @@ const Container = styled(Box)`
   }
 `
 
-export const ArrowContainer = styled(Box)`
-  align-self: flex-start;
-
-  ${ArrowButton} {
-    height: 100%;
-  }
-`
-
 const FeaturedCollectionsContainer = styled(Box)`
   border-top: 1px solid ${color("black10")};
 
@@ -215,8 +228,12 @@ export const FeaturedImage = styled(ResponsiveImage)`
   background-position: top;
 `
 
-const CollectionTitle = styled(Serif)<{ isSmallerScreen: boolean }>`
-  width: ${props => (props.isSmallerScreen ? "246px" : "max-content")};
+export const ArrowContainer = styled(Box)`
+  align-self: flex-start;
+
+  ${ArrowButton} {
+    height: 100%;
+  }
 `
 
 export const StyledLink = styled(RouterLink)`

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -23,6 +23,29 @@ interface Props {
   collectionGroup: FeaturedCollectionsRails_collectionGroup
 }
 
+export const renderCarousel = (
+  members,
+  trackArrowClick,
+  carouselHeight: string
+) => {
+  return (
+    <Carousel
+      height={carouselHeight}
+      options={{
+        wrapAround: sd.IS_MOBILE ? true : false,
+        pageDots: false,
+      }}
+      data={members}
+      render={(slide, slideIndex) => {
+        return (
+          <FeaturedCollectionEntity member={slide} itemNumber={slideIndex} />
+        )
+      }}
+      onArrowClick={() => trackArrowClick()}
+    />
+  )
+}
+
 export const FeaturedCollectionsRails: React.FC<Props> = ({
   collectionGroup,
 }) => {
@@ -49,32 +72,17 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
     })
   }
 
-  const renderCarousel = (carouselHeight: string) => {
-    return (
-      <Carousel
-        height={carouselHeight}
-        options={{
-          wrapAround: sd.IS_MOBILE ? true : false,
-          pageDots: false,
-        }}
-        data={members}
-        render={(slide, slideIndex) => {
-          return (
-            <FeaturedCollectionEntity member={slide} itemNumber={slideIndex} />
-          )
-        }}
-        onArrowClick={() => trackArrowClick()}
-      />
-    )
-  }
-
   return (
     <FeaturedCollectionsContainer>
       <Serif size="5" mt={3}>
         {name}
       </Serif>
-      <Media lessThan="md">{renderCarousel("430px")}</Media>
-      <Media greaterThanOrEqual="md">{renderCarousel("500px")}</Media>
+      <Media lessThan="md">
+        {renderCarousel(members, trackArrowClick, "430px")}
+      </Media>
+      <Media greaterThanOrEqual="md">
+        {renderCarousel(members, trackArrowClick, "500px")}
+      </Media>
       <Spacer pb={2} />
     </FeaturedCollectionsContainer>
   )

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -49,46 +49,18 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
     })
   }
 
-  interface Breakpoints {
-    xs?: boolean
-    sm?: boolean
-    xl?: boolean
-  }
-
-  const renderCarousel = (breakpoints: Breakpoints = {}) => {
+  const renderCarousel = (carouselHeight: string) => {
     return (
       <Carousel
-        height={breakpoints.xs || breakpoints.sm ? "430px" : "500px"}
+        height={carouselHeight}
         options={{
-          groupCells: breakpoints.xs || breakpoints.sm ? 1 : 2,
           wrapAround: sd.IS_MOBILE ? true : false,
-          cellAlign: "left",
           pageDots: false,
-          contain: true,
         }}
         data={members}
         render={(slide, slideIndex) => {
           return (
             <FeaturedCollectionEntity member={slide} itemNumber={slideIndex} />
-          )
-        }}
-        renderLeftArrow={({ Arrow }) => {
-          return (
-            <ArrowContainer>
-              <Arrow />
-            </ArrowContainer>
-          )
-        }}
-        renderRightArrow={({ Arrow }) => {
-          const shouldDisplayArrow = !breakpoints.xl && members.length > 2
-          return (
-            <ArrowContainer>
-              {members.length > 3 ? (
-                <Arrow />
-              ) : (
-                shouldDisplayArrow && <Arrow showArrow={true} />
-              )}
-            </ArrowContainer>
           )
         }}
         onArrowClick={() => trackArrowClick()}
@@ -101,10 +73,8 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
       <Serif size="5" mt={3}>
         {name}
       </Serif>
-      <Media lessThan="md">{renderCarousel({ xs: true, sm: true })}</Media>
-      <Media at="md">{renderCarousel()}</Media>
-      <Media at="lg">{renderCarousel()}</Media>
-      <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
+      <Media lessThan="md">{renderCarousel("430px")}</Media>
+      <Media greaterThanOrEqual="md">{renderCarousel("500px")}</Media>
       <Spacer pb={2} />
     </FeaturedCollectionsContainer>
   )

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionEntity.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionEntity.test.tsx
@@ -9,10 +9,6 @@ import {
 } from "../OtherCollectionEntity"
 
 jest.mock("Artsy/Analytics/useTracking")
-jest.mock("Utils/Hooks/useMedia", () => ({
-  useMedia: () => ({}),
-}))
-
 jest.mock("found", () => ({
   Link: ({ children, ...props }) => <div {...props}>{children}</div>,
 }))

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.test.tsx
@@ -1,7 +1,6 @@
 import { CollectionHubFixture } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton } from "Components/v2/Carousel"
-import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
@@ -45,15 +44,6 @@ describe("CollectionsRail", () => {
     expect(component.text()).toMatch("Artist Posters")
     expect(component.text()).toMatch("Artist Skateboard Decks")
     expect(component.text()).toMatch("KAWS: Bearbricks")
-  })
-
-  it("Renders no arrows when there are less than 5 collections", () => {
-    const component = mount(
-      <MockBoot>
-        <OtherCollectionsRail {...props} />
-      </MockBoot>
-    )
-    expect(component.find(ArrowButton).length).toBe(1)
   })
 
   describe("Tracking", () => {

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.test.tsx
@@ -1,16 +1,13 @@
 import { CollectionHubFixture } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton } from "Components/v2/Carousel"
+import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import { OtherCollectionsRail } from "../index"
 
 jest.mock("Artsy/Analytics/useTracking")
-jest.mock("Utils/Hooks/useMedia", () => ({
-  useMedia: () => ({}),
-}))
-
 jest.mock("found", () => ({
   Link: props => <div>{props.children}</div>,
 }))
@@ -51,7 +48,11 @@ describe("CollectionsRail", () => {
   })
 
   it("Renders no arrows when there are less than 5 collections", () => {
-    const component = mount(<OtherCollectionsRail {...props} />)
+    const component = mount(
+      <MockBoot>
+        <OtherCollectionsRail {...props} />
+      </MockBoot>
+    )
     expect(component.find(ArrowButton).length).toBe(1)
   })
 

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -39,24 +39,16 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
     })
   }
 
-  interface Breakpoints {
-    xs?: boolean
-    sm?: boolean
-    md?: boolean
-    xl?: boolean
-  }
-
-  const renderCarousel = (breakpoints: Breakpoints = {}) => {
-    return (
+  return (
+    <Container mb={4}>
+      <Serif size="5" mt={3} mb={2}>
+        {name}
+      </Serif>
       <Carousel
         height="100px"
         options={{
-          groupCells:
-            breakpoints.xs || breakpoints.sm || breakpoints.md ? 1 : 3,
           wrapAround: sd.IS_MOBILE ? true : false,
-          cellAlign: "left",
           pageDots: false,
-          contain: true,
         }}
         data={members}
         render={(slide, slideIndex) => {
@@ -64,41 +56,8 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
             <OtherCollectionEntity member={slide} itemNumber={slideIndex} />
           )
         }}
-        renderLeftArrow={({ Arrow }) => {
-          return (
-            <ArrowContainer>
-              <Arrow />
-            </ArrowContainer>
-          )
-        }}
-        renderRightArrow={({ Arrow }) => {
-          const shouldDisplayArrow =
-            breakpoints.sm || (breakpoints.md && members.length > 3)
-          return (
-            <ArrowContainer>
-              {members.length > 4 ? (
-                <Arrow />
-              ) : (
-                shouldDisplayArrow && <Arrow showArrow={true} />
-              )}
-            </ArrowContainer>
-          )
-        }}
         onArrowClick={() => trackArrowClick()}
       />
-    )
-  }
-
-  return (
-    <Container mb={4}>
-      <Serif size="5" mt={3} mb={2}>
-        {name}
-      </Serif>
-      <Media lessThan="lg">
-        {renderCarousel({ xs: true, sm: true, md: true })}
-      </Media>
-      <Media at="lg">{renderCarousel()}</Media>
-      <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
     </Container>
   )
 }

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -7,7 +7,6 @@ import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
-import { Media } from "Utils/Responsive"
 import { OtherCollectionsRailsContainer as OtherCollectionEntity } from "./OtherCollectionEntity"
 
 interface OtherCollectionsRailProps {

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -7,7 +7,7 @@ import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
-import { useMedia } from "Utils/Hooks/useMedia"
+import { Media } from "Utils/Responsive"
 import { OtherCollectionsRailsContainer as OtherCollectionEntity } from "./OtherCollectionEntity"
 
 interface OtherCollectionsRailProps {
@@ -18,7 +18,6 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
 }) => {
   const { name, members } = collectionGroup
   const { trackEvent } = useTracking()
-  const { sm, md } = useMedia()
 
   useEffect(() => {
     trackEvent({
@@ -40,18 +39,22 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
     })
   }
 
-  return (
-    <Container mb={4}>
-      <Serif size="5" mt={3} mb={2}>
-        {name}
-      </Serif>
+  interface Breakpoints {
+    xs?: boolean
+    sm?: boolean
+    md?: boolean
+    xl?: boolean
+  }
 
+  const renderCarousel = (breakpoints: Breakpoints = {}) => {
+    return (
       <Carousel
         height="100px"
         options={{
-          groupCells: sd.IS_MOBILE ? 1 : 4,
-          cellAlign: "left",
+          groupCells:
+            breakpoints.xs || breakpoints.sm || breakpoints.md ? 1 : 3,
           wrapAround: sd.IS_MOBILE ? true : false,
+          cellAlign: "left",
           pageDots: false,
           contain: true,
         }}
@@ -68,9 +71,9 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
             </ArrowContainer>
           )
         }}
-        onArrowClick={() => trackArrowClick()}
         renderRightArrow={({ Arrow }) => {
-          const shouldDisplayArrow = sm || (md && members.length > 3)
+          const shouldDisplayArrow =
+            breakpoints.sm || (breakpoints.md && members.length > 3)
           return (
             <ArrowContainer>
               {members.length > 4 ? (
@@ -81,7 +84,21 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
             </ArrowContainer>
           )
         }}
+        onArrowClick={() => trackArrowClick()}
       />
+    )
+  }
+
+  return (
+    <Container mb={4}>
+      <Serif size="5" mt={3} mb={2}>
+        {name}
+      </Serif>
+      <Media lessThan="lg">
+        {renderCarousel({ xs: true, sm: true, md: true })}
+      </Media>
+      <Media at="lg">{renderCarousel()}</Media>
+      <Media greaterThanOrEqual="xl">{renderCarousel({ xl: true })}</Media>
     </Container>
   )
 }

--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -111,6 +111,7 @@ export const LargeCarousel: React.FC<CarouselProps> = props => {
   return (
     <BaseCarousel
       showArrows
+      {...props}
       options={{
         cellAlign: "left",
         contain: true,
@@ -121,7 +122,6 @@ export const LargeCarousel: React.FC<CarouselProps> = props => {
         wrapAround: false,
         ...props.options,
       }}
-      {...props}
     />
   )
 }
@@ -132,6 +132,7 @@ export const SmallCarousel: React.FC<CarouselProps> = props => {
   return (
     <BaseCarousel
       showArrows={false}
+      {...props}
       options={{
         cellAlign: "left",
         draggable: hasMultipleSlides,
@@ -143,7 +144,6 @@ export const SmallCarousel: React.FC<CarouselProps> = props => {
         wrapAround: false,
         ...props.options,
       }}
-      {...props}
     />
   )
 }


### PR DESCRIPTION
Addresses: [GROW-1547](https://artsyproduct.atlassian.net/browse/GROW-1547)

This PR ensures that the collection rails increment by one at smaller breakpoints.

![collection hubs rail](https://user-images.githubusercontent.com/5201004/65698927-49647480-e04b-11e9-923f-2132b8345982.gif)
