### PR TITLE
Re-enable storybooks

### DIFF
--- a/src/__stories__/storiesOf.js
+++ b/src/__stories__/storiesOf.js
@@ -1,8 +1,8 @@
 import React from "react"
 import { storiesOf as _storiesOf } from "@storybook/react"
 import { Boot } from "Artsy/Router"
-import track from "react-tracking"
-import Events from "../Utils/Events"
+// import track from "react-tracking"
+// import Events from "../Utils/Events"
 
 const bootProps = {
   mediator: x => x,
@@ -14,13 +14,14 @@ export function storiesOf(desc, mod) {
   })
 }
 
+// FIXME: breaks storybooks with mp v2, update to use artsy analytics
 // Wrap publishing sub-component stories so tracking events log
-@track(
-  {},
-  {
-    dispatch: data => Events.postEvent(data),
-  }
-)
+// @track(
+//   {},
+//   {
+//     dispatch: data => Events.postEvent(data),
+//   }
+// )
 class PublishingBoot extends React.Component {
   render() {
     return this.props.children


### PR DESCRIPTION
Comment out analytics tracking in publishing storybooks for now, which breaks entire storybook tree. 