### PR TITLE
Don't overwrite the User-Agent header for relay operations

### DIFF
--- a/src/Artsy/Relay/createRelaySSREnvironment.ts
+++ b/src/Artsy/Relay/createRelaySSREnvironment.ts
@@ -38,6 +38,7 @@ interface Config {
   user?: User
   checkStatus?: boolean
   relayNetwork?: RelayNetwork
+  userAgent?: string
 }
 
 export interface RelaySSREnvironment extends Environment {
@@ -46,7 +47,7 @@ export interface RelaySSREnvironment extends Environment {
 }
 
 export function createRelaySSREnvironment(config: Config = {}) {
-  const { cache = {}, checkStatus, user, relayNetwork } = config
+  const { cache = {}, checkStatus, user, relayNetwork, userAgent } = config
 
   const relaySSRMiddleware = isServer
     ? new RelayServerSSR()
@@ -63,7 +64,7 @@ export function createRelaySSREnvironment(config: Config = {}) {
      *
      * See https://bugs.chromium.org/p/chromium/issues/detail?id=571722
      */
-    "User-Agent": USER_AGENT,
+    "User-Agent": userAgent ? `${userAgent}; ${USER_AGENT}` : USER_AGENT,
   }
 
   let timeZone

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -18,6 +18,7 @@ export function buildClientApp(config: RouterConfig) {
       const relayEnvironment = createRelaySSREnvironment({
         cache: JSON.parse(window.__RELAY_BOOTSTRAP__ || "{}"),
         user,
+        userAgent: window.navigator.userAgent,
       })
 
       return relayEnvironment

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -36,7 +36,7 @@ export function buildServerApp(config: RouterConfig & { userAgent?: string }) {
     getRelayEnvironment: () => {
       const relayEnvironment =
         (config.context && config.context.relayEnvironment) ||
-        createRelaySSREnvironment({ user })
+        createRelaySSREnvironment({ user, userAgent: config.userAgent })
 
       return relayEnvironment
     },


### PR DESCRIPTION
Fixes [PURCHASE-1140](https://artsyproduct.atlassian.net/browse/PURCHASE-1140).

It was reported that many of our orders were being created with a user agent of something like `Reaction/16.7.0; Metaphysics`. This user agent is first set in reaction (see below) then appended to in metaphysics. 

https://github.com/artsy/reaction/blob/501d18091180abed728680661456b57f82ad27a8/src/Artsy/Relay/createRelaySSREnvironment.ts#L34

Essentially we just needed to prepend what's in reaction with the UA from the request (or the window if it's on the client). 

