### PR TITLE
Grow-1482 collection rail images are insecure and oversized

### DIFF
--- a/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionEntity.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionEntity.tsx
@@ -38,9 +38,11 @@ export class ArtistCollectionEntity extends React.Component<CollectionProps> {
     } = this.props.collection
     const artworks = artworks_connection.edges.map(({ node }) => node)
     const formattedTitle = (title && title.split(": ")[1]) || title
-    const bgImages = compact(artworks.map(({ image }) => image && image.url))
+    const bgImages = compact(
+      artworks.map(({ image }) => image && image.resized.url)
+    )
     const imageSize =
-      bgImages.length === 1 ? 265 : bgImages.length === 2 ? 131 : 85
+      bgImages.length === 1 ? 262 : bgImages.length === 2 ? 130 : 86
 
     return (
       <Box pr={2}>
@@ -73,7 +75,7 @@ export class ArtistCollectionEntity extends React.Component<CollectionProps> {
               <ArtworkImage
                 src={headerImage}
                 lazyLoad={this.props.lazyLoad}
-                width={265}
+                width={262}
                 style={{ objectFit: "cover", objectPosition: "center" }}
               />
             )}
@@ -139,7 +141,7 @@ export const ArtworkImage = styled(Image)<{ width: number }>`
 `
 
 const ImgWrapper = styled(Flex)`
-  width: 265px;
+  width: 262px;
 `
 
 export const ArtistCollectionEntityFragmentContainer = createFragmentContainer(
@@ -160,7 +162,9 @@ export const ArtistCollectionEntityFragmentContainer = createFragmentContainer(
                 }
                 title
                 image {
-                  url(version: "small")
+                  resized(width: 262) {
+                    url
+                  }
                 }
               }
             }

--- a/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionEntity.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionEntity.tsx
@@ -39,7 +39,7 @@ export class ArtistCollectionEntity extends React.Component<CollectionProps> {
     const artworks = artworks_connection.edges.map(({ node }) => node)
     const formattedTitle = (title && title.split(": ")[1]) || title
     const bgImages = compact(
-      artworks.map(({ image }) => image && image.resized.url)
+      artworks.map(({ image }) => image && image.resized && image.resized.url)
     )
     const imageSize =
       bgImages.length === 1 ? 262 : bgImages.length === 2 ? 130 : 86

--- a/src/Apps/Artist/Components/ArtistCollectionsRail/__tests__/ArtistCollectionEntity.test.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/__tests__/ArtistCollectionEntity.test.tsx
@@ -27,7 +27,7 @@ describe("ArtistCollectionEntity", () => {
       "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg"
     )
     expect(artworkImage.alt).toBe("Jasper Johns, Flag")
-    expect(artworkImage.width).toBe(85)
+    expect(artworkImage.width).toBe(86)
   })
 
   it("Returns proper image size if 2 artworks returned", () => {
@@ -55,7 +55,7 @@ describe("ArtistCollectionEntity", () => {
       .getElement().props
 
     expect(component.find(ArtworkImage).length).toBe(2)
-    expect(artworkImage.width).toBe(131)
+    expect(artworkImage.width).toBe(130)
   })
 
   it("Returns correct number of images if a hit has no image url", () => {
@@ -90,7 +90,7 @@ describe("ArtistCollectionEntity", () => {
       .getElement().props
 
     expect(component.find(ArtworkImage).length).toBe(2)
-    expect(artworkImage.width).toBe(131)
+    expect(artworkImage.width).toBe(130)
   })
 
   it("Renders a backup image if no artworks returned", () => {
@@ -115,7 +115,7 @@ describe("ArtistCollectionEntity", () => {
     expect(artworkImage.src).toBe(
       "http://files.artsy.net/images/jasperjohnsflag.png"
     )
-    expect(artworkImage.width).toBe(265)
+    expect(artworkImage.width).toBe(262)
   })
 
   it("Tracks link clicks", () => {

--- a/src/Apps/Artist/Components/ArtistCollectionsRail/__tests__/ArtistCollectionsRail.test.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/__tests__/ArtistCollectionsRail.test.tsx
@@ -83,8 +83,10 @@ describe("CollectionsRail", () => {
                   },
                   title: "Flag",
                   image: {
-                    url:
-                      "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                    resized: {
+                      url:
+                        "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                    },
                   },
                 },
               },
@@ -95,8 +97,10 @@ describe("CollectionsRail", () => {
                   },
                   title: "Flag (Moratorium)",
                   image: {
-                    url:
-                      "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+                    resized: {
+                      url:
+                        "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+                    },
                   },
                 },
               },
@@ -107,8 +111,10 @@ describe("CollectionsRail", () => {
                   },
                   title: "Flag I",
                   image: {
-                    url:
-                      "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+                    resized: {
+                      url:
+                        "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+                    },
                   },
                 },
               },

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
@@ -198,6 +198,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
             width: imageWidth * (xs ? 2 : 1),
             height: imageHeight * (xs ? 2 : 1),
             quality: 80,
+            convert_to: "jpg",
           })
 
         return (

--- a/src/Apps/__tests__/Fixtures/Collections.ts
+++ b/src/Apps/__tests__/Fixtures/Collections.ts
@@ -52,8 +52,10 @@ export const CollectionsRailFixture = [
               },
               title: "Flag",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                },
               },
             },
           },
