### PR TITLE
User should be redirected to artwork page after confirmation that a bid is winning

### DIFF
--- a/src/Apps/Auction/Routes/ConfirmBid/BidderPositionQuery.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/BidderPositionQuery.tsx
@@ -1,0 +1,33 @@
+import {
+  BidderPositionQueryResponse,
+  BidderPositionQueryVariables,
+} from "__generated__/BidderPositionQuery.graphql"
+import { graphql } from "react-relay"
+import { Environment, fetchQuery } from "relay-runtime"
+
+export const bidderPositionQuery = (
+  environment: Environment,
+  variables: BidderPositionQueryVariables
+) => {
+  return fetchQuery<BidderPositionQueryResponse>(
+    environment,
+    graphql`
+      query BidderPositionQuery($bidderPositionID: String!) {
+        me {
+          bidderPosition: bidder_position(id: $bidderPositionID) {
+            status
+            messageHeader: message_header
+            position {
+              id
+              suggestedNextBid: suggested_next_bid {
+                cents
+                display
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables
+  )
+}

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -227,9 +227,6 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
 
       <Box maxWidth={550} px={[2, 0]} mx="auto" mt={[1, 0]} mb={[1, 100]}>
         <Serif size="8">Confirm your bid</Serif>
-        <Serif size="8">
-          This is a release of reaction off of `auct-pt-master`.
-        </Serif>
 
         <Separator />
 

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -42,7 +42,7 @@ const MAX_POLL_ATTEMPTS = 20
 export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   let pollCount = 0
 
-  const { artwork, relay } = props
+  const { artwork, me, relay } = props
   const { saleArtwork } = artwork
   const { sale } = saleArtwork
 
@@ -224,19 +224,25 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   return (
     <AppContainer>
       <Title>Confirm Bid | Artsy</Title>
+
       <Box maxWidth={550} px={[2, 0]} mx="auto" mt={[1, 0]} mb={[1, 100]}>
         <Serif size="8">Confirm your bid</Serif>
         <Serif size="8">
           This is a release of reaction off of `auct-pt-master`.
         </Serif>
+
         <Separator />
+
         <LotInfo artwork={artwork} saleArtwork={artwork.saleArtwork} />
+
         <Separator />
+
         <BidForm
           initialSelectedBid={getInitialSelectedBid(props.location)}
           showPricingTransparency={false}
           saleArtwork={saleArtwork}
           onSubmit={handleSubmit}
+          me={me}
         />
       </Box>
     </AppContainer>

--- a/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
+++ b/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
@@ -1,3 +1,4 @@
+import { BidderPositionQueryResponse } from "__generated__/BidderPositionQuery.graphql"
 import { ConfirmBidCreateBidderPositionMutationResponse } from "__generated__/ConfirmBidCreateBidderPositionMutation.graphql"
 
 export const createBidderPositionSuccessful: ConfirmBidCreateBidderPositionMutationResponse = {
@@ -20,6 +21,32 @@ export const createBidderPositionFailed: ConfirmBidCreateBidderPositionMutationR
       status: "FAILED",
       message_header: "The `createBidderPosition` mutation failed.",
       message_description_md: null,
+    },
+  },
+}
+
+export const confirmBidBidderPositionQueryWithWinning: BidderPositionQueryResponse = {
+  me: {
+    bidderPosition: {
+      status: "WINNING",
+      messageHeader: null,
+      position: {
+        id: "winning-bidder-position-id-from-polling",
+        suggestedNextBid: null,
+      },
+    },
+  },
+}
+
+export const confirmBidBidderPositionQueryWithPending: BidderPositionQueryResponse = {
+  me: {
+    bidderPosition: {
+      status: "PENDING",
+      messageHeader: null,
+      position: {
+        id: "pending-bidder-position-id-from-polling",
+        suggestedNextBid: null,
+      },
     },
   },
 }

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -1,3 +1,7 @@
+jest.mock("Apps/Auction/Routes/ConfirmBid/BidderPositionQuery", () => ({
+  bidderPositionQuery: jest.fn(),
+}))
+
 import deepMerge from "deepmerge"
 import { createTestEnv } from "DevTools/createTestEnv"
 import React from "react"
@@ -5,9 +9,12 @@ import { graphql } from "react-relay"
 
 import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
 import { ConfirmBidQueryResponseFixture } from "Apps/Auction/__fixtures__/routes_ConfirmBidQuery"
+import { bidderPositionQuery } from "Apps/Auction/Routes/ConfirmBid/BidderPositionQuery"
 import { AnalyticsSchema } from "Artsy/Analytics"
 import { TrackingProp } from "react-tracking"
 import {
+  confirmBidBidderPositionQueryWithPending,
+  confirmBidBidderPositionQueryWithWinning,
   createBidderPositionFailed,
   createBidderPositionSuccessful,
 } from "../__fixtures__/MutationResults/createBidderPosition"
@@ -19,6 +26,7 @@ jest.unmock("react-tracking")
 jest.mock("Utils/Events", () => ({
   postEvent: jest.fn(),
 }))
+const mockBidderPositionQuery = bidderPositionQuery as jest.Mock
 const mockPostEvent = require("Utils/Events").postEvent as jest.Mock
 
 jest.mock("sharify", () => ({
@@ -93,11 +101,14 @@ describe("Routes/ConfirmBid", () => {
     jest.resetAllMocks()
   })
 
-  it("successfully places a bid and redirect to artwork page", async () => {
+  it("successfully places a bid and redirect to artwork page", async done => {
     const env = setupTestEnv()
     const page = await env.buildPage()
 
     env.mutations.useResultsOnce(createBidderPositionSuccessful)
+    mockBidderPositionQuery.mockResolvedValue(
+      confirmBidBidderPositionQueryWithPending
+    )
 
     await page.agreeToTerms()
     await page.submitForm()
@@ -115,40 +126,64 @@ describe("Routes/ConfirmBid", () => {
       }
     )
 
-    expect(window.location.assign).toHaveBeenCalledWith(
-      `https://example.com/auction/${
-        ConfirmBidQueryResponseFixture.artwork.saleArtwork.sale.id
-      }/artwork/${ConfirmBidQueryResponseFixture.artwork.id}`
+    expect(mockBidderPositionQuery).toHaveBeenCalledTimes(1)
+    expect(mockBidderPositionQuery.mock.calls[0][1]).toEqual({
+      bidderPositionID: "positionid",
+    })
+
+    mockBidderPositionQuery.mockReset()
+    mockBidderPositionQuery.mockResolvedValue(
+      confirmBidBidderPositionQueryWithWinning
     )
+
+    setTimeout(() => {
+      expect(mockBidderPositionQuery).toHaveBeenCalledTimes(1)
+      expect(mockBidderPositionQuery.mock.calls[0][1]).toEqual({
+        bidderPositionID: "pending-bidder-position-id-from-polling",
+      })
+
+      expect(window.location.assign).toHaveBeenCalledWith(
+        `https://example.com/artwork/${
+          ConfirmBidQueryResponseFixture.artwork.id
+        }`
+      )
+      done()
+    }, 1001)
   })
 
-  it("tracks a success event to Segment including Criteo info", async () => {
+  it("tracks a success event to Segment including Criteo info", async done => {
     const env = setupTestEnv()
     const page = await env.buildPage()
     env.mutations.useResultsOnce(createBidderPositionSuccessful)
+    mockBidderPositionQuery.mockResolvedValue(
+      confirmBidBidderPositionQueryWithWinning
+    )
 
     await page.agreeToTerms()
     await page.submitForm()
 
-    expect(mockPostEvent).toBeCalledWith({
-      action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
-      context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
-      auction_slug: "saleslug",
-      artwork_slug: "artworkslug",
-      bidder_id: "bidderid",
-      bidder_position_id: "positionid",
-      sale_id: "saleid",
-      user_id: "my-user-id",
-      order_id: "bidderid",
-      products: [
-        {
-          product_id: "artworkid",
-          quantity: 1,
-          price: 50000,
-        },
-      ],
-    })
-    expect(mockPostEvent).toHaveBeenCalledTimes(1)
+    setTimeout(() => {
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toHaveBeenCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "bidderid",
+        bidder_position_id: "winning-bidder-position-id-from-polling",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+        order_id: "bidderid",
+        products: [
+          {
+            product_id: "artworkid",
+            quantity: 1,
+            price: 50000,
+          },
+        ],
+      })
+      done()
+    }, 1001)
   })
 
   it("send an error event to analytics if the mutation fails", async () => {
@@ -216,10 +251,12 @@ describe("Routes/ConfirmBid", () => {
           },
         }),
       })
+
       expect(page.selectBidAmountInput.props().value).toBe(
         specialSelectedBidAmount
       )
     })
+
     it("pre-fills the bid select box with the highest increment if the value is higher than what is available", async () => {
       const specialSelectedBidAmount = "42000000"
       const search = `?bid=${specialSelectedBidAmount}`
@@ -237,8 +274,10 @@ describe("Routes/ConfirmBid", () => {
           },
         }),
       })
+
       expect(page.selectBidAmountInput.props().value).toBe("5000000")
     })
+
     it("pre-fills the bid select box with the lowest increment if the value is lower than what is available", async () => {
       const specialSelectedBidAmount = "420000"
       const search = `?bid=${specialSelectedBidAmount}`
@@ -256,6 +295,7 @@ describe("Routes/ConfirmBid", () => {
           },
         }),
       })
+
       expect(page.selectBidAmountInput.props().value).toBe("5000000")
     })
 

--- a/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
@@ -17,7 +17,8 @@ export interface ConfirmBidQueryResponse
 export const ConfirmBidQueryResponseFixture: ConfirmBidQueryResponse = {
   me: {
     id: "my-user-id",
-    has_qualified_credit_cards: false,
+    has_qualified_credit_cards: true,
+    " $fragmentRefs": null as never,
   },
   artwork: {
     " $fragmentRefs": null as never,
@@ -54,6 +55,7 @@ export const ConfirmBidQueryResponseFixture: ConfirmBidQueryResponse = {
         registrationStatus: {
           id: "bidderid",
           qualified_for_bidding: true,
+          qualifiedForBidding: true,
         },
       },
     },

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -53,6 +53,7 @@ export const routes: RouteConfig[] = [
           }
         }
         me {
+          ...BidForm_me
           id
           has_qualified_credit_cards
         }

--- a/src/DevTools/createTestEnv.tsx
+++ b/src/DevTools/createTestEnv.tsx
@@ -75,6 +75,10 @@ class TestEnv<MutationNames extends string, TestPage extends RootTestPage> {
       {} as any
     )
 
+    beforeEach(() => {
+      this.errors = []
+    })
+
     afterEach(() => {
       const _errors = this.errors
       this.errors = []

--- a/src/__generated__/BidForm_me.graphql.ts
+++ b/src/__generated__/BidForm_me.graphql.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+declare const _BidForm_me$ref: unique symbol;
+export type BidForm_me$ref = typeof _BidForm_me$ref;
+export type BidForm_me = {
+    readonly hasQualifiedCreditCards: boolean | null;
+    readonly " $refType": BidForm_me$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "BidForm_me",
+  "type": "Me",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": "hasQualifiedCreditCards",
+      "name": "has_qualified_credit_cards",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "__id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '7f8137c88b31245f0b14d6df94c90179';
+export default node;

--- a/src/__generated__/BidForm_saleArtwork.graphql.ts
+++ b/src/__generated__/BidForm_saleArtwork.graphql.ts
@@ -11,6 +11,11 @@ export type BidForm_saleArtwork = {
         readonly cents: number | null;
         readonly display: string | null;
     }) | null> | null;
+    readonly sale: ({
+        readonly registrationStatus: ({
+            readonly qualifiedForBidding: boolean | null;
+        }) | null;
+    }) | null;
     readonly " $refType": BidForm_saleArtwork$ref;
 };
 
@@ -21,6 +26,13 @@ var v0 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cents",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
   "args": null,
   "storageKey": null
 };
@@ -70,14 +82,39 @@ return {
       ]
     },
     {
-      "kind": "ScalarField",
+      "kind": "LinkedField",
       "alias": null,
-      "name": "__id",
+      "name": "sale",
+      "storageKey": null,
       "args": null,
-      "storageKey": null
-    }
+      "concreteType": "Sale",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "registrationStatus",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Bidder",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": "qualifiedForBidding",
+              "name": "qualified_for_bidding",
+              "args": null,
+              "storageKey": null
+            },
+            v1
+          ]
+        },
+        v1
+      ]
+    },
+    v1
   ]
 };
 })();
-(node as any).hash = 'f63146f06b2eeaabe48250b3d9b72cac';
+(node as any).hash = '2b29986a93e0cc4abb6c031f75b05cd1';
 export default node;

--- a/src/__generated__/BidderPositionQuery.graphql.ts
+++ b/src/__generated__/BidderPositionQuery.graphql.ts
@@ -1,0 +1,181 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type BidderPositionQueryVariables = {
+    readonly bidderPositionID: string;
+};
+export type BidderPositionQueryResponse = {
+    readonly me: ({
+        readonly bidderPosition: ({
+            readonly status: string;
+            readonly messageHeader: string | null;
+            readonly position: ({
+                readonly id: string;
+                readonly suggestedNextBid: ({
+                    readonly cents: number | null;
+                    readonly display: string | null;
+                }) | null;
+            }) | null;
+        }) | null;
+    }) | null;
+};
+export type BidderPositionQuery = {
+    readonly response: BidderPositionQueryResponse;
+    readonly variables: BidderPositionQueryVariables;
+};
+
+
+
+/*
+query BidderPositionQuery(
+  $bidderPositionID: String!
+) {
+  me {
+    bidderPosition: bidder_position(id: $bidderPositionID) {
+      status
+      messageHeader: message_header
+      position {
+        id
+        suggestedNextBid: suggested_next_bid {
+          cents
+          display
+        }
+        __id
+      }
+    }
+    __id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "bidderPositionID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__id",
+  "args": null,
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "me",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "Me",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": "bidderPosition",
+        "name": "bidder_position",
+        "storageKey": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "id",
+            "variableName": "bidderPositionID",
+            "type": "String!"
+          }
+        ],
+        "concreteType": "BidderPositionResult",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "status",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": "messageHeader",
+            "name": "message_header",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "position",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "BidderPosition",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": "suggestedNextBid",
+                "name": "suggested_next_bid",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "BidderPositionSuggestedNextBid",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cents",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "display",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              v1
+            ]
+          }
+        ]
+      },
+      v1
+    ]
+  }
+];
+return {
+  "kind": "Request",
+  "operationKind": "query",
+  "name": "BidderPositionQuery",
+  "id": null,
+  "text": "query BidderPositionQuery(\n  $bidderPositionID: String!\n) {\n  me {\n    bidderPosition: bidder_position(id: $bidderPositionID) {\n      status\n      messageHeader: message_header\n      position {\n        id\n        suggestedNextBid: suggested_next_bid {\n          cents\n          display\n        }\n        __id\n      }\n    }\n    __id\n  }\n}\n",
+  "metadata": {},
+  "fragment": {
+    "kind": "Fragment",
+    "name": "BidderPositionQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": v0,
+    "selections": v2
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "BidderPositionQuery",
+    "argumentDefinitions": v0,
+    "selections": v2
+  }
+};
+})();
+(node as any).hash = '2b78470f9530768f48359c5a407ca3f4';
+export default node;

--- a/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
+++ b/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
+import { BidForm_me$ref } from "./BidForm_me.graphql";
 import { BidForm_saleArtwork$ref } from "./BidForm_saleArtwork.graphql";
 import { LotInfo_artwork$ref } from "./LotInfo_artwork.graphql";
 import { LotInfo_saleArtwork$ref } from "./LotInfo_saleArtwork.graphql";
@@ -30,6 +31,7 @@ export type ConfirmBidValidTestQueryResponse = {
     readonly me: ({
         readonly id: string;
         readonly has_qualified_credit_cards: boolean | null;
+        readonly " $fragmentRefs": BidForm_me$ref;
     }) | null;
 };
 export type ConfirmBidValidTestQuery = {
@@ -68,6 +70,7 @@ query ConfirmBidValidTestQuery {
     __id
   }
   me {
+    ...BidForm_me
     id
     has_qualified_credit_cards
     __id
@@ -104,6 +107,18 @@ fragment BidForm_saleArtwork on SaleArtwork {
     cents
     display
   }
+  sale {
+    registrationStatus {
+      qualifiedForBidding: qualified_for_bidding
+      __id
+    }
+    __id
+  }
+  __id
+}
+
+fragment BidForm_me on Me {
+  hasQualifiedCreditCards: has_qualified_credit_cards
   __id
 }
 */
@@ -142,93 +157,53 @@ v3 = [
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__id",
+  "name": "qualified_for_bidding",
   "args": null,
   "storageKey": null
 },
 v5 = {
-  "kind": "LinkedField",
+  "kind": "ScalarField",
   "alias": null,
-  "name": "sale",
-  "storageKey": null,
+  "name": "__id",
   "args": null,
-  "concreteType": "Sale",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "registrationStatus",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "Bidder",
-      "plural": false,
-      "selections": [
-        v2,
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "qualified_for_bidding",
-          "args": null,
-          "storageKey": null
-        },
-        v4
-      ]
-    },
-    v1,
-    v2,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "name",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_closed",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_registration_closed",
-      "args": null,
-      "storageKey": null
-    },
-    v4
-  ]
+  "storageKey": null
 },
 v6 = {
-  "kind": "LinkedField",
+  "kind": "ScalarField",
   "alias": null,
-  "name": "me",
-  "storageKey": null,
+  "name": "name",
   "args": null,
-  "concreteType": "Me",
-  "plural": false,
-  "selections": [
-    v2,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "has_qualified_credit_cards",
-      "args": null,
-      "storageKey": null
-    },
-    v4
-  ]
+  "storageKey": null
 },
 v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_closed",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_registration_closed",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "has_qualified_credit_cards",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cents",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -240,7 +215,7 @@ return {
   "operationKind": "query",
   "name": "ConfirmBidValidTestQuery",
   "id": null,
-  "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    id\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  __id\n}\n",
+  "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    ...BidForm_me\n    id\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding: qualified_for_bidding\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -286,14 +261,62 @@ return {
               },
               v1,
               v2,
-              v5,
-              v4
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "sale",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sale",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "registrationStatus",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "plural": false,
+                    "selections": [
+                      v2,
+                      v4,
+                      v5
+                    ]
+                  },
+                  v1,
+                  v2,
+                  v6,
+                  v7,
+                  v8,
+                  v5
+                ]
+              },
+              v5
             ]
           },
-          v4
+          v5
         ]
       },
-      v6
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "BidForm_me",
+            "args": null
+          },
+          v2,
+          v9,
+          v5
+        ]
+      }
     ]
   },
   "operation": {
@@ -339,7 +362,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          v4,
+          v5,
           v2,
           {
             "kind": "LinkedField",
@@ -391,11 +414,11 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v7,
-                  v8
+                  v10,
+                  v11
                 ]
               },
-              v4,
+              v5,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -412,21 +435,78 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
+                  v10,
+                  v11
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "sale",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sale",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "registrationStatus",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": "qualifiedForBidding",
+                        "name": "qualified_for_bidding",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v5,
+                      v2,
+                      v4
+                    ]
+                  },
+                  v5,
+                  v1,
+                  v2,
+                  v6,
                   v7,
                   v8
                 ]
               },
               v1,
-              v2,
-              v5
+              v2
             ]
           }
         ]
       },
-      v6
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": "hasQualifiedCreditCards",
+            "name": "has_qualified_credit_cards",
+            "args": null,
+            "storageKey": null
+          },
+          v5,
+          v2,
+          v9
+        ]
+      }
     ]
   }
 };
 })();
-(node as any).hash = '8f25a025f95a317c927ae659c6d05b0e';
+(node as any).hash = 'ad6e68f098a2b2396f392475bbf96e5e';
 export default node;

--- a/src/__generated__/routes_ConfirmBidQuery.graphql.ts
+++ b/src/__generated__/routes_ConfirmBidQuery.graphql.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
+import { BidForm_me$ref } from "./BidForm_me.graphql";
 import { BidForm_saleArtwork$ref } from "./BidForm_saleArtwork.graphql";
 import { LotInfo_artwork$ref } from "./LotInfo_artwork.graphql";
 import { LotInfo_saleArtwork$ref } from "./LotInfo_saleArtwork.graphql";
@@ -33,6 +34,7 @@ export type routes_ConfirmBidQueryResponse = {
     readonly me: ({
         readonly id: string;
         readonly has_qualified_credit_cards: boolean | null;
+        readonly " $fragmentRefs": BidForm_me$ref;
     }) | null;
 };
 export type routes_ConfirmBidQuery = {
@@ -74,6 +76,7 @@ query routes_ConfirmBidQuery(
     __id
   }
   me {
+    ...BidForm_me
     id
     has_qualified_credit_cards
     __id
@@ -110,6 +113,18 @@ fragment BidForm_saleArtwork on SaleArtwork {
     cents
     display
   }
+  sale {
+    registrationStatus {
+      qualifiedForBidding: qualified_for_bidding
+      __id
+    }
+    __id
+  }
+  __id
+}
+
+fragment BidForm_me on Me {
+  hasQualifiedCreditCards: has_qualified_credit_cards
   __id
 }
 */
@@ -162,93 +177,53 @@ v4 = [
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__id",
+  "name": "qualified_for_bidding",
   "args": null,
   "storageKey": null
 },
 v6 = {
-  "kind": "LinkedField",
+  "kind": "ScalarField",
   "alias": null,
-  "name": "sale",
-  "storageKey": null,
+  "name": "__id",
   "args": null,
-  "concreteType": "Sale",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "registrationStatus",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "Bidder",
-      "plural": false,
-      "selections": [
-        v3,
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "qualified_for_bidding",
-          "args": null,
-          "storageKey": null
-        },
-        v5
-      ]
-    },
-    v2,
-    v3,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "name",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_closed",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "is_registration_closed",
-      "args": null,
-      "storageKey": null
-    },
-    v5
-  ]
+  "storageKey": null
 },
 v7 = {
-  "kind": "LinkedField",
+  "kind": "ScalarField",
   "alias": null,
-  "name": "me",
-  "storageKey": null,
+  "name": "name",
   "args": null,
-  "concreteType": "Me",
-  "plural": false,
-  "selections": [
-    v3,
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "has_qualified_credit_cards",
-      "args": null,
-      "storageKey": null
-    },
-    v5
-  ]
+  "storageKey": null
 },
 v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_closed",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "is_registration_closed",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "has_qualified_credit_cards",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cents",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -260,7 +235,7 @@ return {
   "operationKind": "query",
   "name": "routes_ConfirmBidQuery",
   "id": null,
-  "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    id\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  __id\n}\n",
+  "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    ...BidForm_me\n    id\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding: qualified_for_bidding\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -306,14 +281,62 @@ return {
               },
               v2,
               v3,
-              v6,
-              v5
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "sale",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sale",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "registrationStatus",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "plural": false,
+                    "selections": [
+                      v3,
+                      v5,
+                      v6
+                    ]
+                  },
+                  v2,
+                  v3,
+                  v7,
+                  v8,
+                  v9,
+                  v6
+                ]
+              },
+              v6
             ]
           },
-          v5
+          v6
         ]
       },
-      v7
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "BidForm_me",
+            "args": null
+          },
+          v3,
+          v10,
+          v6
+        ]
+      }
     ]
   },
   "operation": {
@@ -359,7 +382,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          v5,
+          v6,
           v3,
           {
             "kind": "LinkedField",
@@ -411,11 +434,11 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v8,
-                  v9
+                  v11,
+                  v12
                 ]
               },
-              v5,
+              v6,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -432,21 +455,78 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
+                  v11,
+                  v12
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "sale",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sale",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "registrationStatus",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": "qualifiedForBidding",
+                        "name": "qualified_for_bidding",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      v6,
+                      v3,
+                      v5
+                    ]
+                  },
+                  v6,
+                  v2,
+                  v3,
+                  v7,
                   v8,
                   v9
                 ]
               },
               v2,
-              v3,
-              v6
+              v3
             ]
           }
         ]
       },
-      v7
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": "hasQualifiedCreditCards",
+            "name": "has_qualified_credit_cards",
+            "args": null,
+            "storageKey": null
+          },
+          v6,
+          v3,
+          v10
+        ]
+      }
     ]
   }
 };
 })();
-(node as any).hash = '9ac6ed30e7106064e70531ffba6f4563';
+(node as any).hash = 'd98d9bac49c62c2b73eec0cba15eb1c7';
 export default node;


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-712

**Do not squash the commits as each commit has a meaningful message.** 

Adds polling logic that checks the bidding status and redirects the user to the artwork page when the user is winning.

## Screenshots

### Placing a user as a registered user

![AUCT-712](https://user-images.githubusercontent.com/386234/68322194-fee60700-0090-11ea-8b05-ae521b0d16be.gif)

### 

<img width="844" alt="Screen Shot 2019-11-06 at 12 17 05 PM" src="https://user-images.githubusercontent.com/386234/68322216-073e4200-0091-11ea-8e54-ec3a4ee151f6.png">
