### PR TITLE
Add a check for window obj before useLayoutEffect hook

### DIFF
--- a/src/Utils/Hooks/useWindowSize.ts
+++ b/src/Utils/Hooks/useWindowSize.ts
@@ -2,18 +2,22 @@ import { useLayoutEffect, useState } from "react"
 import { getViewportDimensions } from "Utils/viewport"
 
 export const useWindowSize = () => {
-  const [size, setSize] = useState({ width: 0, height: 0 })
+  if (typeof window !== "undefined") {
+    const [size, setSize] = useState({ width: 0, height: 0 })
 
-  useLayoutEffect(() => {
-    function resize() {
-      const { width, height } = getViewportDimensions()
+    useLayoutEffect(() => {
+      function resize() {
+        const { width, height } = getViewportDimensions()
 
-      setSize({ width, height })
-    }
-    window.addEventListener("resize", resize)
-    resize()
-    return () => window.removeEventListener("resize", resize)
-  }, [])
+        setSize({ width, height })
+      }
+      window.addEventListener("resize", resize)
+      resize()
+      return () => window.removeEventListener("resize", resize)
+    }, [])
 
-  return size
+    return size
+  } else {
+    return { width: 0, height: 0 }
+  }
 }

--- a/src/Utils/Hooks/useWindowSize.ts
+++ b/src/Utils/Hooks/useWindowSize.ts
@@ -2,22 +2,22 @@ import { useLayoutEffect, useState } from "react"
 import { getViewportDimensions } from "Utils/viewport"
 
 export const useWindowSize = () => {
-  if (typeof window !== "undefined") {
-    const [size, setSize] = useState({ width: 0, height: 0 })
-
-    useLayoutEffect(() => {
-      function resize() {
-        const { width, height } = getViewportDimensions()
-
-        setSize({ width, height })
-      }
-      window.addEventListener("resize", resize)
-      resize()
-      return () => window.removeEventListener("resize", resize)
-    }, [])
-
-    return size
-  } else {
-    return { width: 0, height: 0 }
+  if (typeof window === "undefined") {
+    return null
   }
+
+  const [size, setSize] = useState({ width: 0, height: 0 })
+
+  useLayoutEffect(() => {
+    function resize() {
+      const { width, height } = getViewportDimensions()
+
+      setSize({ width, height })
+    }
+    window.addEventListener("resize", resize)
+    resize()
+    return () => window.removeEventListener("resize", resize)
+  }, [])
+
+  return size
 }


### PR DESCRIPTION
The useLayoutEffect hook can only be used client-side, so this PR adds a check so the hook isn't called until a window object is present.