### PR TITLE
Moved artist insights to the right PURCHASE-1608

### DIFF
--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -18,7 +18,6 @@ import { TrackingProp } from "react-tracking"
 import { get } from "Utils/get"
 import { ArtistArtworkFilterRefetchContainer as ArtworkFilter } from "./Components/ArtistArtworkFilter"
 import { ArtistRecommendationsQueryRenderer as ArtistRecommendations } from "./Components/ArtistRecommendations"
-import { CurrentEventFragmentContainer as CurrentEvent } from "./Components/CurrentEvent"
 
 export interface OverviewRouteProps {
   artist: Overview_artist
@@ -49,16 +48,9 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
     const showArtistInsights =
       showMarketInsights(this.props.artist) || artist.insights.length > 0
     const showArtistBio = Boolean(artist.biography_blurb.text)
-    const showCurrentEvent = Boolean(artist.currentEvent)
     const showConsignable = Boolean(artist.is_consignable)
     const hideMainOverviewSection =
-      !showArtistInsights &&
-      !showArtistBio &&
-      !showCurrentEvent &&
-      !showConsignable
-
-    // TODO: Hide right column if missing current event. Waiting on feedback
-    const colNum = 9 // artist.currentEvent ? 9 : 12
+      !showArtistInsights && !showArtistBio && !showConsignable
 
     const isClient = typeof window !== "undefined"
     const showRecommendations =
@@ -66,7 +58,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
     return (
       <>
         <Row>
-          <Col sm={colNum}>
+          <Col sm={9}>
             <>
               {showArtistBio && (
                 <>
@@ -98,19 +90,13 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
                   </Sans>
                 </>
               )}
-              {showArtistInsights && (
-                <>
-                  <Spacer mb={2} />
-                  <SelectedCareerAchievements artist={artist} />
-                </>
-              )}
             </>
           </Col>
 
-          {showCurrentEvent && (
+          {showArtistInsights && (
             <Col sm={3}>
               <Box pl={2}>
-                <CurrentEvent artist={artist} />
+                <SelectedCareerAchievements artist={artist} />
               </Box>
             </Col>
           )}

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -58,7 +58,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
     return (
       <>
         <Row>
-          <Col sm={9}>
+          <Col sm={8}>
             <>
               {showArtistBio && (
                 <>
@@ -94,7 +94,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
           </Col>
 
           {showArtistInsights && (
-            <Col sm={3}>
+            <Col sm={4}>
               <Box pl={2}>
                 <SelectedCareerAchievements artist={artist} />
               </Box>

--- a/src/Components/v2/ArtistInsight.tsx
+++ b/src/Components/v2/ArtistInsight.tsx
@@ -93,7 +93,7 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
 
     if (value || (entities && entities.length > 0)) {
       return (
-        <Flex mt={1} width={["100%", "48%"]}>
+        <Flex mt={1} width={"100%"}>
           <Flex pr={1}>{this.renderIcon(type)}</Flex>
           <Flex flexDirection="column">
             <Box>

--- a/src/Components/v2/SelectedCareerAchievements.tsx
+++ b/src/Components/v2/SelectedCareerAchievements.tsx
@@ -117,7 +117,7 @@ export class SelectedCareerAchievements extends React.Component<
               Selected career achievements
             </Sans>
             <Flex
-              flexDirection="row"
+              flexDirection="column"
               flexWrap="wrap"
               justifyContent="space-between"
             >


### PR DESCRIPTION
# Change
https://artsyproduct.atlassian.net/browse/PURCHASE-1608
-  Move Artist Insights to the right side of bio
- Remove current events

# Selfie
![image](https://user-images.githubusercontent.com/1230819/68128376-99a1e280-fee5-11e9-9708-d952948f5875.png)

cc: @samchieng
 