### PR TITLE
[GROW-1580] truncate featured collection description by line count vs characters

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   color,
   Flex,
-  ReadMore,
   ResponsiveImage,
   Sans,
   Serif,
@@ -112,6 +111,30 @@ export const FeaturedCollectionEntity: React.FC<
     })
   }
 
+  const getTruncatedDescription = (lines: number) => {
+    return (
+      <Truncator
+        maxLineCount={lines}
+        ReadMoreLink={() => {
+          return (
+            <>
+              {`... `}
+              <ReadMoreLink size="2" weight="medium" display="inline">
+                Read more
+              </ReadMoreLink>
+            </>
+          )
+        }}
+      >
+        <>
+          {description && (
+            <span dangerouslySetInnerHTML={{ __html: description }} />
+          )}
+        </>
+      </Truncator>
+    )
+  }
+
   return (
     <Container p={2} m={1} width={["261px", "261px", "355px", "355px"]}>
       <StyledLink to={`/collection/${slug}`} onClick={handleClick}>
@@ -125,17 +148,8 @@ export const FeaturedCollectionEntity: React.FC<
           <Sans size="2" color="black60">{`From $${price_guidance}`}</Sans>
         )}
         <ExtendedSerif size="3" mt={1}>
-          <ReadMore
-            disabled
-            maxChars={110}
-            content={
-              <>
-                {description && (
-                  <span dangerouslySetInnerHTML={{ __html: description }} />
-                )}
-              </>
-            }
-          />
+          <Media lessThan="md">{getTruncatedDescription(4)}</Media>
+          <Media greaterThan="sm">{getTruncatedDescription(3)}</Media>
         </ExtendedSerif>
       </StyledLink>
     </Container>
@@ -212,4 +226,8 @@ export const StyledLink = styled(RouterLink)`
   &:hover {
     text-decoration: none;
   }
+`
+
+const ReadMoreLink = styled(Sans)`
+    text-decoration: underline;
 `


### PR DESCRIPTION
Addresses: [GROW-1580](https://artsyproduct.atlassian.net/browse/GROW-1580)

Because we were previously truncating by character count in some cases the description would lead to different container sizes. This PR refactors to use the truncation to be based on line count which eliminates this UI issue.

**Before:**
![Screen Shot 2019-10-11 at 1 27 00 PM](https://user-images.githubusercontent.com/5201004/66671802-d6522500-ec2a-11e9-86e2-86f06a224d7b.png)

**After:**
![Screen Shot 2019-10-11 at 3 02 29 PM](https://user-images.githubusercontent.com/5201004/66677690-356a6680-ec38-11e9-9738-ae188991ba18.png)