### PR TITLE
@eessex => [v2] Correct title for medium-based collect pages

### DIFF
--- a/src/Apps/Collect2/Routes/Collect/Components/CollectMediumMetadata.ts
+++ b/src/Apps/Collect2/Routes/Collect/Components/CollectMediumMetadata.ts
@@ -11,7 +11,7 @@ export function getMetadataForMedium(medium) {
       title = "Photography"
       mediumDescription = "140,000 photographs"
       break
-    case "sculptures":
+    case "sculpture":
       title = "Sculptures"
       mediumDescription = "90,000 sculptures"
       break

--- a/src/Apps/Collect2/Routes/Collect/index.tsx
+++ b/src/Apps/Collect2/Routes/Collect/index.tsx
@@ -27,18 +27,14 @@ export interface CollectAppProps {
   marketingHubCollections: Collect_marketingHubCollections
   viewer: collectRoutes_ArtworkFilterQueryResponse["viewer"]
   filterArtworks: collectRoutes_ArtworkFilterQueryResponse["filterArtworks"]
-  params?: {
-    medium: string
-  }
 }
 
 export const CollectApp = track({
   context_page: Schema.PageName.CollectPage,
 })((props: CollectAppProps) => {
   const {
-    params,
     viewer,
-    match: { location },
+    match: { location, params },
   } = props
   const medium = params && params.medium
   const { description, breadcrumbTitle, title } = getMetadataForMedium(medium)


### PR DESCRIPTION
Reported by @sweir27 during QA.

Also noticed the key for `/collect/sculpture` was incorrect, so that page showed the default title title as well.