### PR TITLE
Remove pageview tracking from hubs modules

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesRail.test.tsx
@@ -59,17 +59,6 @@ describe("ArtistSeriesRail", () => {
   })
 
   describe("Tracking", () => {
-    it("Tracks impressions", () => {
-      mount(<ArtistSeriesRail {...props} />)
-
-      expect(trackEvent).toBeCalledWith({
-        action_type: "Impression",
-        context_page: "Collection",
-        context_module: "ArtistCollectionsRail",
-        context_page_owner_type: "Collection",
-      })
-    })
-
     it("Tracks arrow click", () => {
       props.collectionGroup.members = [
         singleData(),

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
@@ -3,7 +3,7 @@ import { ArtistSeriesRail_collectionGroup } from "__generated__/ArtistSeriesRail
 import { AnalyticsSchema } from "Artsy/Analytics"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton, Carousel } from "Components/v2/Carousel"
-import React, { useEffect } from "react"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
@@ -17,15 +17,6 @@ export const ArtistSeriesRail: React.FC<ArtistSeriesRailProps> = ({
 }) => {
   const { members, name } = collectionGroup
   const { trackEvent } = useTracking()
-
-  useEffect(() => {
-    trackEvent({
-      action_type: AnalyticsSchema.ActionType.Impression,
-      context_page: AnalyticsSchema.PageName.CollectionPage,
-      context_module: AnalyticsSchema.ContextModule.ArtistCollectionsRail,
-      context_page_owner_type: AnalyticsSchema.OwnerType.Collection,
-    })
-  }, [])
 
   const trackArrowClick = () => {
     trackEvent({

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -53,17 +53,6 @@ describe("FeaturedCollectionsRails", () => {
   })
 
   describe("Tracking", () => {
-    it("Tracks impressions", () => {
-      mount(<FeaturedCollectionsRails {...props} />)
-
-      expect(trackEvent).toBeCalledWith({
-        action_type: "Impression",
-        context_page: "Collection",
-        context_module: "FeaturedCollectionsRail",
-        context_page_owner_type: "Collection",
-      })
-    })
-
     it("Tracks arrow click", () => {
       props.collectionGroup.members = [
         memberData(),

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -14,7 +14,7 @@ import { RouterLink } from "Artsy/Router/RouterLink"
 import { Truncator } from "Components/Truncator"
 import { ArrowButton, Carousel } from "Components/v2"
 import currency from "currency.js"
-import React, { useEffect } from "react"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
@@ -52,15 +52,6 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
 }) => {
   const { members, name } = collectionGroup
   const { trackEvent } = useTracking()
-
-  useEffect(() => {
-    trackEvent({
-      action_type: Schema.ActionType.Impression,
-      context_page: Schema.PageName.CollectionPage,
-      context_module: Schema.ContextModule.FeaturedCollectionsRail,
-      context_page_owner_type: Schema.OwnerType.Collection,
-    })
-  }, [])
 
   const trackArrowClick = () => {
     trackEvent({

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.test.tsx
@@ -47,17 +47,6 @@ describe("CollectionsRail", () => {
   })
 
   describe("Tracking", () => {
-    it("Tracks impressions", () => {
-      mount(<OtherCollectionsRail {...props} />)
-
-      expect(trackEvent).toBeCalledWith({
-        action_type: "Impression",
-        context_page: "Collection",
-        context_module: "OtherCollectionsRail",
-        context_page_owner_type: "Collection",
-      })
-    })
-
     it("Tracks arrow click", () => {
       props.collectionGroup.members = [
         memberData(),

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -3,7 +3,7 @@ import { OtherCollectionsRail_collectionGroup } from "__generated__/OtherCollect
 import * as Schema from "Artsy/Analytics/Schema"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { ArrowButton, Carousel } from "Components/v2/Carousel"
-import React, { useEffect } from "react"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
@@ -17,15 +17,6 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
 }) => {
   const { name, members } = collectionGroup
   const { trackEvent } = useTracking()
-
-  useEffect(() => {
-    trackEvent({
-      action_type: Schema.ActionType.Impression,
-      context_page: Schema.PageName.CollectionPage,
-      context_module: Schema.ContextModule.OtherCollectionsRail,
-      context_page_owner_type: Schema.OwnerType.Collection,
-    })
-  }, [])
 
   const trackArrowClick = () => {
     trackEvent({


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-1616

Per @abhitip, we want to remove the pageview tracking of hubs modules for now. 