### PR TITLE
Ensure user agent gets passed from SSR Relay Environment

### DIFF
--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -55,7 +55,7 @@ export function buildServerApp(config: ServerRouterConfig): Promise<Resolve> {
       try {
         const { context = {}, routes = [], url, userAgent } = config
         const user = getUser(context.user)
-        const relayEnvironment = context.relayEnvironment || createRelaySSREnvironment({ user }) // prettier-ignore
+        const relayEnvironment = context.relayEnvironment || createRelaySSREnvironment({ user, userAgent }) // prettier-ignore
         const historyMiddlewares = [
           createQueryMiddleware({
             parse: queryStringParsing,


### PR DESCRIPTION
This should (hopefully) fix [PURCHASE-1140](https://artsyproduct.atlassian.net/browse/PURCHASE-1140).

This was originally introduced in https://github.com/artsy/reaction/pull/2923 and accidentally reverted in https://github.com/artsy/reaction/pull/2935. 

For context, this is required so that the original user agent is passed all the way through the system. Otherwise it gets dropped and isn't recorded in our analytics. 
