### PR TITLE
[NavBar] Rename `Magazine` to `Editorial`

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -96,7 +96,7 @@ export const NavBar: React.FC = track(
             >
               Fairs
             </NavItem>
-            <NavItem href="/articles">Magazine</NavItem>
+            <NavItem href="/articles">Editorial</NavItem>
             <NavItem
               Menu={() => {
                 return (

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -57,7 +57,7 @@ describe("NavBar", () => {
       ["/auctions", "Auctions"],
       ["/galleries", "Galleries"],
       ["/art-fairs", "Fairs"],
-      ["/articles", "Magazine"],
+      ["/articles", "Editorial"],
     ]
 
     it("renders correct lg, xl nav items", () => {


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-1916

Renames the top nav-bar text from `Magazine` to `Editorial`. 