@@ -64,8 +66,10 @@ export const CollectionsRailFixture = [
               },
               title: "Flag (Moratorium)",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+                },
               },
             },
           },
@@ -76,8 +80,10 @@ export const CollectionsRailFixture = [
               },
               title: "Flag I",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+                },
               },
             },
           },
@@ -100,8 +106,10 @@ export const CollectionsRailFixture = [
               },
               title: "Community Chest: Go To Jail",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/DSa-4s-zRJEwW6mZRgDoxQ/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/DSa-4s-zRJEwW6mZRgDoxQ/small.jpg",
+                },
               },
             },
           },
@@ -112,8 +120,10 @@ export const CollectionsRailFixture = [
               },
               title: "DJ Monopoly",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/L0wx7i69h96MUFq9EgOpBQ/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/L0wx7i69h96MUFq9EgOpBQ/small.jpg",
+                },
               },
             },
           },
@@ -124,8 +134,10 @@ export const CollectionsRailFixture = [
               },
               title: "Keith Haring 1982 Dolphin lithograph",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/ZZodXz8Y7v7h0VWlQnZQCw/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/ZZodXz8Y7v7h0VWlQnZQCw/small.jpg",
+                },
               },
             },
           },
@@ -149,8 +161,10 @@ export const CollectionsRailFixture = [
               },
               title: "Untitled",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/VzteQ4joB2Iwjek9kPUrGg/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/VzteQ4joB2Iwjek9kPUrGg/small.jpg",
+                },
               },
             },
           },
@@ -161,8 +175,10 @@ export const CollectionsRailFixture = [
               },
               title: "P8",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/ZN_qyzZgvHz-DRMFW-Wrcw/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/ZN_qyzZgvHz-DRMFW-Wrcw/small.jpg",
+                },
               },
             },
           },
@@ -173,8 +189,10 @@ export const CollectionsRailFixture = [
               },
               title: "Monsters",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/0vJm9FeXzxzZJpBC-A-4ig/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/0vJm9FeXzxzZJpBC-A-4ig/small.jpg",
+                },
               },
             },
           },
@@ -197,8 +215,10 @@ export const CollectionsRailFixture = [
               },
               title: "Migratory Bird I",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/_67k2lYpopsd-UK6LOD61g/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/_67k2lYpopsd-UK6LOD61g/small.jpg",
+                },
               },
             },
           },
@@ -209,8 +229,10 @@ export const CollectionsRailFixture = [
               },
               title: "Bacchanale",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/mepJj80_m4NiWUJviymyBw/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/mepJj80_m4NiWUJviymyBw/small.jpg",
+                },
               },
             },
           },
