### PR TITLE
[Carousel] Fix incorrect invocation of `Flickity.prototype.destroy()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/dd-trace": "0.6.0",
     "@types/dedent": "0.7.0",
     "@types/enzyme": "3.1.11",
-    "@types/flickity": "2.2.0",
+    "@types/flickity": "^2.2.2",
     "@types/graphql": "14.0.5",
     "@types/isomorphic-fetch": "0.0.34",
     "@types/jest": "24.0.18",

--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -1,5 +1,5 @@
 import { Box, ChevronIcon, color, Flex, space } from "@artsy/palette"
-import { Options as FlickityOptions } from "flickity"
+import Flickity, { Options as FlickityOptions } from "flickity"
 import React, { Fragment } from "react"
 import styled from "styled-components"
 import { left, LeftProps, right, RightProps } from "styled-system"
@@ -167,7 +167,7 @@ export class BaseCarousel extends React.Component<
   /**
    * A reference to the Flickity instance
    */
-  flickity = null
+  flickity: Flickity = null
   carouselRef = null
 
   /**
@@ -205,7 +205,6 @@ export class BaseCarousel extends React.Component<
    * client has mounted. During the server-side pass we use a Flex wrapper instead.
    */
   componentDidMount() {
-    const Flickity = require("flickity")
     const { setCarouselRef } = this.props
 
     this.flickity = new Flickity(this.carouselRef, this.options)
@@ -227,7 +226,7 @@ export class BaseCarousel extends React.Component<
   componentWillUnmount() {
     if (this.flickity) {
       this.flickity.off("select")
-      this.flickity.flickity("destroy")
+      this.flickity.destroy()
     }
   }
 

--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -225,7 +225,7 @@ export class BaseCarousel extends React.Component<
 
   componentWillUnmount() {
     if (this.flickity) {
-      this.flickity.off("select")
+      this.flickity.off("select", this.handleSlideChange)
       this.flickity.destroy()
     }
   }
@@ -239,6 +239,9 @@ export class BaseCarousel extends React.Component<
   checkLastItemVisible = () => {
     if (this.flickity && this.flickity.selectedElements) {
       const lastItemVisible = this.flickity.selectedElements.includes(
+        // FIXME: Undocumented API. Is there a way this can be achieved with
+        // something public and commonly available?
+        // @ts-ignore
         this.flickity.getLastCell().element
       )
       return lastItemVisible

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,10 +2486,10 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
-"@types/flickity@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/flickity/-/flickity-2.2.0.tgz#aff71ca3e6a61d17c990464f4cfdef2505e3ee80"
-  integrity sha512-CqBikpvByNOMDycFqlSEfZMs9Td0X94ro/d/q//LiASkdF58wvT1tfauqYn5PnuUQIYPLq8+W0mAyLQi/sx5tA==
+"@types/flickity@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/flickity/-/flickity-2.2.2.tgz#6aa0177b305229f5e5930f43fd8bb148146fee61"
+  integrity sha512-YELdmqtxposhb0dlqjQqeNJr6U/KiMptORxqCpIjypyuXHcPH8vt6rHSQkTkoYkA0WhUks4NOhDQuakaEONRAg==
 
 "@types/graphql@14.0.5":
   version "14.0.5"


### PR DESCRIPTION
https://staging.artsy.net/artist/simon-linke/cv is currently broken:

<img width="776" alt="Screenshot 2019-10-18 at 16 05 17" src="https://user-images.githubusercontent.com/2320/67101018-1f711e80-f1c1-11e9-8ebc-402bd06f12e2.png">

This PR adds the typings for Flickity, but that surfaced another few places where, according to the types at least, we’re incorrectly using the API. Either the typings are incorrect and should be updated or we actually have other issues.

Further work that should be done is to use the Flickity typings in other places where Flickity API/Options are referenced.

@kierangillen Can you take this to completion?