### PR TITLE
@damassi => [Artist] Port meta tags and structured data from Force

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -1,5 +1,6 @@
 import { Box, Col, Row, Separator, Spacer } from "@artsy/palette"
 import { ArtistApp_artist } from "__generated__/ArtistApp_artist.graphql"
+import { ArtistMetaFragmentContainer as ArtistMeta } from "Apps/Artist/Components/ArtistMeta"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Artist/Components/NavigationTabs"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
@@ -34,6 +35,7 @@ export class ArtistApp extends React.Component<ArtistAppProps> {
     return (
       <AppContainer>
         <HorizontalPadding>
+          <ArtistMeta artist={artist} />
           <Row>
             <Col>
               <ArtistHeader artist={artist} />
@@ -79,6 +81,7 @@ export const ArtistAppFragmentContainer = createFragmentContainer(ArtistApp, {
     fragment ArtistApp_artist on Artist {
       _id
       id
+      ...ArtistMeta_artist
       ...ArtistHeader_artist
       ...NavigationTabs_artist
     }

--- a/src/Apps/Artist/Components/ArtistMeta.tsx
+++ b/src/Apps/Artist/Components/ArtistMeta.tsx
@@ -1,0 +1,248 @@
+import { ArtistMeta_artist } from "__generated__/ArtistMeta_artist.graphql"
+import { Person as SeoDataForArtist } from "Components/v2/Seo/Person"
+import { identity, pickBy } from "lodash"
+import React, { Component } from "react"
+import { Link, Meta, Title } from "react-head"
+import { createFragmentContainer, graphql } from "react-relay"
+import { data as sd } from "sharify"
+
+interface Props {
+  artist: ArtistMeta_artist
+}
+
+type ArtworkNode = ArtistMeta_artist["artworks_connection"]["edges"][0]["node"]
+
+export const sellerFromPartner = (partner: ArtworkNode["partner"]) => {
+  if (partner) {
+    const { profile } = partner
+    const image = imageObjectAttributes(profile)
+
+    return {
+      "@context": "http://schema.org",
+      "@type": "ArtGallery",
+      name: partner.name,
+      url: `${sd.APP_URL}${partner.href}`,
+      image,
+    }
+  }
+}
+
+interface ItemWithImage {
+  image?: {
+    small: string
+    large: string
+  }
+}
+
+export const imageObjectAttributes = (item: ItemWithImage) => {
+  if (!item) {
+    return null
+  }
+
+  const thumbnailUrl = item.image && item.image.small
+  const url = item.image && item.image.large
+
+  return (
+    thumbnailUrl && {
+      "@type": "ImageObject",
+      thumbnailUrl,
+      url,
+    }
+  )
+}
+
+export const offersAttributes = (artist: ArtistMeta_artist) => {
+  const { edges } = artist.artworks_connection
+
+  const offers =
+    edges &&
+    edges.map(({ node }) => {
+      const seller = sellerFromPartner(node.partner)
+      const itemOffered = productAttributes(artist, node)
+      const availability =
+        node.availability === "for sale" ? "InStock" : "OutOfStock"
+
+      return {
+        "@type": "Offer",
+        availability,
+        priceCurrency: node.price_currency,
+        seller,
+        itemOffered,
+      }
+    })
+  return offers
+}
+
+export const productAttributes = (
+  artist: ArtistMeta_artist,
+  artwork: ArtworkNode
+) => {
+  const image = imageObjectAttributes(artwork)
+
+  return {
+    "@type": "Product",
+    additionalType: artwork.category,
+    productionDate: artwork.date,
+    name: artwork.title,
+    url: `${sd.APP_URL}${artwork.href}`,
+    image,
+    brand: {
+      "@type": "Person",
+      name: artist.name,
+    },
+  }
+}
+
+export const structuredDataAttributes = (artist: ArtistMeta_artist) => {
+  const makesOffer = offersAttributes(artist)
+  const attributes = {
+    additionalType: "Artist",
+    image: artist.image ? artist.image.large : "",
+    name: artist.name,
+    url: `${sd.APP_URL}${artist.href}`,
+    gender: artist.gender,
+    birthDate: artist.birthday,
+    deathDate: artist.deathday,
+    mainEntityOfPage: `${sd.APP_URL}${artist.href}`,
+    description: artist.meta ? artist.meta.description : "",
+    nationality: {
+      "@type": "Country",
+      name: artist.nationality,
+    },
+    makesOffer,
+  }
+  return pickBy(attributes, identity)
+}
+
+export class ArtistMeta extends Component<Props> {
+  renderImageMetaTags() {
+    const { artist } = this.props
+    const hasImage = artist.image && artist.image.versions.length
+    if (hasImage && artist.image.versions.indexOf("large") !== -1) {
+      return (
+        <>
+          <Meta property="twitter:card" content="summary_large_image" />
+          <Meta property="og:image" content={artist.image.large} />
+          <Meta name="thumbnail" content={artist.image.square} />
+        </>
+      )
+    } else {
+      return (
+        <>
+          <Meta property="twitter:card" content="summary" />
+        </>
+      )
+    }
+  }
+
+  maybeRenderNoIndex() {
+    const { artist } = this.props
+    if (artist.counts.artworks === 0 && !artist.blurb) {
+      return (
+        <>
+          <Meta name="robots" content="noindex, follow" />
+        </>
+      )
+    }
+  }
+
+  renderStructuredData() {
+    const { artist } = this.props
+
+    return <SeoDataForArtist data={structuredDataAttributes(artist)} />
+  }
+
+  render() {
+    const { artist } = this.props
+    return (
+      <>
+        <Title>{artist.meta.title}</Title>
+        <Link rel="canonical" href={`${sd.APP_URL}/artist/${artist.id}`} />
+        <Meta property="og:title" content={artist.meta.title} />
+        <Meta name="description" content={artist.meta.description} />
+        <Meta property="og:description" content={artist.meta.description} />
+        <Meta
+          property="twitter:description"
+          content={artist.meta.description}
+        />
+        <Meta property="og:url" href={`${sd.APP_URL}/artist/${artist.id}`} />
+        <Meta property="og:type" href={`${sd.FACEBOOK_APP_NAMESPACE}:artist`} />
+        {artist.alternate_names && (
+          <Meta
+            name="skos:prefLabel"
+            content={artist.alternate_names.join("; ")}
+          />
+        )}
+
+        {artist.nationality && (
+          <Meta property="og:nationality" content={artist.nationality} />
+        )}
+        {artist.birthday && (
+          <Meta property="og:birthyear" content={artist.birthday} />
+        )}
+        {artist.deathday && (
+          <Meta property="og:deathyear" content={artist.deathday} />
+        )}
+        {this.renderImageMetaTags()}
+        {this.maybeRenderNoIndex()}
+        {this.renderStructuredData()}
+      </>
+    )
+  }
+}
+
+export const ArtistMetaFragmentContainer = createFragmentContainer(ArtistMeta, {
+  artist: graphql`
+    fragment ArtistMeta_artist on Artist {
+      id
+      name
+      nationality
+      birthday
+      deathday
+      gender
+      href
+      meta {
+        title
+        description
+      }
+      alternate_names
+      image {
+        versions
+        large: url(version: "large")
+        square: url(version: "square")
+      }
+      counts {
+        artworks
+      }
+      blurb
+      artworks_connection(first: 10, filter: IS_FOR_SALE, published: true) {
+        edges {
+          node {
+            title
+            date
+            description
+            category
+            price_currency
+            is_price_range
+            availability
+            href
+            image {
+              small: url(version: "small")
+              large: url(version: "large")
+            }
+            partner {
+              name
+              href
+              profile {
+                image {
+                  small: url(version: "small")
+                  large: url(version: "large")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/Apps/Artist/Components/__tests__/ArtistMeta.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistMeta.test.tsx
@@ -1,0 +1,232 @@
+import {
+  offersAttributes,
+  productAttributes,
+  sellerFromPartner,
+  structuredDataAttributes,
+} from "../ArtistMeta"
+
+jest.mock("sharify", () => ({
+  data: {
+    APP_URL: "https://www.artsy-test.net",
+  },
+}))
+
+describe("Meta", () => {
+  const artist = {
+    id: "claes-oldenburg",
+    name: "Claes Oldenburg",
+    nationality: "Swedish",
+    birthday: "1929",
+    alternate_names: null,
+    counts: null,
+    blurb: null,
+    deathday: null,
+    gender: "male",
+    href: "/artist/claes-oldenburg",
+    meta: {
+      title: "cool art",
+      description:
+        "Find the latest shows, biography, and artworks for sale by Claes Oldenburg. “I am for an art that is political-erotical-mystical, that does something more th…",
+    },
+    image: {
+      versions: ["small", "large"],
+      large:
+        "https://d32dm0rphc51dk.cloudfront.net/6q6LeyKvA_vpT5YzHRSNUA/large.jpg",
+      square:
+        "https://d32dm0rphc51dk.cloudfront.net/6q6LeyKvA_vpT5YzHRSNUA/square.jpg",
+    },
+    artworks_connection: {
+      edges: [
+        {
+          node: {
+            date: "1993",
+            title:
+              "'25 Years Studio',  1993, SIGNED by the BIG-8 Contemporary Artists, Gemini G.E.L.",
+            availability: "for sale",
+            description: null,
+            category: "Drawing, Collage or other Work on Paper",
+            price_currency: "USD",
+            is_price_range: false,
+            href:
+              "/artwork/robert-rauschenberg-25-years-studio-1993-signed-by-the-big-8-contemporary-artists-gemini-gel",
+            image: {
+              small:
+                "https://d32dm0rphc51dk.cloudfront.net/PmBrn30fGmg9dGwk2Nf51w/small.jpg",
+              large:
+                "https://d32dm0rphc51dk.cloudfront.net/PmBrn30fGmg9dGwk2Nf51w/large.jpg",
+            },
+            partner: {
+              name: "VINCE fine arts/ephemera",
+              href: "/vince-fine-arts-slash-ephemera",
+              profile: {
+                image: {
+                  small:
+                    "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+                  large:
+                    "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+    " $refType": null,
+  }
+
+  describe("structured data", () => {
+    it("Constructs a json object from data", () => {
+      const json = structuredDataAttributes(artist)
+
+      expect(json).toEqual({
+        additionalType: "Artist",
+        name: "Claes Oldenburg",
+        url: "https://www.artsy-test.net/artist/claes-oldenburg",
+        gender: "male",
+        image:
+          "https://d32dm0rphc51dk.cloudfront.net/6q6LeyKvA_vpT5YzHRSNUA/large.jpg",
+        birthDate: "1929",
+        mainEntityOfPage: "https://www.artsy-test.net/artist/claes-oldenburg",
+        description:
+          "Find the latest shows, biography, and artworks for sale by Claes Oldenburg. “I am for an art that is political-erotical-mystical, that does something more th…",
+        nationality: {
+          "@type": "Country",
+          name: "Swedish",
+        },
+        makesOffer: [
+          {
+            "@type": "Offer",
+            availability: "InStock",
+            itemOffered: {
+              "@type": "Product",
+              additionalType: "Drawing, Collage or other Work on Paper",
+              brand: {
+                "@type": "Person",
+                name: "Claes Oldenburg",
+              },
+              image: {
+                "@type": "ImageObject",
+                thumbnailUrl:
+                  "https://d32dm0rphc51dk.cloudfront.net/PmBrn30fGmg9dGwk2Nf51w/small.jpg",
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/PmBrn30fGmg9dGwk2Nf51w/large.jpg",
+              },
+              name:
+                "'25 Years Studio',  1993, SIGNED by the BIG-8 Contemporary Artists, Gemini G.E.L.",
+              productionDate: "1993",
+              url:
+                "https://www.artsy-test.net/artwork/robert-rauschenberg-25-years-studio-1993-signed-by-the-big-8-contemporary-artists-gemini-gel",
+            },
+            priceCurrency: "USD",
+            seller: {
+              "@context": "http://schema.org",
+              "@type": "ArtGallery",
+              name: "VINCE fine arts/ephemera",
+              url: "https://www.artsy-test.net/vince-fine-arts-slash-ephemera",
+              image: {
+                "@type": "ImageObject",
+                thumbnailUrl:
+                  "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+              },
+            },
+          },
+        ],
+      })
+    })
+
+    it("Omits empty keys", () => {
+      const json = structuredDataAttributes(artist)
+      expect(Object.keys(json).includes("deathday")).toBe(false)
+    })
+
+    it("#artistToJsonOffers constructs offers array from artist", () => {
+      const json = offersAttributes(artist)
+      expect(json).toEqual([
+        {
+          "@type": "Offer",
+          availability: "InStock",
+          itemOffered: {
+            "@type": "Product",
+            additionalType: "Drawing, Collage or other Work on Paper",
+            brand: {
+              "@type": "Person",
+              name: "Claes Oldenburg",
+            },
+            image: {
+              "@type": "ImageObject",
+              url:
+                "https://d32dm0rphc51dk.cloudfront.net/PmBrn30fGmg9dGwk2Nf51w/large.jpg",
+              thumbnailUrl:
+                "https://d32dm0rphc51dk.cloudfront.net/PmBrn30fGmg9dGwk2Nf51w/small.jpg",
+            },
+            productionDate: "1993",
+            name:
+              "'25 Years Studio',  1993, SIGNED by the BIG-8 Contemporary Artists, Gemini G.E.L.",
+            url:
+              "https://www.artsy-test.net/artwork/robert-rauschenberg-25-years-studio-1993-signed-by-the-big-8-contemporary-artists-gemini-gel",
+          },
+          priceCurrency: "USD",
+          seller: {
+            "@context": "http://schema.org",
+            "@type": "ArtGallery",
+            name: "VINCE fine arts/ephemera",
+            url: "https://www.artsy-test.net/vince-fine-arts-slash-ephemera",
+            image: {
+              "@type": "ImageObject",
+              thumbnailUrl:
+                "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+              url:
+                "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+            },
+          },
+        },
+      ])
+    })
+
+    it("#productFromArtistArtwork construct product object from artist/artwork", () => {
+      const artwork = artist.artworks_connection.edges[0].node
+      const json = productAttributes(artist, artwork)
+
+      expect(json).toEqual({
+        "@type": "Product",
+        additionalType: "Drawing, Collage or other Work on Paper",
+        productionDate: "1993",
+        name:
+          "'25 Years Studio',  1993, SIGNED by the BIG-8 Contemporary Artists, Gemini G.E.L.",
+        url:
+          "https://www.artsy-test.net/artwork/robert-rauschenberg-25-years-studio-1993-signed-by-the-big-8-contemporary-artists-gemini-gel",
+        image: {
+          "@type": "ImageObject",
+          thumbnailUrl:
+            "https://d32dm0rphc51dk.cloudfront.net/PmBrn30fGmg9dGwk2Nf51w/small.jpg",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/PmBrn30fGmg9dGwk2Nf51w/large.jpg",
+        },
+        brand: {
+          "@type": "Person",
+          name: "Claes Oldenburg",
+        },
+      })
+    })
+
+    it("#sellerFromPartner constructs seller object from partner", () => {
+      const partner = artist.artworks_connection.edges[0].node.partner
+      const json = sellerFromPartner(partner)
+      expect(json).toEqual({
+        "@context": "http://schema.org",
+        "@type": "ArtGallery",
+        name: "VINCE fine arts/ephemera",
+        url: "https://www.artsy-test.net/vince-fine-arts-slash-ephemera",
+        image: {
+          "@type": "ImageObject",
+          thumbnailUrl:
+            "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+          url:
+            "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+        },
+      })
+    })
+  })
+})

--- a/src/Components/v2/Seo/Person.tsx
+++ b/src/Components/v2/Seo/Person.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { Meta } from "react-head"
+
+export const Person = ({ data }) => {
+  return (
+    <Meta
+      tag="script"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify({
+          "@context": "http://schema.org",
+          "@type": "Person",
+          ...data,
+        }),
+      }}
+    />
+  )
+}

--- a/src/__generated__/ArtistApp_artist.graphql.ts
+++ b/src/__generated__/ArtistApp_artist.graphql.ts
@@ -2,13 +2,14 @@
 
 import { ConcreteFragment } from "relay-runtime";
 import { ArtistHeader_artist$ref } from "./ArtistHeader_artist.graphql";
+import { ArtistMeta_artist$ref } from "./ArtistMeta_artist.graphql";
 import { NavigationTabs_artist$ref } from "./NavigationTabs_artist.graphql";
 declare const _ArtistApp_artist$ref: unique symbol;
 export type ArtistApp_artist$ref = typeof _ArtistApp_artist$ref;
 export type ArtistApp_artist = {
     readonly _id: string;
     readonly id: string;
-    readonly " $fragmentRefs": ArtistHeader_artist$ref & NavigationTabs_artist$ref;
+    readonly " $fragmentRefs": ArtistMeta_artist$ref & ArtistHeader_artist$ref & NavigationTabs_artist$ref;
     readonly " $refType": ArtistApp_artist$ref;
 };
 
@@ -37,6 +38,11 @@ const node: ConcreteFragment = {
     },
     {
       "kind": "FragmentSpread",
+      "name": "ArtistMeta_artist",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
       "name": "ArtistHeader_artist",
       "args": null
     },
@@ -54,5 +60,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '6ec519bff85cfd1957c0c3e0d61027ed';
+(node as any).hash = 'c180840c9d6e8a5c232f176429425255';
 export default node;

--- a/src/__generated__/ArtistMeta_artist.graphql.ts
+++ b/src/__generated__/ArtistMeta_artist.graphql.ts
@@ -1,0 +1,392 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+declare const _ArtistMeta_artist$ref: unique symbol;
+export type ArtistMeta_artist$ref = typeof _ArtistMeta_artist$ref;
+export type ArtistMeta_artist = {
+    readonly id: string;
+    readonly name: string | null;
+    readonly nationality: string | null;
+    readonly birthday: string | null;
+    readonly deathday: string | null;
+    readonly gender: string | null;
+    readonly href: string | null;
+    readonly meta: ({
+        readonly title: string | null;
+        readonly description: string | null;
+    }) | null;
+    readonly alternate_names: ReadonlyArray<string | null> | null;
+    readonly image: ({
+        readonly versions: ReadonlyArray<string | null> | null;
+        readonly large: string | null;
+        readonly square: string | null;
+    }) | null;
+    readonly counts: ({
+        readonly artworks: any | null;
+    }) | null;
+    readonly blurb: string | null;
+    readonly artworks_connection: ({
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly title: string | null;
+                readonly date: string | null;
+                readonly description: string | null;
+                readonly category: string | null;
+                readonly price_currency: string | null;
+                readonly is_price_range: boolean | null;
+                readonly availability: string | null;
+                readonly href: string | null;
+                readonly image: ({
+                    readonly small: string | null;
+                    readonly large: string | null;
+                }) | null;
+                readonly partner: ({
+                    readonly name: string | null;
+                    readonly href: string | null;
+                    readonly profile: ({
+                        readonly image: ({
+                            readonly small: string | null;
+                            readonly large: string | null;
+                        }) | null;
+                    }) | null;
+                }) | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+    readonly " $refType": ArtistMeta_artist$ref;
+};
+
+
+
+const node: ConcreteFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "description",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": "large",
+  "name": "url",
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "version",
+      "value": "large",
+      "type": "[String]"
+    }
+  ],
+  "storageKey": "url(version:\"large\")"
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": "small",
+      "name": "url",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": "small",
+          "type": "[String]"
+        }
+      ],
+      "storageKey": "url(version:\"small\")"
+    },
+    v4,
+    v5
+  ]
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Fragment",
+  "name": "ArtistMeta_artist",
+  "type": "Artist",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "meta",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ArtistMeta",
+      "plural": false,
+      "selections": [
+        v0,
+        v1
+      ]
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "nationality",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "birthday",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "deathday",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "gender",
+      "args": null,
+      "storageKey": null
+    },
+    v2,
+    v3,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "alternate_names",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "image",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Image",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "versions",
+          "args": null,
+          "storageKey": null
+        },
+        v4,
+        {
+          "kind": "ScalarField",
+          "alias": "square",
+          "name": "url",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "square",
+              "type": "[String]"
+            }
+          ],
+          "storageKey": "url(version:\"square\")"
+        },
+        v5
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "counts",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ArtistCounts",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "artworks",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "blurb",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artworks_connection",
+      "storageKey": "artworks_connection(filter:\"IS_FOR_SALE\",first:10,published:true)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "filter",
+          "value": "IS_FOR_SALE",
+          "type": "[ArtistArtworksFilters]"
+        },
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10,
+          "type": "Int"
+        },
+        {
+          "kind": "Literal",
+          "name": "published",
+          "value": true,
+          "type": "Boolean"
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "is_price_range",
+                  "args": null,
+                  "storageKey": null
+                },
+                v0,
+                v1,
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "category",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "price_currency",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "date",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "availability",
+                  "args": null,
+                  "storageKey": null
+                },
+                v2,
+                v6,
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "partner",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Partner",
+                  "plural": false,
+                  "selections": [
+                    v3,
+                    v2,
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "profile",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Profile",
+                      "plural": false,
+                      "selections": [
+                        v6,
+                        v7
+                      ]
+                    },
+                    v7
+                  ]
+                },
+                v7
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    v7
+  ]
+};
+})();
+(node as any).hash = 'e60ab4fdd3eaa30f1ae44ab3c5fa37ff';
+export default node;

--- a/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
@@ -30,8 +30,68 @@ query routes_ArtistTopLevelQuery(
 fragment ArtistApp_artist on Artist {
   _id
   id
+  ...ArtistMeta_artist
   ...ArtistHeader_artist
   ...NavigationTabs_artist
+  __id
+}
+
+fragment ArtistMeta_artist on Artist {
+  id
+  name
+  nationality
+  birthday
+  deathday
+  gender
+  href
+  meta {
+    title
+    description
+  }
+  alternate_names
+  image {
+    versions
+    large: url(version: "large")
+    square: url(version: "square")
+    __id: id
+  }
+  counts {
+    artworks
+  }
+  blurb
+  artworks_connection(first: 10, filter: IS_FOR_SALE, published: true) {
+    edges {
+      node {
+        title
+        date
+        description
+        category
+        price_currency
+        is_price_range
+        availability
+        href
+        image {
+          small: url(version: "small")
+          large: url(version: "large")
+          __id: id
+        }
+        partner {
+          name
+          href
+          profile {
+            image {
+              small: url(version: "small")
+              large: url(version: "large")
+              __id: id
+            }
+            __id
+          }
+          __id
+        }
+        __id
+      }
+    }
+  }
   __id
 }
 
@@ -104,13 +164,89 @@ v2 = {
   "name": "__id",
   "args": null,
   "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "description",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": "large",
+  "name": "url",
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "version",
+      "value": "large",
+      "type": "[String]"
+    }
+  ],
+  "storageKey": "url(version:\"large\")"
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": "small",
+      "name": "url",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": "small",
+          "type": "[String]"
+        }
+      ],
+      "storageKey": "url(version:\"small\")"
+    },
+    v7,
+    v8
+  ]
 };
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "routes_ArtistTopLevelQuery",
   "id": null,
-  "text": "query routes_ArtistTopLevelQuery(\n  $artist_id: String!\n) {\n  artist(id: $artist_id) @principalField {\n    ...ArtistApp_artist\n    __id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  _id\n  id\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  _id\n  id\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment NavigationTabs_artist on Artist {\n  id\n  statuses {\n    shows\n    articles\n    cv(minShowCount: 0)\n    auction_lots\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  name\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
+  "text": "query routes_ArtistTopLevelQuery(\n  $artist_id: String!\n) {\n  artist(id: $artist_id) @principalField {\n    ...ArtistApp_artist\n    __id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  _id\n  id\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n  __id\n}\n\nfragment ArtistMeta_artist on Artist {\n  id\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n    __id: id\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency\n        is_price_range\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n          __id: id\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n              __id: id\n            }\n            __id\n          }\n          __id\n        }\n        __id\n      }\n    }\n  }\n  __id\n}\n\nfragment ArtistHeader_artist on Artist {\n  _id\n  id\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n      __id: id\n    }\n  }\n  ...FollowArtistButton_artist\n  __id\n}\n\nfragment NavigationTabs_artist on Artist {\n  id\n  statuses {\n    shows\n    articles\n    cv(minShowCount: 0)\n    auction_lots\n  }\n  __id\n}\n\nfragment FollowArtistButton_artist on Artist {\n  __id\n  name\n  id\n  is_followed\n  counts {\n    follows\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -155,24 +291,18 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "alternate_names",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "_id",
             "args": null,
             "storageKey": null
           },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "id",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "name",
-            "args": null,
-            "storageKey": null
-          },
+          v3,
           {
             "kind": "ScalarField",
             "alias": null,
@@ -183,9 +313,78 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "years",
+            "name": "birthday",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "deathday",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "gender",
+            "args": null,
+            "storageKey": null
+          },
+          v4,
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "meta",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ArtistMeta",
+            "plural": false,
+            "selections": [
+              v5,
+              v6
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "versions",
+                "args": null,
+                "storageKey": null
+              },
+              v7,
+              {
+                "kind": "ScalarField",
+                "alias": "square",
+                "name": "url",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "square",
+                    "type": "[String]"
+                  }
+                ],
+                "storageKey": "url(version:\"square\")"
+              },
+              v8
+            ]
           },
           {
             "kind": "LinkedField",
@@ -199,11 +398,152 @@ return {
               {
                 "kind": "ScalarField",
                 "alias": null,
+                "name": "artworks",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
                 "name": "follows",
                 "args": null,
                 "storageKey": null
               }
             ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "blurb",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artworks_connection",
+            "storageKey": "artworks_connection(filter:\"IS_FOR_SALE\",first:10,published:true)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "filter",
+                "value": "IS_FOR_SALE",
+                "type": "[ArtistArtworksFilters]"
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10,
+                "type": "Int"
+              },
+              {
+                "kind": "Literal",
+                "name": "published",
+                "value": true,
+                "type": "Boolean"
+              }
+            ],
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "is_price_range",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v5,
+                      v6,
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "category",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "price_currency",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "availability",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v4,
+                      v9,
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          v3,
+                          v4,
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "profile",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Profile",
+                            "plural": false,
+                            "selections": [
+                              v9,
+                              v2
+                            ]
+                          },
+                          v2
+                        ]
+                      },
+                      v2
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          v2,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "years",
+            "args": null,
+            "storageKey": null
           },
           {
             "kind": "LinkedField",
@@ -223,13 +563,7 @@ return {
                 "concreteType": "Image",
                 "plural": true,
                 "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "href",
-                    "args": null,
-                    "storageKey": null
-                  },
+                  v4,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -269,18 +603,11 @@ return {
                       }
                     ]
                   },
-                  {
-                    "kind": "ScalarField",
-                    "alias": "__id",
-                    "name": "id",
-                    "args": null,
-                    "storageKey": null
-                  }
+                  v8
                 ]
               }
             ]
           },
-          v2,
           {
             "kind": "ScalarField",
             "alias": null,


### PR DESCRIPTION
cc @joeyAghion 

This ports over the [current meta](https://github.com/artsy/force/blob/1e76040170d882695a2f73bd4578e3b07f6cc634/src/desktop/apps/artist/components/Meta.js) component from Force into Reaction, using `react-head` and adding a fragment into the overall SSR query.

This Reaction update goes in hand with a Force update that removes this fetch and component from Force.