### PR TITLE
[Refactor] Replace QueryRender with SystemQueryRenderer

### DIFF
--- a/src/Apps/Artist/Components/ArtistCollectionsRail/index.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/index.tsx
@@ -2,8 +2,9 @@ import { Box } from "@artsy/palette"
 import { ArtistCollectionsRailQuery } from "__generated__/ArtistCollectionsRailQuery.graphql"
 import { useSystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 import { ArtistCollectionsRailFragmentContainer as ArtistCollectionsRail } from "./ArtistCollectionsRail"
 
 interface Props {
@@ -16,7 +17,7 @@ export const ArtistCollectionsRailContent: React.SFC<Props> = passedProps => {
 
   return (
     <Box mb={3}>
-      <QueryRenderer<ArtistCollectionsRailQuery>
+      <SystemQueryRenderer<ArtistCollectionsRailQuery>
         environment={relayEnvironment}
         variables={{
           isFeaturedArtistContent: true,

--- a/src/Apps/Artist/Components/MarketDataSummary/index.tsx
+++ b/src/Apps/Artist/Components/MarketDataSummary/index.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 
 import { MarketDataSummaryContentsQuery } from "__generated__/MarketDataSummaryContentsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import MarketDataSummary from "./MarketDataSummary"
 
 export interface Props extends SystemContextProps {
@@ -13,7 +14,7 @@ class MarketDataSummaryContents extends React.Component<Props, null> {
   render() {
     const { artistID, relayEnvironment } = this.props
     return (
-      <QueryRenderer<MarketDataSummaryContentsQuery>
+      <SystemQueryRenderer<MarketDataSummaryContentsQuery>
         environment={relayEnvironment}
         query={graphql`
           query MarketDataSummaryContentsQuery($artistID: String!) {

--- a/src/Apps/Artist/Components/MarketInsights/index.tsx
+++ b/src/Apps/Artist/Components/MarketInsights/index.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 
 import { MarketInsightsContentsQuery } from "__generated__/MarketInsightsContentsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import MarketInsights from "./MarketInsights"
 
 export interface Props extends SystemContextProps {
@@ -13,7 +14,7 @@ class MarketInsightsContents extends React.Component<Props, null> {
   render() {
     const { artistID, relayEnvironment } = this.props
     return (
-      <QueryRenderer<MarketInsightsContentsQuery>
+      <SystemQueryRenderer<MarketInsightsContentsQuery>
         environment={relayEnvironment}
         query={graphql`
           query MarketInsightsContentsQuery($artistID: String!) {

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistRecommendations.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistRecommendations.tsx
@@ -3,11 +3,11 @@ import { ArtistRecommendations_artist } from "__generated__/ArtistRecommendation
 import { ArtistRecommendationsRendererQuery } from "__generated__/ArtistRecommendationsRendererQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext, useState } from "react"
 import {
   createPaginationContainer,
   graphql,
-  QueryRenderer,
   RelayPaginationProp,
 } from "react-relay"
 import { get } from "Utils/get"
@@ -151,7 +151,7 @@ export const ArtistRecommendationsQueryRenderer: React.FC<{
 }> = ({ artistID }) => {
   const { relayEnvironment } = useContext(SystemContext)
   return (
-    <QueryRenderer<ArtistRecommendationsRendererQuery>
+    <SystemQueryRenderer<ArtistRecommendationsRendererQuery>
       environment={relayEnvironment}
       query={graphql`
         query ArtistRecommendationsRendererQuery($artistID: String!) {

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -136,7 +136,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
 
         {!hideMainOverviewSection && <Spacer mb={4} />}
 
-        <Box>{isClient && <ArtistCollectionsRail artistID={artist._id} />}</Box>
+        <Box>{<ArtistCollectionsRail artistID={artist._id} />}</Box>
 
         <Row>
           <Col>

--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -13,6 +13,7 @@ import { Mediator } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import {
   ArtistBioFragmentContainer as ArtistBio,
@@ -21,7 +22,7 @@ import {
 } from "Components/v2"
 import { MIN_EXHIBITIONS } from "Components/v2/SelectedExhibitions"
 import React, { Component } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import Events from "Utils/Events"
 import { get } from "Utils/get"
@@ -274,7 +275,7 @@ export const ArtistInfoQueryRenderer = ({ artistID }: { artistID: string }) => {
     <SystemContextConsumer>
       {({ relayEnvironment }) => {
         return (
-          <QueryRenderer<ArtistInfoQuery>
+          <SystemQueryRenderer<ArtistInfoQuery>
             environment={relayEnvironment}
             variables={{ artistID }}
             query={graphql`

--- a/src/Apps/Artwork/Components/ArtworkBanner/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkBanner/index.tsx
@@ -2,8 +2,9 @@ import { ArtworkBanner_artwork } from "__generated__/ArtworkBanner_artwork.graph
 import { ArtworkBannerQuery } from "__generated__/ArtworkBannerQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
 import { Banner } from "./Banner"
 
@@ -195,7 +196,7 @@ export const ArtworkBannerQueryRenderer = ({
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<ArtworkBannerQuery>
+    <SystemQueryRenderer<ArtworkBannerQuery>
       environment={relayEnvironment}
       variables={{ artworkID }}
       query={graphql`

--- a/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Tab, Tabs } from "@artsy/palette"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import React, { Component, useContext } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { ArtworkDetailsAboutTheWorkFromArtsyFragmentContainer as AboutTheWorkFromArtsy } from "./ArtworkDetailsAboutTheWorkFromArtsy"
 import { ArtworkDetailsAboutTheWorkFromPartnerFragmentContainer as AboutTheWorkFromPartner } from "./ArtworkDetailsAboutTheWorkFromPartner"
@@ -14,6 +14,7 @@ import { ArtworkDetailsQuery } from "__generated__/ArtworkDetailsQuery.graphql"
 import { SystemContext } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import Events from "Utils/Events"
 
 export interface ArtworkDetailsProps {
@@ -114,7 +115,7 @@ export const ArtworkDetailsQueryRenderer = ({
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<ArtworkDetailsQuery>
+    <SystemQueryRenderer<ArtworkDetailsQuery>
       environment={relayEnvironment}
       variables={{ artworkID }}
       query={graphql`

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
@@ -2,8 +2,9 @@ import { ArtworkImageBrowser_artwork } from "__generated__/ArtworkImageBrowser_a
 import { ArtworkImageBrowserQuery } from "__generated__/ArtworkImageBrowserQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkActionsFragmentContainer as ArtworkActions } from "./ArtworkActions"
 import { ArtworkImageBrowser } from "./ArtworkImageBrowser"
 
@@ -86,7 +87,7 @@ export const ArtworkImageBrowserQueryRenderer = ({
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<ArtworkImageBrowserQuery>
+    <SystemQueryRenderer<ArtworkImageBrowserQuery>
       environment={relayEnvironment}
       variables={{ artworkID }}
       query={graphql`

--- a/src/Apps/Artwork/Components/ArtworkSidebar/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/index.tsx
@@ -2,7 +2,7 @@ import { Box, Spacer } from "@artsy/palette"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import { AuctionTimerFragmentContainer as AuctionTimer } from "Components/v2/AuctionTimer"
 import React, { Component, useContext } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkSidebarArtistsFragmentContainer as Artists } from "./ArtworkSidebarArtists"
 import { ArtworkSidebarAuctionPartnerInfoFragmentContainer as AuctionPartnerInfo } from "./ArtworkSidebarAuctionPartnerInfo"
 import { ArtworkSidebarBidActionFragmentContainer as BidAction } from "./ArtworkSidebarBidAction"
@@ -15,6 +15,7 @@ import { ArtworkSidebarPartnerInfoFragmentContainer as PartnerInfo } from "./Art
 import { ArtworkSidebar_artwork } from "__generated__/ArtworkSidebar_artwork.graphql"
 import { ArtworkSidebarQuery } from "__generated__/ArtworkSidebarQuery.graphql"
 import { SystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 
 export interface ArtworkSidebarProps {
   artwork: ArtworkSidebar_artwork
@@ -89,7 +90,7 @@ export const ArtworkSidebarQueryRenderer = ({
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<ArtworkSidebarQuery>
+    <SystemQueryRenderer<ArtworkSidebarQuery>
       environment={relayEnvironment}
       variables={{ artworkID }}
       query={graphql`

--- a/src/Apps/Artwork/Components/OtherAuctions.tsx
+++ b/src/Apps/Artwork/Components/OtherAuctions.tsx
@@ -3,9 +3,10 @@ import { OtherAuctions_sales } from "__generated__/OtherAuctions_sales.graphql"
 import { OtherAuctionsQuery } from "__generated__/OtherAuctionsQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { AuctionCardFragmentContainer as AuctionCard } from "Components/v2/AuctionCard"
 import React, { useContext } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { Header } from "./OtherWorks/Header"
 
@@ -44,7 +45,7 @@ export const OtherAuctionsQueryRenderer = () => {
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<OtherAuctionsQuery>
+    <SystemQueryRenderer<OtherAuctionsQuery>
       environment={relayEnvironment}
       variables={{ size: 4, sort: "TIMELY_AT_NAME_ASC" }}
       query={graphql`

--- a/src/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
@@ -13,12 +13,8 @@ import React, { useContext } from "react"
 import styled from "styled-components"
 import createLogger from "Utils/logger"
 
-import {
-  createRefetchContainer,
-  graphql,
-  QueryRenderer,
-  RelayRefetchProp,
-} from "react-relay"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { get } from "Utils/get"
 
 const logger = createLogger("RelatedWorksArtworkGrid.tsx")
@@ -173,7 +169,7 @@ export const RelatedWorksArtworkGridQueryRenderer: React.SFC<{
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<RelatedWorksArtworkGridQuery>
+    <SystemQueryRenderer<RelatedWorksArtworkGridQuery>
       environment={relayEnvironment}
       variables={{
         artworkSlug,

--- a/src/Apps/Artwork/Components/__stories__/OtherAuctions.story.tsx
+++ b/src/Apps/Artwork/Components/__stories__/OtherAuctions.story.tsx
@@ -1,8 +1,9 @@
 import { OtherAuctionsStoryQuery } from "__generated__/OtherAuctionsStoryQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Utils/Section"
 import { OtherAuctionsFragmentContainer } from "../OtherAuctions"
@@ -11,7 +12,7 @@ const OtherAuctions = ({ size }: { size?: number }) => {
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<OtherAuctionsStoryQuery>
+    <SystemQueryRenderer<OtherAuctionsStoryQuery>
       environment={relayEnvironment}
       query={graphql`
         query OtherAuctionsStoryQuery($size: Int!) {

--- a/src/Apps/Artwork/Components/__stories__/OtherWorks.story.tsx
+++ b/src/Apps/Artwork/Components/__stories__/OtherWorks.story.tsx
@@ -1,8 +1,9 @@
 import { OtherWorksQuery } from "__generated__/OtherWorksQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "Utils/Section"
 import { OtherWorksFragmentContainer } from "../OtherWorks"
@@ -12,7 +13,7 @@ export const OtherWorks = ({ artworkSlug }: { artworkSlug: string }) => {
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<OtherWorksQuery>
+    <SystemQueryRenderer<OtherWorksQuery>
       environment={relayEnvironment}
       variables={{ artworkSlug }}
       query={graphql`

--- a/src/Apps/Auction/Components/AuctionFAQ.tsx
+++ b/src/Apps/Auction/Components/AuctionFAQ.tsx
@@ -3,9 +3,10 @@ import { AuctionFAQ_viewer } from "__generated__/AuctionFAQ_viewer.graphql"
 import { AuctionFAQQuery } from "__generated__/AuctionFAQQuery.graphql"
 import { useSystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React from "react"
 import Markdown from "react-markdown"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 
 interface AuctionFAQProps {
@@ -152,7 +153,7 @@ export const AuctionFAQFragmentContainer = createFragmentContainer(AuctionFAQ, {
 export const AuctionFAQQueryRenderer: React.SFC = () => {
   const { relayEnvironment } = useSystemContext()
   return (
-    <QueryRenderer<AuctionFAQQuery>
+    <SystemQueryRenderer<AuctionFAQQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/Apps/Collect2/Routes/Collection/Components/__stories__/CollectionsHubRails.story.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/__stories__/CollectionsHubRails.story.tsx
@@ -1,7 +1,8 @@
 import { Box } from "@artsy/palette"
 import { SystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
 import styled from "styled-components"
 import { CollectionsHubRailsContainer as CollectionsHubRails } from "../CollectionsHubRails"
@@ -32,7 +33,7 @@ export const CollectionHubRailsQueryRenderer: React.FC<Props> = ({
   if (relayEnvironment) {
     return (
       // tslint:disable-next-line:relay-operation-generics
-      <QueryRenderer
+      <SystemQueryRenderer
         environment={relayEnvironment}
         variables={{
           collectionID,

--- a/src/Apps/WorksForYou/index.tsx
+++ b/src/Apps/WorksForYou/index.tsx
@@ -1,11 +1,12 @@
 import { Box, Spinner, Theme } from "@artsy/palette"
-import { WorksForYouQuery } from "__generated__/WorksForYouQuery.graphql"
 import { ArtistArtworksFilters } from "__generated__/WorksForYouQuery.graphql"
+import { WorksForYouQuery } from "__generated__/WorksForYouQuery.graphql"
 import { MarketingHeader } from "Apps/WorksForYou/MarketingHeader"
 import { SystemContextConsumer, SystemContextProps } from "Artsy"
 import { track } from "Artsy/Analytics"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { Component } from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 import styled from "styled-components"
 import Events from "Utils/Events"
 import { WorksForYouArtistFeedPaginationContainer as WorksForYouArtistFeed } from "./WorksForYouArtistFeed"
@@ -38,7 +39,7 @@ export class WorksForYou extends Component<Props> {
               <>
                 <MarketingHeader />
 
-                <QueryRenderer<WorksForYouQuery>
+                <SystemQueryRenderer<WorksForYouQuery>
                   environment={relayEnvironment}
                   query={graphql`
                     query WorksForYouQuery(

--- a/src/Artsy/Relay/RootQueryRenderer.tsx
+++ b/src/Artsy/Relay/RootQueryRenderer.tsx
@@ -5,8 +5,8 @@ import {
 } from "Artsy"
 import React from "react"
 import { GraphQLTaggedNode, ReadyState } from "react-relay"
-import { QueryRenderer } from "react-relay"
 import { CacheConfig, RerunParam, Variables } from "relay-runtime"
+import { SystemQueryRenderer } from "./SystemQueryRenderer"
 
 /**
  * A copy of the upstream interface, minus the `environment` field.
@@ -26,7 +26,7 @@ const Renderer: React.SFC<Props> = ({
   relayEnvironment,
   children,
   ...props
-}) => <QueryRenderer {...props} environment={relayEnvironment} />
+}) => <SystemQueryRenderer {...props} environment={relayEnvironment} />
 
 const RendererWithContext = withSystemContext(Renderer)
 

--- a/src/Artsy/Relay/SystemQueryRenderer.tsx
+++ b/src/Artsy/Relay/SystemQueryRenderer.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import { QueryRenderer, QueryRendererProps } from "react-relay"
+import { OperationBase, OperationDefaults } from "relay-runtime"
+
+interface SystemQueryRendererState {
+  isMounted: boolean
+}
+
+export class SystemQueryRenderer<
+  T extends OperationBase = OperationDefaults
+> extends React.Component<QueryRendererProps, SystemQueryRendererState> {
+  state = {
+    isMounted: false,
+  }
+
+  componentDidMount() {
+    this.setState({
+      isMounted: true,
+    })
+  }
+
+  render() {
+    if (this.state.isMounted) {
+      return <QueryRenderer<T> {...this.props} />
+    } else {
+      return null
+    }
+  }
+}

--- a/src/Components/CollectionsRail/index.tsx
+++ b/src/Components/CollectionsRail/index.tsx
@@ -1,8 +1,10 @@
 import React, { useContext } from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 
 import { CollectionsRailQuery } from "__generated__/CollectionsRailQuery.graphql"
 import { SystemContext } from "Artsy"
+import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { CollectionsRailFragmentContainer as CollectionsRail } from "./CollectionsRail"
 
 interface Props {
@@ -13,7 +15,7 @@ interface Props {
 export const CollectionsRailContent: React.FC<Props> = passedProps => {
   const { relayEnvironment } = useContext(SystemContext)
   return (
-    <QueryRenderer<CollectionsRailQuery>
+    <SystemQueryRenderer<CollectionsRailQuery>
       environment={relayEnvironment}
       variables={{
         showOnEditorial: true,
@@ -35,13 +37,7 @@ export const CollectionsRailContent: React.FC<Props> = passedProps => {
           }
         }
       `}
-      render={({ props }) => {
-        if (props) {
-          return <CollectionsRail {...props} />
-        } else {
-          return null
-        }
-      }}
+      render={renderWithLoadProgress(CollectionsRail)}
       cacheConfig={{ force: true }}
     />
   )

--- a/src/Components/Gene/index.tsx
+++ b/src/Components/Gene/index.tsx
@@ -1,9 +1,10 @@
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 
 import { GeneContentsArtistsQuery } from "__generated__/GeneContentsArtistsQuery.graphql"
 import { GeneContentsArtworksQuery } from "__generated__/GeneContentsArtworksQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import Artists from "./Artists"
 import GeneArtworks from "./GeneArtworks"
 
@@ -125,7 +126,7 @@ class GeneContents extends React.Component<Props, State> {
   renderArtists() {
     const { geneID, relayEnvironment } = this.props
     return (
-      <QueryRenderer<GeneContentsArtistsQuery>
+      <SystemQueryRenderer<GeneContentsArtistsQuery>
         environment={relayEnvironment}
         query={graphql`
           query GeneContentsArtistsQuery($geneID: String!) {
@@ -156,7 +157,7 @@ class GeneContents extends React.Component<Props, State> {
     const { geneID, relayEnvironment } = this.props
     const { for_sale, medium, price_range, dimension_range, sort } = this.state
     return (
-      <QueryRenderer<GeneContentsArtworksQuery>
+      <SystemQueryRenderer<GeneContentsArtworksQuery>
         environment={relayEnvironment}
         query={graphql`
           query GeneContentsArtworksQuery(

--- a/src/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 
 import { SystemContext } from "Artsy"
 import { get } from "Utils/get"
@@ -25,6 +25,7 @@ import {
   Separator,
   Serif,
 } from "@artsy/palette"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 
 export const NotificationMenuItems: React.FC<
   NotificationsMenuQueryResponse
@@ -95,19 +96,16 @@ export const NotificationMenuItems: React.FC<
  * individual MenuItems for display. During fetch there is a loading spinner.
  */
 export const NotificationsMenu: React.FC = () => {
-  const isClient = typeof window !== "undefined"
   return (
     <Menu title="Activity">
-      {isClient && (
-        <NotificationsQueryRenderer
-          render={renderWithLoadProgress(
-            NotificationMenuItems,
-            {},
-            {},
-            { size: "small" }
-          )}
-        />
-      )}
+      <NotificationsQueryRenderer
+        render={renderWithLoadProgress(
+          NotificationMenuItems,
+          {},
+          {},
+          { size: "small" }
+        )}
+      />
     </Menu>
   )
 }
@@ -123,7 +121,7 @@ export const NotificationsQueryRenderer: React.FC<{
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <QueryRenderer<NotificationsMenuQuery>
+    <SystemQueryRenderer<NotificationsMenuQuery>
       environment={relayEnvironment}
       query={graphql`
         query NotificationsMenuQuery {

--- a/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
@@ -5,12 +5,12 @@ import {
 } from "__generated__/ArtistSearchResultsArtistMutation.graphql"
 import { ArtistSearchResultsQuery } from "__generated__/ArtistSearchResultsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import * as React from "react"
 import {
   commitMutation,
   createFragmentContainer,
   graphql,
-  QueryRenderer,
   RelayProp,
 } from "react-relay"
 import track, { TrackingProp } from "react-tracking"
@@ -204,7 +204,7 @@ const ArtistSearchResultsComponent: React.SFC<
   ContainerProps & SystemContextProps
 > = ({ term, relayEnvironment, updateFollowCount }) => {
   return (
-    <QueryRenderer<ArtistSearchResultsQuery>
+    <SystemQueryRenderer<ArtistSearchResultsQuery>
       environment={relayEnvironment}
       query={graphql`
         query ArtistSearchResultsQuery($term: String!) {

--- a/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
+++ b/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
@@ -5,12 +5,12 @@ import {
 } from "__generated__/PopularArtistsFollowArtistMutation.graphql"
 import { PopularArtistsQuery } from "__generated__/PopularArtistsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import * as React from "react"
 import {
   commitMutation,
   createFragmentContainer,
   graphql,
-  QueryRenderer,
   RelayProp,
 } from "react-relay"
 import track, { TrackingProp } from "react-tracking"
@@ -215,7 +215,7 @@ const PopularArtistsComponent: React.SFC<SystemContextProps & FollowProps> = ({
   updateFollowCount,
 }) => {
   return (
-    <QueryRenderer<PopularArtistsQuery>
+    <SystemQueryRenderer<PopularArtistsQuery>
       environment={relayEnvironment}
       query={graphql`
         query PopularArtistsQuery {

--- a/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
@@ -5,13 +5,13 @@ import {
 } from "__generated__/GeneSearchResultsFollowGeneMutation.graphql"
 import { GeneSearchResultsQuery } from "__generated__/GeneSearchResultsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { garamond } from "Assets/Fonts"
 import * as React from "react"
 import {
   commitMutation,
   createFragmentContainer,
   graphql,
-  QueryRenderer,
   RelayProp,
 } from "react-relay"
 import track, { TrackingProp } from "react-tracking"
@@ -190,7 +190,7 @@ const GeneSearchResultsComponent: React.SFC<
   ContainerProps & SystemContextProps
 > = ({ term, relayEnvironment, updateFollowCount }) => {
   return (
-    <QueryRenderer<GeneSearchResultsQuery>
+    <SystemQueryRenderer<GeneSearchResultsQuery>
       environment={relayEnvironment}
       query={graphql`
         query GeneSearchResultsQuery($term: String!) {

--- a/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
+++ b/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
@@ -5,12 +5,12 @@ import {
 } from "__generated__/SuggestedGenesFollowGeneMutation.graphql"
 import { SuggestedGenesQuery } from "__generated__/SuggestedGenesQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import * as React from "react"
 import {
   commitMutation,
   createFragmentContainer,
   graphql,
-  QueryRenderer,
   RelayProp,
 } from "react-relay"
 import track, { TrackingProp } from "react-tracking"
@@ -167,7 +167,7 @@ const SuggestedGenesComponent: React.SFC<SystemContextProps & FollowProps> = ({
   updateFollowCount,
 }) => {
   return (
-    <QueryRenderer<SuggestedGenesQuery>
+    <SystemQueryRenderer<SuggestedGenesQuery>
       environment={relayEnvironment}
       query={graphql`
         query SuggestedGenesQuery {

--- a/src/Components/Payment/UserSettingsPayments.tsx
+++ b/src/Components/Payment/UserSettingsPayments.tsx
@@ -5,13 +5,9 @@ import { SystemContext, SystemContextProps } from "Artsy"
 import { get } from "Utils/get"
 
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
-import {
-  createFragmentContainer,
-  graphql,
-  QueryRenderer,
-  RelayProp,
-} from "react-relay"
+import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { PaymentFormWrapper } from "./PaymentFormWrapper"
 import { SavedCreditCards } from "./SavedCreditCards"
 
@@ -100,7 +96,7 @@ export const UserSettingsPaymentsQueryRenderer = () => {
   }
 
   return (
-    <QueryRenderer<UserSettingsPaymentsQuery>
+    <SystemQueryRenderer<UserSettingsPaymentsQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/Components/Publishing/ToolTip/TooltipsDataLoader.tsx
+++ b/src/Components/Publishing/ToolTip/TooltipsDataLoader.tsx
@@ -1,12 +1,13 @@
 import { TooltipsDataLoaderQueryResponse } from "__generated__/TooltipsDataLoaderQuery.graphql"
 import { TooltipsDataLoaderQuery } from "__generated__/TooltipsDataLoaderQuery.graphql"
 import * as Artsy from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { getArtsySlugsFromArticle } from "Components/Publishing/Constants"
 import { ArticleData } from "Components/Publishing/Typings"
 import { keyBy } from "lodash"
 import PropTypes from "prop-types"
 import React, { Component } from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 import { ArticleProps } from "../Article"
 
 interface Props extends Artsy.SystemContextProps {
@@ -39,7 +40,7 @@ export class TooltipsDataLoader extends Component<Props> {
     }
 
     return (
-      <QueryRenderer<TooltipsDataLoaderQuery>
+      <SystemQueryRenderer<TooltipsDataLoaderQuery>
         environment={relayEnvironment}
         query={graphql`
           query TooltipsDataLoaderQuery(

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -4,6 +4,7 @@ import { SearchBarSuggestQuery } from "__generated__/SearchBarSuggestQuery.graph
 import { SystemContext, SystemContextProps } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import colors from "Assets/Colors"
 import {
   FirstSuggestionItem,
@@ -11,17 +12,12 @@ import {
   PLACEHOLDER_XS,
   SuggestionItem,
 } from "Components/Search/Suggestions/SuggestionItem"
-import { throttle } from "lodash"
 import { isEmpty } from "lodash"
+import { throttle } from "lodash"
 import qs from "qs"
 import React, { Component, useContext } from "react"
 import Autosuggest from "react-autosuggest"
-import {
-  createRefetchContainer,
-  graphql,
-  QueryRenderer,
-  RelayRefetchProp,
-} from "react-relay"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
 import request from "superagent"
@@ -423,7 +419,7 @@ export const SearchBarRefetchContainer = createRefetchContainer(
 export const SearchBarQueryRenderer: React.FC = () => {
   const { relayEnvironment, searchQuery = "" } = useContext(SystemContext)
   return (
-    <QueryRenderer<SearchBarSuggestQuery>
+    <SystemQueryRenderer<SearchBarSuggestQuery>
       environment={relayEnvironment}
       query={graphql`
         query SearchBarSuggestQuery($term: String!, $hasTerm: Boolean!) {

--- a/src/Components/Tag/index.tsx
+++ b/src/Components/Tag/index.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 
 import { TagContentsArtworksQuery } from "__generated__/TagContentsArtworksQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import TagArtworks from "./TagArtworks"
 
 export interface Filters {
@@ -99,7 +100,7 @@ class TagContents extends React.Component<Props, State> {
     const { tagID, relayEnvironment } = this.props
     const { for_sale, medium, price_range, dimension_range, sort } = this.state
     return (
-      <QueryRenderer<TagContentsArtworksQuery>
+      <SystemQueryRenderer<TagContentsArtworksQuery>
         environment={relayEnvironment}
         query={graphql`
           query TagContentsArtworksQuery(

--- a/src/Components/v2/ArtworkFilter/index.tsx
+++ b/src/Components/v2/ArtworkFilter/index.tsx
@@ -2,12 +2,7 @@ import { isEqual } from "lodash"
 import React, { useEffect, useState } from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 
-import {
-  createRefetchContainer,
-  graphql,
-  QueryRenderer,
-  RelayRefetchProp,
-} from "react-relay"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 
 import { AnalyticsSchema, useSystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
@@ -41,6 +36,7 @@ import {
 } from "@artsy/palette"
 import { ArtistArtworkFilter_artist } from "__generated__/ArtistArtworkFilter_artist.graphql"
 import { Collection_viewer } from "__generated__/Collection_viewer.graphql"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 
 /**
  * Primary ArtworkFilter which is wrapped with a context and refetch container.
@@ -341,7 +337,7 @@ export const ArtworkFilterQueryRenderer = ({ keyword = "andy warhol" }) => {
         keyword,
       }}
     >
-      <QueryRenderer<ArtworkFilterQueryType>
+      <SystemQueryRenderer<ArtworkFilterQueryType>
         environment={relayEnvironment}
         // FIXME: Passing a variable to `query` shouldn't error out in linter
         /* tslint:disable:relay-operation-generics */

--- a/src/Components/v2/AuctionTimer.tsx
+++ b/src/Components/v2/AuctionTimer.tsx
@@ -1,10 +1,11 @@
 import { AuctionTimer_sale } from "__generated__/AuctionTimer_sale.graphql"
 import { AuctionTimerQuery } from "__generated__/AuctionTimerQuery.graphql"
 import { SystemContext } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { Timer } from "Components/v2/Timer"
 import { DateTime } from "luxon"
 import React, { useContext } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 
 export interface Props {
   sale: AuctionTimer_sale
@@ -86,7 +87,7 @@ export const AuctionTimerFragmentContainer = createFragmentContainer(
 export const AuctionTimerQueryRenderer = ({ saleID }: { saleID: string }) => {
   const { relayEnvironment } = useContext(SystemContext)
   return (
-    <QueryRenderer<AuctionTimerQuery>
+    <SystemQueryRenderer<AuctionTimerQuery>
       environment={relayEnvironment}
       variables={{ saleID }}
       query={graphql`

--- a/src/Components/v2/FollowArtistPopover/index.tsx
+++ b/src/Components/v2/FollowArtistPopover/index.tsx
@@ -11,8 +11,9 @@ import {
 import { FollowArtistPopover_suggested } from "__generated__/FollowArtistPopover_suggested.graphql"
 import { FollowArtistPopoverQuery } from "__generated__/FollowArtistPopoverQuery.graphql"
 import { SystemContext, SystemContextProps } from "Artsy"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { SFC, useContext } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { Provider } from "unstated"
 import { FollowArtistPopoverRowFragmentContainer as FollowArtistPopoverRow } from "./FollowArtistPopoverRow"
@@ -101,7 +102,7 @@ export const FollowArtistPopoverQueryRenderer = ({
 }) => {
   const { relayEnvironment, user } = useContext(SystemContext)
   return (
-    <QueryRenderer<FollowArtistPopoverQuery>
+    <SystemQueryRenderer<FollowArtistPopoverQuery>
       environment={relayEnvironment}
       variables={{ artistID }}
       query={graphql`

--- a/src/Components/v2/RecentlyViewed.tsx
+++ b/src/Components/v2/RecentlyViewed.tsx
@@ -5,10 +5,10 @@ import { SystemContext, SystemContextConsumer } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { FillwidthItem } from "Components/Artwork/FillwidthItem"
 import { ArrowButton, Carousel } from "Components/v2/Carousel"
 import React, { useContext } from "react"
-import { QueryRenderer } from "react-relay"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { get } from "Utils/get"
@@ -97,6 +97,7 @@ export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
 
 const ArrowContainer = styled(Box)`
   align-self: flex-start;
+
   ${ArrowButton} {
     height: 60%;
   }
@@ -129,7 +130,7 @@ export const RecentlyViewedQueryRenderer = () => {
     return null
   }
   return (
-    <QueryRenderer<RecentlyViewedQuery>
+    <SystemQueryRenderer<RecentlyViewedQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/Components/v2/__stories__/CollectionsHubsHomepageNav.story.tsx
+++ b/src/Components/v2/__stories__/CollectionsHubsHomepageNav.story.tsx
@@ -2,8 +2,9 @@ import { Theme } from "@artsy/palette"
 import { CollectionsHubsHomepageNavQuery } from "__generated__/CollectionsHubsHomepageNavQuery.graphql"
 import { useSystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
 import { CollectionsHubsHomepageNavFragmentContainer } from "../CollectionsHubsHomepageNav"
 
@@ -20,7 +21,7 @@ const CollectionsHubsHomepageNavQueryRenderer = () => {
   const { relayEnvironment } = useSystemContext()
 
   return (
-    <QueryRenderer<CollectionsHubsHomepageNavQuery>
+    <SystemQueryRenderer<CollectionsHubsHomepageNavQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/Components/v2/__stories__/CollectionsHubsNav.story.tsx
+++ b/src/Components/v2/__stories__/CollectionsHubsNav.story.tsx
@@ -2,8 +2,9 @@ import { Theme } from "@artsy/palette"
 import { CollectionsHubsNavQuery } from "__generated__/CollectionsHubsNavQuery.graphql"
 import { useSystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React from "react"
-import { graphql, QueryRenderer } from "react-relay"
+import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
 import { CollectionsHubsNavFragmentContainer } from "../CollectionsHubsNav"
 
@@ -17,7 +18,7 @@ const CollectionsHubsNavQueryRenderer = () => {
   const { relayEnvironment } = useSystemContext()
 
   return (
-    <QueryRenderer<CollectionsHubsNavQuery>
+    <SystemQueryRenderer<CollectionsHubsNavQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/DevTools/MockRelayRenderer.tsx
+++ b/src/DevTools/MockRelayRenderer.tsx
@@ -1,6 +1,7 @@
 import { SystemContextProvider } from "Artsy"
 import { SystemContextConsumer } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { IMocks } from "graphql-tools/dist/Interfaces"
 import React from "react"
 import { QueryRenderer, RelayContainer } from "react-relay"
@@ -219,7 +220,7 @@ export class MockRelayRenderer<
             {...contextProps}
             relayEnvironment={environment}
           >
-            <QueryRenderer
+            <SystemQueryRenderer
               // tslint:disable-next-line relay-operation-generics
               query={query}
               environment={environment}

--- a/src/DevTools/__tests__/MockRelayRendererFixtures.tsx
+++ b/src/DevTools/__tests__/MockRelayRendererFixtures.tsx
@@ -4,10 +4,11 @@ import { MockRelayRendererFixtures_artworkMetadata } from "__generated__/MockRel
 import { MockRelayRendererFixturesArtistQuery } from "__generated__/MockRelayRendererFixturesArtistQuery.graphql"
 import { SystemContextConsumer } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import cheerio from "cheerio"
 import { render } from "enzyme"
 import * as React from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 
 const Metadata = createFragmentContainer(
   (props: { artworkMetadata: MockRelayRendererFixtures_artworkMetadata }) => (
@@ -64,7 +65,7 @@ const ArtistQueryRenderer = (props: { id: string }) => (
   <SystemContextConsumer>
     {({ relayEnvironment }) => {
       return (
-        <QueryRenderer<MockRelayRendererFixturesArtistQuery>
+        <SystemQueryRenderer<MockRelayRendererFixturesArtistQuery>
           environment={relayEnvironment}
           variables={props}
           query={graphql`


### PR DESCRIPTION
We've run into an issue where QueryRenderers -- presumed to only fetch on the client -- are in fact fetching during SSR renders due to [isomorphic-fetch](https://github.com/artsy/reaction/blob/master/src/Artsy/Relay/createRelaySSREnvironment.ts#L1) being used in our network layer. 

This adds a new component `SystemQueryRenderer` which guards against fetches happening on the server by checking if we're on the client before rendering the component. 