### PR TITLE
Submit bid via new ConfirmBid page

### DIFF
--- a/src/Apps/Auction/Components/BidForm.tsx
+++ b/src/Apps/Auction/Components/BidForm.tsx
@@ -10,7 +10,7 @@ import {
 import { BidForm_saleArtwork } from "__generated__/BidForm_saleArtwork.graphql"
 import { PricingTransparency } from "Apps/Auction/Components/PricingTransparency"
 import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
-import { Formik, FormikActions, FormikValues } from "formik"
+import { Form, Formik, FormikActions, FormikValues } from "formik"
 import { dropWhile } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -53,7 +53,6 @@ export const BidForm: React.FC<Props> = ({
       validationSchema={validationSchema}
       onSubmit={onSubmit}
       render={({
-        handleSubmit,
         values,
         touched,
         errors,
@@ -62,8 +61,8 @@ export const BidForm: React.FC<Props> = ({
         setFieldTouched,
       }) => {
         return (
-          <form onSubmit={handleSubmit}>
-            <Flex flexDirection="column" as="form">
+          <Form>
+            <Flex flexDirection="column">
               <Flex flexDirection="column" py={4}>
                 <Serif pb={0.5} size="4t" weight="semibold" color="black100">
                   Set your max bid
@@ -115,7 +114,7 @@ export const BidForm: React.FC<Props> = ({
                 </Button>
               </Flex>
             </Flex>
-          </form>
+          </Form>
         )
       }}
     />

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -3,6 +3,7 @@ import {
   ConfirmBidCreateBidderPositionMutation,
   ConfirmBidCreateBidderPositionMutationResponse,
 } from "__generated__/ConfirmBidCreateBidderPositionMutation.graphql"
+import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
 import { BidFormFragmentContainer as BidForm } from "Apps/Auction/Components/BidForm"
 import { LotInfoFragmentContainer as LotInfo } from "Apps/Auction/Components/LotInfo"
 import { AppContainer } from "Apps/Components/AppContainer"
@@ -22,8 +23,8 @@ import createLogger from "Utils/logger"
 const logger = createLogger("Apps/Auction/Routes/ConfirmBid")
 
 interface BidProps {
-  artwork: any
-  me: any
+  artwork: routes_ConfirmBidQueryResponse["artwork"]
+  me: routes_ConfirmBidQueryResponse["me"]
   relay: RelayProp
   location: Location
 }

--- a/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
+++ b/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
@@ -1,0 +1,11 @@
+import { ConfirmBidCreateBidderPositionMutationResponse } from "__generated__/ConfirmBidCreateBidderPositionMutation.graphql"
+
+export const createBidderPositionSuccessful: ConfirmBidCreateBidderPositionMutationResponse = {
+  createBidderPosition: {
+    result: {
+      status: "SUCCESS",
+      message_header: null,
+      message_description_md: null,
+    },
+  },
+}

--- a/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
+++ b/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
@@ -8,7 +8,7 @@ storiesOf("Apps/Auction/Routes/Confirm Bid", module)
     return (
       <MockRouter
         routes={auctionRoutes}
-        initialRoute="/auction/shared-live-mocktion-k8s/bid2/nicole-won-hee-maloof-surrealism?bid=11000000"
+        initialRoute="/auction/phillips-editions-and-works-on-paper-5/bid2/jean-dubuffet-lenfle-chic-i-the-inflated-snob-i?bid=11000000"
       />
     )
   })
@@ -16,7 +16,7 @@ storiesOf("Apps/Auction/Routes/Confirm Bid", module)
     return (
       <MockRouter
         routes={auctionRoutes}
-        initialRoute="/auction/shared-live-mocktion-k8s/bid2/nicole-won-hee-maloof-surrealism?bid=11000000&pt=1"
+        initialRoute="/auction/phillips-editions-and-works-on-paper-5/bid2/jean-dubuffet-lenfle-chic-i-the-inflated-snob-i?bid=11000000&pt=1"
       />
     )
   })

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -3,8 +3,8 @@ import { graphql } from "react-relay"
 
 import { createTestEnv } from "DevTools/createTestEnv"
 
-import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
-import { BidQueryResponseFixture } from "Apps/Auction/__fixtures__/routes_BidQuery"
+import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
+import { ConfirmBidQueryResponseFixture } from "Apps/Auction/__fixtures__/routes_ConfirmBidQuery"
 import { createBidderPositionSuccessful } from "../__fixtures__/MutationResults/createBidderPosition"
 import { ConfirmBidRouteFragmentContainer } from "../ConfirmBid"
 import { ConfirmBidTestPage } from "./Utils/ConfirmBidTestPage"
@@ -24,7 +24,7 @@ const mockLocation: any = {
 const setupTestEnv = () => {
   return createTestEnv({
     TestPage: ConfirmBidTestPage,
-    Component: (props: routes_BidQueryResponse) => (
+    Component: (props: routes_ConfirmBidQueryResponse) => (
       <ConfirmBidRouteFragmentContainer location={mockLocation} {...props} />
     ),
     query: graphql`
@@ -55,7 +55,7 @@ const setupTestEnv = () => {
         }
       }
     `,
-    defaultData: BidQueryResponseFixture,
+    defaultData: ConfirmBidQueryResponseFixture,
     defaultMutationResults: {
       createBidderPosition: {},
     },
@@ -102,8 +102,8 @@ describe("Routes/Register ", () => {
 
     expect(window.location.assign).toHaveBeenCalledWith(
       `https://example.com/auction/${
-        BidQueryResponseFixture.artwork.saleArtwork.sale.id
-      }/artwork/${BidQueryResponseFixture.artwork.id}`
+        ConfirmBidQueryResponseFixture.artwork.saleArtwork.sale.id
+      }/artwork/${ConfirmBidQueryResponseFixture.artwork.id}`
     )
   })
 

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -1,0 +1,120 @@
+import React from "react"
+import { graphql } from "react-relay"
+
+import { createTestEnv } from "DevTools/createTestEnv"
+
+import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
+import { BidQueryResponseFixture } from "Apps/Auction/__fixtures__/routes_BidQuery"
+import { createBidderPositionSuccessful } from "../__fixtures__/MutationResults/createBidderPosition"
+import { ConfirmBidRouteFragmentContainer } from "../ConfirmBid"
+import { ConfirmBidTestPage } from "./Utils/ConfirmBidTestPage"
+
+jest.unmock("react-relay")
+
+jest.mock("sharify", () => ({
+  data: {
+    APP_URL: "https://example.com",
+  },
+}))
+
+const mockLocation: any = {
+  search: "",
+}
+
+const setupTestEnv = () => {
+  return createTestEnv({
+    TestPage: ConfirmBidTestPage,
+    Component: (props: routes_BidQueryResponse) => (
+      <ConfirmBidRouteFragmentContainer location={mockLocation} {...props} />
+    ),
+    query: graphql`
+      query ConfirmBidValidTestQuery {
+        artwork(id: "artwork-id") {
+          ...LotInfo_artwork
+          _id
+          id
+          saleArtwork: sale_artwork(sale_id: "example-auction-id") {
+            ...LotInfo_saleArtwork
+            ...BidForm_saleArtwork
+            _id
+            id
+            sale {
+              registrationStatus {
+                qualified_for_bidding
+              }
+              _id
+              id
+              name
+              is_closed
+              is_registration_closed
+            }
+          }
+        }
+        me {
+          has_qualified_credit_cards
+        }
+      }
+    `,
+    defaultData: BidQueryResponseFixture,
+    defaultMutationResults: {
+      createBidderPosition: {},
+    },
+  })
+}
+
+describe("Routes/Register ", () => {
+  beforeAll(() => {
+    // @ts-ignore
+    // tslint:disable-next-line:no-empty
+    window.Stripe = () => {}
+  })
+
+  beforeEach(() => {
+    window.location.assign = jest.fn()
+    window.location.search = ""
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it("successfully places a bid and redirect to artwork page", async () => {
+    const env = setupTestEnv()
+    const page = await env.buildPage()
+
+    env.mutations.useResultsOnce(createBidderPositionSuccessful)
+
+    await page.agreeToTerms()
+    await page.submitForm()
+
+    expect(env.mutations.mockFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "ConfirmBidCreateBidderPositionMutation",
+      }),
+      {
+        input: {
+          artwork_id: "artworkslug",
+          max_bid_amount_cents: 5000000,
+          sale_id: "saleslug",
+        },
+      }
+    )
+
+    expect(window.location.assign).toHaveBeenCalledWith(
+      `https://example.com/auction/${
+        BidQueryResponseFixture.artwork.saleArtwork.sale.id
+      }/artwork/${BidQueryResponseFixture.artwork.id}`
+    )
+  })
+
+  it("requires user to agree to terms", async () => {
+    const env = setupTestEnv()
+    const page = await env.buildPage()
+
+    await page.submitForm()
+
+    expect(env.mutations.mockFetch).not.toBeCalled()
+    expect(window.location.assign).not.toHaveBeenCalled()
+    expect(page.text()).toContain("You must agree to the Conditions of Sale")
+  })
+})

--- a/src/Apps/Auction/Routes/__tests__/Utils/ConfirmBidTestPage.tsx
+++ b/src/Apps/Auction/Routes/__tests__/Utils/ConfirmBidTestPage.tsx
@@ -1,0 +1,35 @@
+import { Checkbox } from "@artsy/palette"
+import { expectOne, RootTestPage } from "DevTools/RootTestPage"
+
+export const ValidFormValues = {
+  name: "Example Name",
+  addressLine1: "123 Example Street",
+  addressLine2: "Apt 1",
+  country: "United States",
+  city: "New York",
+  region: "NY",
+  postalCode: "10012",
+  phoneNumber: "+1 555 212 7878",
+}
+
+export class ConfirmBidTestPage extends RootTestPage {
+  get confirmBidButton() {
+    return this.find("button").filterWhere(btn =>
+      btn.text().includes("Confirm bid")
+    )
+  }
+  get form() {
+    return expectOne(this.find("form"))
+  }
+  get agreeToTermsInput() {
+    return expectOne(this.form.find(Checkbox))
+  }
+  async agreeToTerms() {
+    this.agreeToTermsInput.props().onSelect(true)
+    await this.update()
+  }
+  async submitForm() {
+    this.form.simulate("submit")
+    await this.update()
+  }
+}

--- a/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
@@ -1,21 +1,20 @@
 import { BidForm_saleArtwork } from "__generated__/BidForm_saleArtwork.graphql"
 import { LotInfo_artwork } from "__generated__/LotInfo_artwork.graphql"
 import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
-import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
-
+import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
 type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> }
 
-export interface BidQueryResponse
-  extends DeepWriteable<routes_BidQueryResponse> {
-  artwork: routes_BidQueryResponse["artwork"] &
+export interface ConfirmBidQueryResponse
+  extends DeepWriteable<routes_ConfirmBidQueryResponse> {
+  artwork: routes_ConfirmBidQueryResponse["artwork"] &
     LotInfo_artwork & {
-      saleArtwork: routes_BidQueryResponse["artwork"]["saleArtwork"] &
+      saleArtwork: routes_ConfirmBidQueryResponse["artwork"]["saleArtwork"] &
         LotInfo_saleArtwork &
         BidForm_saleArtwork
     }
 }
 
-export const BidQueryResponseFixture: BidQueryResponse = {
+export const ConfirmBidQueryResponseFixture: ConfirmBidQueryResponse = {
   me: {
     has_qualified_credit_cards: false,
   },

--- a/src/Apps/Auction/__tests__/routes.test.ts
+++ b/src/Apps/Auction/__tests__/routes.test.ts
@@ -1,7 +1,7 @@
 import {
-  BidQueryResponse,
-  BidQueryResponseFixture,
-} from "Apps/Auction/__fixtures__/routes_BidQuery"
+  ConfirmBidQueryResponse,
+  ConfirmBidQueryResponseFixture,
+} from "Apps/Auction/__fixtures__/routes_ConfirmBidQuery"
 import {
   DeFragedRegisterQueryResponse,
   RegisterQueryResponseFixture,
@@ -41,26 +41,26 @@ describe("Auction/routes", () => {
     sale = {},
     me = {},
   }: Partial<{
-    artwork: Partial<BidQueryResponse["artwork"]>
-    sale: Partial<BidQueryResponse["artwork"]["saleArtwork"]["sale"]>
-    saleArtwork: Partial<BidQueryResponse["artwork"]["saleArtwork"]>
-    me: Partial<BidQueryResponse["me"]>
-  }> = {}): BidQueryResponse => ({
-    ...BidQueryResponseFixture,
+    artwork: Partial<ConfirmBidQueryResponse["artwork"]>
+    sale: Partial<ConfirmBidQueryResponse["artwork"]["saleArtwork"]["sale"]>
+    saleArtwork: Partial<ConfirmBidQueryResponse["artwork"]["saleArtwork"]>
+    me: Partial<ConfirmBidQueryResponse["me"]>
+  }> = {}): ConfirmBidQueryResponse => ({
+    ...ConfirmBidQueryResponseFixture,
     artwork: {
-      ...BidQueryResponseFixture.artwork,
+      ...ConfirmBidQueryResponseFixture.artwork,
       ...artwork,
       saleArtwork: {
-        ...BidQueryResponseFixture.artwork.saleArtwork,
+        ...ConfirmBidQueryResponseFixture.artwork.saleArtwork,
         ...saleArtwork,
         sale: {
-          ...BidQueryResponseFixture.artwork.saleArtwork.sale,
+          ...ConfirmBidQueryResponseFixture.artwork.saleArtwork.sale,
           ...sale,
         },
       },
     },
     me: {
-      ...BidQueryResponseFixture.me,
+      ...ConfirmBidQueryResponseFixture.me,
       ...me,
     },
   })
@@ -73,7 +73,7 @@ describe("Auction/routes", () => {
 
   describe("Confirm Bid: /:saleId/bid/:artworkId", () => {
     it("does not redirect if the user is qualified to bid in the sale, the sale is open, and the artwork is biddable", async () => {
-      const fixture: BidQueryResponse = mockConfirmBidResolver()
+      const fixture: ConfirmBidQueryResponse = mockConfirmBidResolver()
       const { redirect, status } = await render(
         `/auction/${fixture.artwork.saleArtwork.sale.id}/bid/${
           fixture.artwork.id
@@ -86,7 +86,7 @@ describe("Auction/routes", () => {
     })
 
     it("redirects to confirm registration page if user is registered but not qualified to bid (to remind them)", async () => {
-      const fixture: BidQueryResponse = mockConfirmBidResolver({
+      const fixture: ConfirmBidQueryResponse = mockConfirmBidResolver({
         sale: { registrationStatus: { qualified_for_bidding: false } },
       })
       const { redirect } = await render(
@@ -102,7 +102,7 @@ describe("Auction/routes", () => {
     })
 
     it("redirects to sale artwork page if the sale is closed", async () => {
-      const fixture: BidQueryResponse = mockConfirmBidResolver({
+      const fixture: ConfirmBidQueryResponse = mockConfirmBidResolver({
         sale: {
           is_closed: true,
         },
@@ -121,7 +121,7 @@ describe("Auction/routes", () => {
     })
 
     it("redirects to the login (plus redirect_uri of sale artwork bid page) if user is not signed in", async () => {
-      const fixture: BidQueryResponse = mockConfirmBidResolver()
+      const fixture: ConfirmBidQueryResponse = mockConfirmBidResolver()
       fixture.me = null
 
       const { redirect } = await render(
@@ -136,7 +136,7 @@ describe("Auction/routes", () => {
     })
 
     it("redirects to the sale artwork page if user is not registered and registration is closed", async () => {
-      const fixture: BidQueryResponse = mockConfirmBidResolver({
+      const fixture: ConfirmBidQueryResponse = mockConfirmBidResolver({
         sale: {
           registrationStatus: null,
           is_registration_closed: true,
@@ -156,7 +156,7 @@ describe("Auction/routes", () => {
     })
 
     it("does not redirect if user is not registered but registration is open", async () => {
-      const fixture: BidQueryResponse = mockConfirmBidResolver({
+      const fixture: ConfirmBidQueryResponse = mockConfirmBidResolver({
         sale: {
           registrationStatus: null,
           is_registration_closed: false,

--- a/src/Apps/Auction/getRedirect.ts
+++ b/src/Apps/Auction/getRedirect.ts
@@ -1,4 +1,4 @@
-import { routes_BidQueryResponse } from "__generated__/routes_BidQuery.graphql"
+import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
 import { routes_RegisterQueryResponse } from "__generated__/routes_RegisterQuery.graphql"
 
 export interface Redirect {
@@ -36,7 +36,7 @@ export function registerRedirect({
 }
 
 export function confirmBidRedirect(
-  data: routes_BidQueryResponse,
+  data: routes_ConfirmBidQueryResponse,
   location: Location
 ): Redirect | null {
   const { artwork, me } = data

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -29,7 +29,7 @@ export const routes: RouteConfig[] = [
       }
     },
     query: graphql`
-      query routes_BidQuery($saleID: String!, $artworkID: String!) {
+      query routes_ConfirmBidQuery($saleID: String!, $artworkID: String!) {
         artwork(id: $artworkID) {
           ...LotInfo_artwork
           _id

--- a/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
+++ b/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
@@ -1,0 +1,128 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type BidderPositionInput = {
+    readonly sale_id: string;
+    readonly artwork_id: string;
+    readonly max_bid_amount_cents: number;
+    readonly clientMutationId?: string | null;
+};
+export type ConfirmBidCreateBidderPositionMutationVariables = {
+    readonly input: BidderPositionInput;
+};
+export type ConfirmBidCreateBidderPositionMutationResponse = {
+    readonly createBidderPosition: ({
+        readonly result: ({
+            readonly status: string;
+            readonly message_header: string | null;
+            readonly message_description_md: string | null;
+        }) | null;
+    }) | null;
+};
+export type ConfirmBidCreateBidderPositionMutation = {
+    readonly response: ConfirmBidCreateBidderPositionMutationResponse;
+    readonly variables: ConfirmBidCreateBidderPositionMutationVariables;
+};
+
+
+
+/*
+mutation ConfirmBidCreateBidderPositionMutation(
+  $input: BidderPositionInput!
+) {
+  createBidderPosition(input: $input) {
+    result {
+      status
+      message_header
+      message_description_md
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "BidderPositionInput!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "createBidderPosition",
+    "storageKey": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input",
+        "type": "BidderPositionInput!"
+      }
+    ],
+    "concreteType": "BidderPositionPayload",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "result",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "BidderPositionResult",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "status",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "message_header",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "message_description_md",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "mutation",
+  "name": "ConfirmBidCreateBidderPositionMutation",
+  "id": null,
+  "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      status\n      message_header\n      message_description_md\n    }\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ConfirmBidCreateBidderPositionMutation",
+    "type": "Mutation",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": v1
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ConfirmBidCreateBidderPositionMutation",
+    "argumentDefinitions": v0,
+    "selections": v1
+  }
+};
+})();
+(node as any).hash = '83a32bbd1213cdb1462815a1707c7e6d';
+export default node;

--- a/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
+++ b/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
@@ -1,0 +1,426 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { BidForm_saleArtwork$ref } from "./BidForm_saleArtwork.graphql";
+import { LotInfo_artwork$ref } from "./LotInfo_artwork.graphql";
+import { LotInfo_saleArtwork$ref } from "./LotInfo_saleArtwork.graphql";
+export type ConfirmBidValidTestQueryVariables = {};
+export type ConfirmBidValidTestQueryResponse = {
+    readonly artwork: ({
+        readonly _id: string;
+        readonly id: string;
+        readonly saleArtwork: ({
+            readonly _id: string;
+            readonly id: string;
+            readonly sale: ({
+                readonly registrationStatus: ({
+                    readonly qualified_for_bidding: boolean | null;
+                }) | null;
+                readonly _id: string;
+                readonly id: string;
+                readonly name: string | null;
+                readonly is_closed: boolean | null;
+                readonly is_registration_closed: boolean | null;
+            }) | null;
+            readonly " $fragmentRefs": LotInfo_saleArtwork$ref & BidForm_saleArtwork$ref;
+        }) | null;
+        readonly " $fragmentRefs": LotInfo_artwork$ref;
+    }) | null;
+    readonly me: ({
+        readonly has_qualified_credit_cards: boolean | null;
+    }) | null;
+};
+export type ConfirmBidValidTestQuery = {
+    readonly response: ConfirmBidValidTestQueryResponse;
+    readonly variables: ConfirmBidValidTestQueryVariables;
+};
+
+
+
+/*
+query ConfirmBidValidTestQuery {
+  artwork(id: "artwork-id") {
+    ...LotInfo_artwork
+    _id
+    id
+    saleArtwork: sale_artwork(sale_id: "example-auction-id") {
+      ...LotInfo_saleArtwork
+      ...BidForm_saleArtwork
+      _id
+      id
+      sale {
+        registrationStatus {
+          qualified_for_bidding
+          __id
+        }
+        _id
+        id
+        name
+        is_closed
+        is_registration_closed
+        __id
+      }
+      __id
+    }
+    __id
+  }
+  me {
+    has_qualified_credit_cards
+    __id
+  }
+}
+
+fragment LotInfo_artwork on Artwork {
+  _id
+  date
+  title
+  imageUrl
+  artistNames: artist_names
+  __id
+}
+
+fragment LotInfo_saleArtwork on SaleArtwork {
+  counts {
+    bidderPositions: bidder_positions
+  }
+  lotLabel: lot_label
+  minimumNextBid: minimum_next_bid {
+    amount
+    cents
+    display
+  }
+  __id
+}
+
+fragment BidForm_saleArtwork on SaleArtwork {
+  minimumNextBid: minimum_next_bid {
+    cents
+  }
+  increments(useMyMaxBid: true) {
+    cents
+    display
+  }
+  __id
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "artwork-id",
+    "type": "String!"
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "_id",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "sale_id",
+    "value": "example-auction-id",
+    "type": "String"
+  }
+],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "sale",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Sale",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "registrationStatus",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Bidder",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "qualified_for_bidding",
+          "args": null,
+          "storageKey": null
+        },
+        v4
+      ]
+    },
+    v1,
+    v2,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "name",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_closed",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_registration_closed",
+      "args": null,
+      "storageKey": null
+    },
+    v4
+  ]
+},
+v6 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "me",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Me",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "has_qualified_credit_cards",
+      "args": null,
+      "storageKey": null
+    },
+    v4
+  ]
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cents",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "display",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "ConfirmBidValidTestQuery",
+  "id": null,
+  "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  __id\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ConfirmBidValidTestQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artwork",
+        "storageKey": "artwork(id:\"artwork-id\")",
+        "args": v0,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "LotInfo_artwork",
+            "args": null
+          },
+          v1,
+          v2,
+          {
+            "kind": "LinkedField",
+            "alias": "saleArtwork",
+            "name": "sale_artwork",
+            "storageKey": "sale_artwork(sale_id:\"example-auction-id\")",
+            "args": v3,
+            "concreteType": "SaleArtwork",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "FragmentSpread",
+                "name": "LotInfo_saleArtwork",
+                "args": null
+              },
+              {
+                "kind": "FragmentSpread",
+                "name": "BidForm_saleArtwork",
+                "args": null
+              },
+              v1,
+              v2,
+              v5,
+              v4
+            ]
+          },
+          v4
+        ]
+      },
+      v6
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ConfirmBidValidTestQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artwork",
+        "storageKey": "artwork(id:\"artwork-id\")",
+        "args": v0,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          v1,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "date",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "imageUrl",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": "artistNames",
+            "name": "artist_names",
+            "args": null,
+            "storageKey": null
+          },
+          v4,
+          v2,
+          {
+            "kind": "LinkedField",
+            "alias": "saleArtwork",
+            "name": "sale_artwork",
+            "storageKey": "sale_artwork(sale_id:\"example-auction-id\")",
+            "args": v3,
+            "concreteType": "SaleArtwork",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "SaleArtworkCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": "bidderPositions",
+                    "name": "bidder_positions",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": "lotLabel",
+                "name": "lot_label",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": "minimumNextBid",
+                "name": "minimum_next_bid",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "SaleArtworkMinimumNextBid",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "amount",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  v7,
+                  v8
+                ]
+              },
+              v4,
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "increments",
+                "storageKey": "increments(useMyMaxBid:true)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "useMyMaxBid",
+                    "value": true,
+                    "type": "Boolean"
+                  }
+                ],
+                "concreteType": "BidIncrementsFormatted",
+                "plural": true,
+                "selections": [
+                  v7,
+                  v8
+                ]
+              },
+              v1,
+              v2,
+              v5
+            ]
+          }
+        ]
+      },
+      v6
+    ]
+  }
+};
+})();
+(node as any).hash = '021be58c4a37c3bc7911be25be0141b5';
+export default node;

--- a/src/__generated__/routes_ConfirmBidQuery.graphql.ts
+++ b/src/__generated__/routes_ConfirmBidQuery.graphql.ts
@@ -4,11 +4,11 @@ import { ConcreteRequest } from "relay-runtime";
 import { BidForm_saleArtwork$ref } from "./BidForm_saleArtwork.graphql";
 import { LotInfo_artwork$ref } from "./LotInfo_artwork.graphql";
 import { LotInfo_saleArtwork$ref } from "./LotInfo_saleArtwork.graphql";
-export type routes_BidQueryVariables = {
+export type routes_ConfirmBidQueryVariables = {
     readonly saleID: string;
     readonly artworkID: string;
 };
-export type routes_BidQueryResponse = {
+export type routes_ConfirmBidQueryResponse = {
     readonly artwork: ({
         readonly _id: string;
         readonly id: string;
@@ -33,15 +33,15 @@ export type routes_BidQueryResponse = {
         readonly has_qualified_credit_cards: boolean | null;
     }) | null;
 };
-export type routes_BidQuery = {
-    readonly response: routes_BidQueryResponse;
-    readonly variables: routes_BidQueryVariables;
+export type routes_ConfirmBidQuery = {
+    readonly response: routes_ConfirmBidQueryResponse;
+    readonly variables: routes_ConfirmBidQueryVariables;
 };
 
 
 
 /*
-query routes_BidQuery(
+query routes_ConfirmBidQuery(
   $saleID: String!
   $artworkID: String!
 ) {
@@ -252,13 +252,13 @@ v9 = {
 return {
   "kind": "Request",
   "operationKind": "query",
-  "name": "routes_BidQuery",
+  "name": "routes_ConfirmBidQuery",
   "id": null,
-  "text": "query routes_BidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  __id\n}\n",
+  "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
-    "name": "routes_BidQuery",
+    "name": "routes_ConfirmBidQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": v0,
@@ -312,7 +312,7 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "routes_BidQuery",
+    "name": "routes_ConfirmBidQuery",
     "argumentDefinitions": v0,
     "selections": [
       {
@@ -442,5 +442,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'af13ddd3e0d60d9cbda2a148ab938c56';
+(node as any).hash = 'ff2da827cde39edcee834e5a15602665';
 export default node;


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/AUCT-645

paired with @erikdstock 

<img width="595" alt="Screen Shot 2019-10-22 at 12 16 20 PM" src="https://user-images.githubusercontent.com/19369/67307035-db826000-f4c5-11e9-83cc-2c85a74456b1.png">


**Acceptance Criteria**

- ensure that the confirm bid page is moved to reaction
- current page: https://github.com/artsy/force/blob/3e8e7cc0b0a12a3fd39df59e5e4609b744ecd188/src/mobile/apps/feature/templates
- A developer is able to place a bid in Reaction’s storybooks
- Reaction app has tests