### PR TITLE
[Collection/Id] Re-add missing price sort

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -92,6 +92,8 @@ export class CollectionApp extends Component<CollectionAppProps> {
               filters={location.query}
               sortOptions={[
                 { value: "-decayed_merch", text: "Default" },
+                { value: "sold,-has_price,-prices", text: "Price (desc.)" },
+                { value: "sold,-has_price,prices", text: "Price (asc.)" },
                 { value: "-partner_updated_at", text: "Recently updated" },
                 { value: "-published_at", text: "Recently added" },
                 { value: "-year", text: "Artwork year (desc.)" },


### PR DESCRIPTION
Re-adds missing price sort to `/collection/id`. (Based on old code [here](https://github.com/artsy/reaction/blob/ea30e243d868ab47fd09179a225ce0f498e53ff2/src/Apps/Collect2/Components/Filters/SortFilterSortTypes.tsx#L6-L23).)