### PR TITLE
@sweir27 => [v2] Use correct id for edition set in BNMO mutations

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -209,7 +209,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                   artworkId: this.props.artwork.internalID,
                   editionSetId: get(
                     this.state,
-                    state => state.selectedEditionSet.id
+                    state => state.selectedEditionSet.internalID
                   ),
                 },
               },
@@ -293,7 +293,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                   artworkId: this.props.artwork.internalID,
                   editionSetId: get(
                     this.state,
-                    state => state.selectedEditionSet.id
+                    state => state.selectedEditionSet.internalID
                   ),
                 },
               },


### PR DESCRIPTION
I was taking a look at the remaining blocker for V2 (basically BNMO mutations not working), and while this is a blind change 🙈 , I bet it's the correct one!

We want to pass our Mongo id for an edition set (aka `internalID`) into the mutation, and not the opaque Relay `id`.