### PR TITLE
Remove snapping effect from mobile carousels because it causes weirdness in iOS 13.

### DIFF
--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -136,7 +136,7 @@ export const SmallCarousel: React.FC<CarouselProps> = props => {
       options={{
         cellAlign: "left",
         draggable: hasMultipleSlides,
-        freeScroll: false,
+        freeScroll: true,
         contain: true,
         friction: 0.3,
         pageDots: hasMultipleSlides,


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-1591.

This PR removes the snapping effect from all instances of `<SmallCarousel>`, which is effectively all carousels in Reaction at the "xs" breakpoint.

In iOS 13, the snapping action made it really difficult to swipe through the carousel (see below video). [This is a known issue in the flickity library](https://github.com/metafizzy/flickity/issues/959). We're going to add a follow-up ticket to try to address it, but for now we're removing the snapping effect to move forward with a launch of collection hubs.

---

## Before this PR

![snapping-ios12](https://user-images.githubusercontent.com/1627089/66866062-25b39080-ef5e-11e9-9210-c72ca00342bd.gif)

---

## The issue in iOS 13

![ios13-snapping](https://user-images.githubusercontent.com/1627089/66866118-47ad1300-ef5e-11e9-8e9e-b85de17a1523.gif)

---

## After this PR

![remove-snapping](https://user-images.githubusercontent.com/1627089/66866409-d9b51b80-ef5e-11e9-86e8-c431f2600daf.gif)

