### PR TITLE
[Bugfix] Fix analytics event on /search filter

### DIFF
--- a/src/Apps/Search/Routes/Artworks/index.tsx
+++ b/src/Apps/Search/Routes/Artworks/index.tsx
@@ -22,8 +22,17 @@ export const SearchResultsArtworksRoute: React.FC<
     <Box pt={2}>
       <ArtworkFilter
         viewer={props.viewer}
-        filters={props.location.query as any}
+        filters={props.location.query}
         onChange={updateUrl}
+        onArtworkBrickClick={(artwork, artworkBrickProps) => {
+          tracking.trackEvent({
+            action_type: AnalyticsSchema.ActionType.SelectedItemFromSearchPage,
+            query: artworkBrickProps.term,
+            item_type: "Artwork",
+            item_id: artwork.id,
+            destination_path: artwork.href,
+          })
+        }}
         onFilterClick={(key, value, filterState) => {
           tracking.trackEvent({
             action_type:


### PR DESCRIPTION
Fixes issue where artwork bricks aren't being tracked on click. This matches the event pre-artwork-filter refactor.

<img width="637" alt="Screen Shot 2019-10-14 at 6 09 13 PM" src="https://user-images.githubusercontent.com/236943/66792485-c8600680-eead-11e9-8108-6c279eeda309.png">
