### PR TITLE
Define redirects on Confirm Bid route

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,5 +48,5 @@
     "**/*.snap",
     "**/*.story.tsx"
   ],
-  "debug.node.autoAttach": "off"
+  "debug.node.autoAttach": "on"
 }

--- a/src/Apps/Auction/__fixtures__/routes_BidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_BidQuery.ts
@@ -1,6 +1,3 @@
-// import { Bid_me } from "__generated__/Bid_me.graphql"
-// import { Bid_artwork } from "__generated__/Bid_artwork.graphql"
-// import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
 import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
 import { BidForm_saleArtwork } from "../../../__generated__/BidForm_saleArtwork.graphql"
 import { LotInfo_artwork } from "../../../__generated__/LotInfo_artwork.graphql"
@@ -31,7 +28,6 @@ export const BidQueryResponseFixture: BidQueryResponse = {
     saleArtwork: {
       " $fragmentRefs": null as never,
       " $refType": null as never,
-      // " $fragmentRefs": null,
       _id: "saleArtworkid",
       id: "saleArtworkslug",
       counts: { bidderPositions: 3 },

--- a/src/Apps/Auction/__fixtures__/routes_BidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_BidQuery.ts
@@ -1,0 +1,61 @@
+// import { Bid_me } from "__generated__/Bid_me.graphql"
+// import { Bid_artwork } from "__generated__/Bid_artwork.graphql"
+// import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
+import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
+import { BidForm_saleArtwork } from "../../../__generated__/BidForm_saleArtwork.graphql"
+import { LotInfo_artwork } from "../../../__generated__/LotInfo_artwork.graphql"
+import { routes_BidQueryResponse } from "../../../__generated__/routes_BidQuery.graphql"
+
+export interface BidQueryResponse extends routes_BidQueryResponse {
+  artwork: routes_BidQueryResponse["artwork"] &
+    LotInfo_artwork & {
+      saleArtwork: routes_BidQueryResponse["artwork"]["saleArtwork"] &
+        LotInfo_saleArtwork &
+        BidForm_saleArtwork
+    }
+}
+
+export const BidQueryResponseFixture: BidQueryResponse = {
+  me: {
+    has_qualified_credit_cards: false,
+  },
+  artwork: {
+    " $fragmentRefs": null as never,
+    " $refType": null as never,
+    _id: "artworkid",
+    id: "artworkslug",
+    date: "may 4",
+    title: "artworkid",
+    imageUrl: "artworkid",
+    artistNames: "artworkid",
+    saleArtwork: {
+      " $fragmentRefs": null as never,
+      " $refType": null as never,
+      // " $fragmentRefs": null,
+      _id: "saleArtworkid",
+      id: "saleArtworkslug",
+      counts: { bidderPositions: 3 },
+      increments: [
+        { cents: 5000000, display: "$50,000" },
+        { cents: 6000000, display: "$60,000" },
+        { cents: 7000000, display: "$70,000" },
+      ],
+      lotLabel: "13",
+      minimumNextBid: {
+        amount: "50000",
+        cents: 5000000,
+        display: "$50,000USD",
+      },
+      sale: {
+        _id: "saleid",
+        id: "saleslug",
+        name: "Art Sale 2019",
+        is_closed: false,
+        is_registration_closed: false,
+        registrationStatus: {
+          qualified_for_bidding: true,
+        },
+      },
+    },
+  },
+}

--- a/src/Apps/Auction/__tests__/routes.test.ts
+++ b/src/Apps/Auction/__tests__/routes.test.ts
@@ -140,22 +140,22 @@ describe("Auction/routes", () => {
       )
     })
 
-    it("redirects to the registration page if user is not registered and registration is open", async () => {
+    it("does not redirect if user is not registered but registration is open", async () => {
       const fixture: BidQueryResponse = mockConfirmBidResolver({
         sale: {
           registrationStatus: null,
           is_registration_closed: false,
         },
       })
-      const { redirect } = await render(
+      const { redirect, status } = await render(
         `/auction/${fixture.artwork.saleArtwork.sale.id}/bid/${
           fixture.artwork.id
         }`,
         fixture
       )
-      expect(redirect.url).toBe(
-        `/auction/${fixture.artwork.saleArtwork.sale.id}/registration-flow`
-      )
+
+      expect(status).toBe(200)
+      expect(redirect).toBeUndefined
     })
   })
 

--- a/src/Apps/Auction/getRedirect.ts
+++ b/src/Apps/Auction/getRedirect.ts
@@ -12,7 +12,7 @@ export function registerRedirect(
 ): Redirect | null {
   if (me.has_qualified_credit_cards) {
     return {
-      path: `/auction/${sale.id}/registration-flow`,
+      path: registrationFlowPath(sale),
       reason: "user already has a qualified credit card",
     }
   } else if (!sale.is_auction) {
@@ -22,12 +22,12 @@ export function registerRedirect(
     }
   } else if (!isRegisterable(sale)) {
     return {
-      path: `/auction/${sale.id}`,
+      path: auctionPath(sale),
       reason: "auction must be registerable",
     }
   } else if (userRegisteredToBid(sale)) {
     return {
-      path: `/auction/${sale.id}/confirm-registration`,
+      path: confirmRegistrationPath(sale),
       reason: "user is already registered to bid",
     }
   }

--- a/src/Apps/Auction/getRedirect.ts
+++ b/src/Apps/Auction/getRedirect.ts
@@ -1,0 +1,93 @@
+import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
+import { routes_RegisterQueryResponse } from "__generated__/routes_RegisterQuery.graphql"
+
+export interface Redirect {
+  path: string
+  reason: string
+}
+
+export function registerRedirect(
+  sale: routes_RegisterQueryResponse["sale"],
+  me: routes_RegisterQueryResponse["me"]
+): Redirect | null {
+  if (me.has_qualified_credit_cards) {
+    return {
+      path: `/auction/${sale.id}/registration-flow`,
+      reason: "user already has a qualified credit card",
+    }
+  } else if (!sale.is_auction) {
+    return {
+      path: `/sale/${sale.id}`,
+      reason: "sale must be an auction",
+    }
+  } else if (!isRegisterable(sale)) {
+    return {
+      path: `/auction/${sale.id}`,
+      reason: "auction must be registerable",
+    }
+  } else if (userRegisteredToBid(sale)) {
+    return {
+      path: `/auction/${sale.id}/confirm-registration`,
+      reason: "user is already registered to bid",
+    }
+  }
+
+  return null
+}
+
+export function confirmBidRedirect(
+  artwork: routes_BidQueryResponse["artwork"],
+  me: routes_BidQueryResponse["me"]
+): Redirect | null {
+  const { saleArtwork } = artwork
+  const { sale } = saleArtwork
+  const { registrationStatus } = sale
+
+  if (!registrationStatus)
+    return sale.is_registration_closed
+      ? {
+          path: artworkPath(sale, artwork),
+          reason: "user is not registered, registration closed",
+        }
+      : {
+          path: registrationFlowPath(sale),
+          reason: "user is not registered to bid",
+        }
+
+  if (!registrationStatus.qualified_for_bidding) {
+    return {
+      path: confirmRegistrationPath(sale),
+      reason: "user is not qualified for bidding",
+    }
+  }
+
+  if (sale.is_closed) {
+    return {
+      path: artworkPath(sale, artwork),
+      reason: "sale is closed",
+    }
+  }
+  return null
+}
+
+const auctionPath = (sale: { id: string }): string => `/auction/${sale.id}`
+const registrationFlowPath = (sale: { id: string }): string =>
+  auctionPath(sale) + "/registration-flow"
+const confirmRegistrationPath = (sale: { id: string }): string =>
+  auctionPath(sale) + "/confirm-registration"
+const artworkPath = (sale: { id: string }, artwork: { id: string }): string =>
+  auctionPath(sale) + `/artwork/${artwork.id}`
+
+function isRegisterable(sale: {
+  is_preview: boolean
+  is_open: boolean
+  is_registration_closed: boolean
+}): boolean {
+  return (sale.is_preview || sale.is_open) && !sale.is_registration_closed
+}
+
+function userRegisteredToBid(sale: {
+  registrationStatus: { qualified_for_bidding: boolean }
+}): boolean {
+  return !!sale.registrationStatus
+}

--- a/src/Apps/Auction/getRedirect.ts
+++ b/src/Apps/Auction/getRedirect.ts
@@ -43,24 +43,18 @@ export function confirmBidRedirect(
   const { sale } = saleArtwork
   const { registrationStatus } = sale
 
-  if (!registrationStatus)
-    return sale.is_registration_closed
-      ? {
-          path: artworkPath(sale, artwork),
-          reason: "user is not registered, registration closed",
-        }
-      : {
-          path: registrationFlowPath(sale),
-          reason: "user is not registered to bid",
-        }
-
-  if (!registrationStatus.qualified_for_bidding) {
+  if (!registrationStatus && sale.is_registration_closed) {
+    return {
+      path: artworkPath(sale, artwork),
+      reason: "user is not registered, registration closed",
+    }
+  }
+  if (registrationStatus && !registrationStatus.qualified_for_bidding) {
     return {
       path: confirmRegistrationPath(sale),
       reason: "user is not qualified for bidding",
     }
   }
-
   if (sale.is_closed) {
     return {
       path: artworkPath(sale, artwork),

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -5,7 +5,7 @@ import { graphql } from "react-relay"
 import createLogger from "Utils/logger"
 import { AuctionFAQQueryRenderer as AuctionFAQ } from "./Components/AuctionFAQ"
 import { confirmBidRedirect, Redirect, registerRedirect } from "./getRedirect"
-import { ConfirmBidRouteFragmentContainer as ConfirmBidRoute } from "./Routes/ConfirmBid"
+import { ConfirmBidRouteFragmentContainer } from "./Routes/ConfirmBid"
 import { RegisterRouteFragmentContainer } from "./Routes/Register"
 
 const logger = createLogger("Apps/Auction/routes")
@@ -17,7 +17,7 @@ export const routes: RouteConfig[] = [
   },
   {
     path: "/auction/:saleID/bid(2)?/:artworkID",
-    Component: ConfirmBidRoute,
+    Component: ConfirmBidRouteFragmentContainer,
     render: ({ Component, props }) => {
       if (Component && props) {
         const { artwork, me, location } = props as any
@@ -53,7 +53,6 @@ export const routes: RouteConfig[] = [
         }
         me {
           has_qualified_credit_cards
-          # Pretty sure entire query will fail if the user is not registered
         }
       }
     `,

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -1,22 +1,14 @@
-import { routes_RegisterQueryResponse } from "__generated__/routes_RegisterQuery.graphql"
 import { ErrorPage } from "Components/ErrorPage"
 import { RedirectException, RouteConfig } from "found"
 import React from "react"
 import { graphql } from "react-relay"
 import createLogger from "Utils/logger"
 import { AuctionFAQQueryRenderer as AuctionFAQ } from "./Components/AuctionFAQ"
+import { confirmBidRedirect, Redirect, registerRedirect } from "./getRedirect"
 import { ConfirmBidRouteFragmentContainer as ConfirmBidRoute } from "./Routes/ConfirmBid"
 import { RegisterRouteFragmentContainer } from "./Routes/Register"
 
 const logger = createLogger("Apps/Auction/routes")
-
-interface Redirect {
-  path: string
-  reason: string
-}
-
-type Sale = routes_RegisterQueryResponse["sale"]
-type Me = routes_RegisterQueryResponse["me"]
 
 export const routes: RouteConfig[] = [
   {
@@ -24,7 +16,7 @@ export const routes: RouteConfig[] = [
     Component: AuctionFAQ,
   },
   {
-    path: "auction/:saleID/bid(2)?/:artworkID",
+    path: "/auction/:saleID/bid(2)?/:artworkID",
     Component: ConfirmBidRoute,
     render: ({ Component, props }) => {
       if (Component && props) {
@@ -32,7 +24,7 @@ export const routes: RouteConfig[] = [
         if (!artwork) {
           return <ErrorPage code={404} />
         }
-        handleRedirect(bidRedirect(artwork.saleArtwork.sale, me), location)
+        handleRedirect(confirmBidRedirect(artwork, me), location)
         return <Component {...props} />
       }
     },
@@ -48,21 +40,20 @@ export const routes: RouteConfig[] = [
             _id
             id
             sale {
+              registrationStatus {
+                qualified_for_bidding
+              }
               _id
               id
               name
+              is_closed
+              is_registration_closed
             }
           }
         }
         me {
           has_qualified_credit_cards
           # Pretty sure entire query will fail if the user is not registered
-          bidders(sale_id: $saleID) {
-            qualified_for_bidding
-            sale {
-              name
-            }
-          }
         }
       }
     `,
@@ -115,56 +106,4 @@ function handleRedirect(redirect: Redirect, location: Location) {
     )
     throw new RedirectException(redirect.path)
   }
-}
-
-// (TODO) Clarify redirect logic
-function bidRedirect(sale: Sale, me: Me): Redirect | null {
-  const bidder = (me as any).bidders[0]
-  if (!bidder)
-    return {
-      path: `/auction/${sale.id}/registration-flow`,
-      reason: "user is not registered to bid",
-    }
-  if (!bidder.qualified_for_bidding) {
-    return {
-      path: `/auction/${sale.id}`,
-      reason: "user is not qualified for bidding",
-    }
-  }
-  return null
-}
-
-function registerRedirect(sale: Sale, me: Me): Redirect | null {
-  let redirect = null
-  if (me.has_qualified_credit_cards) {
-    redirect = {
-      path: `/auction/${sale.id}/registration-flow`,
-      reason: "user already has a qualified credit card",
-    }
-  } else if (!sale.is_auction) {
-    redirect = {
-      path: `/sale/${sale.id}`,
-      reason: "sale must be an auction",
-    }
-  } else if (!isRegisterable(sale)) {
-    redirect = {
-      path: `/auction/${sale.id}`,
-      reason: "auction must be registerable",
-    }
-  } else if (userRegisteredToBid(sale)) {
-    redirect = {
-      path: `/auction/${sale.id}/confirm-registration`,
-      reason: "user is already registered to bid",
-    }
-  }
-
-  return redirect
-}
-
-function isRegisterable(sale: Sale): boolean {
-  return (sale.is_preview || sale.is_open) && !sale.is_registration_closed
-}
-
-function userRegisteredToBid(sale: Sale): boolean {
-  return !!sale.registrationStatus
 }

--- a/src/__generated__/routes_BidQuery.graphql.ts
+++ b/src/__generated__/routes_BidQuery.graphql.ts
@@ -16,9 +16,14 @@ export type routes_BidQueryResponse = {
             readonly _id: string;
             readonly id: string;
             readonly sale: ({
+                readonly registrationStatus: ({
+                    readonly qualified_for_bidding: boolean | null;
+                }) | null;
                 readonly _id: string;
                 readonly id: string;
                 readonly name: string | null;
+                readonly is_closed: boolean | null;
+                readonly is_registration_closed: boolean | null;
             }) | null;
             readonly " $fragmentRefs": LotInfo_saleArtwork$ref & BidForm_saleArtwork$ref;
         }) | null;
@@ -26,12 +31,6 @@ export type routes_BidQueryResponse = {
     }) | null;
     readonly me: ({
         readonly has_qualified_credit_cards: boolean | null;
-        readonly bidders: ReadonlyArray<({
-            readonly qualified_for_bidding: boolean | null;
-            readonly sale: ({
-                readonly name: string | null;
-            }) | null;
-        }) | null> | null;
     }) | null;
 };
 export type routes_BidQuery = {
@@ -56,9 +55,15 @@ query routes_BidQuery(
       _id
       id
       sale {
+        registrationStatus {
+          qualified_for_bidding
+          __id
+        }
         _id
         id
         name
+        is_closed
+        is_registration_closed
         __id
       }
       __id
@@ -67,14 +72,6 @@ query routes_BidQuery(
   }
   me {
     has_qualified_credit_cards
-    bidders(sale_id: $saleID) {
-      qualified_for_bidding
-      sale {
-        name
-        __id
-      }
-      __id
-    }
     __id
   }
 }
@@ -161,18 +158,11 @@ v4 = [
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v6 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "sale",
@@ -181,13 +171,52 @@ v7 = {
   "concreteType": "Sale",
   "plural": false,
   "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "registrationStatus",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Bidder",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "qualified_for_bidding",
+          "args": null,
+          "storageKey": null
+        },
+        v5
+      ]
+    },
     v2,
     v3,
-    v5,
-    v6
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "name",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_closed",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_registration_closed",
+      "args": null,
+      "storageKey": null
+    },
+    v5
   ]
 },
-v8 = {
+v7 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "me",
@@ -203,49 +232,17 @@ v8 = {
       "args": null,
       "storageKey": null
     },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "bidders",
-      "storageKey": null,
-      "args": v4,
-      "concreteType": "Bidder",
-      "plural": true,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "qualified_for_bidding",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "sale",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "Sale",
-          "plural": false,
-          "selections": [
-            v5,
-            v6
-          ]
-        },
-        v6
-      ]
-    },
-    v6
+    v5
   ]
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cents",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -257,7 +254,7 @@ return {
   "operationKind": "query",
   "name": "routes_BidQuery",
   "id": null,
