### PR TITLE
Collection hubs QA

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -32,6 +32,7 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
     bgImages!.length === 1 ? 221 : bgImages!.length === 2 ? 109 : 72
 
   const { trackEvent } = useTracking()
+  const isMobileDevice = sd.IS_MOBILE
 
   const handleLinkClick = () => {
     trackEvent({
@@ -44,6 +45,7 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
       item_number: itemNumber,
     })
   }
+
   return (
     <Container px={2} pt={2} pb={2} m={1}>
       <StyledLink to={`/collection/${slug}`} onClick={handleLinkClick}>
@@ -72,7 +74,7 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
             : headerImage && <ArtworkImage src={headerImage} width={221} />}
         </ImgWrapper>
         {
-          <CollectionTitle pt={1} pb={0.5} size="3">
+          <CollectionTitle pt={1} pb={0.5} size="3" isMobile={isMobileDevice}>
             {title}
           </CollectionTitle>
         }
@@ -128,8 +130,11 @@ const SingleImgContainer = styled(Box)`
   }
 `
 
-const CollectionTitle = styled(Serif)`
-  width: 100%;
+const CollectionTitle = styled(Serif)<{ isMobile: boolean }>`
+  width: ${props => (props.isMobile ? "220px" : "224px")};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 export const ImgWrapper = styled(Flex)`

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -3,6 +3,7 @@ import { ArtistSeriesEntity_member } from "__generated__/ArtistSeriesEntity_memb
 import { AnalyticsSchema } from "Artsy/Analytics"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { RouterLink } from "Artsy/Router/RouterLink"
+import { Truncator } from "Components/Truncator"
 import currency from "currency.js"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -32,7 +33,6 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
     bgImages!.length === 1 ? 221 : bgImages!.length === 2 ? 109 : 72
 
   const { trackEvent } = useTracking()
-  const isMobileDevice = sd.IS_MOBILE
 
   const handleLinkClick = () => {
     trackEvent({
@@ -74,8 +74,8 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
             : headerImage && <ArtworkImage src={headerImage} width={221} />}
         </ImgWrapper>
         {
-          <CollectionTitle pt={1} pb={0.5} size="3" isMobile={isMobileDevice}>
-            {title}
+          <CollectionTitle pt={1} pb={0.5} size="3">
+            <Truncator maxLineCount={1}>{title}</Truncator>
           </CollectionTitle>
         }
         {price_guidance && (
@@ -130,11 +130,8 @@ const SingleImgContainer = styled(Box)`
   }
 `
 
-const CollectionTitle = styled(Serif)<{ isMobile: boolean }>`
-  width: ${props => (props.isMobile ? "220px" : "224px")};
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+const CollectionTitle = styled(Serif)`
+  width: 100%;
 `
 
 export const ImgWrapper = styled(Flex)`

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -34,7 +34,7 @@ export const OtherCollectionEntity: React.FC<CollectionProps> = ({
 
   return (
     <StyledLink to={`/collection/${slug}`} onClick={handleClick}>
-      <Flex alignItems="center">
+      <Flex alignItems="center" height="60px">
         {thumbnail && (
           <ImageContainer>
             <ThumbnailImage src={thumbnail} />

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -63,10 +63,6 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
 
 const Container = styled(Box)`
   border-top: 1px solid ${color("black10")};
-`
-
-export const ArrowContainer = styled(Box)`
-  align-self: flex-start;
 
   ${ArrowButton} {
     height: 60%;


### PR DESCRIPTION
Addresses: [GROW-1574](https://artsyproduct.atlassian.net/browse/GROW-1574) & [GROW-1575](https://artsyproduct.atlassian.net/browse/GROW-1575)

- Fixes OtherCollectionsEntity when there is a missing thumbnail image (ensure a fixed height)
![Screen Shot 2019-10-03 at 5 43 36 PM](https://user-images.githubusercontent.com/5201004/66166442-5b26b880-e605-11e9-8cad-7bba17d8fc77.png)

- Truncate long titles for ArtistSeriesEntity component
![Screen Shot 2019-10-03 at 5 44 26 PM](https://user-images.githubusercontent.com/5201004/66166488-7691c380-e605-11e9-8ef8-65cb4e75d7bd.png)


