### PR TITLE
Use h1 element for page title

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/Header.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/Header.test.tsx
@@ -124,7 +124,7 @@ describe("collections header", () => {
 
       const component = mountComponent(props)
 
-      expect(component.text()).toContain("Scooby Doo")
+      expect(component.find("h1").text()).toContain("Scooby Doo")
     })
 
     it("renders breadcrumb category", () => {

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
@@ -248,7 +248,9 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     <Link to={categoryTarget}>{collection.category}</Link>
                   </BreadcrumbContainer>
                   <Spacer mt={1} />
-                  <Serif size={["6", "10"]}>{collection.title}</Serif>
+                  <Serif size={["6", "10"]} element="h1">
+                    {collection.title}
+                  </Serif>
                 </MetaContainer>
                 <Grid>
                   <Row>


### PR DESCRIPTION
Uncovered while adding integration tests, we should use an `h1` for page title.