### PR TITLE
@pepopowitz => [Artwork] Be defensive in SEO meta tag component to artworks w/o part…

### DIFF
--- a/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
+++ b/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
@@ -38,7 +38,8 @@ export const SeoDataForArtwork: React.FC<SeoDataForArtworkProps> = ({
     },
   }
 
-  if (artwork.partner.type === "Institution") {
+  const partnerType = get(artwork, a => a.partner.type)
+  if (partnerType === "Institution") {
     return <CreativeWork data={artworkMetaData} />
   }
 

--- a/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
+++ b/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
@@ -30,6 +30,14 @@ describe("SeoDataForArtwork", () => {
       .props().data
 
   describe("SeoDataForArtworkFragmentContainer", () => {
+    it("Renders without a partner", async () => {
+      const wrapper = await getWrapper({
+        ...SeoDataForArtworkFixture,
+        partner: null,
+      })
+
+      expect(wrapper).toBeTruthy()
+    })
     it("Renders a CreativeWork for an institution", async () => {
       const wrapper = await getWrapper({
         ...SeoDataForArtworkFixture,


### PR DESCRIPTION
Fixes https://sentry.io/organizations/artsynet/issues/890333409/?project=159064&query=is%3Aunresolved&statsPeriod=14d

Artworks can lack partners, and that node would [return `null`](https://github.com/artsy/metaphysics/blob/d269bec2e8bb3346fd396ddef1081960dd4e9f16/src/schema/v1/artwork/index.ts#L535-L536) in the graph.