### PR TITLE
Revert dropping htmlparser2 for now due to difficulty running Force test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
   "dependencies": {
     "@artsy/arc": "^1.4.2",
     "@artsy/detect-responsive-traits": "^0.0.5",
-    "@artsy/react-html-parser": "^3.0.0",
     "@artsy/react-responsive-media": "^2.0.0-beta.5",
     "@types/luxon": "^1.15.1",
     "autosuggest-highlight": "^3.1.1",
@@ -196,6 +195,7 @@
     "react-css-transition-replace": "^3.0.2",
     "react-gpt": "^2.0.1",
     "react-head": "^3.0.0",
+    "react-html-parser": "^2.0.2",
     "react-lazy-load-image-component": "^1.1.1",
     "react-lines-ellipsis": "^0.14.0",
     "react-markdown": "^2.5.0",

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -1,6 +1,6 @@
-import ReactHtmlParser, { convertNodeToElement } from "@artsy/react-html-parser"
 import { startsWith } from "lodash"
 import React, { Component } from "react"
+import ReactHtmlParser, { convertNodeToElement } from "react-html-parser"
 import { get } from "Utils/get"
 import { ArticleLayout } from "../Typings"
 import { StyledText } from "./StyledText"
@@ -59,12 +59,12 @@ export class Text extends Component<Props, State> {
     return cleanedHtml
   }
 
-  shouldShowTooltipForURL = (node: Element) => {
+  shouldShowTooltipForURL = node => {
     const urlBase = "https://www.artsy.net/"
     const types = ["artist/", "gene/"]
 
     for (const type of types) {
-      if (startsWith(node.getAttribute("href"), urlBase + type)) {
+      if (startsWith(node.attribs.href, urlBase + type)) {
         return true
       }
     }
@@ -72,41 +72,41 @@ export class Text extends Component<Props, State> {
     return false
   }
 
-  transformNode = (node: Element, index) => {
+  transformNode = (node, index) => {
     const { color } = this.props
     // Dont include relay components unless necessary
     // To avoid 'regeneratorRuntime' error
     const LinkWithTooltip = require("../ToolTip/LinkWithTooltip").default
 
-    if (node.tagName === "P") {
-      const newNode = node.ownerDocument.createElement("div")
-      newNode.setAttribute("class", "paragraph")
-      Array.from(node.childNodes).forEach(child => newNode.appendChild(child))
-      return convertNodeToElement(newNode, index, this.transformNode)
+    if (node.name === "p") {
+      node.name = "div"
+      node.attribs.class = "paragraph"
+      return convertNodeToElement(node, index, this.transformNode)
     }
 
-    if (node.tagName === "A" && this.shouldShowTooltipForURL(node)) {
-      const href = node.getAttribute("href")
-      const linkNode = node.childNodes[0]
+    if (node.name === "a" && this.shouldShowTooltipForURL(node)) {
+      const href = node.attribs.href
+      const linkNode = get(node, n => n.children[0].data && n.children[0], {})
 
-      if (linkNode && linkNode.textContent) {
+      if (linkNode.data) {
         const props = { key: href + index, url: href, color }
-        const next = node.nextSibling
-        const text = linkNode.textContent
+        const next = linkNode.parent && linkNode.parent.next
+        const text = linkNode.data
+        const apostropheRe = /[’'][a-zA-Z]/
 
         // Check to see if there's an apostrophe following a linked section of
         // text and if found, return it.
         const apostrophe = get(next, n => {
-          const str = n.textContent.substr(0, 2)
-          if (/[’'][a-zA-Z]/.test(str)) {
+          const str = n.data.substr(0, 2)
+          if (apostropheRe.test(str)) {
             return str
           }
         })
 
         if (apostrophe) {
           // Remove the apostrophe from the original text
-          next.textContent = next.textContent.substring(2)
-          // And wrap the whole thing with a span preventing whitespace breaks
+          next.data = next.data.substring(2)
+          // And wrap the whole thing with with a span preventing whitespace breaks
           return (
             <span
               className="preventLineBreak"

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,11 +41,6 @@
     styled-system "^3.1.11"
     trunc-html "^1.1.2"
 
-"@artsy/react-html-parser@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.0.tgz#0d8f640644824765b81760e0b8fe2e99d89e61da"
-  integrity sha512-GTCfk0OMTfXWggQVJYWa2wf8Qmv03iuw8TAtFjrEHlTPaC+yJ/o8WySqc76ceXC9p96Y/rVDGMpZGqIarCWQzA==
-
 "@artsy/react-responsive-media@^2.0.0-beta.5":
   version "2.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.5.tgz#d61e1a9f215d38d90ec2bb97dc1ff7409d0346fa"
@@ -8268,7 +8263,7 @@ html-webpack-plugin@^4.0.0-beta.2:
     tapable "^1.1.0"
     util.promisify "1.0.0"
 
-htmlparser2@^3.9.1, htmlparser2@^3.9.2:
+htmlparser2@^3.9.0, htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   integrity sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=
@@ -12864,6 +12859,13 @@ react-hotkeys@2.0.0-pre4:
   integrity sha512-oa+UncSWyOwMK3GExt+oELXaR7T3ItgcMolsupQFdKvwkEhVAluJd5rYczsRSQpQlVkdNoHG46De2NUeuS+88Q==
   dependencies:
     prop-types "^15.6.1"
+
+react-html-parser@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-html-parser/-/react-html-parser-2.0.2.tgz#6dbe1ddd2cebc1b34ca15215158021db5fc5685e"
+  integrity sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==
+  dependencies:
+    htmlparser2 "^3.9.0"
 
 react-input-autosize@^2.1.2:
   version "2.2.1"


### PR DESCRIPTION
See CI results of https://github.com/artsy/force/pull/4668

Revert "Merge pull request #2897 from artsy/use-react-html-parser-fork-without-htmlparser2-dependency"

This reverts commit 0aed477fc42ca696cad6d2af2afef0e76a6cda38, reversing
changes made to 769c6be0060794379723f23d2863f07b3155f845.