@@ -221,8 +243,10 @@ export const CollectionsRailFixture = [
               },
               title: "Mitered Squares-Apricot ",
               image: {
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/CbgUJdNK5lWvhKzziYgx7w/small.jpg",
+                resized: {
+                  url:
+                    "https://d32dm0rphc51dk.cloudfront.net/CbgUJdNK5lWvhKzziYgx7w/small.jpg",
+                },
               },
             },
           },

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -37,7 +37,7 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
     } = this.props.collection
     const artworks = artworks_connection.edges.map(({ node }) => node)
     const bgImages = compact(
-      artworks.map(({ image }) => image && image.resized.url)
+      artworks.map(({ image }) => image && image.resized && image.resized.url)
     )
     const imageSize =
       bgImages.length === 1 ? 262 : bgImages.length === 2 ? 130 : 86

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -36,9 +36,11 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
       title,
     } = this.props.collection
     const artworks = artworks_connection.edges.map(({ node }) => node)
-    const bgImages = compact(artworks.map(({ image }) => image && image.url))
+    const bgImages = compact(
+      artworks.map(({ image }) => image && image.resized.url)
+    )
     const imageSize =
-      bgImages.length === 1 ? 265 : bgImages.length === 2 ? 131 : 85
+      bgImages.length === 1 ? 262 : bgImages.length === 2 ? 130 : 86
 
     return (
       <Box pr={2}>
@@ -66,7 +68,7 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
                 )
               })
             ) : (
-              <ArtworkImage src={headerImage} width={265} />
+              <ArtworkImage src={headerImage} width={262} />
             )}
           </ImgWrapper>
           <CollectionTitle size="3">{title}</CollectionTitle>
@@ -130,7 +132,7 @@ export const ArtworkImage = styled.img<{ width: number }>`
 `
 
 const ImgWrapper = styled(Flex)`
-  width: 265px;
+  width: 262px;
 `
 
 export const RelatedCollectionEntityFragmentContainer = createFragmentContainer(
@@ -151,7 +153,9 @@ export const RelatedCollectionEntityFragmentContainer = createFragmentContainer(
                 }
                 title
                 image {
-                  url(version: "small")
+                  resized(width: 262) {
+                    url
+                  }
                 }
               }
             }

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionEntity.test.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionEntity.test.tsx
@@ -34,7 +34,7 @@ describe("RelatedCollectionEntity", () => {
       "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg"
     )
     expect(artworkImage.alt).toBe("Jasper Johns, Flag")
-    expect(artworkImage.width).toBe(85)
+    expect(artworkImage.width).toBe(86)
   })
 
   it("Returns proper image size if 2 artworks returned", () => {
@@ -46,7 +46,7 @@ describe("RelatedCollectionEntity", () => {
       .getElement().props
 
     expect(component.find(ArtworkImage).length).toBe(2)
-    expect(artworkImage.width).toBe(131)
+    expect(artworkImage.width).toBe(130)
   })
 
   it("Renders a backup image if no artworks returned", () => {
@@ -61,7 +61,7 @@ describe("RelatedCollectionEntity", () => {
     expect(artworkImage.src).toBe(
       "http://files.artsy.net/images/jasperjohnsflag.png"
     )
-    expect(artworkImage.width).toBe(265)
+    expect(artworkImage.width).toBe(262)
   })
 
   it("Tracks link clicks", () => {

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.test.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.test.tsx
@@ -84,8 +84,10 @@ describe("CollectionsRail", () => {
                   },
                   title: "Flag",
                   image: {
-                    url:
-                      "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                    resized: {
+                      url:
+                        "https://d32dm0rphc51dk.cloudfront.net/4izTOpDv-ew-g1RFXeREcQ/small.jpg",
+                    },
                   },
                 },
               },
@@ -96,8 +98,10 @@ describe("CollectionsRail", () => {
                   },
                   title: "Flag (Moratorium)",
                   image: {
-                    url:
-                      "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+                    resized: {
+                      url:
+                        "https://d32dm0rphc51dk.cloudfront.net/Jyhryk2bLDdkpNflvWO0Lg/small.jpg",
+                    },
                   },
                 },
               },
@@ -108,8 +112,10 @@ describe("CollectionsRail", () => {
                   },
                   title: "Flag I",
                   image: {
-                    url:
-                      "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+                    resized: {
+                      url:
+                        "https://d32dm0rphc51dk.cloudfront.net/gM-IwaZ9C24Y_RQTRW6F5A/small.jpg",
+                    },
                   },
                 },
               },

