### PR TITLE
[Publishing] Revert SystemQueryRenderer change

### DIFF
--- a/src/Components/Publishing/ToolTip/TooltipsDataLoader.tsx
+++ b/src/Components/Publishing/ToolTip/TooltipsDataLoader.tsx
@@ -1,12 +1,12 @@
 import { TooltipsDataLoaderQueryResponse } from "__generated__/TooltipsDataLoaderQuery.graphql"
 import { TooltipsDataLoaderQuery } from "__generated__/TooltipsDataLoaderQuery.graphql"
 import * as Artsy from "Artsy"
-import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { getArtsySlugsFromArticle } from "Components/Publishing/Constants"
 import { ArticleData } from "Components/Publishing/Typings"
 import { keyBy } from "lodash"
 import PropTypes from "prop-types"
 import React, { Component } from "react"
+import { QueryRenderer } from "react-relay"
 import { graphql } from "react-relay"
 import { ArticleProps } from "../Article"
 


### PR DESCRIPTION
This reverts the change to our ToolTip rendering code so that the article pages can SSR render. 

See [this thread](https://artsy.slack.com/archives/CC56D129X/p1571058681060700) for more info. 