### PR TITLE
WIP: Add retargetting tracking to confirm bid

### DIFF
--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -39,12 +39,6 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   const { me, artwork, tracking } = props
   const { saleArtwork } = artwork
   const { sale } = saleArtwork
-  logger.log({
-    me,
-    sale,
-    artwork,
-    saleArtwork,
-  })
 
   function createBidderPosition(maxBidAmountCents: number) {
     return new Promise(async (resolve, reject) => {

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -115,6 +115,21 @@ describe("Routes/ConfirmBid", () => {
       }
     )
 
+    expect(window.location.assign).toHaveBeenCalledWith(
+      `https://example.com/auction/${
+        ConfirmBidQueryResponseFixture.artwork.saleArtwork.sale.id
+      }/artwork/${ConfirmBidQueryResponseFixture.artwork.id}`
+    )
+  })
+
+  it("tracks a success event to Segment including product information", async () => {
+    const env = setupTestEnv()
+    const page = await env.buildPage()
+    env.mutations.useResultsOnce(createBidderPositionSuccessful)
+
+    await page.agreeToTerms()
+    await page.submitForm()
+
     expect(mockPostEvent).toBeCalledWith({
       action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
       context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
@@ -124,14 +139,16 @@ describe("Routes/ConfirmBid", () => {
       bidder_position_id: "positionid",
       sale_id: "saleid",
       user_id: "my-user-id",
+      order_id: "bidderid",
+      products: [
+        {
+          product_id: "artworkid",
+          quantity: 1,
+          price: 50000,
+        },
+      ],
     })
     expect(mockPostEvent).toHaveBeenCalledTimes(1)
-
-    expect(window.location.assign).toHaveBeenCalledWith(
-      `https://example.com/auction/${
-        ConfirmBidQueryResponseFixture.artwork.saleArtwork.sale.id
-      }/artwork/${ConfirmBidQueryResponseFixture.artwork.id}`
-    )
   })
 
   it("send an error event to analytics if the mutation fails", async () => {
@@ -165,6 +182,7 @@ describe("Routes/ConfirmBid", () => {
       bidder_id: "bidderid",
       sale_id: "saleid",
       user_id: "my-user-id",
+      order_id: "bidderid",
     })
     expect(mockPostEvent).toHaveBeenCalledTimes(1)
     expect(window.location.assign).not.toHaveBeenCalled()

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -122,7 +122,7 @@ describe("Routes/ConfirmBid", () => {
     )
   })
 
-  it("tracks a success event to Segment including product information", async () => {
+  it("tracks a success event to Segment including Criteo info", async () => {
     const env = setupTestEnv()
     const page = await env.buildPage()
     env.mutations.useResultsOnce(createBidderPositionSuccessful)
@@ -182,7 +182,6 @@ describe("Routes/ConfirmBid", () => {
       bidder_id: "bidderid",
       sale_id: "saleid",
       user_id: "my-user-id",
-      order_id: "bidderid",
     })
     expect(mockPostEvent).toHaveBeenCalledTimes(1)
     expect(window.location.assign).not.toHaveBeenCalled()

--- a/src/Apps/Auction/Routes/__tests__/Utils/ConfirmBidTestPage.tsx
+++ b/src/Apps/Auction/Routes/__tests__/Utils/ConfirmBidTestPage.tsx
@@ -1,17 +1,6 @@
 import { Checkbox } from "@artsy/palette"
 import { expectOne, RootTestPage } from "DevTools/RootTestPage"
 
-export const ValidFormValues = {
-  name: "Example Name",
-  addressLine1: "123 Example Street",
-  addressLine2: "Apt 1",
-  country: "United States",
-  city: "New York",
-  region: "NY",
-  postalCode: "10012",
-  phoneNumber: "+1 555 212 7878",
-}
-
 export class ConfirmBidTestPage extends RootTestPage {
   get confirmBidButton() {
     return this.find("button").filterWhere(btn =>

--- a/src/Artsy/Analytics/Schema/AuctionInfo.ts
+++ b/src/Artsy/Analytics/Schema/AuctionInfo.ts
@@ -1,0 +1,21 @@
+export interface AuctionInfo {
+  /**
+   * database id of a Bidder record (instance of user registered for an auction)
+   */
+  bidder_id: string
+
+  /**
+   * database id of a Bidder Position record
+   *
+   * Bidder position is the term used in Gravity to track the intent of a Bidder
+   * to bid on a lot. Typically this is a "max bid" (they could win at a lower value),
+   * but occasionally it is a fixed bid amount.
+   */
+  bidder_position_id: string
+  /**
+   * List of reasons why there's a failure event
+   *
+   *  Used by the auction registration flow.
+   */
+  error_messages: string[]
+}

--- a/src/Artsy/Analytics/Schema/CriteoInfo.ts
+++ b/src/Artsy/Analytics/Schema/CriteoInfo.ts
@@ -1,0 +1,34 @@
+/** CriteoInfo models the information needed for Segment to meaningfully communicate
+ * with Criteo to represent (at least bids) as a "product". Important for
+ * retargetting.
+ *
+ * Relevant Force context: https://github.com/artsy/force/pull/4041
+ */
+export interface CriteoInfo {
+  /** Primary key used by Criteo to represent an "order" */
+  order_id: string
+
+  /** list of "products" associated with the order */
+  products: CriteoProduct[]
+}
+
+interface CriteoProduct {
+  /**
+   * The identifier of the product in Criteo
+   *
+   * When used in the context on an auction lot, the product_id should be the
+   * database ID of the artwork (not sale artwork), being bid on.
+   */
+  product_id: string
+
+  /**
+   * The number of items considered to be within the "product"
+   *
+   * When used in the context of an auction lot, the quantity should be 1 for
+   * each bid.
+   */
+  quantity: number
+
+  /** Price of the product in minor units (cents for USD, for example). */
+  price: number
+}

--- a/src/Artsy/Analytics/Schema/Interaction.ts
+++ b/src/Artsy/Analytics/Schema/Interaction.ts
@@ -52,15 +52,3 @@ export interface AuthenticationInteraction extends Interaction {
    */
   trigger?: string
 }
-
-interface Product {
-  product_id: string
-  quantity: number
-  price: number
-}
-/** ProductInfo models the information needed for Segment to consider
- * the information as "productize-able", which is important for downstream services.
- */
-export interface ProductInfo {
-  products: Product[]
-}

--- a/src/Artsy/Analytics/Schema/Interaction.ts
+++ b/src/Artsy/Analytics/Schema/Interaction.ts
@@ -52,3 +52,15 @@ export interface AuthenticationInteraction extends Interaction {
    */
   trigger?: string
 }
+
+interface Product {
+  product_id: string
+  quantity: number
+  price: number
+}
+/** ProductInfo models the information needed for Segment to consider
+ * the information as "productize-able", which is important for downstream services.
+ */
+export interface ProductInfo {
+  products: Product[]
+}

--- a/src/Artsy/Analytics/Schema/index.ts
+++ b/src/Artsy/Analytics/Schema/index.ts
@@ -9,8 +9,10 @@
 
 export * from "./Values"
 
+import { AuctionInfo } from "./AuctionInfo"
 import { ContextModule } from "./ContextModule"
 import { ContextPage } from "./ContextPage"
+import { CriteoInfo } from "./CriteoInfo"
 import { Flow } from "./Flow"
 import { AuthenticationInteraction, Interaction } from "./Interaction"
 import { Label } from "./Label"
@@ -42,6 +44,8 @@ export type Trackables =
   | Failure
   | Type
   | Uncategorized
+  | AuctionInfo
+  | CriteoInfo
 
 /**
  * A sentinel type used to signal that anything goes in order to be able to


### PR DESCRIPTION
See commits:
- 07af125

```
* Create a ProductInfo interface in analytics schema
  + I have no idea if this is the right place to place this type, but
    wanted to start somewhere.
* Add tests for product info for bid success case
* Still need to get this working for submission failed

Jira: https://artsyproduct.atlassian.net/browse/AUCT-667
```

- 3f12b2b

```
Why?

* This allows us to use the type schema, better protecting ourselves
incorrect tracking code.

* It also allows better factor common tracking components by replacing
dependency injection with composition with common properties defined
at the component level.

Details

- add common tracking properties to HOC call and delete commonProperties
- Remove incorrect assertion about `order_id` in failing case
- Extend analytics schema with Criteo and Auctions info
  + Add `CriteoInfo` interface to describe core information about
    integrating with Criteo
  + Add `AuctionInfo` interface to describe assorted auction-related
    properties.
- Use p instead of props in track-wrapping to avoid “props shadowing”
  error.
```