### PR TITLE
QA for Grow 1577 Analytics tracking for hub entry points 

### DIFF
--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -14,16 +14,17 @@ interface CollectionsHubsHomepageNavProps {
 }
 
 export const CollectionsHubsHomepageNav = track(
-  {},
+  {
+    context_page: AnalyticsSchema.PageName.HomePage,
+    context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
+    subject: AnalyticsSchema.Subject.FeaturedCategories,
+  },
   { dispatch: data => Events.postEvent(data) }
 )((props: CollectionsHubsHomepageNavProps) => {
   const { trackEvent } = useTracking()
   useEffect(() => {
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Impression,
-      context_page: AnalyticsSchema.PageName.HomePage,
-      context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
-      subject: AnalyticsSchema.Subject.FeaturedCategories,
     })
   }, [])
 

--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -5,6 +5,7 @@ import { AnalyticsSchema } from "Artsy/Analytics"
 import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import track, { useTracking } from "react-tracking"
+import Events from "Utils/Events"
 import { resize } from "Utils/resizer"
 import { ImageLink } from "./ImageLink"
 
@@ -12,53 +13,54 @@ interface CollectionsHubsHomepageNavProps {
   marketingHubCollections: CollectionsHubsHomepageNav_marketingHubCollections
 }
 
-export const CollectionsHubsHomepageNav = track()(
-  (props: CollectionsHubsHomepageNavProps) => {
-    const { trackEvent } = useTracking()
-    useEffect(() => {
-      trackEvent({
-        action_type: AnalyticsSchema.ActionType.Impression,
-        context_page: AnalyticsSchema.PageName.HomePage,
-        context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
-        subject: AnalyticsSchema.Subject.FeaturedCategories,
-      })
-    }, [])
+export const CollectionsHubsHomepageNav = track(
+  {},
+  { dispatch: data => Events.postEvent(data) }
+)((props: CollectionsHubsHomepageNavProps) => {
+  const { trackEvent } = useTracking()
+  useEffect(() => {
+    trackEvent({
+      action_type: AnalyticsSchema.ActionType.Impression,
+      context_page: AnalyticsSchema.PageName.HomePage,
+      context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
+      subject: AnalyticsSchema.Subject.FeaturedCategories,
+    })
+  }, [])
 
-    return (
-      <CSSGrid
-        as="aside"
-        gridTemplateColumns={[
-          "repeat(2, 1fr)",
-          "repeat(2, 1fr)",
-          "repeat(3, 1fr)",
-        ]}
-        gridGap={20}
-      >
-        {props.marketingHubCollections.slice(0, 6).map(hub => (
-          <ImageLink
-            to={`/collection/${hub.slug}`}
-            src={resize(hub.thumbnail, { width: 357, height: 175 })}
-            ratio={[0.49]}
-            title={<Serif size={["3", "4"]}>{hub.title}</Serif>}
-            subtitle={<Serif size="2">{subtitleFor(hub.title)}</Serif>}
-            key={hub.id}
-            onClick={() => {
-              trackEvent({
-                action_type: AnalyticsSchema.ActionType.Click,
-                context_page: AnalyticsSchema.PageName.HomePage,
-                context_module:
-                  AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
-                subject: AnalyticsSchema.Subject.FeaturedCategories,
-                type: AnalyticsSchema.Type.Thumbnail,
-                desination_path: `/collection/${hub.slug}`,
-              })
-            }}
-          />
-        ))}
-      </CSSGrid>
-    )
-  }
-)
+  return (
+    <CSSGrid
+      as="aside"
+      gridTemplateColumns={[
+        "repeat(2, 1fr)",
+        "repeat(2, 1fr)",
+        "repeat(3, 1fr)",
+      ]}
+      gridGap={20}
+    >
+      {props.marketingHubCollections.slice(0, 6).map(hub => (
+        <ImageLink
+          to={`/collection/${hub.slug}`}
+          src={resize(hub.thumbnail, { width: 357, height: 175 })}
+          ratio={[0.49]}
+          title={<Serif size={["3", "4"]}>{hub.title}</Serif>}
+          subtitle={<Serif size="2">{subtitleFor(hub.title)}</Serif>}
+          key={hub.id}
+          onClick={() => {
+            trackEvent({
+              action_type: AnalyticsSchema.ActionType.Click,
+              context_page: AnalyticsSchema.PageName.HomePage,
+              context_module:
+                AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
+              subject: AnalyticsSchema.Subject.FeaturedCategories,
+              type: AnalyticsSchema.Type.Thumbnail,
+              desination_path: `/collection/${hub.slug}`,
+            })
+          }}
+        />
+      ))}
+    </CSSGrid>
+  )
+})
 
 export const CollectionsHubsHomepageNavFragmentContainer = createFragmentContainer(
   CollectionsHubsHomepageNav,

--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -2,7 +2,7 @@ import { CSSGrid } from "@artsy/palette"
 import { Serif } from "@artsy/palette"
 import { CollectionsHubsHomepageNav_marketingHubCollections } from "__generated__/CollectionsHubsHomepageNav_marketingHubCollections.graphql"
 import { AnalyticsSchema } from "Artsy/Analytics"
-import React, { useEffect } from "react"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import track, { useTracking } from "react-tracking"
 import Events from "Utils/Events"
@@ -18,16 +18,12 @@ export const CollectionsHubsHomepageNav = track(
     context_page: AnalyticsSchema.PageName.HomePage,
     context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
     subject: AnalyticsSchema.Subject.FeaturedCategories,
+    action_type: AnalyticsSchema.ActionType.Impression,
   },
   { dispatch: data => Events.postEvent(data) }
 )((props: CollectionsHubsHomepageNavProps) => {
   const { trackEvent } = useTracking()
-  useEffect(() => {
-    trackEvent({
-      action_type: AnalyticsSchema.ActionType.Impression,
-    })
-  }, [])
-
+  trackEvent({})
   return (
     <CSSGrid
       as="aside"
@@ -49,10 +45,6 @@ export const CollectionsHubsHomepageNav = track(
           onClick={() => {
             trackEvent({
               action_type: AnalyticsSchema.ActionType.Click,
-              context_page: AnalyticsSchema.PageName.HomePage,
-              context_module:
-                AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
-              subject: AnalyticsSchema.Subject.FeaturedCategories,
               type: AnalyticsSchema.Type.Thumbnail,
               desination_path: `/collection/${hub.slug}`,
             })


### PR DESCRIPTION
Address : [1577](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1577)

Previous PR: https://github.com/artsy/reaction/pull/2922


On staging, tracking does not work.
Based on the previous PR, I added `dispatch: data => Events.postEvent(data)`.
Since @xtina-starr is working on the AB test for the Collection Hub on the Collect App.
Some requirements (it needs to track entry point on the homepage and the collect page) from the ticket will be ignored temporally. 
In this PR, I only changed the CollectionHubEntry point on the homepage.
