### PR TITLE
SEO Improvements to the Artist page

### DIFF
--- a/src/Apps/Artist/Routes/Overview/__tests__/Index.fixture.tsx
+++ b/src/Apps/Artist/Routes/Overview/__tests__/Index.fixture.tsx
@@ -28,6 +28,7 @@ export const defaultArtist = {
         {
           node: {
             id: "cubism",
+            href: "/gene/cubism",
           },
         },
       ],

--- a/src/Apps/Artist/Routes/Overview/__tests__/index.test.tsx
+++ b/src/Apps/Artist/Routes/Overview/__tests__/index.test.tsx
@@ -24,7 +24,7 @@ describe("OverviewRoute", () => {
       )
     }
 
-    it.only("Does not display recommendations if related.artists is empty", () => {
+    it("Does not display recommendations if related.artists is empty", () => {
       const wrapper = getWrapper(defaultArtist)
 
       expect(wrapper.find(ArtistRecommendations).length).toEqual(0)

--- a/src/Apps/Artist/Routes/Overview/__tests__/index.test.tsx
+++ b/src/Apps/Artist/Routes/Overview/__tests__/index.test.tsx
@@ -24,7 +24,7 @@ describe("OverviewRoute", () => {
       )
     }
 
-    it("Does not display recommendations if related.artists is empty", () => {
+    it.only("Does not display recommendations if related.artists is empty", () => {
       const wrapper = getWrapper(defaultArtist)
 
       expect(wrapper.find(ArtistRecommendations).length).toEqual(0)

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -100,7 +100,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                       href="/consign"
                       onClick={this.handleConsignClick.bind(this)}
                     >
-                      Learn more
+                      Consign with Artsy
                     </a>
                     .
                   </Sans>

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -47,13 +47,6 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
     // no-op
   }
 
-  maybeShowGenes() {
-    const { isReadMoreExpanded } = this.state
-    const hasNoBio = !this.props.artist.biography_blurb.text
-
-    return isReadMoreExpanded || hasNoBio
-  }
-
   render() {
     if (!this.props) {
       return null
@@ -74,7 +67,6 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
 
     // TODO: Hide right column if missing current event. Waiting on feedback
     const colNum = 9 // artist.currentEvent ? 9 : 12
-    const showGenes = this.maybeShowGenes()
 
     const isClient = typeof window !== "undefined"
     const showRecommendations =
@@ -94,13 +86,11 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
                   />
                 </>
               )}
-              {showGenes && (
-                <>
-                  <Spacer mb={1} />
-                  <Genes artist={artist} />
-                  <Spacer mb={1} />
-                </>
-              )}
+              <>
+                <Spacer mb={1} />
+                <Genes artist={artist} />
+                <Spacer mb={1} />
+              </>
               {showConsignable && (
                 <>
                   <Spacer mb={1} />

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -27,16 +27,8 @@ export interface OverviewRouteProps {
   tracking?: TrackingProp
 }
 
-interface State {
-  isReadMoreExpanded: boolean
-}
-
 @track()
-export class OverviewRoute extends React.Component<OverviewRouteProps, State> {
-  state = {
-    isReadMoreExpanded: false,
-  }
-
+export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
   @track<OverviewRouteProps>(props => ({
     action_type: Schema.ActionType.Click,
     // TODO: Feel like these should become enums too

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarExtraLinks.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarExtraLinks.tsx
@@ -160,7 +160,8 @@ class ArtworkSidebarExtraLinksContainer extends React.Component<
       <Container>
         Want to sell a work by{" "}
         {artistsCount === 1 ? "this artist" : "these artists"}?{" "}
-        <Link onClick={this.onClickConsign.bind(this)}>Learn more</Link>.
+        <Link onClick={this.onClickConsign.bind(this)}>Consign with Artsy</Link>
+        .
       </Container>
     )
   }

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarExtraLinks.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarExtraLinks.test.tsx
@@ -73,9 +73,9 @@ describe("ArtworkSidebarExtraLinks", () => {
       // TODO: verify mediator call with openAuctionAskSpecialistModal
     })
     it("displays consign link that opens consign page", () => {
-      expect(wrapper.find('a[children="Learn more"]').length).toBe(1)
+      expect(wrapper.find('a[children="Consign with Artsy"]').length).toBe(1)
       wrapper
-        .find('a[children="Learn more"]')
+        .find('a[children="Consign with Artsy"]')
         .at(0)
         .simulate("click")
 
@@ -118,9 +118,9 @@ describe("ArtworkSidebarExtraLinks", () => {
       // TODO: verify mediator call with openBuyNowAskSpecialistModal
     })
     it("displays consign link that opens consign page", () => {
-      expect(wrapper.find('a[children="Learn more"]').length).toBe(1)
+      expect(wrapper.find('a[children="Consign with Artsy"]').length).toBe(1)
       wrapper
-        .find('a[children="Learn more"]')
+        .find('a[children="Consign with Artsy"]')
         .at(0)
         .simulate("click")
 

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarExtraLinks.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarExtraLinks.test.tsx
@@ -41,7 +41,7 @@ describe("ArtworkSidebarExtraLinks", () => {
         "Have a question? Read our auction FAQs or ask a specialist."
       )
       expect(wrapper.text()).toContain(
-        "Want to sell a work by this artist? Learn more."
+        "Want to sell a work by this artist? Consign with Artsy."
       )
     })
     it("displays conditions of sale link that opens conditions of sale page", () => {
@@ -95,7 +95,7 @@ describe("ArtworkSidebarExtraLinks", () => {
         "Have a question? Read our FAQ or ask a specialist."
       )
       expect(wrapper.text()).toContain(
-        "Want to sell a work by this artist? Learn more."
+        "Want to sell a work by this artist? Consign with Artsy."
       )
     })
     it("displays FAQ link that opens Buy now FAQ page", () => {
@@ -141,7 +141,7 @@ describe("ArtworkSidebarExtraLinks", () => {
     it("displays proper text", () => {
       expect(wrapper.text()).toContain("Have a question? Read our FAQ.")
       expect(wrapper.text()).toContain(
-        "Want to sell a work by these artists? Learn more."
+        "Want to sell a work by these artists? Consign with Artsy."
       )
     })
     it("displays FAQ link that brings collector FAQ modal", () => {
@@ -153,9 +153,9 @@ describe("ArtworkSidebarExtraLinks", () => {
       // TODO: verify mediator call with openCollectorFAQModal
     })
     it("displays consign link that opens consign page", () => {
-      expect(wrapper.find('a[children="Learn more"]').length).toBe(1)
+      expect(wrapper.find('a[children="Consign with Artsy"]').length).toBe(1)
       wrapper
-        .find('a[children="Learn more"]')
+        .find('a[children="Consign with Artsy"]')
         .at(0)
         .simulate("click")
 
@@ -173,13 +173,13 @@ describe("ArtworkSidebarExtraLinks", () => {
     it("displays proper text", () => {
       expect(wrapper.text()).not.toContain("Have a question? Read our FAQ")
       expect(wrapper.text()).toContain(
-        "Want to sell a work by this artist? Learn more."
+        "Want to sell a work by this artist? Consign with Artsy."
       )
     })
     it("displays consign link that opens consign page", () => {
-      expect(wrapper.find('a[children="Learn more"]').length).toBe(1)
+      expect(wrapper.find('a[children="Consign with Artsy"]').length).toBe(1)
       wrapper
-        .find('a[children="Learn more"]')
+        .find('a[children="Consign with Artsy"]')
         .at(0)
         .simulate("click")
 

--- a/src/Components/v2/ArtistBio.tsx
+++ b/src/Components/v2/ArtistBio.tsx
@@ -2,6 +2,7 @@ import { Serif } from "@artsy/palette"
 import { ArtistBio_bio } from "__generated__/ArtistBio_bio.graphql"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components"
 
 export interface ArtistBioProps {
   bio: ArtistBio_bio
@@ -9,17 +10,12 @@ export interface ArtistBioProps {
   maxChars?: number
 }
 
-export const MAX_CHARS = {
-  xs: 100,
-  default: 320,
-}
-
 export class ArtistBio extends React.Component<ArtistBioProps> {
   render() {
     const { bio } = this.props
     return (
       <Serif size="3">
-        <span
+        <BioSpan
           dangerouslySetInnerHTML={{
             __html: bio.biography_blurb.text,
           }}
@@ -38,3 +34,18 @@ export const ArtistBioFragmentContainer = createFragmentContainer(ArtistBio, {
     }
   `,
 })
+
+/*
+  Using dangerouslySetInnerHTML in our span adds an inline <p>.
+  Here we make sure the inline <p> is formatted properly.
+*/
+const BioSpan = styled.span`
+  > * {
+    margin-block-start: 0;
+    margin-block-end: 0;
+    padding-bottom: 1em;
+  }
+  > *:last-child {
+    display: inline;
+  }
+`

--- a/src/Components/v2/ArtistBio.tsx
+++ b/src/Components/v2/ArtistBio.tsx
@@ -1,8 +1,7 @@
-import { ReadMore, Serif } from "@artsy/palette"
+import { Serif } from "@artsy/palette"
 import { ArtistBio_bio } from "__generated__/ArtistBio_bio.graphql"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Media } from "Utils/Responsive"
 
 export interface ArtistBioProps {
   bio: ArtistBio_bio
@@ -16,20 +15,15 @@ export const MAX_CHARS = {
 }
 
 export class ArtistBio extends React.Component<ArtistBioProps> {
-  renderReadMore = size => {
-    return (
-      <ReadMore
-        onReadMoreClicked={this.props.onReadMoreClicked}
-        maxChars={size === "xs" ? MAX_CHARS.xs : MAX_CHARS.default}
-        content={this.props.bio.biography_blurb.text}
-      />
-    )
-  }
   render() {
+    const { bio } = this.props
     return (
       <Serif size="3">
-        <Media at="xs">{this.renderReadMore("xs")}</Media>
-        <Media greaterThan="xs">{this.renderReadMore("rest")}</Media>
+        <span
+          dangerouslySetInnerHTML={{
+            __html: bio.biography_blurb.text,
+          }}
+        />
       </Serif>
     )
   }

--- a/src/Components/v2/__tests__/ArtistBio.test.tsx
+++ b/src/Components/v2/__tests__/ArtistBio.test.tsx
@@ -43,19 +43,4 @@ describe("ArtistBio", () => {
 
     expect(wrapper.html()).toContain(biography_blurb.text)
   })
-
-  it("renders a ReadMore expandable area", async () => {
-    const wrapper = await getWrapper()
-    expect(wrapper.find("ReadMore").length).toBe(1)
-  })
-
-  // TODO: Chris, this test needs finishing.
-  xit("triggers callback when clicked", async done => {
-    const wrapper = await getWrapper({
-      onReadMoreClicked: () => {
-        done()
-      },
-    })
-    wrapper.find("Container").simulate("click")
-  })
 })


### PR DESCRIPTION
# Changes
- Show Artist's full bio and related categories by removing "Read More": https://artsyproduct.atlassian.net/browse/PURCHASE-1569

- Update consignment links to mention consign instead of learn more: 
https://artsyproduct.atlassian.net/browse/PURCHASE-1579

![image](https://user-images.githubusercontent.com/1230819/66961196-160a7980-f03c-11e9-98c9-0d947eae9af3.png)


cc: @samchieng