### PR TITLE
Loosen rules on phone numbers in AddressForm for international numbers.

### DIFF
--- a/src/Apps/Auction/Routes/__tests__/Register.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/Register.test.tsx
@@ -91,7 +91,7 @@ describe("Routes/Register ", () => {
     jest.resetAllMocks()
   })
 
-  it("emits a RegistrationSubmitFailed analtyics event and halts submission", async () => {
+  it("emits a RegistrationSubmitFailed analytics event and halts submission", async () => {
     const env = setupTestEnv()
     const page = await env.buildPage()
 

--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -212,7 +212,7 @@ export class AddressForm extends React.Component<
                 type="tel"
                 description={this.phoneNumberInputDescription()}
                 placeholder="+1-222-222-2222"
-                pattern="[^a-z]"
+                pattern="[^a-z]+"
                 value={this.props.value.phoneNumber}
                 onChange={this.changeEventHandler("phoneNumber")}
                 error={this.getError("phoneNumber")}

--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -209,9 +209,10 @@ export class AddressForm extends React.Component<
               <Input
                 id="AddressForm_phoneNumber"
                 title="Phone number"
+                type="tel"
                 description={this.phoneNumberInputDescription()}
-                placeholder="Add phone"
-                pattern="[0-9]*"
+                placeholder="+1-222-222-2222"
+                pattern="[^a-z]"
                 value={this.props.value.phoneNumber}
                 onChange={this.changeEventHandler("phoneNumber")}
                 error={this.getError("phoneNumber")}

--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -211,7 +211,7 @@ export class AddressForm extends React.Component<
                 title="Phone number"
                 type="tel"
                 description={this.phoneNumberInputDescription()}
-                placeholder="+1-222-222-2222"
+                placeholder="Add phone"
                 pattern="[^a-z]+"
                 value={this.props.value.phoneNumber}
                 onChange={this.changeEventHandler("phoneNumber")}


### PR DESCRIPTION
Problem:

It was discovered that users weren't able to enter country codes or
white-space when providing a phone number when registering for an
auction. Moreover, due to the way that HTML5 validations work, users were
getting generic "Please match the requested format" messages, which is a
confusing UX.

Solution:

* Change the `pattern` attribute for the phone `Input` so that only
letters are not allowed in client side validations.
  + This is in-sufficient to ensure that all phone numbers are
    deliverable, but notably there are multiple ways to specify a phone
    number on Artsy, including the settings page on www.artsy.net, so
    additional constraints should likely be implemented at the API layer.
* Set the input type to `tel` to make the DOM as semantic and HTML5 nice
* Add a placeholder that includes a country code and will pass client
side validations.

Jira 🔒: https://artsyproduct.atlassian.net/browse/AUCT-687

---

<img width="1819" alt="new-empty-state-for-phone-number" src="https://user-images.githubusercontent.com/1561546/67246136-a1648000-f42b-11e9-9283-df7cad8863a0.png">
<img width="1819" alt="new-phone-number-validation" src="https://user-images.githubusercontent.com/1561546/67246137-a1648000-f42b-11e9-9d7f-95b19bf5440f.png">
