### PR TITLE
[GROW-1587] Ensure content below collection header image respond to image resize at small breakpoint

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
@@ -232,7 +232,14 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     key={collection.slug}
                   />
                 )}
-                <MetaContainer mb={2} mt={[0, imageHeightSizes.sm + space(3)]}>
+                <MetaContainer
+                  mb={2}
+                  mt={[
+                    0,
+                    imageHeightSizes.xs + space(3),
+                    imageHeightSizes.sm + space(3),
+                  ]}
+                >
                   <BreadcrumbContainer size={["2", "3"]} mt={[2, 0]}>
                     <Link to="/collect">All works</Link> /{" "}
                     <Link to={categoryTarget}>{collection.category}</Link>


### PR DESCRIPTION
Addresses: [GROW-1587](https://artsyproduct.atlassian.net/browse/GROW-1587)

At smaller breakpoints the content below the header didn't respond to image resizing. This PR adds a style rule to address that.

**Before:**
![default header](https://user-images.githubusercontent.com/5201004/66524104-77bc6800-eabf-11e9-92f2-c64740f0e8f1.gif)

**After:**
![default header 2](https://user-images.githubusercontent.com/5201004/66524173-a8040680-eabf-11e9-83ea-e52a737b7e7c.gif)


