### PR TITLE
Drop htmlparser2 and parse5 deps from runtime deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "@artsy/react-responsive-media": "^2.0.0-beta.5",
     "@types/luxon": "^1.15.1",
     "autosuggest-highlight": "^3.1.1",
-    "cheerio": "^1.0.0-rc.2",
     "currency.js": "^1.2.1",
     "formik": "^1.5.8",
     "history": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
   "dependencies": {
     "@artsy/arc": "^1.4.2",
     "@artsy/detect-responsive-traits": "^0.0.5",
+    "@artsy/react-html-parser": "^3.0.0",
     "@artsy/react-responsive-media": "^2.0.0-beta.5",
     "@types/luxon": "^1.15.1",
     "autosuggest-highlight": "^3.1.1",
@@ -195,7 +196,6 @@
     "react-css-transition-replace": "^3.0.2",
     "react-gpt": "^2.0.1",
     "react-head": "^3.0.0",
-    "react-html-parser": "^2.0.2",
     "react-lazy-load-image-component": "^1.1.1",
     "react-lines-ellipsis": "^0.14.0",
     "react-markdown": "^2.5.0",

--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -1,4 +1,3 @@
-import cheerio from "cheerio"
 import { compact, last, uniq } from "lodash"
 import { DateTime } from "luxon"
 import url from "url"
@@ -184,19 +183,16 @@ export const getArtsySlugsFromHTML = (
   html: string,
   model: string
 ): string[] => {
-  const $ = cheerio.load(html)
+  const parser = new window.DOMParser()
+  const doc = parser.parseFromString(html, "text/html")
 
-  const slugs = compact($("a")).map(a => {
-    const href = $(a).attr("href")
-    if (href) {
-      if (href.match(`artsy.net/${model}`)) {
-        return last(url.parse(href).pathname.split("/"))
-      } else {
-        return null
-      }
-    } else {
-      return null
+  const slugs: string[] = []
+  doc.querySelectorAll("a").forEach(anchor => {
+    const href = anchor.getAttribute("href")
+    if (href && href.match(`artsy.net/${model}`)) {
+      slugs.push(last(url.parse(href).pathname.split("/")))
     }
   })
+
   return compact(slugs)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,11 @@
     styled-system "^3.1.11"
     trunc-html "^1.1.2"
 
+"@artsy/react-html-parser@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.0.tgz#0d8f640644824765b81760e0b8fe2e99d89e61da"
+  integrity sha512-GTCfk0OMTfXWggQVJYWa2wf8Qmv03iuw8TAtFjrEHlTPaC+yJ/o8WySqc76ceXC9p96Y/rVDGMpZGqIarCWQzA==
+
 "@artsy/react-responsive-media@^2.0.0-beta.5":
   version "2.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.5.tgz#d61e1a9f215d38d90ec2bb97dc1ff7409d0346fa"
@@ -8263,7 +8268,7 @@ html-webpack-plugin@^4.0.0-beta.2:
     tapable "^1.1.0"
     util.promisify "1.0.0"
 
-htmlparser2@^3.9.0, htmlparser2@^3.9.1, htmlparser2@^3.9.2:
+htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   integrity sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=
@@ -12859,13 +12864,6 @@ react-hotkeys@2.0.0-pre4:
   integrity sha512-oa+UncSWyOwMK3GExt+oELXaR7T3ItgcMolsupQFdKvwkEhVAluJd5rYczsRSQpQlVkdNoHG46De2NUeuS+88Q==
   dependencies:
     prop-types "^15.6.1"
-
-react-html-parser@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/react-html-parser/-/react-html-parser-2.0.2.tgz#6dbe1ddd2cebc1b34ca15215158021db5fc5685e"
-  integrity sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==
-  dependencies:
-    htmlparser2 "^3.9.0"
 
 react-input-autosize@^2.1.2:
   version "2.2.1"


### PR DESCRIPTION
Alright, re-applying https://github.com/artsy/reaction/pull/2897 and adding an additional change to drop usage of cheerio, which depends on parse5, in favour of DOMParser.