### PR TITLE
[GROW-1639] close collection hubs entry points a/b test on the collect page

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -19,7 +19,6 @@ const {
   ADMIN_URL,
   APP_URL,
   CI,
-  COLLECTION_HUB_ENTRYPOINTS_TEST,
   CMS_URL,
   FACEBOOK_APP_NAMESPACE,
   PREDICTION_URL,
@@ -51,7 +50,6 @@ const notOnCI = value => (isCI ? [] : [value])
 const sharifyPath = sharify({
   ADMIN_URL,
   APP_URL,
-  COLLECTION_HUB_ENTRYPOINTS_TEST,
   CMS_URL,
   FACEBOOK_APP_NAMESPACE,
   FORCE_CLOUDFRONT_URL,

--- a/src/Apps/Collect2/Routes/Collect/index.tsx
+++ b/src/Apps/Collect2/Routes/Collect/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Separator, Serif, Spacer } from "@artsy/palette"
 import { Location, Router } from "found"
-import React, { useEffect } from "react"
+import React from "react"
 import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -18,12 +18,10 @@ import { getMetadataForMedium } from "./Components/CollectMediumMetadata"
 
 import { Collect_marketingHubCollections } from "__generated__/Collect_marketingHubCollections.graphql"
 import { collectRoutes_ArtworkFilterQueryResponse } from "__generated__/collectRoutes_ArtworkFilterQuery.graphql"
-import { useSystemContext } from "Artsy"
 import { ArtworkFilter } from "Components/v2/ArtworkFilter"
 import { CollectionsHubsNavFragmentContainer as CollectionsHubsNav } from "Components/v2/CollectionsHubsNav"
 
 export interface CollectAppProps {
-  COLLECTION_HUB_ENTRYPOINTS_TEST?: string
   location: Location
   router: Router
   marketingHubCollections: Collect_marketingHubCollections
@@ -42,29 +40,9 @@ export const CollectApp = track({
   const { description, breadcrumbTitle, title } = getMetadataForMedium(medium)
   const { trackEvent } = useTracking()
 
-  // FIXME: Remove after A/B test completes
-  // @ts-ignore
-  const { COLLECTION_HUB_ENTRYPOINTS_TEST } = useSystemContext()
-
-  useEffect(() => {
-    const experiment = "collection_hub_entrypoints_test"
-    trackEvent({
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: COLLECTION_HUB_ENTRYPOINTS_TEST,
-      variation_name: COLLECTION_HUB_ENTRYPOINTS_TEST,
-      nonInteraction: 1,
-    })
-  }, [])
-
   const canonicalHref = medium
     ? `${sd.APP_URL}/collect/${medium}`
     : `${sd.APP_URL}/collect`
-
-  // Client renders will get COLLECTION_HUB_ENTRYPOINTS_TEST from sd; server renders
-  // will get it from the SystemContext.
-  const showCollectionHubs = COLLECTION_HUB_ENTRYPOINTS_TEST === "experiment"
 
   const { filterArtworks } = props
 
@@ -100,15 +78,11 @@ export const CollectApp = track({
           </Serif>
           <Separator mt={2} mb={[2, 2, 2, 4]} />
 
-          {showCollectionHubs && (
-            <>
-              <CollectionsHubsNav
-                marketingHubCollections={props.marketingHubCollections}
-              />
+          <CollectionsHubsNav
+            marketingHubCollections={props.marketingHubCollections}
+          />
 
-              <Spacer mb={2} mt={[2, 2, 2, 4]} />
-            </>
-          )}
+          <Spacer mb={2} mt={[2, 2, 2, 4]} />
         </Box>
 
         <Box>

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -20,7 +20,6 @@ declare module "sharify" {
       readonly APP_URL: string
       readonly ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test
       readonly ARTIST_COLLECTIONS_RAIL_IDS: string[]
-      readonly COLLECTION_HUB_ENTRYPOINTS_TEST: string
       readonly CMS_URL: string
       readonly FACEBOOK_APP_NAMESPACE: string
       readonly FACEBOOK_ID: string


### PR DESCRIPTION
Addresses: [GROW-1639](https://artsyproduct.atlassian.net/browse/GROW-1639)

This removes a/b test logic for the collection hubs entry points on the collect page and rolls the entry points out to 100%. Related to https://github.com/artsy/force/pull/4779.