-  "text": "query routes_BidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        _id\n        id\n        name\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    has_qualified_credit_cards\n    bidders(sale_id: $saleID) {\n      qualified_for_bidding\n      sale {\n        name\n        __id\n      }\n      __id\n    }\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  __id\n}\n",
+  "text": "query routes_BidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -303,14 +300,14 @@ return {
               },
               v2,
               v3,
-              v7,
-              v6
+              v6,
+              v5
             ]
           },
-          v6
+          v5
         ]
       },
-      v8
+      v7
     ]
   },
   "operation": {
@@ -356,7 +353,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          v6,
+          v5,
           v3,
           {
             "kind": "LinkedField",
@@ -408,11 +405,11 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v9,
-                  v10
+                  v8,
+                  v9
                 ]
               },
-              v6,
+              v5,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -429,21 +426,21 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
-                  v9,
-                  v10
+                  v8,
+                  v9
                 ]
               },
               v2,
               v3,
-              v7
+              v6
             ]
           }
         ]
       },
-      v8
+      v7
     ]
   }
 };
 })();
-(node as any).hash = 'aee93f965a54247486b2cd0865c16860';
+(node as any).hash = 'af13ddd3e0d60d9cbda2a148ab938c56';
 export default node;


### PR DESCRIPTION
[Jira Ticket](https://artsyproduct.atlassian.net/browse/AUCT-655) 🔐
This PR sets up some basic redirects with tests for the new confirm bid route. It also reorganizes some of our redirect handling code.

@damassi suggested that we should consider doing redirects in the route components themselves rather than a separate `render` prop on our route config. I'm not sure the best way to organize some of the shared types in this case, but open to it.