--- a/src/Utils/resizer.ts
+++ b/src/Utils/resizer.ts
@@ -48,9 +48,10 @@ export const resize = (
     width?: number
     height?: number
     quality?: number
+    convert_to?: string
   }
 ) => {
-  const { width, height, quality } = options
+  const { width, height, quality, convert_to } = options
 
   // dont call gemini with empty src
   if (!src) return null
@@ -70,6 +71,7 @@ export const resize = (
     width,
     height,
     quality: quality || 80,
+    convert_to,
   }
 
   return [GEMINI_CLOUDFRONT_URL, qs.stringify(config)].join("?")

--- a/src/__generated__/ArtistCollectionEntity_collection.graphql.ts
+++ b/src/__generated__/ArtistCollectionEntity_collection.graphql.ts
@@ -17,7 +17,9 @@ export type ArtistCollectionEntity_collection = {
                     }) | null;
                     readonly title: string | null;
                     readonly image: ({
-                        readonly url: string | null;
+                        readonly resized: ({
+                            readonly url: string | null;
+                        }) | null;
                     }) | null;
                 }) | null;
             }) | null> | null;
@@ -167,18 +169,29 @@ return {
                       "plural": false,
                       "selections": [
                         {
-                          "kind": "ScalarField",
+                          "kind": "LinkedField",
                           "alias": null,
-                          "name": "url",
+                          "name": "resized",
+                          "storageKey": "resized(width:262)",
                           "args": [
                             {
                               "kind": "Literal",
-                              "name": "version",
-                              "value": "small",
-                              "type": "[String]"
+                              "name": "width",
+                              "value": 262,
+                              "type": "Int"
                             }
                           ],
-                          "storageKey": "url(version:\"small\")"
+                          "concreteType": "ResizedImageUrl",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "kind": "ScalarField",
+                              "alias": null,
+                              "name": "url",
+                              "args": null,
+                              "storageKey": null
+                            }
+                          ]
                         },
                         v2
                       ]
@@ -197,5 +210,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '288b038a5e57b8a4730f120cb06796ef';
+(node as any).hash = '80972a14c0109d823f6537d3e1e93002';
 export default node;

--- a/src/__generated__/ArtistCollectionsRailQuery.graphql.ts
+++ b/src/__generated__/ArtistCollectionsRailQuery.graphql.ts
@@ -51,7 +51,9 @@ fragment ArtistCollectionEntity_collection on MarketingCollection {
           }
           title
           image {
-            url(version: "small")
+            resized(width: 262) {
+              url
+            }
             __id: id
           }
           __id
@@ -131,7 +133,7 @@ return {
   "operationKind": "query",
   "name": "ArtistCollectionsRailQuery",
   "id": null,
-  "text": "query ArtistCollectionsRailQuery(\n  $isFeaturedArtistContent: Boolean\n  $size: Int\n  $artistID: String\n) {\n  collections: marketingCollections(isFeaturedArtistContent: $isFeaturedArtistContent, size: $size, artistID: $artistID) {\n    ...ArtistCollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n  __id: id\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            url(version: \"small\")\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query ArtistCollectionsRailQuery(\n  $isFeaturedArtistContent: Boolean\n  $size: Int\n  $artistID: String\n) {\n  collections: marketingCollections(isFeaturedArtistContent: $isFeaturedArtistContent, size: $size, artistID: $artistID) {\n    ...ArtistCollectionsRail_collections\n    __id: id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n  __id: id\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            resized(width: 262) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -283,18 +285,29 @@ return {
                             "plural": false,
                             "selections": [
                               {
-                                "kind": "ScalarField",
+                                "kind": "LinkedField",
                                 "alias": null,
-                                "name": "url",
+                                "name": "resized",
+                                "storageKey": "resized(width:262)",
                                 "args": [
                                   {
                                     "kind": "Literal",
-                                    "name": "version",
-                                    "value": "small",
-                                    "type": "[String]"
+                                    "name": "width",
+                                    "value": 262,
+                                    "type": "Int"
                                   }
                                 ],
-                                "storageKey": "url(version:\"small\")"
+                                "concreteType": "ResizedImageUrl",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "url",
+                                    "args": null,
+                                    "storageKey": null
+                                  }
+                                ]
                               },
                               v2
                             ]

