### PR TITLE
@joeyAghion => [v2] Strictly support and generate snake case filter params in URLs

### DIFF
--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -3,6 +3,7 @@ import {
   initialArtworkFilterState,
 } from "Components/v2/ArtworkFilter/ArtworkFilterContext"
 import { isDefaultFilter } from "Components/v2/ArtworkFilter/Utils/isDefaultFilter"
+import { paramsToCamelCase } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { Redirect, RouteConfig } from "found"
 import { graphql } from "react-relay"
 import { ArtistAppFragmentContainer as ArtistApp } from "./ArtistApp"
@@ -38,13 +39,14 @@ export const routes: RouteConfig[] = [
           // FIXME: The initial render includes `location` in props, but subsequent
           // renders (such as tabbing back to this route in your browser) will not.
           const filterStateFromUrl = props.location ? props.location.query : {}
+
           const filterParams = {
             ...initialArtworkFilterState,
-            ...filterStateFromUrl,
+            ...paramsToCamelCase(filterStateFromUrl),
             ...params,
           }
 
-          filterParams.hasFilter = Object.entries(filterStateFromUrl).some(
+          filterParams.hasFilter = Object.entries(filterParams).some(
             ([k, v]: [keyof ArtworkFilters, any]) => {
               return !isDefaultFilter(k, v)
             }

--- a/src/Apps/Collect2/Utils/urlBuilder.ts
+++ b/src/Apps/Collect2/Utils/urlBuilder.ts
@@ -1,5 +1,8 @@
 import { ArtworkFilters } from "Components/v2/ArtworkFilter/ArtworkFilterContext"
-import { removeDefaultValues } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
+import {
+  paramsToSnakeCase,
+  removeDefaultValues,
+} from "Components/v2/ArtworkFilter/Utils/urlBuilder"
 import qs from "qs"
 
 export const buildUrlForCollectApp = (state: ArtworkFilters): string => {
@@ -16,5 +19,5 @@ const buildCollectUrlFragmentFromState = (state: ArtworkFilters): string => {
     return emptyOrSpecificMedium
   }
 
-  return `${emptyOrSpecificMedium}?${qs.stringify(params)}`
+  return `${emptyOrSpecificMedium}?${qs.stringify(paramsToSnakeCase(params))}`
 }

--- a/src/Apps/Collect2/collectRoutes.tsx
+++ b/src/Apps/Collect2/collectRoutes.tsx
@@ -4,6 +4,7 @@ import { graphql } from "react-relay"
 import { CollectAppFragmentContainer as CollectApp } from "./Routes/Collect"
 import { CollectionsAppFragmentContainer as CollectionsApp } from "./Routes/Collections"
 
+import { paramsToCamelCase } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
 import {
   CollectionAppQuery,
   CollectionRefetchContainer as CollectionApp,
@@ -106,7 +107,7 @@ function initializeVariablesWithFilterState(params, props) {
 
   const state = {
     sort: "-decayed_merch",
-    ...initialFilterState,
+    ...paramsToCamelCase(initialFilterState),
     ...params,
   }
 

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -8,11 +8,12 @@ import { SearchResultsEntityRouteFragmentContainer as SearchResultsEntityRoute }
 
 import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
 import { ArtworkQueryFilter } from "Components/v2/ArtworkFilter"
+import { paramsToCamelCase } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { SearchAppFragmentContainer as SearchApp } from "./SearchApp"
 
 const prepareVariables = (_params, { location }) => {
   return {
-    ...location.query,
+    ...paramsToCamelCase(location.query),
     keyword: location.query.term,
   }
 }

--- a/src/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
@@ -4,6 +4,7 @@ import useDeepCompareEffect from "use-deep-compare-effect"
 import { hasFilters } from "./Utils/hasFilters"
 import { isDefaultFilter } from "./Utils/isDefaultFilter"
 import { rangeToTuple } from "./Utils/rangeToTuple"
+import { paramsToCamelCase } from "./Utils/urlBuilder"
 
 /**
  * Initial filter state
@@ -160,7 +161,7 @@ export const ArtworkFilterContextProvider: React.FC<
 }) => {
   const initialFilterState = {
     ...initialArtworkFilterState,
-    ...filters,
+    ...paramsToCamelCase(filters),
   }
 
   const [artworkFilterState, dispatch] = useReducer(

--- a/src/Components/v2/ArtworkFilter/Utils/__tests__/urlBuilder.test.tsx
+++ b/src/Components/v2/ArtworkFilter/Utils/__tests__/urlBuilder.test.tsx
@@ -1,0 +1,35 @@
+import { paramsToCamelCase, paramsToSnakeCase } from "../urlBuilder"
+
+describe(paramsToSnakeCase, () => {
+  it("converts camel cased filter arguments to snake case", () => {
+    const params = {
+      partnerID: "gagosian-gallery",
+      forSale: true,
+      atAuction: true,
+      inquireableOnly: false,
+    }
+    expect(paramsToSnakeCase(params)).toEqual({
+      partner_id: "gagosian-gallery",
+      for_sale: true,
+      at_auction: true,
+      inquireable_only: false,
+    })
+  })
+})
+
+describe(paramsToCamelCase, () => {
+  it("converts snake cased filter arguments to camel case", () => {
+    const params = {
+      partner_id: "gagosian-gallery",
+      for_sale: true,
+      at_auction: true,
+      inquireable_only: false,
+    }
+    expect(paramsToCamelCase(params)).toEqual({
+      partnerID: "gagosian-gallery",
+      forSale: true,
+      atAuction: true,
+      inquireableOnly: false,
+    })
+  })
+})

--- a/src/Components/v2/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/Components/v2/ArtworkFilter/Utils/urlBuilder.tsx
@@ -1,10 +1,28 @@
 import { ArtworkFilters } from "Components/v2/ArtworkFilter/ArtworkFilterContext"
 import { isDefaultFilter } from "Components/v2/ArtworkFilter/Utils/isDefaultFilter"
+import { camelCase, snakeCase } from "lodash"
 import qs from "qs"
+
+// Utility method to convert keys of a hash into snake case.
+export const paramsToSnakeCase = params => {
+  return Object.entries(params).reduce((acc, [field, value]) => {
+    return { ...acc, [snakeCase(field)]: value }
+  }, {})
+}
+
+// Utility method to convert keys of a hash into camel case.
+// It will fully capitalize an `_id` suffix as well.
+export const paramsToCamelCase = params => {
+  return Object.entries(params).reduce((acc, [field, value]) => {
+    const camelCasedField = camelCase(field).replace(/Id$/, "ID")
+    return { ...acc, [camelCasedField]: value }
+  }, {})
+}
 
 export const buildUrl = (state: ArtworkFilters): string => {
   const params = removeDefaultValues(state)
-  const queryString = qs.stringify(params)
+
+  const queryString = qs.stringify(paramsToSnakeCase(params))
   const url = queryString
     ? `${window.location.pathname}?${queryString}`
     : window.location.pathname

--- a/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterContext.test.tsx
+++ b/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterContext.test.tsx
@@ -112,7 +112,7 @@ describe("ArtworkFilterContext", () => {
         },
       })
       expect(context.filters.acquireable).toEqual(true)
-      expect(context.filters.at_auction).toEqual(true)
+      expect(context.filters.atAuction).toEqual(true)
 
       act(() => {
         context.resetFilters()


### PR DESCRIPTION
As discussed.

This updates URL's based on filter interactions to be **snake-cased** (`?inquireable_only=true`, vs. `?inquireableOnly=true`). This matches the format of URL's we've already been generating.

Additionally, this continues to support that format of URL's, by converting them to camel case before passing in to filter queries.