### PR TITLE
[GROW-1587] ensure custom collection header image height is correct at small breakpoint

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -14,6 +14,7 @@ import { useTracking } from "Artsy/Analytics/useTracking"
 import { RouterLink } from "Artsy/Router/RouterLink"
 import { Truncator } from "Components/Truncator"
 import { ArrowButton, Carousel } from "Components/v2"
+import currency from "currency.js"
 import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -99,6 +100,10 @@ export const FeaturedCollectionEntity: React.FC<
 > = ({ itemNumber, member }) => {
   const { description, price_guidance, slug, thumbnail, title } = member
   const { trackEvent } = useTracking()
+  const formattedPrice = currency(price_guidance, {
+    separator: ",",
+    precision: 0,
+  }).format()
 
   const handleClick = () => {
     trackEvent({
@@ -122,7 +127,7 @@ export const FeaturedCollectionEntity: React.FC<
           <Truncator maxLineCount={1}>{title}</Truncator>
         </Serif>
         {price_guidance && (
-          <Sans size="2" color="black60">{`From $${price_guidance}`}</Sans>
+          <Sans size="2" color="black60">{`From $${formattedPrice}`}</Sans>
         )}
         <ExtendedSerif size="3" mt={1}>
           <ReadMore

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
@@ -180,11 +180,13 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
       {({ xs, sm, md, lg }) => {
         const size = xs ? "xs" : sm ? "sm" : md ? "md" : lg ? "lg" : "xl"
         const imageWidth = imageWidthSizes[size]
-        const imageHeight = xs ? imageHeightSizes.xs : imageHeightSizes.sm
+        const smallerScreen = size === "xs" || size === "sm"
+        const imageHeight = smallerScreen
+          ? imageHeightSizes.xs
+          : imageHeightSizes.sm
         const chars = maxChars[size]
         const categoryTarget = `/collections#${slugify(collection.category)}`
         const artistsCount = size === "xs" ? 9 : 12
-        const smallerScreen = size === "xs" || size === "sm"
         const featuredArtists = getFeaturedArtists(
           artistsCount,
           collection,

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
@@ -180,13 +180,13 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
       {({ xs, sm, md, lg }) => {
         const size = xs ? "xs" : sm ? "sm" : md ? "md" : lg ? "lg" : "xl"
         const imageWidth = imageWidthSizes[size]
-        const smallerScreen = size === "xs" || size === "sm"
+        const smallerScreen = xs || sm
         const imageHeight = smallerScreen
           ? imageHeightSizes.xs
           : imageHeightSizes.sm
         const chars = maxChars[size]
         const categoryTarget = `/collections#${slugify(collection.category)}`
-        const artistsCount = size === "xs" ? 9 : 12
+        const artistsCount = xs ? 9 : 12
         const featuredArtists = getFeaturedArtists(
           artistsCount,
           collection,


### PR DESCRIPTION
Addresses: [GROW-1587](https://artsyproduct.atlassian.net/browse/GROW-1587) (also sneaking [GROW-1583](https://artsyproduct.atlassian.net/browse/GROW-1583) in here)

After [fixing the default header](https://github.com/artsy/reaction/pull/2892) I saw the custom header image had the wrong image height which causes the collection title to lay over top of the image. This PR fixes the custom header image per the [spec](https://app.zeplin.io/project/5aabc5e0786bbb29b6e3dc7f/screen/5cd98bcd27264913e9451971). 

This PR also formats the price guidance for featured collections rail with a comma (i.e. $1,600).

**Before:**
![Screen Shot 2019-10-10 at 12 29 56 PM](https://user-images.githubusercontent.com/5201004/66588478-8dcb3680-eb5a-11e9-80f3-1b1fb4828c95.png)

**After:**
![Screen Shot 2019-10-10 at 12 37 20 PM](https://user-images.githubusercontent.com/5201004/66588551-bbb07b00-eb5a-11e9-986f-cd78a0e9184f.png)

**Formatted price guidance:**
![Screen Shot 2019-10-10 at 12 56 33 PM](https://user-images.githubusercontent.com/5201004/66589995-c9b3cb00-eb5d-11e9-8e64-6907b08d05c4.png)