--- a/src/__generated__/CollectionRefetch2Query.graphql.ts
+++ b/src/__generated__/CollectionRefetch2Query.graphql.ts
@@ -469,7 +469,9 @@ fragment RelatedCollectionEntity_collection on MarketingCollection {
           }
           title
           image {
-            url(version: "small")
+            resized(width: 262) {
+              url
+            }
             __id: id
           }
           __id
@@ -650,145 +652,75 @@ v10 = {
   "value": "-decayed_merch",
   "type": "String"
 },
-v11 = {
+v11 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "TOTAL"
+    ],
+    "type": "[ArtworkAggregation]"
+  },
+  v10
+],
+v12 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 3,
+    "type": "Int"
+  }
+],
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v13 = [
-  v11,
-  v12
+v15 = [
+  v13,
+  v14
 ],
-v14 = {
+v16 = {
   "kind": "LinkedField",
   "alias": null,
-  "name": "artworks",
-  "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
-  "args": [
-    {
-      "kind": "Literal",
-      "name": "aggregations",
-      "value": [
-        "TOTAL"
-      ],
-      "type": "[ArtworkAggregation]"
-    },
-    v10
-  ],
-  "concreteType": "FilterArtworks",
+  "name": "artist",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Artist",
   "plural": false,
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "artworks_connection",
-      "storageKey": "artworks_connection(first:3)",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 3,
-          "type": "Int"
-        }
-      ],
-      "concreteType": "ArtworkConnection",
-      "plural": false,
-      "selections": [
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "edges",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "ArtworkEdge",
-          "plural": true,
-          "selections": [
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "node",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "Artwork",
-              "plural": false,
-              "selections": [
-                {
-                  "kind": "LinkedField",
-                  "alias": null,
-                  "name": "artist",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "Artist",
-                  "plural": false,
-                  "selections": v13
-                },
-                v3,
-                {
-                  "kind": "LinkedField",
-                  "alias": null,
-                  "name": "image",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "Image",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "kind": "ScalarField",
-                      "alias": null,
-                      "name": "url",
-                      "args": [
-                        {
-                          "kind": "Literal",
-                          "name": "version",
-                          "value": "small",
-                          "type": "[String]"
-                        }
-                      ],
-                      "storageKey": "url(version:\"small\")"
-                    },
-                    v2
-                  ]
-                },
-                v12
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    v12
-  ]
+  "selections": v15
 },
-v15 = {
+v17 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "url",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
   "kind": "Variable",
   "name": "aggregations",
   "variableName": "aggregations",
   "type": "[ArtworkAggregation]"
 },
-v16 = {
+v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v17 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "url",
-    "args": null,
-    "storageKey": null
-  },
+v20 = [
+  v17,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -804,14 +736,14 @@ v17 = [
     "storageKey": null
   }
 ],
-v18 = {
+v21 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "_id",
   "args": null,
   "storageKey": null
 },
-v19 = [
+v22 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -825,21 +757,21 @@ v19 = [
     "type": "Int"
   }
 ],
