### PR TITLE
Create typeSupport & simplify relay fixture creation

### DIFF
--- a/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
@@ -2,10 +2,10 @@ import { BidForm_saleArtwork } from "__generated__/BidForm_saleArtwork.graphql"
 import { LotInfo_artwork } from "__generated__/LotInfo_artwork.graphql"
 import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
 import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
-type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> }
 
+// This complicated type is needed in order to include nested/masked relay queries
 export interface ConfirmBidQueryResponse
-  extends DeepWriteable<routes_ConfirmBidQueryResponse> {
+  extends routes_ConfirmBidQueryResponse {
   artwork: routes_ConfirmBidQueryResponse["artwork"] &
     LotInfo_artwork & {
       saleArtwork: routes_ConfirmBidQueryResponse["artwork"]["saleArtwork"] &

--- a/src/Apps/Auction/__fixtures__/routes_RegisterQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_RegisterQuery.ts
@@ -1,9 +1,7 @@
 import { Register_me } from "__generated__/Register_me.graphql"
 import { Register_sale } from "__generated__/Register_sale.graphql"
 import { routes_RegisterQueryResponse } from "__generated__/routes_RegisterQuery.graphql"
-
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
-type DeFraged<T> = Omit<T, " $refType" | " $fragmentRefs">
+import { DeFraged } from "Utils/typeSupport"
 
 export interface DeFragedRegisterQueryResponse {
   sale: DeFraged<routes_RegisterQueryResponse["sale"] & Register_sale>

--- a/src/Apps/__tests__/Fixtures/Auction/Routes/Register/index.ts
+++ b/src/Apps/__tests__/Fixtures/Auction/Routes/Register/index.ts
@@ -2,7 +2,6 @@ import { Register_me } from "__generated__/Register_me.graphql"
 import { Register_sale } from "__generated__/Register_sale.graphql"
 import { routes_RegisterQueryResponse } from "__generated__/routes_RegisterQuery.graphql"
 
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 type DeFraged<T> = Omit<T, " $refType" | " $fragmentRefs">
 
 export interface DeFragedRegisterQueryResponse {

--- a/src/Components/v2/__tests__/ArtistBio.test.tsx
+++ b/src/Components/v2/__tests__/ArtistBio.test.tsx
@@ -10,8 +10,6 @@ import {
 
 jest.unmock("react-relay")
 
-type Omit<T, K> = { [k in Exclude<keyof T, K>]: T[k] }
-
 describe("ArtistBio", () => {
   const biography_blurb = {
     text: '<a href="hi">hello how are you</a>',

--- a/src/Utils/typeSupport.ts
+++ b/src/Utils/typeSupport.ts
@@ -1,0 +1,35 @@
+/** Remove the special relay properties from an interface */
+export type DeFraged<T> = Omit<T, " $refType" | " $fragmentRefs">
+
+/** Utility Types (credit: https://github.com/krzkaczor/ts-essentials) */
+
+export type Primitive =
+  | string
+  | number
+  | boolean
+  | bigint
+  | symbol
+  | undefined
+  | null
+
+/** Like Partial but recursive
+ * https://github.com/krzkaczor/ts-essentials/blob/25fe670e54451420b5087cd9ce26c26935022864/lib/types.ts
+ */
+// tslint:disable
+export type DeepPartial<T> = T extends Primitive
+  ? T
+  : T extends Function
+  ? T
+  : T extends Date
+  ? T
+  : T extends Map<infer K, infer V>
+  ? DeepPartialMap<K, V>
+  : T extends Set<infer U>
+  ? DeepPartialSet<U>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>
+interface DeepPartialSet<ItemType> extends Set<DeepPartial<ItemType>> {}
+interface DeepPartialMap<KeyType, ValueType>
+  extends Map<DeepPartial<KeyType>, DeepPartial<ValueType>> {}
+// tslint:enable


### PR DESCRIPTION
This PR makes it easier to define fixtures in the Auction app by simplifying our ConfirmBid mock query resolver code to use deep merge. In order to do that we brought in a mapped type from the [`ts-essentials`](https://github.com/krzkaczor/ts-essentials/commit/9536fd57a0c89ba358a16dd657054cf7960bdb59#diff-f0110f871bbb78393553f89381b8a4fdR9) package (we did not add it to node_modules because of its educational value).

Extra context: This allows us to define `{me: null}` when calling the fixture factory function rather than saying `fixture.me = null` (see https://github.com/artsy/reaction/commit/a438ffbe6fa8e462ef341f6bcc518248e27e047d) after creation, which in turn allows us to _not_ make the fixture a special `DeepWriteable` type to avoid `readonly` errors. It also drastically simplifies some nested fixture merging code that all really just amounted to a deep merge.

Refactor auction tests to use deepmerge in fixture creation
- Create Utils/typeSupport for colocating utility/mapped types
- remove DeepWriteable<T> type (not needed after switching to deepmerge)
- copy DeepPartial from krzkaczor/ts-essentials
- remove redundant `type Omit`s as they are now included in our ts version

Paired on this with @dleve123 