### PR TITLE
[Refactor] Alias SystemQueryRenderer as QueryRenderer for linting

### DIFF
--- a/src/Apps/Artist/Components/ArtistCollectionsRail/index.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/index.tsx
@@ -2,7 +2,7 @@ import { Box } from "@artsy/palette"
 import { ArtistCollectionsRailQuery } from "__generated__/ArtistCollectionsRailQuery.graphql"
 import { useSystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React from "react"
 import { graphql } from "react-relay"
 import { ArtistCollectionsRailFragmentContainer as ArtistCollectionsRail } from "./ArtistCollectionsRail"
@@ -17,7 +17,7 @@ export const ArtistCollectionsRailContent: React.SFC<Props> = passedProps => {
 
   return (
     <Box mb={3}>
-      <SystemQueryRenderer<ArtistCollectionsRailQuery>
+      <QueryRenderer<ArtistCollectionsRailQuery>
         environment={relayEnvironment}
         variables={{
           isFeaturedArtistContent: true,

--- a/src/Apps/Artist/Components/MarketDataSummary/index.tsx
+++ b/src/Apps/Artist/Components/MarketDataSummary/index.tsx
@@ -3,7 +3,7 @@ import { graphql } from "react-relay"
 
 import { MarketDataSummaryContentsQuery } from "__generated__/MarketDataSummaryContentsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import MarketDataSummary from "./MarketDataSummary"
 
 export interface Props extends SystemContextProps {
@@ -14,7 +14,7 @@ class MarketDataSummaryContents extends React.Component<Props, null> {
   render() {
     const { artistID, relayEnvironment } = this.props
     return (
-      <SystemQueryRenderer<MarketDataSummaryContentsQuery>
+      <QueryRenderer<MarketDataSummaryContentsQuery>
         environment={relayEnvironment}
         query={graphql`
           query MarketDataSummaryContentsQuery($artistID: String!) {

--- a/src/Apps/Artist/Components/MarketInsights/index.tsx
+++ b/src/Apps/Artist/Components/MarketInsights/index.tsx
@@ -3,7 +3,7 @@ import { graphql } from "react-relay"
 
 import { MarketInsightsContentsQuery } from "__generated__/MarketInsightsContentsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import MarketInsights from "./MarketInsights"
 
 export interface Props extends SystemContextProps {
@@ -14,7 +14,7 @@ class MarketInsightsContents extends React.Component<Props, null> {
   render() {
     const { artistID, relayEnvironment } = this.props
     return (
-      <SystemQueryRenderer<MarketInsightsContentsQuery>
+      <QueryRenderer<MarketInsightsContentsQuery>
         environment={relayEnvironment}
         query={graphql`
           query MarketInsightsContentsQuery($artistID: String!) {

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistRecommendations.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistRecommendations.tsx
@@ -3,7 +3,7 @@ import { ArtistRecommendations_artist } from "__generated__/ArtistRecommendation
 import { ArtistRecommendationsRendererQuery } from "__generated__/ArtistRecommendationsRendererQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext, useState } from "react"
 import {
   createPaginationContainer,
@@ -151,7 +151,7 @@ export const ArtistRecommendationsQueryRenderer: React.FC<{
 }> = ({ artistID }) => {
   const { relayEnvironment } = useContext(SystemContext)
   return (
-    <SystemQueryRenderer<ArtistRecommendationsRendererQuery>
+    <QueryRenderer<ArtistRecommendationsRendererQuery>
       environment={relayEnvironment}
       query={graphql`
         query ArtistRecommendationsRendererQuery($artistID: String!) {

--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -13,7 +13,7 @@ import { Mediator } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import {
   ArtistBioFragmentContainer as ArtistBio,
@@ -275,7 +275,7 @@ export const ArtistInfoQueryRenderer = ({ artistID }: { artistID: string }) => {
     <SystemContextConsumer>
       {({ relayEnvironment }) => {
         return (
-          <SystemQueryRenderer<ArtistInfoQuery>
+          <QueryRenderer<ArtistInfoQuery>
             environment={relayEnvironment}
             variables={{ artistID }}
             query={graphql`

--- a/src/Apps/Artwork/Components/ArtworkBanner/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkBanner/index.tsx
@@ -2,7 +2,7 @@ import { ArtworkBanner_artwork } from "__generated__/ArtworkBanner_artwork.graph
 import { ArtworkBannerQuery } from "__generated__/ArtworkBannerQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
@@ -196,7 +196,7 @@ export const ArtworkBannerQueryRenderer = ({
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<ArtworkBannerQuery>
+    <QueryRenderer<ArtworkBannerQuery>
       environment={relayEnvironment}
       variables={{ artworkID }}
       query={graphql`

--- a/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -14,7 +14,7 @@ import { ArtworkDetailsQuery } from "__generated__/ArtworkDetailsQuery.graphql"
 import { SystemContext } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import Events from "Utils/Events"
 
 export interface ArtworkDetailsProps {
@@ -115,7 +115,7 @@ export const ArtworkDetailsQueryRenderer = ({
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<ArtworkDetailsQuery>
+    <QueryRenderer<ArtworkDetailsQuery>
       environment={relayEnvironment}
       variables={{ artworkID }}
       query={graphql`

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/index.tsx
@@ -2,7 +2,7 @@ import { ArtworkImageBrowser_artwork } from "__generated__/ArtworkImageBrowser_a
 import { ArtworkImageBrowserQuery } from "__generated__/ArtworkImageBrowserQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkActionsFragmentContainer as ArtworkActions } from "./ArtworkActions"
@@ -87,7 +87,7 @@ export const ArtworkImageBrowserQueryRenderer = ({
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<ArtworkImageBrowserQuery>
+    <QueryRenderer<ArtworkImageBrowserQuery>
       environment={relayEnvironment}
       variables={{ artworkID }}
       query={graphql`

--- a/src/Apps/Artwork/Components/ArtworkSidebar/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/index.tsx
@@ -15,7 +15,7 @@ import { ArtworkSidebarPartnerInfoFragmentContainer as PartnerInfo } from "./Art
 import { ArtworkSidebar_artwork } from "__generated__/ArtworkSidebar_artwork.graphql"
 import { ArtworkSidebarQuery } from "__generated__/ArtworkSidebarQuery.graphql"
 import { SystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 
 export interface ArtworkSidebarProps {
   artwork: ArtworkSidebar_artwork
@@ -90,7 +90,7 @@ export const ArtworkSidebarQueryRenderer = ({
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<ArtworkSidebarQuery>
+    <QueryRenderer<ArtworkSidebarQuery>
       environment={relayEnvironment}
       variables={{ artworkID }}
       query={graphql`

--- a/src/Apps/Artwork/Components/OtherAuctions.tsx
+++ b/src/Apps/Artwork/Components/OtherAuctions.tsx
@@ -3,7 +3,7 @@ import { OtherAuctions_sales } from "__generated__/OtherAuctions_sales.graphql"
 import { OtherAuctionsQuery } from "__generated__/OtherAuctionsQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { AuctionCardFragmentContainer as AuctionCard } from "Components/v2/AuctionCard"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -45,7 +45,7 @@ export const OtherAuctionsQueryRenderer = () => {
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<OtherAuctionsQuery>
+    <QueryRenderer<OtherAuctionsQuery>
       environment={relayEnvironment}
       variables={{ size: 4, sort: "TIMELY_AT_NAME_ASC" }}
       query={graphql`

--- a/src/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
@@ -13,7 +13,7 @@ import React, { useContext } from "react"
 import styled from "styled-components"
 import createLogger from "Utils/logger"
 
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { get } from "Utils/get"
 
@@ -169,7 +169,7 @@ export const RelatedWorksArtworkGridQueryRenderer: React.SFC<{
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<RelatedWorksArtworkGridQuery>
+    <QueryRenderer<RelatedWorksArtworkGridQuery>
       environment={relayEnvironment}
       variables={{
         artworkSlug,

--- a/src/Apps/Artwork/Components/__stories__/OtherAuctions.story.tsx
+++ b/src/Apps/Artwork/Components/__stories__/OtherAuctions.story.tsx
@@ -1,7 +1,7 @@
 import { OtherAuctionsStoryQuery } from "__generated__/OtherAuctionsStoryQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
 import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
@@ -12,7 +12,7 @@ const OtherAuctions = ({ size }: { size?: number }) => {
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<OtherAuctionsStoryQuery>
+    <QueryRenderer<OtherAuctionsStoryQuery>
       environment={relayEnvironment}
       query={graphql`
         query OtherAuctionsStoryQuery($size: Int!) {

--- a/src/Apps/Artwork/Components/__stories__/OtherWorks.story.tsx
+++ b/src/Apps/Artwork/Components/__stories__/OtherWorks.story.tsx
@@ -1,7 +1,7 @@
 import { OtherWorksQuery } from "__generated__/OtherWorksQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
 import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
@@ -13,7 +13,7 @@ export const OtherWorks = ({ artworkSlug }: { artworkSlug: string }) => {
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<OtherWorksQuery>
+    <QueryRenderer<OtherWorksQuery>
       environment={relayEnvironment}
       variables={{ artworkSlug }}
       query={graphql`

--- a/src/Apps/Auction/Components/AuctionFAQ.tsx
+++ b/src/Apps/Auction/Components/AuctionFAQ.tsx
@@ -3,7 +3,7 @@ import { AuctionFAQ_viewer } from "__generated__/AuctionFAQ_viewer.graphql"
 import { AuctionFAQQuery } from "__generated__/AuctionFAQQuery.graphql"
 import { useSystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React from "react"
 import Markdown from "react-markdown"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -153,7 +153,7 @@ export const AuctionFAQFragmentContainer = createFragmentContainer(AuctionFAQ, {
 export const AuctionFAQQueryRenderer: React.SFC = () => {
   const { relayEnvironment } = useSystemContext()
   return (
-    <SystemQueryRenderer<AuctionFAQQuery>
+    <QueryRenderer<AuctionFAQQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/Apps/Collect2/Routes/Collection/Components/__stories__/CollectionsHubRails.story.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/__stories__/CollectionsHubRails.story.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@artsy/palette"
 import { SystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
 import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
@@ -33,7 +33,7 @@ export const CollectionHubRailsQueryRenderer: React.FC<Props> = ({
   if (relayEnvironment) {
     return (
       // tslint:disable-next-line:relay-operation-generics
-      <SystemQueryRenderer
+      <QueryRenderer
         environment={relayEnvironment}
         variables={{
           collectionID,

--- a/src/Apps/WorksForYou/index.tsx
+++ b/src/Apps/WorksForYou/index.tsx
@@ -4,7 +4,7 @@ import { WorksForYouQuery } from "__generated__/WorksForYouQuery.graphql"
 import { MarketingHeader } from "Apps/WorksForYou/MarketingHeader"
 import { SystemContextConsumer, SystemContextProps } from "Artsy"
 import { track } from "Artsy/Analytics"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { Component } from "react"
 import { graphql } from "react-relay"
 import styled from "styled-components"
@@ -39,7 +39,7 @@ export class WorksForYou extends Component<Props> {
               <>
                 <MarketingHeader />
 
-                <SystemQueryRenderer<WorksForYouQuery>
+                <QueryRenderer<WorksForYouQuery>
                   environment={relayEnvironment}
                   query={graphql`
                     query WorksForYouQuery(

--- a/src/Components/CollectionsRail/index.tsx
+++ b/src/Components/CollectionsRail/index.tsx
@@ -4,7 +4,7 @@ import { graphql } from "react-relay"
 import { CollectionsRailQuery } from "__generated__/CollectionsRailQuery.graphql"
 import { SystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { CollectionsRailFragmentContainer as CollectionsRail } from "./CollectionsRail"
 
 interface Props {
@@ -15,7 +15,7 @@ interface Props {
 export const CollectionsRailContent: React.FC<Props> = passedProps => {
   const { relayEnvironment } = useContext(SystemContext)
   return (
-    <SystemQueryRenderer<CollectionsRailQuery>
+    <QueryRenderer<CollectionsRailQuery>
       environment={relayEnvironment}
       variables={{
         showOnEditorial: true,

--- a/src/Components/Gene/index.tsx
+++ b/src/Components/Gene/index.tsx
@@ -4,7 +4,7 @@ import { graphql } from "react-relay"
 import { GeneContentsArtistsQuery } from "__generated__/GeneContentsArtistsQuery.graphql"
 import { GeneContentsArtworksQuery } from "__generated__/GeneContentsArtworksQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import Artists from "./Artists"
 import GeneArtworks from "./GeneArtworks"
 
@@ -126,7 +126,7 @@ class GeneContents extends React.Component<Props, State> {
   renderArtists() {
     const { geneID, relayEnvironment } = this.props
     return (
-      <SystemQueryRenderer<GeneContentsArtistsQuery>
+      <QueryRenderer<GeneContentsArtistsQuery>
         environment={relayEnvironment}
         query={graphql`
           query GeneContentsArtistsQuery($geneID: String!) {
@@ -157,7 +157,7 @@ class GeneContents extends React.Component<Props, State> {
     const { geneID, relayEnvironment } = this.props
     const { for_sale, medium, price_range, dimension_range, sort } = this.state
     return (
-      <SystemQueryRenderer<GeneContentsArtworksQuery>
+      <QueryRenderer<GeneContentsArtworksQuery>
         environment={relayEnvironment}
         query={graphql`
           query GeneContentsArtworksQuery(

--- a/src/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -25,7 +25,7 @@ import {
   Separator,
   Serif,
 } from "@artsy/palette"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 
 export const NotificationMenuItems: React.FC<
   NotificationsMenuQueryResponse
@@ -121,7 +121,7 @@ export const NotificationsQueryRenderer: React.FC<{
   const { relayEnvironment } = useContext(SystemContext)
 
   return (
-    <SystemQueryRenderer<NotificationsMenuQuery>
+    <QueryRenderer<NotificationsMenuQuery>
       environment={relayEnvironment}
       query={graphql`
         query NotificationsMenuQuery {

--- a/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
@@ -5,7 +5,7 @@ import {
 } from "__generated__/ArtistSearchResultsArtistMutation.graphql"
 import { ArtistSearchResultsQuery } from "__generated__/ArtistSearchResultsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import * as React from "react"
 import {
   commitMutation,
@@ -204,7 +204,7 @@ const ArtistSearchResultsComponent: React.SFC<
   ContainerProps & SystemContextProps
 > = ({ term, relayEnvironment, updateFollowCount }) => {
   return (
-    <SystemQueryRenderer<ArtistSearchResultsQuery>
+    <QueryRenderer<ArtistSearchResultsQuery>
       environment={relayEnvironment}
       query={graphql`
         query ArtistSearchResultsQuery($term: String!) {

--- a/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
+++ b/src/Components/Onboarding/Steps/Artists/PopularArtists.tsx
@@ -5,7 +5,7 @@ import {
 } from "__generated__/PopularArtistsFollowArtistMutation.graphql"
 import { PopularArtistsQuery } from "__generated__/PopularArtistsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import * as React from "react"
 import {
   commitMutation,
@@ -215,7 +215,7 @@ const PopularArtistsComponent: React.SFC<SystemContextProps & FollowProps> = ({
   updateFollowCount,
 }) => {
   return (
-    <SystemQueryRenderer<PopularArtistsQuery>
+    <QueryRenderer<PopularArtistsQuery>
       environment={relayEnvironment}
       query={graphql`
         query PopularArtistsQuery {

--- a/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
+++ b/src/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
@@ -5,7 +5,7 @@ import {
 } from "__generated__/GeneSearchResultsFollowGeneMutation.graphql"
 import { GeneSearchResultsQuery } from "__generated__/GeneSearchResultsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { garamond } from "Assets/Fonts"
 import * as React from "react"
 import {
@@ -190,7 +190,7 @@ const GeneSearchResultsComponent: React.SFC<
   ContainerProps & SystemContextProps
 > = ({ term, relayEnvironment, updateFollowCount }) => {
   return (
-    <SystemQueryRenderer<GeneSearchResultsQuery>
+    <QueryRenderer<GeneSearchResultsQuery>
       environment={relayEnvironment}
       query={graphql`
         query GeneSearchResultsQuery($term: String!) {

--- a/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
+++ b/src/Components/Onboarding/Steps/Genes/SuggestedGenes.tsx
@@ -5,7 +5,7 @@ import {
 } from "__generated__/SuggestedGenesFollowGeneMutation.graphql"
 import { SuggestedGenesQuery } from "__generated__/SuggestedGenesQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import * as React from "react"
 import {
   commitMutation,
@@ -167,7 +167,7 @@ const SuggestedGenesComponent: React.SFC<SystemContextProps & FollowProps> = ({
   updateFollowCount,
 }) => {
   return (
-    <SystemQueryRenderer<SuggestedGenesQuery>
+    <QueryRenderer<SuggestedGenesQuery>
       environment={relayEnvironment}
       query={graphql`
         query SuggestedGenesQuery {

--- a/src/Components/Payment/UserSettingsPayments.tsx
+++ b/src/Components/Payment/UserSettingsPayments.tsx
@@ -5,7 +5,7 @@ import { SystemContext, SystemContextProps } from "Artsy"
 import { get } from "Utils/get"
 
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { PaymentFormWrapper } from "./PaymentFormWrapper"
@@ -96,7 +96,7 @@ export const UserSettingsPaymentsQueryRenderer = () => {
   }
 
   return (
-    <SystemQueryRenderer<UserSettingsPaymentsQuery>
+    <QueryRenderer<UserSettingsPaymentsQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/Components/Publishing/ToolTip/TooltipsDataLoader.tsx
+++ b/src/Components/Publishing/ToolTip/TooltipsDataLoader.tsx
@@ -1,7 +1,7 @@
 import { TooltipsDataLoaderQueryResponse } from "__generated__/TooltipsDataLoaderQuery.graphql"
 import { TooltipsDataLoaderQuery } from "__generated__/TooltipsDataLoaderQuery.graphql"
 import * as Artsy from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { getArtsySlugsFromArticle } from "Components/Publishing/Constants"
 import { ArticleData } from "Components/Publishing/Typings"
 import { keyBy } from "lodash"
@@ -40,7 +40,7 @@ export class TooltipsDataLoader extends Component<Props> {
     }
 
     return (
-      <SystemQueryRenderer<TooltipsDataLoaderQuery>
+      <QueryRenderer<TooltipsDataLoaderQuery>
         environment={relayEnvironment}
         query={graphql`
           query TooltipsDataLoaderQuery(

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -4,7 +4,7 @@ import { SearchBarSuggestQuery } from "__generated__/SearchBarSuggestQuery.graph
 import { SystemContext, SystemContextProps } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import colors from "Assets/Colors"
 import {
   FirstSuggestionItem,
@@ -419,7 +419,7 @@ export const SearchBarRefetchContainer = createRefetchContainer(
 export const SearchBarQueryRenderer: React.FC = () => {
   const { relayEnvironment, searchQuery = "" } = useContext(SystemContext)
   return (
-    <SystemQueryRenderer<SearchBarSuggestQuery>
+    <QueryRenderer<SearchBarSuggestQuery>
       environment={relayEnvironment}
       query={graphql`
         query SearchBarSuggestQuery($term: String!, $hasTerm: Boolean!) {

--- a/src/Components/Tag/index.tsx
+++ b/src/Components/Tag/index.tsx
@@ -3,7 +3,7 @@ import { graphql } from "react-relay"
 
 import { TagContentsArtworksQuery } from "__generated__/TagContentsArtworksQuery.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import TagArtworks from "./TagArtworks"
 
 export interface Filters {
@@ -100,7 +100,7 @@ class TagContents extends React.Component<Props, State> {
     const { tagID, relayEnvironment } = this.props
     const { for_sale, medium, price_range, dimension_range, sort } = this.state
     return (
-      <SystemQueryRenderer<TagContentsArtworksQuery>
+      <QueryRenderer<TagContentsArtworksQuery>
         environment={relayEnvironment}
         query={graphql`
           query TagContentsArtworksQuery(

--- a/src/Components/v2/ArtworkFilter/index.tsx
+++ b/src/Components/v2/ArtworkFilter/index.tsx
@@ -36,7 +36,7 @@ import {
 } from "@artsy/palette"
 import { ArtistArtworkFilter_artist } from "__generated__/ArtistArtworkFilter_artist.graphql"
 import { Collection_viewer } from "__generated__/Collection_viewer.graphql"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 
 /**
  * Primary ArtworkFilter which is wrapped with a context and refetch container.
@@ -337,7 +337,7 @@ export const ArtworkFilterQueryRenderer = ({ keyword = "andy warhol" }) => {
         keyword,
       }}
     >
-      <SystemQueryRenderer<ArtworkFilterQueryType>
+      <QueryRenderer<ArtworkFilterQueryType>
         environment={relayEnvironment}
         // FIXME: Passing a variable to `query` shouldn't error out in linter
         /* tslint:disable:relay-operation-generics */

--- a/src/Components/v2/AuctionTimer.tsx
+++ b/src/Components/v2/AuctionTimer.tsx
@@ -1,7 +1,7 @@
 import { AuctionTimer_sale } from "__generated__/AuctionTimer_sale.graphql"
 import { AuctionTimerQuery } from "__generated__/AuctionTimerQuery.graphql"
 import { SystemContext } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { Timer } from "Components/v2/Timer"
 import { DateTime } from "luxon"
 import React, { useContext } from "react"
@@ -87,7 +87,7 @@ export const AuctionTimerFragmentContainer = createFragmentContainer(
 export const AuctionTimerQueryRenderer = ({ saleID }: { saleID: string }) => {
   const { relayEnvironment } = useContext(SystemContext)
   return (
-    <SystemQueryRenderer<AuctionTimerQuery>
+    <QueryRenderer<AuctionTimerQuery>
       environment={relayEnvironment}
       variables={{ saleID }}
       query={graphql`

--- a/src/Components/v2/FollowArtistPopover/index.tsx
+++ b/src/Components/v2/FollowArtistPopover/index.tsx
@@ -11,7 +11,7 @@ import {
 import { FollowArtistPopover_suggested } from "__generated__/FollowArtistPopover_suggested.graphql"
 import { FollowArtistPopoverQuery } from "__generated__/FollowArtistPopoverQuery.graphql"
 import { SystemContext, SystemContextProps } from "Artsy"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React, { SFC, useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
@@ -102,7 +102,7 @@ export const FollowArtistPopoverQueryRenderer = ({
 }) => {
   const { relayEnvironment, user } = useContext(SystemContext)
   return (
-    <SystemQueryRenderer<FollowArtistPopoverQuery>
+    <QueryRenderer<FollowArtistPopoverQuery>
       environment={relayEnvironment}
       variables={{ artistID }}
       query={graphql`

--- a/src/Components/v2/RecentlyViewed.tsx
+++ b/src/Components/v2/RecentlyViewed.tsx
@@ -5,7 +5,7 @@ import { SystemContext, SystemContextConsumer } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { FillwidthItem } from "Components/Artwork/FillwidthItem"
 import { ArrowButton, Carousel } from "Components/v2/Carousel"
 import React, { useContext } from "react"
@@ -130,7 +130,7 @@ export const RecentlyViewedQueryRenderer = () => {
     return null
   }
   return (
-    <SystemQueryRenderer<RecentlyViewedQuery>
+    <QueryRenderer<RecentlyViewedQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/Components/v2/__stories__/CollectionsHubsHomepageNav.story.tsx
+++ b/src/Components/v2/__stories__/CollectionsHubsHomepageNav.story.tsx
@@ -2,7 +2,7 @@ import { Theme } from "@artsy/palette"
 import { CollectionsHubsHomepageNavQuery } from "__generated__/CollectionsHubsHomepageNavQuery.graphql"
 import { useSystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React from "react"
 import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
@@ -21,7 +21,7 @@ const CollectionsHubsHomepageNavQueryRenderer = () => {
   const { relayEnvironment } = useSystemContext()
 
   return (
-    <SystemQueryRenderer<CollectionsHubsHomepageNavQuery>
+    <QueryRenderer<CollectionsHubsHomepageNavQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/Components/v2/__stories__/CollectionsHubsNav.story.tsx
+++ b/src/Components/v2/__stories__/CollectionsHubsNav.story.tsx
@@ -2,7 +2,7 @@ import { Theme } from "@artsy/palette"
 import { CollectionsHubsNavQuery } from "__generated__/CollectionsHubsNavQuery.graphql"
 import { useSystemContext } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import React from "react"
 import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
@@ -18,7 +18,7 @@ const CollectionsHubsNavQueryRenderer = () => {
   const { relayEnvironment } = useSystemContext()
 
   return (
-    <SystemQueryRenderer<CollectionsHubsNavQuery>
+    <QueryRenderer<CollectionsHubsNavQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`

--- a/src/DevTools/__tests__/MockRelayRendererFixtures.tsx
+++ b/src/DevTools/__tests__/MockRelayRendererFixtures.tsx
@@ -4,7 +4,7 @@ import { MockRelayRendererFixtures_artworkMetadata } from "__generated__/MockRel
 import { MockRelayRendererFixturesArtistQuery } from "__generated__/MockRelayRendererFixturesArtistQuery.graphql"
 import { SystemContextConsumer } from "Artsy"
 import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
-import { SystemQueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import cheerio from "cheerio"
 import { render } from "enzyme"
 import * as React from "react"
@@ -65,7 +65,7 @@ const ArtistQueryRenderer = (props: { id: string }) => (
   <SystemContextConsumer>
     {({ relayEnvironment }) => {
       return (
-        <SystemQueryRenderer<MockRelayRendererFixturesArtistQuery>
+        <QueryRenderer<MockRelayRendererFixturesArtistQuery>
           environment={relayEnvironment}
           variables={props}
           query={graphql`


### PR DESCRIPTION
Updated `SystemQueryRenderer` to `QueryRenderer` so that our tslint autofixer is supported. 