### PR TITLE
@joeyAghion => [RelatedArtworks] Be defensive about missing layer

### DIFF
--- a/src/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
@@ -19,6 +19,7 @@ import {
   QueryRenderer,
   RelayRefetchProp,
 } from "react-relay"
+import { get } from "Utils/get"
 
 const logger = createLogger("RelatedWorksArtworkGrid.tsx")
 
@@ -75,22 +76,20 @@ class RelatedWorksArtworkGrid extends React.Component<
 
   render() {
     const {
-      artwork: {
-        layers,
-        layer: { artworksConnection },
-      },
+      artwork: { layers, layer },
       mediator,
     } = this.props
+
+    // The layer might have failed to fetch, so we use the `get` helper
+    // instead of ordinary destructuring.
+    const artworksConnection = get(layer, l => l.artworksConnection)
 
     if (hideGrid(artworksConnection)) {
       return null
     }
 
     // For sale artworks are already rendered on the page so we filter them from related works
-    const names = take(
-      layers.filter(layer => layer.name !== "For Sale"),
-      MAX_TAB_ITEMS
-    )
+    const names = take(layers.filter(l => l.name !== "For Sale"), MAX_TAB_ITEMS)
 
     if (!names.length) {
       return <></>

--- a/src/Apps/Artwork/Components/__tests__/OtherWorks.test.tsx
+++ b/src/Apps/Artwork/Components/__tests__/OtherWorks.test.tsx
@@ -178,5 +178,11 @@ describe("OtherWorks", () => {
       expect(component.find("RelatedWorksArtworkGrid").length).toEqual(0)
       expect(component.find("OtherAuctionsQueryRenderer").length).toEqual(1)
     })
+
+    it("safely renders when there's a missing layer", () => {
+      genericOtherWorksData.layer = null
+      const component = mount(<OtherWorks artwork={genericOtherWorksData} />)
+      expect(component.find("RelatedWorksArtworkGrid").length).toEqual(1)
+    })
   })
 })


### PR DESCRIPTION
Fixes https://sentry.io/organizations/artsynet/issues/1244747616/?project=159064&query=is%3Aunresolved&statsPeriod=14d

Checking out the [resolver for the `layer` field](https://github.com/artsy/metaphysics/blob/9ace7f1313817939f6128c4388c3072e4b306eb4/src/schema/v1/artwork/index.ts#L486), and we see that it can certainly error or not return a layer, and thus be `null`. Nested destructuring is thus a problem, so we should switch to the safer `get`. 