-v20 = {
+v23 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v21 = {
+v24 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
-v22 = [
+v25 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -847,7 +779,7 @@ v22 = [
     "type": "Boolean"
   }
 ],
-v23 = [
+v26 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -864,14 +796,14 @@ v23 = [
   },
   v2
 ],
-v24 = {
+v27 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v25 = {
+v28 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "aggregations",
@@ -897,7 +829,7 @@ v25 = {
       "plural": true,
       "selections": [
         v7,
-        v11,
+        v13,
         {
           "kind": "ScalarField",
           "alias": null,
@@ -905,28 +837,28 @@ v25 = {
           "args": null,
           "storageKey": null
         },
-        v12
+        v14
       ]
     }
   ]
 },
-v26 = {
+v29 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v27 = {
+v30 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v28 = [
-  v26,
-  v27,
+v31 = [
+  v29,
+  v30,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -935,7 +867,7 @@ v28 = [
     "storageKey": null
   }
 ],
-v29 = {
+v32 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -947,7 +879,7 @@ return {
   "operationKind": "query",
   "name": "CollectionRefetch2Query",
   "id": null,
-  "text": "query CollectionRefetch2Query(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $at_auction: Boolean\n  $color: String\n  $for_sale: Boolean\n  $height: String\n  $inquireable_only: Boolean\n  $major_periods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $price_range: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  viewer: marketingCollection(slug: $slug) {\n    ...Collection_viewer_2aBr8l\n    __id: id\n  }\n}\n\nfragment Collection_viewer_2aBr8l on MarketingCollection {\n  category\n  credit\n  description\n  headerImage\n  id\n  slug\n  title\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    __id: id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworks(aggregations: $aggregations, include_medium_filter_in_aggregation: true, size: 12, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  filtered_artworks: artworks(acquireable: $acquireable, aggregations: $aggregations, at_auction: $at_auction, color: $color, for_sale: $for_sale, height: $height, inquireable_only: $inquireable_only, major_periods: $major_periods, medium: $medium, offerable: $offerable, page: $page, price_range: $price_range, size: 0, sort: $sort, width: $width) {\n    __id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n  __id: id\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  __id: id\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Header_artworks on FilterArtworks {\n  ...DefaultHeader_headerArtworks\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworks {\n  __id\n  aggregations {\n    slice\n    counts {\n      id\n      name\n      count\n      __id\n    }\n  }\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __id\n      }\n    }\n    ...ArtworkGrid_artworks\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworks {\n  hits {\n    href\n    id\n    image {\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n      large: resized(height: 220) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  name\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    id\n    slug\n    title\n    description\n    price_guidance\n    thumbnail\n    __id: id\n  }\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  members {\n    ...ArtistSeriesEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            url(version: \"small\")\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n  __id: id\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            url(version: \"small\")\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n",
+  "text": "query CollectionRefetch2Query(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $at_auction: Boolean\n  $color: String\n  $for_sale: Boolean\n  $height: String\n  $inquireable_only: Boolean\n  $major_periods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $price_range: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  viewer: marketingCollection(slug: $slug) {\n    ...Collection_viewer_2aBr8l\n    __id: id\n  }\n}\n\nfragment Collection_viewer_2aBr8l on MarketingCollection {\n  category\n  credit\n  description\n  headerImage\n  id\n  slug\n  title\n  query {\n    artist_ids\n    artist_id\n    gene_id\n    __id: id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    __id: id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworks(aggregations: $aggregations, include_medium_filter_in_aggregation: true, size: 12, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        id\n        name\n        count\n        __id\n      }\n    }\n    __id\n  }\n  filtered_artworks: artworks(acquireable: $acquireable, aggregations: $aggregations, at_auction: $at_auction, color: $color, for_sale: $for_sale, height: $height, inquireable_only: $inquireable_only, major_periods: $major_periods, medium: $medium, offerable: $offerable, page: $page, price_range: $price_range, size: 0, sort: $sort, width: $width) {\n    __id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n  __id: id\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  __id: id\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Header_artworks on FilterArtworks {\n  ...DefaultHeader_headerArtworks\n  merchandisable_artists {\n    id\n    _id\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    __id\n  }\n  __id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists(shallow: true) {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworks {\n  __id\n  aggregations {\n    slice\n    counts {\n      id\n      name\n      count\n      __id\n    }\n  }\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __id\n      }\n    }\n    ...ArtworkGrid_artworks\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworks {\n  hits {\n    href\n    id\n    image {\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n      large: resized(height: 220) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n    __id\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  name\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    id\n    slug\n    title\n    description\n    price_guidance\n    thumbnail\n    __id: id\n  }\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  members {\n    ...ArtistSeriesEntity_member\n    __id: id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            url(version: \"small\")\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n  __id: id\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance\n  artworks(aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    artworks_connection(first: 3) {\n      edges {\n        node {\n          artist {\n            name\n            __id\n          }\n          title\n          image {\n            resized(width: 262) {\n              url\n            }\n            __id: id\n          }\n          __id\n        }\n      }\n    }\n    __id\n  }\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -1133,7 +1065,85 @@ return {
               v8,
               v3,
               v9,
-              v14,
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artworks",
+                "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
+                "args": v11,
+                "concreteType": "FilterArtworks",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artworks_connection",
+                    "storageKey": "artworks_connection(first:3)",
+                    "args": v12,
+                    "concreteType": "ArtworkConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "edges",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtworkEdge",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "node",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "plural": false,
+                            "selections": [
+                              v16,
+                              v3,
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "image",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "resized",
+                                    "storageKey": "resized(width:262)",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "width",
+                                        "value": 262,
+                                        "type": "Int"
+                                      }
+                                    ],
+                                    "concreteType": "ResizedImageUrl",
+                                    "plural": false,
+                                    "selections": [
+                                      v17
+                                    ]
+                                  },
+                                  v2
+                                ]
+                              },
+                              v14
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  v14
+                ]
+              },
               v2
             ]
           },
