### PR TITLE
[Collection Hubs Entry Points] Moves Experiment Viewed to collect app

### DIFF
--- a/src/Apps/Collect2/Routes/Collect/index.tsx
+++ b/src/Apps/Collect2/Routes/Collect/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Separator, Serif, Spacer } from "@artsy/palette"
 import { Location, Router } from "found"
-import React from "react"
+import React, { useEffect } from "react"
 import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -45,6 +45,18 @@ export const CollectApp = track({
   // FIXME: Remove after A/B test completes
   // @ts-ignore
   const { COLLECTION_HUB_ENTRYPOINTS_TEST } = useSystemContext()
+
+  useEffect(() => {
+    const experiment = "collection_hub_entrypoints_test"
+    trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: COLLECTION_HUB_ENTRYPOINTS_TEST,
+      variation_name: COLLECTION_HUB_ENTRYPOINTS_TEST,
+      nonInteraction: 1,
+    })
+  }, [])
 
   const canonicalHref = medium
     ? `${sd.APP_URL}/collect/${medium}`
@@ -92,7 +104,6 @@ export const CollectApp = track({
             <>
               <CollectionsHubsNav
                 marketingHubCollections={props.marketingHubCollections}
-                collectionHubTestVariation={COLLECTION_HUB_ENTRYPOINTS_TEST}
               />
 
               <Spacer mb={2} mt={[2, 2, 2, 4]} />

--- a/src/Components/v2/CollectionsHubsNav.tsx
+++ b/src/Components/v2/CollectionsHubsNav.tsx
@@ -1,31 +1,18 @@
 import { CSSGrid, Serif } from "@artsy/palette"
 import { CollectionsHubsNav_marketingHubCollections } from "__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
+import { useTracking } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
-import { useTracking } from "Artsy/Analytics/useTracking"
-import React, { FC, useEffect } from "react"
+import React, { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { resize } from "Utils/resizer"
 import { ImageLink } from "./ImageLink"
 
 interface CollectionsHubsNavProps {
   marketingHubCollections: CollectionsHubsNav_marketingHubCollections
-  collectionHubTestVariation: string
 }
 
 export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
   const { trackEvent } = useTracking()
-
-  useEffect(() => {
-    const experiment = "collection_hub_entrypoints_test"
-    trackEvent({
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: props.collectionHubTestVariation,
-      variation_name: props.collectionHubTestVariation,
-      nonInteraction: 1,
-    })
-  }, [])
 
   return (
     <CSSGrid


### PR DESCRIPTION
This PR moves the 'Experiment Viewed' event to the base Collect component to ensure we fire it for _both_ the control and the experiment  group.

For more context see: https://artsy.slack.com/archives/C9SATFLUU/p1572022915428900?thread_ts=1571949171.406700&cid=C9SATFLUU