### PR TITLE
Remove Magazine from mobile nav

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/DefaultHeader.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/DefaultHeader.test.tsx
@@ -35,9 +35,8 @@ describe("default collections header artworks", () => {
 
   it("returns only the number of artworks necessary to fill the header", () => {
     const artworks = defaultCollectionHeaderArtworks.hits
-    console.log("TCL: artworks", artworks.length)
-
     const headerArtworks = getHeaderArtworks(artworks, 675, false)
+
     expect(headerArtworks.length).toBeLessThan(artworks.length)
     expect(headerArtworks).toHaveLength(4)
   })

--- a/src/Components/NavBar/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu.tsx
@@ -42,7 +42,7 @@ export const MobileNavMenu: React.FC = () => {
       <MobileLink href="/institutions">Museums</MobileLink>
       <MobileLink href="/fairs">Fairs</MobileLink>
       <MobileLink href="/auctions">Auctions</MobileLink>
-      <MobileLink href="/articles">Magazine</MobileLink>
+      <MobileLink href="/articles">Editorial</MobileLink>
 
       <Box px={2}>
         <Separator my={[1, 4]} />

--- a/src/Components/NavBar/Menus/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/MobileNavMenu.test.tsx
@@ -30,7 +30,7 @@ describe("MobileNavMenu", () => {
     ["/institutions", "Museums"],
     ["/fairs", "Fairs"],
     ["/auctions", "Auctions"],
-    ["/articles", "Magazine"],
+    ["/articles", "Editorial"],
   ]
 
   describe("nav structure", () => {

--- a/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBarTracking.test.tsx
@@ -215,20 +215,20 @@ describe("NavBarTracking", () => {
 
       wrapper
         .find("MobileLink")
-        .last()
+        .at(1)
         .simulate("click", {
           target: {
-            innerText: "Magazine",
+            innerText: "Artists",
             parentNode: {
-              getAttribute: () => "/articles",
+              getAttribute: () => "/artists",
             },
           },
         })
 
       expect(trackEvent).toBeCalledWith({
         action_type: AnalyticsSchema.ActionType.Click,
-        subject: "Magazine",
-        destination_path: "/articles",
+        subject: "Artists",
+        destination_path: "/artists",
       })
     })
   })

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Footer.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Footer.tsx
@@ -30,7 +30,7 @@ export const VanguardFooter = () => {
         </Flex>
         <Separator mb={2} />
         <Serif size="3">
-          Back to <a href="/magazine">Artsy Editorial</a>
+          Back to <a href="/articles">Artsy Editorial</a>
         </Serif>
       </Box>
     </Box>

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/__tests__/__snapshots__/index.test.tsx.snap
@@ -21671,7 +21671,7 @@ has been added to clarify their involvement with the exhibition.
       >
         Back to 
         <a
-          href="/magazine"
+          href="/articles"
         >
           Artsy Editorial
         </a>

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -2101,7 +2101,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           fontSize="22px"
         >
           <a
-            href="/magazine"
+            href="/articles"
           >
             Artsy Editorial
           </a>
@@ -8025,7 +8025,7 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
           fontSize="22px"
         >
           <a
-            href="/magazine"
+            href="/articles"
           >
             Artsy Editorial
           </a>

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1108,7 +1108,7 @@ exports[`series layout renders a series 1`] = `
           fontSize="22px"
         >
           <a
-            href="/magazine"
+            href="/articles"
           >
             Artsy Editorial
           </a>
@@ -2806,7 +2806,7 @@ exports[`series layout renders a sponsored series 1`] = `
           fontSize="22px"
         >
           <a
-            href="/magazine"
+            href="/articles"
           >
             Artsy Editorial
           </a>

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -1034,7 +1034,7 @@ exports[`Video Layout ads renders the video layout properly with ads 1`] = `
           fontSize="22px"
         >
           <a
-            href="/magazine"
+            href="/articles"
           >
             Artsy Editorial
           </a>
@@ -3261,7 +3261,7 @@ exports[`Video Layout matches the snapshot 1`] = `
           fontSize="22px"
         >
           <a
-            href="/magazine"
+            href="/articles"
           >
             Artsy Editorial
           </a>

--- a/src/Components/Publishing/Nav/Nav.tsx
+++ b/src/Components/Publishing/Nav/Nav.tsx
@@ -74,7 +74,7 @@ export class Nav extends React.Component<Props, State> {
 
           <Media greaterThan="xs">
             <Title size="5" color={color} weight="semibold" textAlign="center">
-              {title ? title : <a href="/magazine">Artsy Editorial</a>}
+              {title ? title : <a href="/articles">Artsy Editorial</a>}
             </Title>
           </Media>
           {children}

--- a/src/Components/Publishing/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/src/Components/Publishing/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`Nav renders a Nav 1`] = `
         fontSize="22px"
       >
         <a
-          href="/magazine"
+          href="/articles"
         >
           Artsy Editorial
         </a>
@@ -357,7 +357,7 @@ exports[`Nav renders a sponsored nav 1`] = `
         fontSize="22px"
       >
         <a
-          href="/magazine"
+          href="/articles"
         >
           Artsy Editorial
         </a>
@@ -518,7 +518,7 @@ exports[`Nav renders a transparent nav 1`] = `
         fontSize="22px"
       >
         <a
-          href="/magazine"
+          href="/articles"
         >
           Artsy Editorial
         </a>


### PR DESCRIPTION
Follow up to https://github.com/artsy/reaction/pull/2955

- Replaces "Magazine" in mobile nav with "Editorial"
- Removes instances of "magazine" in repo
- Remove errant console.log