### PR TITLE
Grow-1677 Analytics tracking for hub entry points

### DIFF
--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -9,6 +9,7 @@ export enum PageName {
   CollectPage = "Collect page",
   CollectionPage = "Collection",
   SearchPage = "Search page",
+  HomePage = "Home",
 }
 
 /**
@@ -252,6 +253,11 @@ export enum Subject {
   Login = "Log In",
   Signup = "Sign Up",
   SmallScreenMenuSandwichIcon = "Small Screen Menu Sandwich Icon",
+
+  /**
+   * CollectionHub
+   */
+  FeaturedCategories = "Featured Categories",
 }
 
 /**
@@ -323,6 +329,11 @@ export enum ContextModule {
    * Collections Rails
    */
   CollectionsRail = "CollectionsRail",
+
+  /**
+   * CollectionHub Entry Point in home page
+   */
+  CollectionHubEntryPoint = "HubEntrypoint",
 
   /**
    * Other Collections Rail

--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -1,8 +1,10 @@
 import { CSSGrid } from "@artsy/palette"
 import { Serif } from "@artsy/palette"
 import { CollectionsHubsHomepageNav_marketingHubCollections } from "__generated__/CollectionsHubsHomepageNav_marketingHubCollections.graphql"
-import React, { FC } from "react"
+import { AnalyticsSchema } from "Artsy/Analytics"
+import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import track, { useTracking } from "react-tracking"
 import { resize } from "Utils/resizer"
 import { ImageLink } from "./ImageLink"
 
@@ -10,32 +12,53 @@ interface CollectionsHubsHomepageNavProps {
   marketingHubCollections: CollectionsHubsHomepageNav_marketingHubCollections
 }
 
-export const CollectionsHubsHomepageNav: FC<
-  CollectionsHubsHomepageNavProps
-> = props => {
-  return (
-    <CSSGrid
-      as="aside"
-      gridTemplateColumns={[
-        "repeat(2, 1fr)",
-        "repeat(2, 1fr)",
-        "repeat(3, 1fr)",
-      ]}
-      gridGap={20}
-    >
-      {props.marketingHubCollections.slice(0, 6).map(hub => (
-        <ImageLink
-          to={`/collection/${hub.slug}`}
-          src={resize(hub.thumbnail, { width: 357, height: 175 })}
-          ratio={[0.49]}
-          title={<Serif size={["3", "4"]}>{hub.title}</Serif>}
-          subtitle={<Serif size="2">{subtitleFor(hub.title)}</Serif>}
-          key={hub.id}
-        />
-      ))}
-    </CSSGrid>
-  )
-}
+export const CollectionsHubsHomepageNav = track()(
+  (props: CollectionsHubsHomepageNavProps) => {
+    const { trackEvent } = useTracking()
+    useEffect(() => {
+      trackEvent({
+        action_type: AnalyticsSchema.ActionType.Impression,
+        context_page: AnalyticsSchema.PageName.HomePage,
+        context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
+        subject: AnalyticsSchema.Subject.FeaturedCategories,
+      })
+    }, [])
+
+    return (
+      <CSSGrid
+        as="aside"
+        gridTemplateColumns={[
+          "repeat(2, 1fr)",
+          "repeat(2, 1fr)",
+          "repeat(3, 1fr)",
+        ]}
+        gridGap={20}
+      >
+        {props.marketingHubCollections.slice(0, 6).map(hub => (
+          <ImageLink
+            to={`/collection/${hub.slug}`}
+            src={resize(hub.thumbnail, { width: 357, height: 175 })}
+            ratio={[0.49]}
+            title={<Serif size={["3", "4"]}>{hub.title}</Serif>}
+            subtitle={<Serif size="2">{subtitleFor(hub.title)}</Serif>}
+            key={hub.id}
+            onClick={() => {
+              trackEvent({
+                action_type: AnalyticsSchema.ActionType.Click,
+                context_page: AnalyticsSchema.PageName.HomePage,
+                context_module:
+                  AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
+                subject: AnalyticsSchema.Subject.FeaturedCategories,
+                type: AnalyticsSchema.Type.Thumbnail,
+                desination_path: `/collection/${hub.slug}`,
+              })
+            }}
+          />
+        ))}
+      </CSSGrid>
+    )
+  }
+)
 
 export const CollectionsHubsHomepageNavFragmentContainer = createFragmentContainer(
   CollectionsHubsHomepageNav,

--- a/src/Components/v2/CollectionsHubsNav.tsx
+++ b/src/Components/v2/CollectionsHubsNav.tsx
@@ -1,9 +1,10 @@
 import { CSSGrid } from "@artsy/palette"
+import { Serif } from "@artsy/palette"
 import { CollectionsHubsNav_marketingHubCollections } from "__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
+import { AnalyticsSchema } from "Artsy/Analytics"
+import { useTracking } from "Artsy/Analytics/useTracking"
 import React, { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-
-import { Serif } from "@artsy/palette"
 import { resize } from "Utils/resizer"
 import { ImageLink } from "./ImageLink"
 
@@ -12,6 +13,7 @@ interface CollectionsHubsNavProps {
 }
 
 export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
+  const { trackEvent } = useTracking()
   return (
     <CSSGrid
       as="aside"
@@ -29,6 +31,16 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
           ratio={[0.49]}
           title={<Serif size="4t">{hub.title}</Serif>}
           key={hub.id}
+          onClick={() => {
+            trackEvent({
+              action_type: AnalyticsSchema.ActionType.Click,
+              context_page: AnalyticsSchema.PageName.CollectPage,
+              context_module:
+                AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
+              type: AnalyticsSchema.Type.Thumbnail,
+              destination_path: `/collection/${hub.slug}`,
+            })
+          }}
         />
       ))}
     </CSSGrid>

--- a/src/Components/v2/ImageLink.tsx
+++ b/src/Components/v2/ImageLink.tsx
@@ -60,6 +60,8 @@ interface ImageLinkProps {
 
   /** A number corresponding to the ratio of height/width (inverted from the usual width/height aspect ratio) */
   ratio: number | number[]
+
+  onClick?: () => void
 }
 
 export const ImageLink: FC<ImageLinkProps> = ({
@@ -68,9 +70,10 @@ export const ImageLink: FC<ImageLinkProps> = ({
   title,
   subtitle,
   ratio,
+  onClick,
 }) => {
   return (
-    <OuterLink to={to}>
+    <OuterLink to={to} onClick={onClick}>
       <ImageContainer>
         <ImageOverlay>
           <HubImage src={src} width="100%" ratio={ratio} />


### PR DESCRIPTION
Address: [Grow-1577](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1577).

This PR : 

1. Adding the `onClick` property to `imagelink`, then the clicking action becomes trackable.
2. For the `CollectionsHubsHomepageNav`. Adding the `track()` as the higher(higher than the relay) order component. Because `useTracking ` still need to wrap the component with decorator or hoc, this is the FC, so here I used hoc.
3. For the `CollectionHubsNav`. He has a parent component(which is `CollectApp`, it already wrapped up with `track()` ), so, I just added `useTracking` in `CollectionHubsNav`.
4. I found out these two nav components do not have test suites. 