### PR TITLE
[Order] Don't refer to graphql-js at runtime.

### DIFF
--- a/src/Apps/Order/Utils/commitMutation.tsx
+++ b/src/Apps/Order/Utils/commitMutation.tsx
@@ -1,5 +1,4 @@
 import { SystemContext } from "Artsy"
-import { GraphQLError } from "graphql"
 import React, { useContext } from "react"
 import {
   commitMutation as relayCommitMutation,
@@ -45,7 +44,7 @@ class ProvideMutationContext extends React.Component<
           onCompleted: (data, errors) => {
             this.setState({ isCommittingMutation: false }, () => {
               if (errors) {
-                reject(new GraphQLError(errors.join("\n")))
+                reject(new Error(errors.join("\n")))
                 return
               }
               resolve(data)


### PR DESCRIPTION
Part of https://artsyproduct.atlassian.net/browse/PLATFORM-1890

As this leads to graphql-js being included in Force's client bundles.