### PR TITLE
Return default object on server from useWindowSize, instead of null

### DIFF
--- a/src/Utils/Hooks/useWindowSize.ts
+++ b/src/Utils/Hooks/useWindowSize.ts
@@ -3,7 +3,7 @@ import { getViewportDimensions } from "Utils/viewport"
 
 export const useWindowSize = () => {
   if (typeof window === "undefined") {
-    return null
+    return { width: 0, height: 0 }
   }
 
   const [size, setSize] = useState({ width: 0, height: 0 })


### PR DESCRIPTION
This should resolve the "Cannot read property 'width' of null" errors currently in staging, which were a result of returning `null` on the server in #2919.