@@ -1153,7 +1163,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              v11,
+              v13,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1177,7 +1187,80 @@ return {
                   },
                   v2,
                   v6,
-                  v14
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artworks",
+                    "storageKey": "artworks(aggregations:[\"TOTAL\"],sort:\"-decayed_merch\")",
+                    "args": v11,
+                    "concreteType": "FilterArtworks",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artworks_connection",
+                        "storageKey": "artworks_connection(first:3)",
+                        "args": v12,
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  v16,
+                                  v3,
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "url",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": "small",
+                                            "type": "[String]"
+                                          }
+                                        ],
+                                        "storageKey": "url(version:\"small\")"
+                                      },
+                                      v2
+                                    ]
+                                  },
+                                  v14
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      v14
+                    ]
+                  }
                 ]
               }
             ]
@@ -1188,7 +1271,7 @@ return {
             "name": "artworks",
             "storageKey": null,
             "args": [
-              v15,
+              v18,
               {
                 "kind": "Literal",
                 "name": "include_medium_filter_in_aggregation",
@@ -1215,7 +1298,7 @@ return {
                 "concreteType": "Artwork",
                 "plural": true,
                 "selections": [
-                  v16,
+                  v19,
                   v7,
                   {
                     "kind": "LinkedField",
@@ -1241,7 +1324,7 @@ return {
                         ],
                         "concreteType": "ResizedImageUrl",
                         "plural": false,
-                        "selections": v17
+                        "selections": v20
                       },
                       {
                         "kind": "LinkedField",
@@ -1258,15 +1341,15 @@ return {
                         ],
                         "concreteType": "ResizedImageUrl",
                         "plural": false,
-                        "selections": v17
+                        "selections": v20
                       },
                       v2
                     ]
                   },
-                  v12
+                  v14
                 ]
               },
-              v12,
+              v14,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1277,8 +1360,8 @@ return {
                 "plural": true,
                 "selections": [
                   v7,
-                  v18,
-                  v11,
+                  v21,
+                  v13,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1300,7 +1383,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v12,
+                  v14,
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1333,7 +1416,7 @@ return {
                 "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v19,
+                "args": v22,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -1362,11 +1445,11 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v12,
+                          v14,
                           v4,
-                          v20,
-                          v16,
-                          v21,
+                          v23,
+                          v19,
+                          v24,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1394,10 +1477,10 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v22,
+                            "args": v25,
                             "concreteType": "Artist",
                             "plural": true,
-                            "selections": v13
+                            "selections": v15
                           },
                           {
                             "kind": "LinkedField",
@@ -1407,7 +1490,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v23
+                            "selections": v26
                           },
                           {
                             "kind": "LinkedField",
@@ -1426,12 +1509,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v22,
+                            "args": v25,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v11,
-                              v24,
+                              v13,
+                              v27,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -1449,9 +1532,9 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v23
+                                    "selections": v26
                                   },
-                                  v12
+                                  v14
                                 ]
                               },
                               {
@@ -1519,10 +1602,10 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  v12
+                                  v14
                                 ]
                               },
-                              v12
+                              v14
                             ]
                           }
                         ]
@@ -1531,7 +1614,7 @@ return {
                   }
                 ]
               },
