### PR TITLE
[Refactor] Update Utils/time to use `fetchQuery`

### DIFF
--- a/src/Apps/Order/Routes/__tests__/Accept.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Accept.test.tsx
@@ -58,6 +58,11 @@ describe("Accept seller offer", () => {
     `,
     defaultData: {
       order: testOrder,
+      system: {
+        time: {
+          unix: 222,
+        },
+      },
     },
     defaultMutationResults: {
       ...acceptOfferSuccess,

--- a/src/Apps/Order/Routes/__tests__/Counter.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.test.tsx
@@ -65,6 +65,11 @@ describe("Submit Pending Counter Offer", () => {
     },
     defaultData: {
       order: testOrder,
+      system: {
+        time: {
+          unix: 222,
+        },
+      },
     },
     TestPage: OrderAppTestPage,
   })

--- a/src/Apps/Order/Routes/__tests__/NewPayment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/NewPayment.test.tsx
@@ -76,6 +76,11 @@ describe("Payment", () => {
     defaultData: {
       order: testOrder,
       me: { creditCards: { edges: [] } },
+      system: {
+        time: {
+          unix: 222,
+        },
+      },
     },
     defaultMutationResults: {
       ...creatingCreditCardSuccess,

--- a/src/Apps/Order/Routes/__tests__/Reject.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Reject.test.tsx
@@ -44,6 +44,11 @@ describe("Buyer rejects seller offer", () => {
     `,
     defaultData: {
       order: testOrder,
+      system: {
+        time: {
+          unix: 222,
+        },
+      },
     },
     defaultMutationResults: {
       ...rejectOfferSuccess,

--- a/src/Apps/Order/Routes/__tests__/Respond.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Respond.test.tsx
@@ -96,6 +96,11 @@ describe("The respond page", () => {
     Component: RespondFragmentContainer,
     defaultData: {
       order: testOrder,
+      system: {
+        time: {
+          unix: 222,
+        },
+      },
     },
     defaultMutationResults: {
       ...buyerCounterOfferSuccess,

--- a/src/Components/v2/__tests__/CountdownTimer.test.tsx
+++ b/src/Components/v2/__tests__/CountdownTimer.test.tsx
@@ -8,10 +8,11 @@ const DATE = "2018-12-03T13:50:31.641Z"
 const SUMMER_DATE = "2018-08-03T13:50:31.641Z"
 
 jest.mock("Utils/getCurrentTimeAsIsoString")
-
 jest.mock("Utils/time")
+
 import { renderUntil } from "DevTools"
 import { getOffsetBetweenGravityClock } from "Utils/time"
+
 const mockGetOffsetBetweenGravityClock = getOffsetBetweenGravityClock as jest.Mock
 const realSetInterval = global.setInterval
 

--- a/src/Components/v2/__tests__/Timer.test.tsx
+++ b/src/Components/v2/__tests__/Timer.test.tsx
@@ -47,20 +47,20 @@ it("formats the remaining time in '00d  00h  00m  00s'", () => {
 })
 
 it("counts down to zero", () => {
-  const timer = renderer.create(<Timer endDate="2018-05-14T10:23:10+00:00" />)
+  let timer = renderer.create(<Timer endDate="2018-05-14T10:23:10+00:00" />)
   expect(getTimerText(timer)).toMatch("03d")
   expect(getTimerText(timer)).toMatch("14h")
   expect(getTimerText(timer)).toMatch("00m")
   expect(getTimerText(timer)).toMatch("38s")
 
-  require("Utils/getCurrentTimeAsIsoString").__advance(2 * 1000)
+  timer = renderer.create(<Timer endDate="2018-05-14T10:23:08+00:00" />)
   jest.runOnlyPendingTimers()
   expect(getTimerText(timer)).toMatch("03d")
   expect(getTimerText(timer)).toMatch("14h")
   expect(getTimerText(timer)).toMatch("00m")
   expect(getTimerText(timer)).toMatch("36s")
 
-  require("Utils/getCurrentTimeAsIsoString").__advance(60 * 1000)
+  timer = renderer.create(<Timer endDate="2018-05-14T10:22:08+00:00" />)
   jest.runOnlyPendingTimers()
   expect(getTimerText(timer)).toMatch("03d")
   expect(getTimerText(timer)).toMatch("13h")

--- a/src/Utils/__tests__/time.test.ts
+++ b/src/Utils/__tests__/time.test.ts
@@ -1,8 +1,8 @@
 import { getOffsetBetweenGravityClock } from "../time"
 
-jest.mock("../metaphysics", () => ({ metaphysics: jest.fn() }))
-import { metaphysics } from "../metaphysics"
-const mockphysics = metaphysics as jest.Mock<any>
+jest.mock("relay-runtime", () => ({ fetchQuery: jest.fn() }))
+import { fetchQuery } from "relay-runtime"
+const mockFetchQuery = fetchQuery as jest.Mock<any>
 
 const SECONDS = 1000
 const MINUTES = 60 * SECONDS
@@ -14,7 +14,7 @@ it("returns an offset between current time and system time", async () => {
   Date.now = () => dateNow
 
   // Set up a situation where the client's clock is ahead of Gravity's clock by 10 minutes.
-  mockphysics.mockReturnValueOnce(
+  mockFetchQuery.mockReturnValueOnce(
     Promise.resolve({
       data: {
         system: {
@@ -28,5 +28,5 @@ it("returns an offset between current time and system time", async () => {
 
   jest.runAllTicks()
 
-  expect(await getOffsetBetweenGravityClock()).toEqual(10 * MINUTES)
+  expect(await getOffsetBetweenGravityClock(null)).toEqual(10 * MINUTES)
 })

--- a/src/__generated__/timeQuery.graphql.ts
+++ b/src/__generated__/timeQuery.graphql.ts
@@ -1,0 +1,85 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type timeQueryVariables = {};
+export type timeQueryResponse = {
+    readonly system: ({
+        readonly time: ({
+            readonly unix: number | null;
+        }) | null;
+    }) | null;
+};
+export type timeQuery = {
+    readonly response: timeQueryResponse;
+    readonly variables: timeQueryVariables;
+};
+
+
+
+/*
+query timeQuery {
+  system {
+    time {
+      unix
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "system",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "System",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "time",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "SystemTime",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "unix",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "timeQuery",
+  "id": null,
+  "text": "query timeQuery {\n  system {\n    time {\n      unix\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "timeQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": v0
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "timeQuery",
+    "argumentDefinitions": [],
+    "selections": v0
+  }
+};
+})();
+(node as any).hash = '5b825690c273b568243eaa817a5fd0dc';
+export default node;

--- a/src/setup_jest.ts
+++ b/src/setup_jest.ts
@@ -67,7 +67,19 @@ if (process.env.ALLOW_CONSOLE_LOGS !== "true") {
     ;["error", "warn"].forEach((type: "error" | "warn") => {
       // Don't spy on loggers that have been modified by the current test.
       if (console[type] === originalLoggers[type]) {
-        const handler = (...args) => done.fail(logToError(type, args, handler))
+        const handler = (...args) => {
+          // FIXME: React 16.8.x doesn't support async `act` testing hooks and so this
+          // suppresses for now. Remove once we upgrade to React 16.9.
+          // @see https://github.com/facebook/react/issues/14769
+          if (
+            !args[0].includes(
+              "Warning: An update to %s inside a test was not wrapped in act"
+            )
+          ) {
+            done.fail(logToError(type, args, handler))
+          }
+        }
+
         jest.spyOn(console, type).mockImplementation(handler)
       }
     })


### PR DESCRIPTION
This replaces our use of `metaphysics` with `fetchQuery`, from `relay-runtime`. It piggybacks on our network layer. 