### PR TITLE
Ensure makesOffer isn't null before getting length

### DIFF
--- a/src/Apps/Artist/Components/ArtistMeta.tsx
+++ b/src/Apps/Artist/Components/ArtistMeta.tsx
@@ -125,7 +125,7 @@ export const offerAttributes = (artwork: ArtworkNode) => {
 
 export const structuredDataAttributes = (artist: ArtistMeta_artist) => {
   let makesOffer = offersAttributes(artist)
-  if (makesOffer.length === 0) {
+  if (makesOffer && makesOffer.length === 0) {
     makesOffer = undefined
   }
   const attributes = {


### PR DESCRIPTION
Fix a minor error discovered in force acceptance tests where `makesOffer` could  be null if no artworks are contained in the payload. 

https://circleci.com/gh/artsy/force/33987