### PR TITLE
Add codemod command to simplify running codemods in reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "styled-components": "^4"
   },
   "scripts": {
+    "codemod": "./scripts/codemod.sh",
     "clean": "rm -rf .cache && rm -rf dist",
     "compile": "babel src --out-dir dist -s --source-map --extensions '.js,.jsx,.ts,.tsx' --ignore src/**/__tests__,src/**/__stories__",
     "deploy-storybook-pr": "yarn relay && NODE_ENV=production build-storybook -s ./public -o storybook_build ",

--- a/scripts/codemod.sh
+++ b/scripts/codemod.sh
@@ -1,0 +1,4 @@
+../codemods/node_modules/.bin/jscodeshift --extensions=ts,tsx --transform=../codemods/src/$1.ts src
+
+changed_files=`git diff --name-only | grep -E '\.tsx?$'`
+yarn prettier-write $changed_files


### PR DESCRIPTION
This is a really small change just to make running codemods easier in reaction. 

I'll likely pull this out into `artsy/cli` later, but for the MPv2 efforts it'll be a time saver. 

Just run it like this:

```
yarn codemod <codemod-file-name>
```