### PR TITLE
[Collection Hubs] only display Related Collections Rail on non-hubs collections

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -121,13 +121,17 @@ export class CollectionApp extends Component<CollectionAppProps> {
               />
             </ArtworkFilterContextProvider>
           </Box>
-          <Separator mt={6} mb={3} />
-          <Box mt="3">
-            <RelatedCollectionsRail
-              collections={viewer.relatedCollections}
-              title={viewer.title}
-            />
-          </Box>
+          {viewer.linkedCollections.length === 0 && (
+            <>
+              <Separator mt={6} mb={3} />
+              <Box mt="3">
+                <RelatedCollectionsRail
+                  collections={viewer.relatedCollections}
+                  title={viewer.title}
+                />
+              </Box>
+            </>
+          )}
         </FrameWithRecentlyViewed>
       </AppContainer>
     )


### PR DESCRIPTION
During a QA session we mentioned removing the bottom RelatedCollectionsRail from Collection Hubs and only showing them on regular collection pages. This PR does that.

**Collection Hubs Page**
![Screen Shot 2019-10-22 at 2 58 43 PM](https://user-images.githubusercontent.com/5201004/67320628-79812500-f4dc-11e9-8a24-f26c816957be.png)

**Regular Collections Page**
![Screen Shot 2019-10-22 at 2 59 31 PM](https://user-images.githubusercontent.com/5201004/67320702-93226c80-f4dc-11e9-9690-2ad4e31c129b.png)
