### PR TITLE
Updates jscodeshift to 0.6.4 (maybe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "jest-junit": "6.4.0",
     "jest-raw-loader": "1.0.1",
     "jest-styled-components": "7.0.0-2",
+    "jscodeshift": "^0.6.4",
     "json5": "2.1.0",
     "klaw-sync": "6.0.0",
     "lint-staged": "4.3.0",

--- a/patches/jscodeshift+0.6.4.patch
+++ b/patches/jscodeshift+0.6.4.patch
@@ -1,0 +1,62 @@
+diff --git a/node_modules/jscodeshift/dist/Worker.js b/node_modules/jscodeshift/dist/Worker.js
+index 3c96e2b..9329390 100644
+--- a/node_modules/jscodeshift/dist/Worker.js
++++ b/node_modules/jscodeshift/dist/Worker.js
+@@ -134,7 +134,7 @@ function run(data) {
+   async.each(
+     files,
+     function(file, callback) {
+-      fs.readFile(file, function(err, source) {
++      fs.readFile(file, async function(err, source) {
+         if (err) {
+           updateStatus('error', file, 'File error: ' + err);
+           callback();
+@@ -143,7 +143,7 @@ function run(data) {
+         source = source.toString();
+         try {
+           const jscodeshift = prepareJscodeshift(options);
+-          const out = transform(
++          const out = await transform(
+             {
+               path: file,
+               source: source,
+diff --git a/node_modules/jscodeshift/src/testUtils.js b/node_modules/jscodeshift/src/testUtils.js
+index 7ccbf4f..24d79d4 100644
+--- a/node_modules/jscodeshift/src/testUtils.js
++++ b/node_modules/jscodeshift/src/testUtils.js
+@@ -56,16 +56,16 @@ exports.runInlineTest = runInlineTest;
+  * - Test data should be located in a directory called __testfixtures__
+  *   alongside the transform and __tests__ directory.
+  */
+-function runTest(dirName, transformName, options, testFilePrefix) {
++function runTest(dirName, transformName, options, testFilePrefix, testFileExtname) {
+   if (!testFilePrefix) {
+     testFilePrefix = transformName;
+   }
+ 
+   const fixtureDir = path.join(dirName, '..', '__testfixtures__');
+-  const inputPath = path.join(fixtureDir, testFilePrefix + '.input.js');
++  const inputPath = path.join(fixtureDir, testFilePrefix + '.input.' + (testFileExtname || 'js'));
+   const source = fs.readFileSync(inputPath, 'utf8');
+   const expectedOutput = fs.readFileSync(
+-    path.join(fixtureDir, testFilePrefix + '.output.js'),
++    path.join(fixtureDir, testFilePrefix + '.output.' + (testFileExtname || 'js')),
+     'utf8'
+   );
+   // Assumes transform is one level up from __tests__ directory
+@@ -81,13 +81,13 @@ exports.runTest = runTest;
+  * Handles some boilerplate around defining a simple jest/Jasmine test for a
+  * jscodeshift transform.
+  */
+-function defineTest(dirName, transformName, options, testFilePrefix) {
++function defineTest(dirName, transformName, options, testFilePrefix, testFileExtname) {
+   const testName = testFilePrefix
+     ? `transforms correctly using "${testFilePrefix}" data`
+     : 'transforms correctly';
+   describe(transformName, () => {
+     it(testName, () => {
+-      runTest(dirName, transformName, options, testFilePrefix);
++      runTest(dirName, transformName, options, testFilePrefix, testFileExtname);
+     });
+   });
+ }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9669,6 +9669,30 @@ jscodeshift@^0.6.3:
     temp "^0.8.1"
     write-file-atomic "^2.3.0"
 
+jscodeshift@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.6.4.tgz#e19ab86214edac86a75c4557fc88b3937d558a8e"
+  integrity sha512-+NF/tlNbc2WEhXUuc4WEJLsJumF84tnaMUZW2hyJw3jThKKRvsPX4sPJVgO1lPE28z0gNL+gwniLG9d8mYvQCQ==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/parser" "^7.1.6"
+    "@babel/plugin-proposal-class-properties" "^7.1.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/preset-env" "^7.1.6"
+    "@babel/preset-flow" "^7.0.0"
+    "@babel/preset-typescript" "^7.1.0"
+    "@babel/register" "^7.0.0"
+    babel-core "^7.0.0-bridge.0"
+    colors "^1.1.2"
+    flow-parser "0.*"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    neo-async "^2.5.0"
+    node-dir "^0.1.17"
+    recast "^0.16.1"
+    temp "^0.8.1"
+    write-file-atomic "^2.3.0"
+
 jsdom@^11.5.1:
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.11.0.tgz#df486efad41aee96c59ad7a190e2449c7eb1110e"


### PR DESCRIPTION
For the id codemod I need to be able to use promises in the transform. I've updated the version of jscodeshift in reaction with this patch.

This _isn't_ theoretically required. We could always just remove `jscodeshift` altogether from reaction and run the codemods like...

```../codemods/node_modules/.bin/jscodeshift ...```

That'd reduce a dep in reaction and centralize the dependency........ hmmm