-              v25
+              v28
             ]
           },
           {
@@ -1546,7 +1629,7 @@ return {
                 "variableName": "acquireable",
                 "type": "Boolean"
               },
-              v15,
+              v18,
               {
                 "kind": "Variable",
                 "name": "at_auction",
@@ -1629,14 +1712,14 @@ return {
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v12,
-              v25,
+              v14,
+              v28,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v19,
+                "args": v22,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -1682,7 +1765,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": true,
-                        "selections": v28
+                        "selections": v31
                       },
                       {
                         "kind": "LinkedField",
@@ -1692,7 +1775,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v28
+                        "selections": v31
                       },
                       {
                         "kind": "LinkedField",
@@ -1702,7 +1785,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v28
+                        "selections": v31
                       },
                       {
                         "kind": "LinkedField",
@@ -1713,8 +1796,8 @@ return {
                         "concreteType": "PageCursor",
                         "plural": false,
                         "selections": [
-                          v26,
-                          v27
+                          v29,
+                          v30
                         ]
                       }
                     ]
@@ -1742,17 +1825,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v22,
+                            "args": v25,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v12,
-                              v16,
-                              v11
+                              v14,
+                              v19,
+                              v13
                             ]
                           },
-                          v12,
-                          v16,
+                          v14,
+                          v19,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1793,7 +1876,7 @@ return {
                               }
                             ]
                           },
-                          v18,
+                          v21,
                           v3,
                           {
                             "kind": "ScalarField",
@@ -1802,7 +1885,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v20,
+                          v23,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1830,14 +1913,14 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v22,
+                            "args": v25,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v11,
-                              v16,
-                              v12,
-                              v24
+                              v13,
+                              v19,
+                              v14,
+                              v27
                             ]
                           },
                           {
@@ -1863,7 +1946,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v12,
+                              v14,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1930,7 +2013,7 @@ return {
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
                                 "selections": [
-                                  v29,
+                                  v32,
                                   v2
                                 ]
                               },
@@ -1943,10 +2026,10 @@ return {
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
                                 "selections": [
-                                  v29
+                                  v32
                                 ]
                               },
-                              v12
+                              v14
                             ]
                           },
                           {
@@ -1970,7 +2053,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v21,
+                          v24,
                           {
                             "kind": "ScalarField",
                             "alias": null,

--- a/src/__generated__/RelatedCollectionEntity_collection.graphql.ts
+++ b/src/__generated__/RelatedCollectionEntity_collection.graphql.ts
@@ -17,7 +17,9 @@ export type RelatedCollectionEntity_collection = {
                     }) | null;
                     readonly title: string | null;
                     readonly image: ({
-                        readonly url: string | null;
+                        readonly resized: ({
+                            readonly url: string | null;
+                        }) | null;
                     }) | null;
                 }) | null;
             }) | null> | null;
@@ -167,18 +169,29 @@ return {
                       "plural": false,
                       "selections": [
                         {
-                          "kind": "ScalarField",
+                          "kind": "LinkedField",
                           "alias": null,
-                          "name": "url",
+                          "name": "resized",
+                          "storageKey": "resized(width:262)",
                           "args": [
                             {
                               "kind": "Literal",
-                              "name": "version",
-                              "value": "small",
-                              "type": "[String]"
+                              "name": "width",
+                              "value": 262,
+                              "type": "Int"
                             }
                           ],
-                          "storageKey": "url(version:\"small\")"
+                          "concreteType": "ResizedImageUrl",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "kind": "ScalarField",
+                              "alias": null,
+                              "name": "url",
+                              "args": null,
+                              "storageKey": null
+                            }
+                          ]
                         },
                         v2
                       ]
@@ -197,5 +210,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'd83ff6b1bae5fd0f0cc405596b3c2e2d';
+(node as any).hash = '62656e0f6791fb5013052961265cf689';
 export default node;


### PR DESCRIPTION
Address: [Grow-1482](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1482)

This PR is going to do 3 things. You can see below.

1. For the header image, the resized will transfers the format from PNG to JPG on the collection page. You can see the image below, see the size is much smaller.
<img width="562" alt="Screen Shot 2019-10-04 at 12 40 51" src="https://user-images.githubusercontent.com/45926410/66235582-570aa180-e6be-11e9-80a1-d891178dc6fb.png">

2. For the images in the collection rail and related collection rail, it will get a secure URL when it does the query.

3. Based on the Zeplin, [Zeplin Collection Page](https://app.zeplin.io/project/5aabc5e0786bbb29b6e3dc7f/screen/5cd1af05e05b3067d84963cd), [Zeplin Artist Page](https://app.zeplin.io/project/5aabc5e0786bbb29b6e3dc7f/screen/5c7403e192623b407fcec158),
In order to fit the requirement in the Zeplin, this PR changes the size a little bit.
