### PR TITLE
Track ad impressions and clicks on 3rd party served ads

### DIFF
--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -354,6 +354,11 @@ export enum ContextModule {
    * NSO 'bank transfer experiment
    */
   BankTransferExperiment = "BankTransferExperiment",
+
+  /**
+   * Ad Server
+   */
+  AdServer = "AdServer",
 }
 
 export enum Flow {

--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -3,10 +3,9 @@ import * as AnalyticsSchema from "Artsy/Analytics/Schema"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { is300x50AdUnit } from "Components/Publishing/Display/DisplayTargeting"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
-import React, { SFC, useState } from "react"
+import React, { SFC, useEffect, useState } from "react"
 import { Bling as GPT } from "react-gpt"
 import styled from "styled-components"
-import { useDidMount } from "Utils/Hooks/useDidMount"
 
 export interface DisplayAdProps extends FlexProps {
   adUnit: AdUnit
@@ -43,9 +42,8 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
   const [isAdEmpty, setAdEmpty] = useState(null)
   const isMobileLeaderboardAd = is300x50AdUnit(adDimension)
   const { trackEvent } = useTracking()
-  const isMounted = useDidMount()
 
-  if (isMounted) {
+  useEffect(() => {
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Impression,
       context_page: AnalyticsSchema.PageName.ArticlePage,
@@ -54,7 +52,7 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
       context_page_owner_slug: props.articleSlug,
       context_page_owner_type: AnalyticsSchema.OwnerType.Article,
     })
-  }
+  }, [])
 
   const onClickAd = () => {
     trackEvent({

--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -43,9 +43,22 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
   const [isAdEmpty, setAdEmpty] = useState(null)
   const isMobileLeaderboardAd = is300x50AdUnit(adDimension)
   const { trackEvent } = useTracking()
+  const isMounted = useDidMount()
+
+  if (isMounted) {
+    trackEvent({
+      action_type: AnalyticsSchema.ActionType.Impression,
+      context_page: AnalyticsSchema.PageName.ArticlePage,
+      context_module: AnalyticsSchema.ContextModule.AdServer,
+      context_page_owner_id: props.targetingData.post_id,
+      context_page_owner_slug: props.articleSlug,
+      context_page_owner_type: AnalyticsSchema.OwnerType.Article,
+    })
+  }
 
   const onClickAd = () => {
     trackEvent({
+      action_type: AnalyticsSchema.ActionType.Click,
       context_page: AnalyticsSchema.PageName.ArticlePage,
       context_module: AnalyticsSchema.ContextModule.AdServer,
       context_page_owner_id: props.targetingData.post_id,
@@ -68,16 +81,6 @@ export const DisplayAd: SFC<DisplayAdProps> = props => {
 
   if (isAdEmpty) {
     return null
-  }
-
-  if (useDidMount) {
-    trackEvent({
-      context_page: AnalyticsSchema.PageName.ArticlePage,
-      context_module: AnalyticsSchema.ContextModule.AdServer,
-      context_page_owner_id: props.targetingData.post_id,
-      context_page_owner_slug: props.articleSlug,
-      context_page_owner_type: AnalyticsSchema.OwnerType.Article,
-    })
   }
 
   return (

--- a/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
@@ -77,6 +77,17 @@ describe("Display Ad", () => {
     expect(gptProps.slotSize).toEqual([970, 250])
   })
 
+  it("Tracks display ad impression", () => {
+    expect(trackEvent).toBeCalledWith({
+      action_type: "Impression",
+      context_page: "Article",
+      context_module: "AdServer",
+      context_page_owner_type: "Article",
+      context_page_owner_id: StandardArticle.id,
+      context_page_owner_slug: StandardArticle.slug,
+    })
+  })
+
   it("Tracks display ad click", () => {
     const component = mount(
       <DisplayAd
@@ -90,6 +101,7 @@ describe("Display Ad", () => {
     component.at(0).simulate("click")
 
     expect(trackEvent).toBeCalledWith({
+      action_type: "Click",
       context_page: "Article",
       context_module: "AdServer",
       context_page_owner_type: "Article",

--- a/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
@@ -1,3 +1,4 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import {
   DisplayAd,
   DisplayAdProps,
@@ -11,51 +12,89 @@ import { Bling as GPT } from "react-gpt"
 import renderer from "react-test-renderer"
 import { StandardArticleHostedAdCanvas as AdData } from "../../Fixtures/Components"
 
-it("renders the new canvas in standard layout", () => {
-  const component = renderer
-    .create(
+jest.mock("Artsy/Analytics/useTracking")
+
+describe("Display Ad", () => {
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  it("renders the new canvas in standard layout", () => {
+    const component = renderer
+      .create(
+        <DisplayAd
+          adDimension={AdData.adDimension}
+          adUnit={AdData.adUnit}
+          targetingData={targetingData(StandardArticle, "article")}
+          articleSlug={StandardArticle.slug}
+        />
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
+
+  it("renders the component with the correct data and properties in standard layout articles", () => {
+    const ad = mount(
       <DisplayAd
         adDimension={AdData.adDimension}
         adUnit={AdData.adUnit}
         targetingData={targetingData(StandardArticle, "article")}
+        articleSlug={StandardArticle.slug}
       />
     )
-    .toJSON()
-  expect(component).toMatchSnapshot()
-})
 
-it("renders the component with the correct data and properties in standard layout articles", () => {
-  const ad = mount(
-    <DisplayAd
-      adDimension={AdData.adDimension}
-      adUnit={AdData.adUnit}
-      targetingData={targetingData(StandardArticle, "article")}
-    />
-  )
-
-  const adProps: DisplayAdProps = ad.props()
-  expect(adProps.adDimension).toEqual("970x250")
-  expect(adProps.adUnit).toEqual("Desktop_TopLeaderboard")
-  expect(ad).toHaveLength(1)
-})
-
-it("renders GPT with the correct properties in standard layout articles", () => {
-  const ad = mount(
-    <DisplayAd
-      adDimension={AdData.adDimension}
-      adUnit={AdData.adUnit}
-      targetingData={targetingData(StandardArticle, "article")}
-    />
-  )
-
-  const gptComponent = ad.find(GPT)
-  const gptProps: any = gptComponent.props()
-  expect(gptProps.adUnitPath).toEqual("/21805539690/Desktop_TopLeaderboard")
-  expect(gptProps.targeting).toEqual({
-    is_testing: true,
-    page_type: "article",
-    post_id: "594a7e2254c37f00177c0ea9",
-    tags: "Art Market",
+    const adProps: DisplayAdProps = ad.props()
+    expect(adProps.adDimension).toEqual("970x250")
+    expect(adProps.adUnit).toEqual("Desktop_TopLeaderboard")
+    expect(ad).toHaveLength(1)
   })
-  expect(gptProps.slotSize).toEqual([970, 250])
+
+  it("renders GPT with the correct properties in standard layout articles", () => {
+    const ad = mount(
+      <DisplayAd
+        adDimension={AdData.adDimension}
+        adUnit={AdData.adUnit}
+        targetingData={targetingData(StandardArticle, "article")}
+        articleSlug={StandardArticle.slug}
+      />
+    )
+
+    const gptComponent = ad.find(GPT)
+    const gptProps: any = gptComponent.props()
+    expect(gptProps.adUnitPath).toEqual("/21805539690/Desktop_TopLeaderboard")
+    expect(gptProps.targeting).toEqual({
+      is_testing: true,
+      page_type: "article",
+      post_id: "594a7e2254c37f00177c0ea9",
+      tags: "Art Market",
+    })
+    expect(gptProps.slotSize).toEqual([970, 250])
+  })
+
+  it("Tracks display ad click", () => {
+    const component = mount(
+      <DisplayAd
+        adDimension={AdData.adDimension}
+        adUnit={AdData.adUnit}
+        targetingData={targetingData(StandardArticle, "article")}
+        articleSlug={StandardArticle.slug}
+      />
+    )
+
+    component.at(0).simulate("click")
+
+    expect(trackEvent).toBeCalledWith({
+      context_page: "Article",
+      context_module: "AdServer",
+      context_page_owner_type: "Article",
+      context_page_owner_id: StandardArticle.id,
+      context_page_owner_slug: StandardArticle.slug,
+    })
+  })
 })

--- a/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
@@ -10,7 +10,7 @@ import "jest-styled-components"
 import React from "react"
 import { Bling as GPT } from "react-gpt"
 import renderer from "react-test-renderer"
-import { StandardArticleHostedAdCanvas as AdData } from "../../Fixtures/Components"
+import { ArticleDisplayAdProps as AdData } from "../../Fixtures/Components"
 
 jest.mock("Artsy/Analytics/useTracking")
 

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders the new canvas in standard layout 1`] = `
+exports[`Display Ad renders the new canvas in standard layout 1`] = `
 .c1 {
   margin: auto;
 }
@@ -35,6 +35,7 @@ exports[`renders the new canvas in standard layout 1`] = `
 <div
   className="c0"
   height="1px"
+  onClick={[Function]}
 >
   <div
     className="c1"

--- a/src/Components/Publishing/Fixtures/Components.ts
+++ b/src/Components/Publishing/Fixtures/Components.ts
@@ -189,18 +189,8 @@ export const Authors = [
   },
 ]
 
-export const StandardArticleHostedAdPanel: DisplayAdProps = {
-  adUnit: "Desktop_RightRail1" as AdUnit,
-  adDimension: "300x250" as AdDimension,
-  targetingData: {
-    is_testing: true,
-    page_type: "article",
-    post_id: "123",
-    tags: "Art Market",
-  },
-}
-
-export const StandardArticleHostedAdCanvas: DisplayAdProps = {
+export const ArticleDisplayAdProps: DisplayAdProps = {
+  articleSlug: "a-standard-article",
   adUnit: "Desktop_TopLeaderboard" as AdUnit,
   adDimension: "970x250" as AdDimension,
   targetingData: {

--- a/src/Components/Publishing/Layouts/NewsLayout.tsx
+++ b/src/Components/Publishing/Layouts/NewsLayout.tsx
@@ -122,6 +122,7 @@ export class NewsLayout extends Component<Props, State> {
             adUnit={adUnit}
             adDimension={adDimension}
             targetingData={targetingData(article, "newslanding")}
+            articleSlug={article.slug}
           />
         )}
         {relatedArticlesForCanvas && (

--- a/src/Components/Publishing/Layouts/SeriesLayout.tsx
+++ b/src/Components/Publishing/Layouts/SeriesLayout.tsx
@@ -74,6 +74,7 @@ export class SeriesLayout extends Component<Props, null> {
             isSponsored ? "sponsorlanding" : "standardseries"
           )}
           isSeries
+          articleSlug={article.slug}
         />
       </SeriesContainer>
     )

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -65,6 +65,7 @@ export class StandardLayout extends React.Component<
 
   renderSideRailDisplayAd(isMobileAd: boolean) {
     const { article, isSuper } = this.props
+    console.log("TCL: renderSideRailDisplayAd -> article", article.slug)
 
     if (isSuper) {
       return
@@ -81,6 +82,7 @@ export class StandardLayout extends React.Component<
             : AdDimension.Desktop_RightRail1
         }
         targetingData={targetingData(article, "article")}
+        articleSlug={article.slug}
       />
     )
   }
@@ -104,6 +106,7 @@ export class StandardLayout extends React.Component<
         }
         adDimension={adDimension}
         targetingData={targetingData(article, "article")}
+        articleSlug={article.slug}
       />
     )
   }

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -65,7 +65,6 @@ export class StandardLayout extends React.Component<
 
   renderSideRailDisplayAd(isMobileAd: boolean) {
     const { article, isSuper } = this.props
-    console.log("TCL: renderSideRailDisplayAd -> article", article.slug)
 
     if (isSuper) {
       return

--- a/src/Components/Publishing/Layouts/VideoLayout.tsx
+++ b/src/Components/Publishing/Layouts/VideoLayout.tsx
@@ -132,6 +132,7 @@ export class VideoLayout extends Component<Props, State> {
             isSponsored ? "sponsorfeature" : "video"
           )}
           isSeries
+          articleSlug={article.slug}
         />
       </VideoLayoutContainer>
     )

--- a/src/Components/Publishing/Layouts/__tests__/ArticleWithFullScreen.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/ArticleWithFullScreen.test.tsx
@@ -1,3 +1,4 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import {
   FeatureArticle,
   StandardArticle,
@@ -24,6 +25,18 @@ jest.mock(
 jest.mock("Components/Publishing/ToolTip/TooltipsDataLoader", () => ({
   TooltipsData: props => props.children,
 }))
+
+jest.mock("Artsy/Analytics/useTracking")
+
+const trackEvent = jest.fn()
+
+beforeEach(() => {
+  ;(useTracking as jest.Mock).mockImplementation(() => {
+    return {
+      trackEvent,
+    }
+  })
+})
 
 it("indexes and titles images", () => {
   const props = {

--- a/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/FeatureLayout.test.tsx
@@ -1,3 +1,4 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
 import {
   FeatureArticle,
@@ -21,6 +22,16 @@ jest.mock(
     withFullScreen: x => x,
   })
 )
+jest.mock("Artsy/Analytics/useTracking")
+
+const trackEvent = jest.fn()
+beforeEach(() => {
+  ;(useTracking as jest.Mock).mockImplementation(() => {
+    return {
+      trackEvent,
+    }
+  })
+})
 
 it("renders RelatedArticlesCanvas if article is not super or in a series", () => {
   const article = mount(

--- a/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/NewsLayout.test.tsx
@@ -1,3 +1,4 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
 import { NewsArticle } from "Components/Publishing/Fixtures/Articles"
 import { RelatedCanvas } from "Components/Publishing/Fixtures/Components"
@@ -17,6 +18,7 @@ global.fetch = jest.fn(() =>
     json: () => Promise.resolve({}),
   })
 )
+jest.mock("Artsy/Analytics/useTracking")
 
 describe("News Layout", () => {
   const dateNow = Date.now
@@ -128,12 +130,18 @@ describe("News Layout with display ads", () => {
   const getWrapper = (passedProps = props) => {
     return mount(<NewsLayout {...passedProps} />)
   }
+  const trackEvent = jest.fn()
 
   beforeEach(() => {
     props = {
       shouldAdRender: true,
       article: NewsArticle,
     }
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
   })
 
   it("renders the news layout properly with display ads", () => {

--- a/src/Components/Publishing/Layouts/__tests__/SeriesLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/SeriesLayout.test.tsx
@@ -1,3 +1,4 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
 import {
   SeriesArticle,
@@ -11,21 +12,29 @@ import React from "react"
 import renderer from "react-test-renderer"
 import { SeriesLayout } from "../SeriesLayout"
 
-let props
-function renderComponent() {
-  return renderer.create(<SeriesLayout {...props} />)
-}
-function mountComponent() {
-  return mount(<SeriesLayout {...props} />)
-}
+jest.mock("Artsy/Analytics/useTracking")
 
 describe("series layout", () => {
+  const trackEvent = jest.fn()
+  const renderComponent = () => {
+    return renderer.create(<SeriesLayout {...props} />)
+  }
+  const mountComponent = () => {
+    return mount(<SeriesLayout {...props} />)
+  }
+  let props
+
   beforeEach(() => {
     props = {
       article: SeriesArticle,
       relatedArticles: [VideoArticle, StandardArticle],
       isSeries: true,
     }
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
   })
 
   it("renders a series", () => {

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -174,90 +174,90 @@ describe("Standard Article", () => {
         .props().adUnit
     ).toBe("Mobile_InContentMR1")
   })
-})
 
-describe("standard article ad data", () => {
-  it("renders the top rail display ad component with the correct data and properties on standard articles", () => {
-    const ad = mount(
-      <DisplayAd
-        adDimension={AdDimension.Desktop_TopLeaderboard}
-        adUnit={AdUnit.Desktop_TopLeaderboard}
-        targetingData={targetingData(StandardArticle, "article")}
-        articleSlug={StandardArticle.slug}
-      />
-    )
+  describe("Standard Article Display Ads", () => {
+    it("renders the top rail display ad component with the correct data and properties on standard articles", () => {
+      const ad = mount(
+        <DisplayAd
+          adDimension={AdDimension.Desktop_TopLeaderboard}
+          adUnit={AdUnit.Desktop_TopLeaderboard}
+          targetingData={targetingData(StandardArticle, "article")}
+          articleSlug={StandardArticle.slug}
+        />
+      )
 
-    expect(ad.props().adDimension).toEqual("970x250")
-    expect(ad.props().adUnit).toEqual("Desktop_TopLeaderboard")
-    expect(ad.props().targetingData).toEqual({
-      is_testing: true,
-      page_type: "article",
-      post_id: "594a7e2254c37f00177c0ea9",
-      tags: "Art Market",
+      expect(ad.props().adDimension).toEqual("970x250")
+      expect(ad.props().adUnit).toEqual("Desktop_TopLeaderboard")
+      expect(ad.props().targetingData).toEqual({
+        is_testing: true,
+        page_type: "article",
+        post_id: "594a7e2254c37f00177c0ea9",
+        tags: "Art Market",
+      })
+      expect(ad).toHaveLength(1)
     })
-    expect(ad).toHaveLength(1)
-  })
 
-  it("renders the side rail display ad component with the correct data and properties on standard articles", () => {
-    const ad = mount(
-      <DisplayAd
-        adDimension={AdDimension.Desktop_RightRail1}
-        adUnit={AdUnit.Desktop_RightRail1}
-        targetingData={targetingData(StandardArticle, "article")}
-        articleSlug={StandardArticle.slug}
-      />
-    )
+    it("renders the side rail display ad component with the correct data and properties on standard articles", () => {
+      const ad = mount(
+        <DisplayAd
+          adDimension={AdDimension.Desktop_RightRail1}
+          adUnit={AdUnit.Desktop_RightRail1}
+          targetingData={targetingData(StandardArticle, "article")}
+          articleSlug={StandardArticle.slug}
+        />
+      )
 
-    expect(ad.props().adDimension).toEqual("300x250")
-    expect(ad.props().adUnit).toEqual("Desktop_RightRail1")
-    expect(ad.props().targetingData).toEqual({
-      is_testing: true,
-      page_type: "article",
-      post_id: "594a7e2254c37f00177c0ea9",
-      tags: "Art Market",
+      expect(ad.props().adDimension).toEqual("300x250")
+      expect(ad.props().adUnit).toEqual("Desktop_RightRail1")
+      expect(ad.props().targetingData).toEqual({
+        is_testing: true,
+        page_type: "article",
+        post_id: "594a7e2254c37f00177c0ea9",
+        tags: "Art Market",
+      })
+      expect(ad).toHaveLength(1)
     })
-    expect(ad).toHaveLength(1)
-  })
 
-  it("renders the side rail display ad component with the correct data and properties on standard articles on mobile", () => {
-    const ad = mount(
-      <DisplayAd
-        adDimension={AdDimension.Mobile_InContentMR1}
-        adUnit={AdUnit.Mobile_InContentMR1}
-        targetingData={targetingData(StandardArticle, "article")}
-        articleSlug={StandardArticle.slug}
-      />
-    )
+    it("renders the side rail display ad component with the correct data and properties on standard articles on mobile", () => {
+      const ad = mount(
+        <DisplayAd
+          adDimension={AdDimension.Mobile_InContentMR1}
+          adUnit={AdUnit.Mobile_InContentMR1}
+          targetingData={targetingData(StandardArticle, "article")}
+          articleSlug={StandardArticle.slug}
+        />
+      )
 
-    expect(ad.props().adDimension).toEqual("300x50")
-    expect(ad.props().adUnit).toEqual("Mobile_InContentMR1")
-    expect(ad.props().targetingData).toEqual({
-      is_testing: true,
-      page_type: "article",
-      post_id: "594a7e2254c37f00177c0ea9",
-      tags: "Art Market",
+      expect(ad.props().adDimension).toEqual("300x50")
+      expect(ad.props().adUnit).toEqual("Mobile_InContentMR1")
+      expect(ad.props().targetingData).toEqual({
+        is_testing: true,
+        page_type: "article",
+        post_id: "594a7e2254c37f00177c0ea9",
+        tags: "Art Market",
+      })
+      expect(ad).toHaveLength(1)
     })
-    expect(ad).toHaveLength(1)
-  })
 
-  it("renders the top rail display ad component with the correct data and properties on standard articles on mobile", () => {
-    const ad = mount(
-      <DisplayAd
-        adDimension={AdDimension.Mobile_TopLeaderboard}
-        adUnit={AdUnit.Mobile_TopLeaderboard}
-        targetingData={targetingData(StandardArticle, "article")}
-        articleSlug={StandardArticle.slug}
-      />
-    )
+    it("renders the top rail display ad component with the correct data and properties on standard articles on mobile", () => {
+      const ad = mount(
+        <DisplayAd
+          adDimension={AdDimension.Mobile_TopLeaderboard}
+          adUnit={AdUnit.Mobile_TopLeaderboard}
+          targetingData={targetingData(StandardArticle, "article")}
+          articleSlug={StandardArticle.slug}
+        />
+      )
 
-    expect(ad.props().adDimension).toEqual("300x50")
-    expect(ad.props().adUnit).toEqual("Mobile_TopLeaderboard")
-    expect(ad.props().targetingData).toEqual({
-      is_testing: true,
-      page_type: "article",
-      post_id: "594a7e2254c37f00177c0ea9",
-      tags: "Art Market",
+      expect(ad.props().adDimension).toEqual("300x50")
+      expect(ad.props().adUnit).toEqual("Mobile_TopLeaderboard")
+      expect(ad.props().targetingData).toEqual({
+        is_testing: true,
+        page_type: "article",
+        post_id: "594a7e2254c37f00177c0ea9",
+        tags: "Art Market",
+      })
+      expect(ad).toHaveLength(1)
     })
-    expect(ad).toHaveLength(1)
   })
 })

--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -1,3 +1,4 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
 import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
 import {
@@ -25,13 +26,15 @@ jest.mock(
     withFullScreen: x => x,
   })
 )
+jest.mock("Artsy/Analytics/useTracking")
 
 describe("Standard Article", () => {
+  const trackEvent = jest.fn()
   const getWrapper = _props => {
     return mount(<StandardLayout {..._props} />)
   }
-
   let props
+
   beforeEach(() => {
     props = {
       article: StandardArticle,
@@ -39,6 +42,11 @@ describe("Standard Article", () => {
       relatedArticlesForCanvas: RelatedCanvas,
       relatedArticlesForPanel: RelatedPanel,
     }
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
   })
 
   afterEach(() => {
@@ -175,6 +183,7 @@ describe("standard article ad data", () => {
         adDimension={AdDimension.Desktop_TopLeaderboard}
         adUnit={AdUnit.Desktop_TopLeaderboard}
         targetingData={targetingData(StandardArticle, "article")}
+        articleSlug={StandardArticle.slug}
       />
     )
 
@@ -195,6 +204,7 @@ describe("standard article ad data", () => {
         adDimension={AdDimension.Desktop_RightRail1}
         adUnit={AdUnit.Desktop_RightRail1}
         targetingData={targetingData(StandardArticle, "article")}
+        articleSlug={StandardArticle.slug}
       />
     )
 
@@ -215,6 +225,7 @@ describe("standard article ad data", () => {
         adDimension={AdDimension.Mobile_InContentMR1}
         adUnit={AdUnit.Mobile_InContentMR1}
         targetingData={targetingData(StandardArticle, "article")}
+        articleSlug={StandardArticle.slug}
       />
     )
 
@@ -235,6 +246,7 @@ describe("standard article ad data", () => {
         adDimension={AdDimension.Mobile_TopLeaderboard}
         adUnit={AdUnit.Mobile_TopLeaderboard}
         targetingData={targetingData(StandardArticle, "article")}
+        articleSlug={StandardArticle.slug}
       />
     )
 

--- a/src/Components/Publishing/Layouts/__tests__/VideoLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/VideoLayout.test.tsx
@@ -133,6 +133,7 @@ describe("display ad data on video series", () => {
           VideoArticleSponsored,
           isSponsored ? "sponsorlanding" : "video"
         )}
+        articleSlug={VideoArticleSponsored.slug}
       />
     )
 
@@ -160,6 +161,7 @@ describe("display ad data on video series", () => {
           VideoArticleFixture,
           isSponsored ? "sponsorlanding" : "video"
         )}
+        articleSlug={VideoArticleSponsored.slug}
       />
     )
 
@@ -187,6 +189,7 @@ describe("display ad data on video series", () => {
           VideoArticleFixture,
           isSponsored ? "sponsorlanding" : "video"
         )}
+        articleSlug={VideoArticleSponsored.slug}
       />
     )
 
@@ -205,6 +208,7 @@ describe("display ad data on video series", () => {
         adUnit={AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom}
         isSeries
         targetingData={targetingData(VideoArticleFixture, "sponsorlanding")}
+        articleSlug={VideoArticleSponsored.slug}
       />
     )
 

--- a/src/Components/Publishing/Layouts/__tests__/VideoLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/VideoLayout.test.tsx
@@ -1,3 +1,4 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
 import { targetingData } from "Components/Publishing/Display/DisplayTargeting"
 import {
@@ -23,7 +24,19 @@ import React from "react"
 import renderer from "react-test-renderer"
 import { VideoLayout } from "../VideoLayout"
 
+jest.mock("Artsy/Analytics/useTracking")
+
 describe("Video Layout", () => {
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
   const VideoSeriesArticle = clone({
     ...VideoArticle,
     seriesArticle: SeriesArticle,
@@ -87,133 +100,121 @@ describe("Video Layout", () => {
     component.instance().onPlayToggle(false)
     expect(component.state().isPlaying).toBe(false)
   })
-})
 
-describe("Video Layout ads", () => {
-  let props
-  const getWrapper = (passedProps = props) => {
-    return mount(<VideoLayout {...passedProps} />)
-  }
+  describe("Video Layout ads", () => {
+    it("renders the video layout properly with ads", () => {
+      const layout = renderer
+        .create(<VideoLayout article={VideoArticleFixture} />)
+        .toJSON()
+      expect(layout).toMatchSnapshot()
+    })
 
-  beforeEach(() => {
-    props = {
-      article: VideoArticleFixture,
-      isSeries: true,
-    }
-  })
+    it("renders an ad component on video series", () => {
+      const component = getWrapper()
 
-  it("renders the video layout properly with ads", () => {
-    const layout = renderer
-      .create(<VideoLayout article={VideoArticleFixture} />)
-      .toJSON()
-    expect(layout).toMatchSnapshot()
-  })
-
-  it("renders an ad component on video series", () => {
-    const component = getWrapper()
-
-    expect(component.find(DisplayAd).length).toBe(1)
-  })
-})
-
-describe("display ad data on video series", () => {
-  it("renders the component with the correct target properties when video article is sponsored", () => {
-    const isSponsored = isEditorialSponsored(VideoArticleSponsored.sponsor)
-
-    const canvas = mount(
-      <DisplayAd
-        adDimension={
-          AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-        }
-        adUnit={
-          AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-        }
-        isSeries
-        targetingData={targetingData(
-          VideoArticleSponsored,
-          isSponsored ? "sponsorlanding" : "video"
-        )}
-        articleSlug={VideoArticleSponsored.slug}
-      />
-    )
-
-    expect(canvas.props().targetingData).toEqual({
-      is_testing: true,
-      page_type: "sponsorlanding",
-      post_id: "597b9f652d35b80017a2a6a7",
-      tags: "Art Market",
+      expect(component.find(DisplayAd).length).toBe(1)
     })
   })
 
-  it("renders the component with the correct target properties when video article is not sponsored", () => {
-    const isSponsored = isEditorialSponsored(VideoArticleFixture.sponsor)
+  describe("display ad data on video series", () => {
+    it("renders the component with the correct target properties when video article is sponsored", () => {
+      const isSponsored = isEditorialSponsored(VideoArticleSponsored.sponsor)
 
-    const canvas = mount(
-      <DisplayAd
-        adDimension={
-          AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-        }
-        adUnit={
-          AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-        }
-        isSeries
-        targetingData={targetingData(
-          VideoArticleFixture,
-          isSponsored ? "sponsorlanding" : "video"
-        )}
-        articleSlug={VideoArticleSponsored.slug}
-      />
-    )
+      const canvas = mount(
+        <DisplayAd
+          adDimension={
+            AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
+          }
+          adUnit={
+            AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
+          }
+          isSeries
+          targetingData={targetingData(
+            VideoArticleSponsored,
+            isSponsored ? "sponsorlanding" : "video"
+          )}
+          articleSlug={VideoArticleSponsored.slug}
+        />
+      )
 
-    expect(canvas.props().targetingData).toEqual({
-      is_testing: true,
-      page_type: "video",
-      post_id: "597b9f652d35b80017a2a6a7",
-      tags: "Art Market",
+      expect(canvas.props().targetingData).toEqual({
+        is_testing: true,
+        page_type: "sponsorlanding",
+        post_id: "597b9f652d35b80017a2a6a7",
+        tags: "Art Market",
+      })
     })
-  })
 
-  it("renders the component with the correct data and properties on video landing pages on desktop", () => {
-    const isSponsored = isEditorialSponsored(VideoArticleFixture.sponsor)
+    it("renders the component with the correct target properties when video article is not sponsored", () => {
+      const isSponsored = isEditorialSponsored(VideoArticleFixture.sponsor)
 
-    const canvas = mount(
-      <DisplayAd
-        adDimension={
-          AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-        }
-        adUnit={
-          AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-        }
-        isSeries
-        targetingData={targetingData(
-          VideoArticleFixture,
-          isSponsored ? "sponsorlanding" : "video"
-        )}
-        articleSlug={VideoArticleSponsored.slug}
-      />
-    )
+      const canvas = mount(
+        <DisplayAd
+          adDimension={
+            AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
+          }
+          adUnit={
+            AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
+          }
+          isSeries
+          targetingData={targetingData(
+            VideoArticleFixture,
+            isSponsored ? "sponsorlanding" : "video"
+          )}
+          articleSlug={VideoArticleSponsored.slug}
+        />
+      )
 
-    expect(canvas.props().adDimension).toEqual("970x250")
-    expect(canvas.props().adUnit).toEqual("Desktop_InContentLB2")
+      expect(canvas.props().targetingData).toEqual({
+        is_testing: true,
+        page_type: "video",
+        post_id: "597b9f652d35b80017a2a6a7",
+        tags: "Art Market",
+      })
+    })
 
-    expect(canvas).toHaveLength(1)
-  })
+    it("renders the component with the correct data and properties on video landing pages on desktop", () => {
+      const isSponsored = isEditorialSponsored(VideoArticleFixture.sponsor)
 
-  it("renders the component with the correct data and properties on series landing pages on mobile", () => {
-    const canvas = mount(
-      <DisplayAd
-        adDimension={
-          AdDimension.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
-        }
-        adUnit={AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom}
-        isSeries
-        targetingData={targetingData(VideoArticleFixture, "sponsorlanding")}
-        articleSlug={VideoArticleSponsored.slug}
-      />
-    )
+      const canvas = mount(
+        <DisplayAd
+          adDimension={
+            AdDimension.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
+          }
+          adUnit={
+            AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
+          }
+          isSeries
+          targetingData={targetingData(
+            VideoArticleFixture,
+            isSponsored ? "sponsorlanding" : "video"
+          )}
+          articleSlug={VideoArticleSponsored.slug}
+        />
+      )
 
-    expect(canvas.props().adDimension).toEqual("300x250")
-    expect(canvas.props().adUnit).toEqual("Mobile_InContentLB2")
-    expect(canvas).toHaveLength(1)
+      expect(canvas.props().adDimension).toEqual("970x250")
+      expect(canvas.props().adUnit).toEqual("Desktop_InContentLB2")
+
+      expect(canvas).toHaveLength(1)
+    })
+
+    it("renders the component with the correct data and properties on series landing pages on mobile", () => {
+      const canvas = mount(
+        <DisplayAd
+          adDimension={
+            AdDimension.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
+          }
+          adUnit={AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom}
+          isSeries
+          targetingData={targetingData(VideoArticleFixture, "sponsorlanding")}
+          articleSlug={VideoArticleSponsored.slug}
+        />
+      )
+
+      expect(canvas.props().adDimension).toEqual("300x250")
+      expect(canvas.props().adUnit).toEqual("Mobile_InContentLB2")
+      expect(canvas).toHaveLength(1)
+    })
   })
 })

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
@@ -2866,6 +2866,7 @@ exports[`News Layout with display ads renders the news layout properly with disp
   <div
     className="c23"
     height="1px"
+    onClick={[Function]}
   >
     <div
       className="c24"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1577,6 +1577,7 @@ exports[`series layout renders a series 1`] = `
   <div
     className="c42"
     height="1px"
+    onClick={[Function]}
   >
     <div
       className="c43"
@@ -3351,6 +3352,7 @@ exports[`series layout renders a sponsored series 1`] = `
   <div
     className="c50"
     height="1px"
+    onClick={[Function]}
   >
     <div
       className="c51"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video Layout ads renders the video layout properly with ads 1`] = `
+exports[`Video Layout Video Layout ads renders the video layout properly with ads 1`] = `
 .c31 {
   max-width: 1200px;
   margin-left: auto;
@@ -1624,6 +1624,7 @@ exports[`Video Layout ads renders the video layout properly with ads 1`] = `
   <div
     className="c56"
     height="1px"
+    onClick={[Function]}
   >
     <div
       className="c57"
@@ -4305,6 +4306,7 @@ exports[`Video Layout matches the snapshot 1`] = `
   <div
     className="c83"
     height="1px"
+    onClick={[Function]}
   >
     <div
       className="c84"

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -318,6 +318,7 @@ export class Sections extends Component<Props, State> {
                 article,
                 isSponsored ? "sponsorfeature" : "feature"
               )}
+              articleSlug={article.slug}
             />
           </AdWrapper>
         )

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
@@ -1,3 +1,4 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { DisplayAd } from "Components/Publishing/Display/DisplayAd"
 import {
   FeatureArticle,
@@ -31,6 +32,8 @@ jest.mock("react-dom/server", () => ({
   renderToStaticMarkup: x => x,
 }))
 
+jest.mock("Artsy/Analytics/useTracking")
+
 declare const global: any
 const renderSnapshot = props => {
   return renderer
@@ -43,15 +46,22 @@ const mountWrapper = props => {
 }
 
 describe("Sections", () => {
+  const trackEvent = jest.fn()
+
   let props
-  beforeEach(
-    () =>
-      (props = {
-        article: StandardArticle,
-        DisplayPanel: () => <div>hi!</div>,
-        isMobile: true,
-      })
-  )
+
+  beforeEach(() => {
+    props = {
+      article: StandardArticle,
+      DisplayPanel: () => <div>hi!</div>,
+      isMobile: true,
+    }
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
 
   describe("snapshots tests", () => {
     it("renders properly", () => {

--- a/src/Components/Publishing/__tests__/Article.test.tsx
+++ b/src/Components/Publishing/__tests__/Article.test.tsx
@@ -1,7 +1,10 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { mount, shallow } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import { Article } from "../Article"
+import { BannerWrapper } from "../Banner/Banner"
+import { PixelTracker } from "../Display/ExternalTrackers"
 import {
   FeatureArticle,
   NewsArticle,
@@ -10,9 +13,6 @@ import {
   StandardArticle,
   VideoArticle,
 } from "../Fixtures/Articles"
-
-import { BannerWrapper } from "../Banner/Banner"
-import { PixelTracker } from "../Display/ExternalTrackers"
 import { ArticleWithFullScreen } from "../Layouts/ArticleWithFullScreen"
 import { NewsLayout } from "../Layouts/NewsLayout"
 import { SeriesLayout } from "../Layouts/SeriesLayout"
@@ -31,6 +31,17 @@ global.fetch = jest.fn(() =>
 jest.mock("../ToolTip/TooltipsDataLoader", () => ({
   TooltipsData: props => props.children,
 }))
+jest.mock("Artsy/Analytics/useTracking")
+
+const trackEvent = jest.fn()
+
+beforeEach(() => {
+  ;(useTracking as jest.Mock).mockImplementation(() => {
+    return {
+      trackEvent,
+    }
+  })
+})
 
 it("renders standard articles in fullscreen layout", () => {
   const article = mount(<Article article={StandardArticle} />)


### PR DESCRIPTION
[Ad Server Analytics Tracking--GROW-1545](https://artsyproduct.atlassian.net/browse/GROW-1545)


Adds click and impression tracking to ads being served through the 3rd party ad server.