### PR TITLE
Be defensive about list price accessors

### DIFF
--- a/src/Apps/Artist/Components/ArtistMeta.tsx
+++ b/src/Apps/Artist/Components/ArtistMeta.tsx
@@ -105,6 +105,9 @@ export const offerAttributes = (artwork: ArtworkNode) => {
   if (!artwork.listPrice) return null
   switch (artwork.listPrice.__typename) {
     case "PriceRange":
+      if (!artwork.listPrice.minPrice || !artwork.listPrice.maxPrice) {
+        return null
+      }
       return {
         "@type": "AggregateOffer",
         lowPrice: artwork.listPrice.minPrice.major,


### PR DESCRIPTION
cc @sepans @joeyAghion

We're seeing an increased rate of errors in production because not all of the `listPrice` ranges have a min or max value? Not sure why that would happen, but this guard should put a band-aid on the issue until we can dig deeper. 