### PR TITLE
remove pricing transparency query param, make a story for it

### DIFF
--- a/src/Apps/Auction/Components/__stories__/PricingTransparency.story.tsx
+++ b/src/Apps/Auction/Components/__stories__/PricingTransparency.story.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+import { storiesOf } from "storybook/storiesOf"
+import { Section } from "Utils/Section"
+import { PricingTransparency } from "../PricingTransparency"
+
+storiesOf("Apps/Auction/Components", module).add("Pricing Transparency", () => {
+  return (
+    <Section>
+      <PricingTransparency />
+    </Section>
+  )
+})

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -126,7 +126,7 @@ export const ConfirmBidRoute: React.FC<BidProps> = props => {
         <Separator />
         <BidForm
           initialSelectedBid={getInitialSelectedBid(props.location)}
-          showPricingTransparency={Boolean(/pt=1/.test(props.location.search))}
+          showPricingTransparency={false}
           saleArtwork={saleArtwork}
           onSubmit={handleSubmit}
         />

--- a/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
+++ b/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
@@ -25,11 +25,3 @@ storiesOf("Apps/Auction/Routes/Confirm Bid", module)
       />
     )
   })
-  .add("Pricing Transparency", () => {
-    return (
-      <MockRouter
-        routes={auctionRoutes}
-        initialRoute={confirmBidRoute + "?&pt=1"}
-      />
-    )
-  })


### PR DESCRIPTION
This PR creates a rudimentary story for the pricing transparency component stub and removes the query parameter that can trigger it so that it won't accidentally be visible (in theory) in force's `bid2` route.