### PR TITLE
Fix title of Confirm Bid route

### DIFF
--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -161,7 +161,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
 
   return (
     <AppContainer>
-      <Title>Auction Registration</Title>
+      <Title>Confirm Bid | Artsy</Title>
       <Box maxWidth={550} px={[2, 0]} mx="auto" mt={[1, 0]} mb={[1, 100]}>
         <Serif size="8">Confirm your bid</Serif>
         <Separator />


### PR DESCRIPTION
Problem

* Title was previously "Auction Registration"

Solution

* Name the page "Confirm Bid | Artsy"
  + consistent with naming convection of other pages
  + there isn't a title for the Force-backed page
    -  [example page][0] (must be registered for sale to see the page render)

Related Jira: https://artsyproduct.atlassian.net/browse/AUCT-667

[0]: https://staging.artsy.net/auction/shared-live-mocktion/bid/john-l-doyle-clown?bid=190000