### PR TITLE
Safe access to artwork image in `ArtworkSummaryItem`

### DIFF
--- a/src/Apps/Order/Components/ArtworkSummaryItem.tsx
+++ b/src/Apps/Order/Components/ArtworkSummaryItem.tsx
@@ -27,15 +27,12 @@ const ArtworkSummaryItem: React.SFC<ArtworkSummaryItemProps> = ({
 }) => {
   const artwork = get({}, props => lineItems.edges[0].node.artwork)
 
-  const {
-    artist_names,
-    title,
-    date,
-    shippingOrigin,
-    image: {
-      resized_ArtworkSummaryItem: { url: imageURL },
-    },
-  } = artwork
+  const { artist_names, title, date, shippingOrigin, image } = artwork
+
+  const imageURL =
+    image &&
+    image.resized_ArtworkSummaryItem &&
+    image.resized_ArtworkSummaryItem.url
 
   const truncateTextStyle = {
     whiteSpace: "nowrap",
@@ -46,7 +43,7 @@ const ArtworkSummaryItem: React.SFC<ArtworkSummaryItemProps> = ({
   return (
     <StackableBorderBox flexDirection="row" {...others}>
       <Box height="auto">
-        <Image src={imageURL} width="55px" mr={1} />
+        {imageURL && <Image src={imageURL} width="55px" mr={1} />}
       </Box>
       <Flex flexDirection="column" style={{ overflow: "hidden" }}>
         <Serif


### PR DESCRIPTION
to prevent integrity tests failing because of slow staging gemini

Fixes [PURCHASE-1620](https://artsyproduct.atlassian.net/browse/PURCHASE-1620)

without image URL:

<img width="334" alt="Screen Shot 2019-11-04 at 1 16 27 PM" src="https://user-images.githubusercontent.com/687513/68146768-b26ec000-ff06-11e9-80f9-819299ee0c56.png">
