### PR TITLE
Collections breadcrumb navigation bug fix

### DIFF
--- a/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
+++ b/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
@@ -12,6 +12,7 @@ import {
   Spacer,
 } from "@artsy/palette"
 import { Router } from "found"
+import styled from "styled-components"
 
 export interface CollectionEntity {
   title: string
@@ -31,7 +32,8 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
     const hasShortRow = collections.length % 3 !== 0 // Preserve left align
 
     return (
-      <Box pb={80} id={name && slugify(name)}>
+      <Box pb={80}>
+        <CollectionsGridAnchor id={name && slugify(name)} />
         <Sans size="3" weight="medium" pb={15}>
           {name}
         </Sans>
@@ -83,3 +85,10 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
     )
   }
 }
+
+const CollectionsGridAnchor = styled.a`
+  display: block;
+  position: relative;
+  top: -90px;
+  visibility: hidden;
+`


### PR DESCRIPTION
Because of the positioning of the navigation bar, when a user clicks on a breadcrumb to nav back to the collections index, the top of the collection title appears to be pushed down the page.

This PR adds an offset to push the collections title below the nav bar.

[Links to GROW-1505](https://artsyproduct.atlassian.net/browse/GROW-1505)



The Fix:
![Kapture 2019-10-14 at 16 18 47](https://user-images.githubusercontent.com/10385964/66758758-3cdf7900-ee9f-11e9-95bf-439153df2c3e.gif)


The Problem:
![Kapture 2019-10-14 at 16 26 32](https://user-images.githubusercontent.com/10385964/66758898-79ab7000-ee9f-11e9-8a80-78912936013c.gif)
