### PR TITLE
Fillwidth doesn't fail when image is absent

### DIFF
--- a/src/Utils/fillwidth.ts
+++ b/src/Utils/fillwidth.ts
@@ -41,7 +41,7 @@ const fillwidthDimensions = (
     // Set id and aspectRatio for Relay or publishing
     if (item.node) {
       id = item.node.__id
-      aspectRatio = item.node.image.aspect_ratio
+      aspectRatio = item.node.image && item.node.image.aspect_ratio
     } else {
       id = item.url ? item.url : item.image
       aspectRatio = item.width / item.height


### PR DESCRIPTION
Addresses https://sentry.io/organizations/artsynet/issues/912351641/

Fillwidth components were failing on artworks without images, because calculations of size expected `image.aspect_ratio`. 

This change ensures we reach the more descriptive error logging in the `FillwidthItem` component:
<img width="950" alt="Screen Shot 2019-10-07 at 2 20 05 PM" src="https://user-images.githubusercontent.com/1497424/66337698-a72b7300-e90d-11e9-8762-8198460f73f6.png">

