### PR TITLE
[Carousel] Ensure we only import flickity on client

### DIFF
--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -1,5 +1,5 @@
 import { Box, ChevronIcon, color, Flex, space } from "@artsy/palette"
-import Flickity, { Options as FlickityOptions } from "flickity"
+import { Options as FlickityOptions } from "flickity"
 import React, { Fragment } from "react"
 import styled from "styled-components"
 import { left, LeftProps, right, RightProps } from "styled-system"
@@ -206,6 +206,7 @@ export class BaseCarousel extends React.Component<
    */
   componentDidMount() {
     const { setCarouselRef } = this.props
+    const Flickity = require("flickity")
 
     this.flickity = new Flickity(this.carouselRef, this.options)
 


### PR DESCRIPTION
Fixes `window is not defined` issue when SSR'ing in Force, which reverts [this line from #2927](https://github.com/artsy/reaction/pull/2927/files#diff-46847d5408e9ceb7bf8d5b5f1c59f0b5L208)

#trivial 