### PR TITLE
@damassi => [Artist] Defer collection rail to client

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -79,6 +79,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     const showRecommendations =
       get(artist, a => a.related.artists.edges.length, 0) > 0
 
+    const isClient = typeof window !== "undefined"
     return (
       <>
         <Row>
@@ -136,9 +137,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
 
         {!hideMainOverviewSection && <Spacer mb={4} />}
 
-        <Box>
-          <ArtistCollectionsRail artistID={artist._id} />
-        </Box>
+        <Box>{isClient && <ArtistCollectionsRail artistID={artist._id} />}</Box>
 
         <Row>
           <Col>


### PR DESCRIPTION
Testing locally, and this works the way we want! 😅 

Previously, the fetch would happen server-side. The data would fill-in client-side, with a spinner (which isn't needed since the data is already there). Hitting the page w/ JS disabled and you would see a spinner.

Now, when curl'ing or viewing the page w/ JS disabled there is no spinner (the component isn't rendered at all), and the fetch doesn't happen. When the client loads, the request is kicked off and the component loads (spinner, and then rail).

This...should help our response time and error rate!