### PR TITLE
Auct 465 pricing stub

### DIFF
--- a/src/Apps/Auction/Components/BidForm.tsx
+++ b/src/Apps/Auction/Components/BidForm.tsx
@@ -8,6 +8,7 @@ import {
   Serif,
 } from "@artsy/palette"
 import { BidForm_saleArtwork } from "__generated__/BidForm_saleArtwork.graphql"
+import { PricingTransparency } from "Apps/Auction/Components/PricingTransparency"
 import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
 import { Formik, FormikActions, FormikValues } from "formik"
 import { dropWhile } from "lodash"
@@ -16,6 +17,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import Yup from "yup"
 
 interface Props {
+  showPricingTransparency?: boolean
   saleArtwork: BidForm_saleArtwork
   onSubmit: (values: FormikValues, actions: FormikActions<object>) => void
 }
@@ -33,7 +35,11 @@ const validationSchema = Yup.object().shape({
   ),
 })
 
-export const BidForm: React.FC<Props> = ({ onSubmit, saleArtwork }) => {
+export const BidForm: React.FC<Props> = ({
+  onSubmit,
+  saleArtwork,
+  showPricingTransparency = false,
+}) => {
   const displayIncrements = dropWhile(
     saleArtwork.increments,
     increment => increment.cents < saleArtwork.minimumNextBid.cents
@@ -75,8 +81,8 @@ export const BidForm: React.FC<Props> = ({ onSubmit, saleArtwork }) => {
                     {errors.selectedBid}
                   </Sans>
                 )}
+                {showPricingTransparency && <PricingTransparency />}
               </Flex>
-
               <Separator />
               <Flex
                 py={3}

--- a/src/Apps/Auction/Components/PricingTransparency.tsx
+++ b/src/Apps/Auction/Components/PricingTransparency.tsx
@@ -1,4 +1,4 @@
-import { Flex, Sans, Serif } from "@artsy/palette"
+import { Box, Flex, Sans, Serif } from "@artsy/palette"
 import React from "react"
 
 export const PricingTransparency: React.FC<{}> = () => {
@@ -14,16 +14,16 @@ export const PricingTransparency: React.FC<{}> = () => {
         alignItems="baseline"
         pb={1}
       >
-        <div>
+        <Box>
           <Serif size="3t" color="black100">
             Your max bid
           </Serif>
-        </div>
-        <div>
+        </Box>
+        <Box>
           <Serif size="3t" color="black100">
             £18,000
           </Serif>
-        </div>
+        </Box>
       </Flex>
       <Flex
         flexDirection="row"
@@ -31,16 +31,16 @@ export const PricingTransparency: React.FC<{}> = () => {
         alignItems="baseline"
         pb={2}
       >
-        <div>
+        <Box>
           <Serif size="3t" color="black100">
             Buyer's Premium
           </Serif>
-        </div>
-        <div>
+        </Box>
+        <Box>
           <Serif size="3t" color="black100">
             £3,600
           </Serif>
-        </div>
+        </Box>
       </Flex>
       <Flex
         flexDirection="row"
@@ -48,16 +48,16 @@ export const PricingTransparency: React.FC<{}> = () => {
         alignItems="baseline"
         pb={1}
       >
-        <div>
+        <Box>
           <Serif size="3t" color="black100">
             Subtotal
           </Serif>
-        </div>
-        <div>
+        </Box>
+        <Box>
           <Serif size="3t" color="black100">
             £21,600
           </Serif>
-        </div>
+        </Box>
       </Flex>
       <Sans size="2" color="black60">
         Plus any applicable shipping, taxes, and fees.

--- a/src/Apps/Auction/Components/PricingTransparency.tsx
+++ b/src/Apps/Auction/Components/PricingTransparency.tsx
@@ -1,0 +1,67 @@
+import { Flex, Sans, Serif } from "@artsy/palette"
+import React from "react"
+
+export const PricingTransparency: React.FC<{}> = () => {
+  return (
+    <Flex pt={3} flexDirection="column">
+      <Serif pb={1} size="4t" weight="semibold" color="black100">
+        Summary
+      </Serif>
+
+      <Flex
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="baseline"
+        pb={1}
+      >
+        <div>
+          <Serif size="3t" color="black100">
+            Your max bid
+          </Serif>
+        </div>
+        <div>
+          <Serif size="3t" color="black100">
+            £18,000
+          </Serif>
+        </div>
+      </Flex>
+      <Flex
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="baseline"
+        pb={2}
+      >
+        <div>
+          <Serif size="3t" color="black100">
+            Buyer's Premium
+          </Serif>
+        </div>
+        <div>
+          <Serif size="3t" color="black100">
+            £3,600
+          </Serif>
+        </div>
+      </Flex>
+      <Flex
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="baseline"
+        pb={1}
+      >
+        <div>
+          <Serif size="3t" color="black100">
+            Subtotal
+          </Serif>
+        </div>
+        <div>
+          <Serif size="3t" color="black100">
+            £21,600
+          </Serif>
+        </div>
+      </Flex>
+      <Sans size="2" color="black60">
+        Plus any applicable shipping, taxes, and fees.
+      </Sans>
+    </Flex>
+  )
+}

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -14,6 +14,7 @@ interface BidProps {
   artwork: any
   me: any
   relay: RelayProp
+  location: Location
 }
 
 export const ConfirmBidRoute: React.FC<BidProps> = props => {
@@ -36,6 +37,7 @@ export const ConfirmBidRoute: React.FC<BidProps> = props => {
         <LotInfo artwork={artwork} saleArtwork={artwork.saleArtwork} />
         <Separator />
         <BidForm
+          showPricingTransparency={Boolean(/pt=1/.test(props.location.search))}
           saleArtwork={saleArtwork}
           onSubmit={(values, actions) => {
             setTimeout(() => {

--- a/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
+++ b/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
@@ -8,7 +8,7 @@ storiesOf("Apps/Auction/Routes/Confirm Bid", module)
     return (
       <MockRouter
         routes={auctionRoutes}
-        initialRoute="/auction/shared-live-mocktion-k8s/bid2/nicole-won-hee-maloof-surrealism?bid=11000000?bid=65000"
+        initialRoute="/auction/shared-live-mocktion-k8s/bid2/nicole-won-hee-maloof-surrealism?bid=11000000"
       />
     )
   })

--- a/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
+++ b/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
@@ -1,0 +1,22 @@
+import { routes as auctionRoutes } from "Apps/Auction/routes"
+import { MockRouter } from "DevTools/MockRouter"
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+
+storiesOf("Apps/Auction/Routes/Confirm Bid", module)
+  .add("Plain", () => {
+    return (
+      <MockRouter
+        routes={auctionRoutes}
+        initialRoute="/auction/shared-live-mocktion-k8s/bid2/nicole-won-hee-maloof-surrealism?bid=11000000?bid=65000"
+      />
+    )
+  })
+  .add("Pricing Transparency", () => {
+    return (
+      <MockRouter
+        routes={auctionRoutes}
+        initialRoute="/auction/shared-live-mocktion-k8s/bid2/nicole-won-hee-maloof-surrealism?bid=11000000&pt=1"
+      />
+    )
+  })

--- a/src/Apps/Auction/Routes/__stories__/Register.story.tsx
+++ b/src/Apps/Auction/Routes/__stories__/Register.story.tsx
@@ -3,20 +3,11 @@ import { MockRouter } from "DevTools/MockRouter"
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 
-storiesOf("Apps/Auction/Routes", module)
-  .add("Register", () => {
-    return (
-      <MockRouter
-        routes={auctionRoutes}
-        initialRoute="/auction-registration/shared-live-mocktion-k8s"
-      />
-    )
-  })
-  .add("Bid", () => {
-    return (
-      <MockRouter
-        routes={auctionRoutes}
-        initialRoute="/auction/shared-live-mocktion-k8s/bid2/karen-halverson-painting?bid=65000"
-      />
-    )
-  })
+storiesOf("Apps/Auction/Routes", module).add("Register", () => {
+  return (
+    <MockRouter
+      routes={auctionRoutes}
+      initialRoute="/auction-registration/shared-live-mocktion-k8s"
+    />
+  )
+})

--- a/src/Apps/Auction/__fixtures__/routes_BidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_BidQuery.ts
@@ -1,7 +1,7 @@
 import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
-import { BidForm_saleArtwork } from "../../../__generated__/BidForm_saleArtwork.graphql"
-import { LotInfo_artwork } from "../../../__generated__/LotInfo_artwork.graphql"
-import { routes_BidQueryResponse } from "../../../__generated__/routes_BidQuery.graphql"
+import { BidForm_saleArtwork } from "__generated__/BidForm_saleArtwork.graphql"
+import { LotInfo_artwork } from "__generated__/LotInfo_artwork.graphql"
+import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
 
 export interface BidQueryResponse extends routes_BidQueryResponse {
   artwork: routes_BidQueryResponse["artwork"] &

--- a/src/Apps/Auction/__fixtures__/routes_BidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_BidQuery.ts
@@ -1,6 +1,6 @@
-import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
 import { BidForm_saleArtwork } from "__generated__/BidForm_saleArtwork.graphql"
 import { LotInfo_artwork } from "__generated__/LotInfo_artwork.graphql"
+import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
 import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
 
 export interface BidQueryResponse extends routes_BidQueryResponse {

--- a/src/Apps/Auction/__tests__/routes.test.ts
+++ b/src/Apps/Auction/__tests__/routes.test.ts
@@ -1,17 +1,17 @@
+import {
+  BidQueryResponse,
+  BidQueryResponseFixture,
+} from "Apps/Auction/__fixtures__/routes_BidQuery"
+import {
+  DeFragedRegisterQueryResponse,
+  RegisterQueryResponseFixture,
+} from "Apps/Auction/__fixtures__/routes_RegisterQuery"
 import { routes } from "Apps/Auction/routes"
 import { createMockNetworkLayer2 } from "DevTools/createMockNetworkLayer"
 import { createRender } from "found"
 import { Resolver } from "found-relay"
 import getFarceResult from "found/lib/server/getFarceResult"
 import { Environment, RecordSource, Store } from "relay-runtime"
-import {
-  BidQueryResponse,
-  BidQueryResponseFixture,
-} from "../__fixtures__/routes_BidQuery"
-import {
-  DeFragedRegisterQueryResponse,
-  RegisterQueryResponseFixture,
-} from "../__fixtures__/routes_RegisterQuery"
 
 describe("Auction/routes", () => {
   async function render(url, mockData) {


### PR DESCRIPTION
This PR sets up a skeleton component with hard-coded values for pricing transparency. It has an accompanying view in storybook and can be triggered by adding `pt=1` to the query string (once the view is mounted in force).

It also includes some #minor cleanup.

### Storybook with pricing transparency:
![image](https://user-images.githubusercontent.com/9088720/66965695-9a62f980-f048-11e9-902d-b54836c824a0.png)


### Without pricing transparency:
![image](https://user-images.githubusercontent.com/9088720/66965577-245e9280-f048-11e9-9076-425dd06e0c4f.png)
