### PR TITLE
Add DOMParser polyfill for the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   "dependencies": {
     "@artsy/arc": "^1.4.2",
     "@artsy/detect-responsive-traits": "^0.0.5",
-    "@artsy/react-html-parser": "^3.0.0",
+    "@artsy/react-html-parser": "^3.0.2",
     "@artsy/react-responsive-media": "^2.0.0-beta.5",
     "@types/luxon": "^1.15.1",
     "autosuggest-highlight": "^3.1.1",

--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -183,7 +183,7 @@ export const getArtsySlugsFromHTML = (
   html: string,
   model: string
 ): string[] => {
-  const parser = new window.DOMParser()
+  const parser = new DOMParser()
   const doc = parser.parseFromString(html, "text/html")
 
   const slugs: string[] = []

--- a/src/Polyfills/DOMParser.ts
+++ b/src/Polyfills/DOMParser.ts
@@ -1,0 +1,13 @@
+// These globals don't expose any instance specific data, nor do they persist or
+// share data across requests in any way. These could have been exported
+// separately by jsdom, but they aren’t and thus the need for a JSDOM instance.
+// However, if/when more is exposed, be sure to not expose instance data that
+// may lead to sharing of data across requests.
+
+import { JSDOM } from "jsdom"
+
+const jsdom = new JSDOM()
+
+const _global = global as any
+_global.DOMParser = jsdom.window.DOMParser
+_global.Node = jsdom.window.Node

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,10 +41,10 @@
     styled-system "^3.1.11"
     trunc-html "^1.1.2"
 
-"@artsy/react-html-parser@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.0.tgz#0d8f640644824765b81760e0b8fe2e99d89e61da"
-  integrity sha512-GTCfk0OMTfXWggQVJYWa2wf8Qmv03iuw8TAtFjrEHlTPaC+yJ/o8WySqc76ceXC9p96Y/rVDGMpZGqIarCWQzA==
+"@artsy/react-html-parser@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
+  integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
 "@artsy/react-responsive-media@^2.0.0-beta.5":
   version "2.0.0-beta.5"


### PR DESCRIPTION
This so clients don’t need HTML parser deps, which the browser already provides, but for some components we obviously need to render on both server and client.