### PR TITLE
@damassi => [Nav] Move notifications dropdown fetching to client

### DIFF
--- a/src/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -95,16 +95,19 @@ export const NotificationMenuItems: React.FC<
  * individual MenuItems for display. During fetch there is a loading spinner.
  */
 export const NotificationsMenu: React.FC = () => {
+  const isClient = typeof window !== "undefined"
   return (
     <Menu title="Activity">
-      <NotificationsQueryRenderer
-        render={renderWithLoadProgress(
-          NotificationMenuItems,
-          {},
-          {},
-          { size: "small" }
-        )}
-      />
+      {isClient && (
+        <NotificationsQueryRenderer
+          render={renderWithLoadProgress(
+            NotificationMenuItems,
+            {},
+            {},
+            { size: "small" }
+          )}
+        />
+      )}
     </Menu>
   )
 }

--- a/src/Components/NavBar/NotificationsBadge.tsx
+++ b/src/Components/NavBar/NotificationsBadge.tsx
@@ -17,7 +17,8 @@ export const NotificationsBadge: React.FC<{
    */
   hover?: boolean
 }> = ({ hover }) => {
-  return (
+  const isClient = typeof window !== "undefined"
+  return isClient ? (
     <NotificationsQueryRenderer
       render={({ error, props }: ReadyState) => {
         // If there's an error hide the badge
@@ -73,6 +74,8 @@ export const NotificationsBadge: React.FC<{
         )
       }}
     />
+  ) : (
+    <CircularCount />
   )
 }
 


### PR DESCRIPTION
cc @alloy 

Closes https://artsyproduct.atlassian.net/browse/PLATFORM-1831

We were seeing up to 3 server side queries happening on the artist page, with 2 in parallel, and 1 happening after the first 2.

The first 2 are intentionally separated: querying for 'top level' content above the tabs, and then a query for the tab's contents. (As we roll out client side routing everywhere, we might revisit this design decision).

The last one, is for the notifications dropdown, and only appears when logged in. This might also be pretty slow, plus we use a cookie to immediately render the badge, so should definitely be deferred.

This affects any pages using the new NAV/shell (not just artist).