### PR TITLE
User without an existing credit card should be able to bid and register

### DIFF
--- a/src/Apps/Auction/Components/BidForm.tsx
+++ b/src/Apps/Auction/Components/BidForm.tsx
@@ -17,6 +17,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import Yup from "yup"
 
+import { CreditCardInstructions } from "Apps/Auction/Components/CreditCardInstructions"
 import { Address, AddressForm } from "Apps/Order/Components/AddressForm"
 import { CreditCardInput } from "Apps/Order/Components/CreditCardInput"
 
@@ -184,17 +185,7 @@ export const BidForm: React.FC<Props> = ({
                 {requiresPaymentInformation && (
                   <Box>
                     <Separator mb={3} />
-
-                    <Serif size="4" color="black100">
-                      Please enter your credit card information below. The name
-                      on your Artsy account must match the name on the card, and
-                      a valid credit card is required in order to bid.
-                    </Serif>
-                    <Serif size="4" mt={2} color="black100">
-                      Registration is free. Artsy will never charge this card
-                      without your permission, and you are not required to use
-                      this card to pay if you win.
-                    </Serif>
+                    <CreditCardInstructions />
 
                     <Serif
                       mt={4}

--- a/src/Apps/Auction/Components/CreditCardInstructions.tsx
+++ b/src/Apps/Auction/Components/CreditCardInstructions.tsx
@@ -1,0 +1,18 @@
+import { Serif } from "@artsy/palette"
+import React from "react"
+
+export const CreditCardInstructions = () => {
+  return (
+    <>
+      <Serif size="4" color="black100">
+        Please enter your credit card information below. The name on your Artsy
+        account must match the name on the card, and a valid credit card is
+        required in order to bid.
+      </Serif>
+      <Serif size="4" mt={2} color="black100">
+        Registration is free. Artsy will never charge this card without your
+        permission, and you are not required to use this card to pay if you win.
+      </Serif>
+    </>
+  )
+}

--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Flex, Sans, Serif } from "@artsy/palette"
+import { CreditCardInstructions } from "Apps/Auction/Components/CreditCardInstructions"
 import { Address, AddressForm } from "Apps/Order/Components/AddressForm"
 import { CreditCardInput } from "Apps/Order/Components/CreditCardInput"
 import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
@@ -221,15 +222,7 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = props => {
 
   return (
     <Box maxWidth={550}>
-      <Serif size="4" color="black100">
-        Please enter your credit card information below. The name on your Artsy
-        account must match the name on the card, and a valid credit card is
-        required in order to bid.
-      </Serif>
-      <Serif size="4" mt={2} color="black100">
-        Registration is free. Artsy will never charge this card without your
-        permission, and you are not required to use this card to pay if you win.
-      </Serif>
+      <CreditCardInstructions />
 
       <Box mt={2}>
         <Formik

--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -230,6 +230,7 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = props => {
         Registration is free. Artsy will never charge this card without your
         permission, and you are not required to use this card to pay if you win.
       </Serif>
+
       <Box mt={2}>
         <Formik
           initialValues={initialValues}

--- a/src/Apps/Auction/Routes/Register/index.tsx
+++ b/src/Apps/Auction/Routes/Register/index.tsx
@@ -36,6 +36,68 @@ interface RegisterProps {
   tracking: TrackingProp
 }
 
+// TODO: Extract.
+export function createCreditCardAndUpdatePhone(relayEnvironment, phone, token) {
+  return new Promise(async (resolve, reject) => {
+    commitMutation<RegisterCreateCreditCardAndUpdatePhoneMutation>(
+      relayEnvironment,
+      {
+        onCompleted: (data, errors) => {
+          const {
+            createCreditCard: { creditCardOrError },
+          } = data
+
+          if (creditCardOrError.creditCardEdge) {
+            resolve()
+          } else {
+            if (errors) {
+              reject(errors)
+            } else {
+              reject(creditCardOrError.mutationError)
+            }
+          }
+        },
+        onError: reject,
+        mutation: graphql`
+          mutation RegisterCreateCreditCardAndUpdatePhoneMutation(
+            $creditCardInput: CreditCardInput!
+            $profileInput: UpdateMyProfileInput!
+          ) {
+            updateMyUserProfile(input: $profileInput) {
+              user {
+                id
+              }
+            }
+
+            createCreditCard(input: $creditCardInput) {
+              creditCardOrError {
+                ... on CreditCardMutationSuccess {
+                  creditCardEdge {
+                    node {
+                      last_digits
+                    }
+                  }
+                }
+                ... on CreditCardMutationFailure {
+                  mutationError {
+                    type
+                    message
+                    detail
+                  }
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          creditCardInput: { token },
+          profileInput: { phone },
+        },
+      }
+    )
+  })
+}
+
 export const RegisterRoute: React.FC<RegisterProps> = props => {
   const { me, relay, sale, tracking } = props
 
@@ -87,67 +149,6 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
     })
   }
 
-  function createCreditCardAndUpdatePhone(phone, token) {
-    return new Promise(async (resolve, reject) => {
-      commitMutation<RegisterCreateCreditCardAndUpdatePhoneMutation>(
-        relay.environment,
-        {
-          onCompleted: (data, errors) => {
-            const {
-              createCreditCard: { creditCardOrError },
-            } = data
-
-            if (creditCardOrError.creditCardEdge) {
-              resolve()
-            } else {
-              if (errors) {
-                reject(errors)
-              } else {
-                reject(creditCardOrError.mutationError)
-              }
-            }
-          },
-          onError: reject,
-          mutation: graphql`
-            mutation RegisterCreateCreditCardAndUpdatePhoneMutation(
-              $creditCardInput: CreditCardInput!
-              $profileInput: UpdateMyProfileInput!
-            ) {
-              updateMyUserProfile(input: $profileInput) {
-                user {
-                  id
-                }
-              }
-
-              createCreditCard(input: $creditCardInput) {
-                creditCardOrError {
-                  ... on CreditCardMutationSuccess {
-                    creditCardEdge {
-                      node {
-                        last_digits
-                      }
-                    }
-                  }
-                  ... on CreditCardMutationFailure {
-                    mutationError {
-                      type
-                      message
-                      detail
-                    }
-                  }
-                }
-              }
-            }
-          `,
-          variables: {
-            creditCardInput: { token },
-            profileInput: { phone },
-          },
-        }
-      )
-    })
-  }
-
   function handleMutationError(actions: FormikActions<object>, error: Error) {
     logger.error(error)
 
@@ -167,7 +168,11 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
   }
 
   function handleSubmit(actions: FormikActions<object>, result: FormResult) {
-    createCreditCardAndUpdatePhone(result.phoneNumber, result.token.id)
+    createCreditCardAndUpdatePhone(
+      relay.environment,
+      result.phoneNumber,
+      result.token.id
+    )
       .then(() => {
         createBidder()
           .then((data: RegisterCreateBidderMutationResponse) => {

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -44,6 +44,7 @@ import {
 import { stripeTokenResponse } from "../__fixtures__/Stripe"
 import { ConfirmBidRouteFragmentContainer } from "../ConfirmBid"
 import { ConfirmBidTestPage } from "./Utils/ConfirmBidTestPage"
+import { ValidFormValues } from "./Utils/RegisterTestPage"
 
 jest.unmock("react-relay")
 jest.unmock("react-tracking")
@@ -572,6 +573,26 @@ describe("Routes/ConfirmBid", () => {
           ConfirmBidQueryResponseFixture.artwork.id
         }`
       )
+    })
+
+    it("displays an error when user did not add his/her address", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithoutCreditCard,
+      })
+
+      createTokenMock.mockResolvedValue(stripeTokenResponse)
+
+      const address = Object.assign({}, ValidFormValues)
+      address.phoneNumber = "    "
+
+      await page.fillAddressForm(address)
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(page.text()).toMatch("Telephone is required")
+      expect(env.mutations.mockFetch).not.toBeCalled()
+      expect(window.location.assign).not.toHaveBeenCalled()
     })
 
     it("displays an error when Stripe returns an error", async () => {

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -1,6 +1,27 @@
+import {
+  createCreditCardAndUpdatePhoneFailed,
+  createCreditCardAndUpdatePhoneSuccessful,
+} from "../__fixtures__/MutationResults/createCreditCardAndUpdatePhone"
+
 jest.mock("Apps/Auction/Routes/ConfirmBid/BidderPositionQuery", () => ({
   bidderPositionQuery: jest.fn(),
 }))
+
+jest.mock("react-stripe-elements", () => {
+  const stripeMock = {
+    createToken: jest.fn(),
+  }
+
+  return {
+    Elements: ({ children }) => children,
+    StripeProvider: ({ children }) => children,
+    CardElement: ({ onReady, hidePostalCode, ...props }) => <div {...props} />,
+    __stripeMock: stripeMock,
+    injectStripe: Component => props => (
+      <Component stripe={stripeMock} {...props} />
+    ),
+  }
+})
 
 import deepMerge from "deepmerge"
 import { createTestEnv } from "DevTools/createTestEnv"
@@ -20,6 +41,7 @@ import {
   createBidderPositionSuccessful,
   createBidderPositionSuccessfulAndBidder,
 } from "../__fixtures__/MutationResults/createBidderPosition"
+import { stripeTokenResponse } from "../__fixtures__/Stripe"
 import { ConfirmBidRouteFragmentContainer } from "../ConfirmBid"
 import { ConfirmBidTestPage } from "./Utils/ConfirmBidTestPage"
 
@@ -30,6 +52,8 @@ jest.mock("Utils/Events", () => ({
 }))
 const mockBidderPositionQuery = bidderPositionQuery as jest.Mock
 const mockPostEvent = require("Utils/Events").postEvent as jest.Mock
+const createTokenMock = require("react-stripe-elements").__stripeMock
+  .createToken as jest.Mock
 
 jest.mock("sharify", () => ({
   data: {
@@ -81,21 +105,26 @@ const setupTestEnv = ({
           }
         }
         me {
-          ...BidForm_me
           id
-          has_qualified_credit_cards
+          ...ConfirmBid_me
         }
       }
     `,
     defaultData: ConfirmBidQueryResponseFixture,
     defaultMutationResults: {
       createBidderPosition: {},
+      createCreditCard: {},
+      updateMyUserProfile: {},
     },
   })
 }
 
 describe("Routes/ConfirmBid", () => {
   beforeEach(() => {
+    // @ts-ignore
+    // tslint:disable-next-line:no-empty
+    window.Stripe = () => {}
+
     window.location.assign = jest.fn()
     window.location.search = ""
   })
@@ -309,7 +338,7 @@ describe("Routes/ConfirmBid", () => {
       ConfirmBidQueryResponseFixture,
       {
         me: {
-          has_qualified_credit_cards: true,
+          hasQualifiedCreditCards: true,
         },
         artwork: {
           saleArtwork: {
@@ -463,6 +492,146 @@ describe("Routes/ConfirmBid", () => {
         auction_slug: "saleslug",
         artwork_slug: "artworkslug",
         bidder_id: "new-bidder-id",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+    })
+  })
+
+  describe("for unregistered users without credit cards", () => {
+    const FixtureForUnregisteredUserWithoutCreditCard = deepMerge(
+      ConfirmBidQueryResponseFixture,
+      {
+        me: {
+          hasQualifiedCreditCards: false,
+        },
+        artwork: {
+          saleArtwork: {
+            sale: {
+              registrationStatus: null,
+            },
+          },
+        },
+      }
+    )
+
+    it("allows the user to place a bid after agreeing to terms", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithoutCreditCard,
+      })
+
+      createTokenMock.mockResolvedValue(stripeTokenResponse)
+      env.mutations.useResultsOnce(createCreditCardAndUpdatePhoneSuccessful)
+      env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithWinning
+      )
+
+      await page.fillFormWithValidValues()
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(createTokenMock).toHaveBeenCalledWith({
+        address_city: "New York",
+        address_country: "United States",
+        address_line1: "123 Example Street",
+        address_line2: "Apt 1",
+        address_state: "NY",
+        address_zip: "10012",
+        name: "Example Name",
+      })
+      expect(env.mutations.mockFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "RegisterCreateCreditCardAndUpdatePhoneMutation",
+        }),
+        {
+          creditCardInput: { token: "tok_abcabcabcabcabcabcabc" },
+          profileInput: { phone: "+1 555 212 7878" },
+        }
+      )
+      expect(env.mutations.mockFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "ConfirmBidCreateBidderPositionMutation",
+        }),
+        {
+          input: {
+            artwork_id: "artworkslug",
+            max_bid_amount_cents: 5000000,
+            sale_id: "saleslug",
+          },
+        }
+      )
+
+      expect(mockBidderPositionQuery).toHaveBeenCalledTimes(1)
+      expect(mockBidderPositionQuery.mock.calls[0][1]).toEqual({
+        bidderPositionID: "positionid",
+      })
+      expect(window.location.assign).toHaveBeenCalledWith(
+        `https://example.com/artwork/${
+          ConfirmBidQueryResponseFixture.artwork.id
+        }`
+      )
+    })
+
+    it("displays an error when Stripe returns an error", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithoutCreditCard,
+      })
+
+      createTokenMock.mockResolvedValue({ error: { message: "Card inlivad" } })
+
+      await page.fillFormWithValidValues()
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(window.location.assign).not.toHaveBeenCalled()
+      expect(page.text()).toContain(
+        "Please make sure your internet connection is active and try again"
+      )
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["JavaScript error: Stripe error: Card inlivad"],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: null,
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+    })
+
+    it("displays an error when CreateCreditCardAndUpdatePhoneMutation returns an error", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithoutCreditCard,
+      })
+
+      createTokenMock.mockResolvedValue(stripeTokenResponse)
+      env.mutations.useResultsOnce(createCreditCardAndUpdatePhoneFailed)
+
+      await page.fillFormWithValidValues()
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(window.location.assign).not.toHaveBeenCalled()
+      expect(page.text()).toContain(
+        "Please make sure your internet connection is active and try again"
+      )
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: [
+          "JavaScript error: The `createCreditCard` mutation failed.",
+        ],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: null,
         sale_id: "saleid",
         user_id: "my-user-id",
       })

--- a/src/Apps/Auction/Routes/__tests__/Utils/ConfirmBidTestPage.tsx
+++ b/src/Apps/Auction/Routes/__tests__/Utils/ConfirmBidTestPage.tsx
@@ -1,4 +1,7 @@
 import { Checkbox } from "@artsy/palette"
+
+import { ValidFormValues } from "Apps/Auction/Routes/__tests__/Utils/RegisterTestPage"
+import { Address, AddressForm } from "Apps/Order/Components/AddressForm"
 import { expectOne, RootTestPage } from "DevTools/RootTestPage"
 
 export class ConfirmBidTestPage extends RootTestPage {
@@ -7,19 +10,37 @@ export class ConfirmBidTestPage extends RootTestPage {
       btn.text().includes("Confirm bid")
     )
   }
+
   get selectBidAmountInput() {
     return expectOne(this.find("select"))
   }
+
   get form() {
     return expectOne(this.find("form"))
   }
+
+  get addressInput() {
+    return expectOne(this.form.find(AddressForm))
+  }
+
   get agreeToTermsInput() {
     return expectOne(this.form.find(Checkbox))
   }
+
+  async fillAddressForm(address: Address) {
+    this.addressInput.props().onChange(address, "city")
+  }
+
+  async fillFormWithValidValues() {
+    this.fillAddressForm(ValidFormValues)
+    await this.update()
+  }
+
   async agreeToTerms() {
     this.agreeToTermsInput.props().onSelect(true)
     await this.update()
   }
+
   async submitForm() {
     this.form.simulate("submit")
     await this.update()

--- a/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
@@ -1,4 +1,5 @@
 import { BidForm_saleArtwork } from "__generated__/BidForm_saleArtwork.graphql"
+import { ConfirmBid_me } from "__generated__/ConfirmBid_me.graphql"
 import { LotInfo_artwork } from "__generated__/LotInfo_artwork.graphql"
 import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
 import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
@@ -6,6 +7,7 @@ import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQ
 // This complicated type is needed in order to include nested/masked relay queries
 export interface ConfirmBidQueryResponse
   extends routes_ConfirmBidQueryResponse {
+  me: ConfirmBid_me | routes_ConfirmBidQueryResponse["me"] | any // TODO: Kill any
   artwork: routes_ConfirmBidQueryResponse["artwork"] &
     LotInfo_artwork & {
       saleArtwork: routes_ConfirmBidQueryResponse["artwork"]["saleArtwork"] &
@@ -17,8 +19,9 @@ export interface ConfirmBidQueryResponse
 export const ConfirmBidQueryResponseFixture: ConfirmBidQueryResponse = {
   me: {
     id: "my-user-id",
-    has_qualified_credit_cards: true,
+    hasQualifiedCreditCards: true,
     " $fragmentRefs": null as never,
+    " $refType": null as never,
   },
   artwork: {
     " $fragmentRefs": null as never,

--- a/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
@@ -20,6 +20,7 @@ export const ConfirmBidQueryResponseFixture: ConfirmBidQueryResponse = {
   me: {
     id: "my-user-id",
     hasQualifiedCreditCards: true,
+    has_qualified_credit_cards: true,
     " $fragmentRefs": null as never,
     " $refType": null as never,
   },

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -54,6 +54,7 @@ export const routes: RouteConfig[] = [
         }
         me {
           ...ConfirmBid_me
+          has_qualified_credit_cards
         }
       }
     `,

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -53,9 +53,7 @@ export const routes: RouteConfig[] = [
           }
         }
         me {
-          ...BidForm_me
-          id
-          has_qualified_credit_cards
+          ...ConfirmBid_me
         }
       }
     `,

--- a/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
+++ b/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-import { BidForm_me$ref } from "./BidForm_me.graphql";
 import { BidForm_saleArtwork$ref } from "./BidForm_saleArtwork.graphql";
+import { ConfirmBid_me$ref } from "./ConfirmBid_me.graphql";
 import { LotInfo_artwork$ref } from "./LotInfo_artwork.graphql";
 import { LotInfo_saleArtwork$ref } from "./LotInfo_saleArtwork.graphql";
 export type ConfirmBidValidTestQueryVariables = {};
@@ -30,8 +30,7 @@ export type ConfirmBidValidTestQueryResponse = {
     }) | null;
     readonly me: ({
         readonly id: string;
-        readonly has_qualified_credit_cards: boolean | null;
-        readonly " $fragmentRefs": BidForm_me$ref;
+        readonly " $fragmentRefs": ConfirmBid_me$ref;
     }) | null;
 };
 export type ConfirmBidValidTestQuery = {
@@ -70,9 +69,8 @@ query ConfirmBidValidTestQuery {
     __id
   }
   me {
-    ...BidForm_me
     id
-    has_qualified_credit_cards
+    ...ConfirmBid_me
     __id
   }
 }
@@ -114,6 +112,13 @@ fragment BidForm_saleArtwork on SaleArtwork {
     }
     __id
   }
+  __id
+}
+
+fragment ConfirmBid_me on Me {
+  id
+  hasQualifiedCreditCards: has_qualified_credit_cards
+  ...BidForm_me
   __id
 }
 
@@ -192,18 +197,11 @@ v8 = {
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "has_qualified_credit_cards",
-  "args": null,
-  "storageKey": null
-},
-v10 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "cents",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -215,7 +213,7 @@ return {
   "operationKind": "query",
   "name": "ConfirmBidValidTestQuery",
   "id": null,
-  "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    ...BidForm_me\n    id\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding: qualified_for_bidding\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  __id\n}\n",
+  "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    id\n    ...ConfirmBid_me\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding: qualified_for_bidding\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ConfirmBid_me on Me {\n  id\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  ...BidForm_me\n  __id\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -307,13 +305,12 @@ return {
         "concreteType": "Me",
         "plural": false,
         "selections": [
+          v2,
           {
             "kind": "FragmentSpread",
-            "name": "BidForm_me",
+            "name": "ConfirmBid_me",
             "args": null
           },
-          v2,
-          v9,
           v5
         ]
       }
@@ -414,8 +411,8 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v10,
-                  v11
+                  v9,
+                  v10
                 ]
               },
               v5,
@@ -435,8 +432,8 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
-                  v10,
-                  v11
+                  v9,
+                  v10
                 ]
               },
               {
@@ -492,6 +489,7 @@ return {
         "concreteType": "Me",
         "plural": false,
         "selections": [
+          v2,
           {
             "kind": "ScalarField",
             "alias": "hasQualifiedCreditCards",
@@ -499,14 +497,12 @@ return {
             "args": null,
             "storageKey": null
           },
-          v5,
-          v2,
-          v9
+          v5
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = 'ad6e68f098a2b2396f392475bbf96e5e';
+(node as any).hash = '6b7c8ac1bbc520f7ead854f71bdb77a2';
 export default node;

--- a/src/__generated__/ConfirmBid_me.graphql.ts
+++ b/src/__generated__/ConfirmBid_me.graphql.ts
@@ -1,0 +1,52 @@
+/* tslint:disable */
+
+import { ConcreteFragment } from "relay-runtime";
+import { BidForm_me$ref } from "./BidForm_me.graphql";
+declare const _ConfirmBid_me$ref: unique symbol;
+export type ConfirmBid_me$ref = typeof _ConfirmBid_me$ref;
+export type ConfirmBid_me = {
+    readonly id: string;
+    readonly hasQualifiedCreditCards: boolean | null;
+    readonly " $fragmentRefs": BidForm_me$ref;
+    readonly " $refType": ConfirmBid_me$ref;
+};
+
+
+
+const node: ConcreteFragment = {
+  "kind": "Fragment",
+  "name": "ConfirmBid_me",
+  "type": "Me",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "id",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "hasQualifiedCreditCards",
+      "name": "has_qualified_credit_cards",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "BidForm_me",
+      "args": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "__id",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '1d5fb927e240a30087d3ea0cdb5d7ca6';
+export default node;

--- a/src/__generated__/routes_ConfirmBidQuery.graphql.ts
+++ b/src/__generated__/routes_ConfirmBidQuery.graphql.ts
@@ -32,6 +32,7 @@ export type routes_ConfirmBidQueryResponse = {
         readonly " $fragmentRefs": LotInfo_artwork$ref;
     }) | null;
     readonly me: ({
+        readonly has_qualified_credit_cards: boolean | null;
         readonly " $fragmentRefs": ConfirmBid_me$ref;
     }) | null;
 };
@@ -75,6 +76,7 @@ query routes_ConfirmBidQuery(
   }
   me {
     ...ConfirmBid_me
+    has_qualified_credit_cards
     __id
   }
 }
@@ -215,11 +217,18 @@ v9 = {
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "cents",
+  "name": "has_qualified_credit_cards",
   "args": null,
   "storageKey": null
 },
 v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cents",
+  "args": null,
+  "storageKey": null
+},
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -231,7 +240,7 @@ return {
   "operationKind": "query",
   "name": "routes_ConfirmBidQuery",
   "id": null,
-  "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    ...ConfirmBid_me\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding: qualified_for_bidding\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ConfirmBid_me on Me {\n  id\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  ...BidForm_me\n  __id\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  __id\n}\n",
+  "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    ...ConfirmBid_me\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding: qualified_for_bidding\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ConfirmBid_me on Me {\n  id\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  ...BidForm_me\n  __id\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -328,6 +337,7 @@ return {
             "name": "ConfirmBid_me",
             "args": null
           },
+          v10,
           v6
         ]
       }
@@ -428,8 +438,8 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v10,
-                  v11
+                  v11,
+                  v12
                 ]
               },
               v6,
@@ -449,8 +459,8 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
-                  v10,
-                  v11
+                  v11,
+                  v12
                 ]
               },
               {
@@ -514,12 +524,13 @@ return {
             "args": null,
             "storageKey": null
           },
-          v6
+          v6,
+          v10
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = '1354b3087cb33e60c8f600b0da643bcb';
+(node as any).hash = '3bf3d8492b0a9d727ae41b71a8b75416';
 export default node;

--- a/src/__generated__/routes_ConfirmBidQuery.graphql.ts
+++ b/src/__generated__/routes_ConfirmBidQuery.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-import { BidForm_me$ref } from "./BidForm_me.graphql";
 import { BidForm_saleArtwork$ref } from "./BidForm_saleArtwork.graphql";
+import { ConfirmBid_me$ref } from "./ConfirmBid_me.graphql";
 import { LotInfo_artwork$ref } from "./LotInfo_artwork.graphql";
 import { LotInfo_saleArtwork$ref } from "./LotInfo_saleArtwork.graphql";
 export type routes_ConfirmBidQueryVariables = {
@@ -32,9 +32,7 @@ export type routes_ConfirmBidQueryResponse = {
         readonly " $fragmentRefs": LotInfo_artwork$ref;
     }) | null;
     readonly me: ({
-        readonly id: string;
-        readonly has_qualified_credit_cards: boolean | null;
-        readonly " $fragmentRefs": BidForm_me$ref;
+        readonly " $fragmentRefs": ConfirmBid_me$ref;
     }) | null;
 };
 export type routes_ConfirmBidQuery = {
@@ -76,9 +74,7 @@ query routes_ConfirmBidQuery(
     __id
   }
   me {
-    ...BidForm_me
-    id
-    has_qualified_credit_cards
+    ...ConfirmBid_me
     __id
   }
 }
@@ -120,6 +116,13 @@ fragment BidForm_saleArtwork on SaleArtwork {
     }
     __id
   }
+  __id
+}
+
+fragment ConfirmBid_me on Me {
+  id
+  hasQualifiedCreditCards: has_qualified_credit_cards
+  ...BidForm_me
   __id
 }
 
@@ -212,18 +215,11 @@ v9 = {
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "has_qualified_credit_cards",
-  "args": null,
-  "storageKey": null
-},
-v11 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "cents",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -235,7 +231,7 @@ return {
   "operationKind": "query",
   "name": "routes_ConfirmBidQuery",
   "id": null,
-  "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    ...BidForm_me\n    id\n    has_qualified_credit_cards\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding: qualified_for_bidding\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  __id\n}\n",
+  "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    _id\n    id\n    saleArtwork: sale_artwork(sale_id: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      _id\n      id\n      sale {\n        registrationStatus {\n          id\n          qualified_for_bidding\n          __id\n        }\n        _id\n        id\n        name\n        is_closed\n        is_registration_closed\n        __id\n      }\n      __id\n    }\n    __id\n  }\n  me {\n    ...ConfirmBid_me\n    __id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  _id\n  date\n  title\n  imageUrl\n  artistNames: artist_names\n  __id\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions: bidder_positions\n  }\n  lotLabel: lot_label\n  minimumNextBid: minimum_next_bid {\n    amount\n    cents\n    display\n  }\n  __id\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid: minimum_next_bid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding: qualified_for_bidding\n      __id\n    }\n    __id\n  }\n  __id\n}\n\nfragment ConfirmBid_me on Me {\n  id\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  ...BidForm_me\n  __id\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards: has_qualified_credit_cards\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -329,11 +325,9 @@ return {
         "selections": [
           {
             "kind": "FragmentSpread",
-            "name": "BidForm_me",
+            "name": "ConfirmBid_me",
             "args": null
           },
-          v3,
-          v10,
           v6
         ]
       }
@@ -434,8 +428,8 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  v11,
-                  v12
+                  v10,
+                  v11
                 ]
               },
               v6,
@@ -455,8 +449,8 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
-                  v11,
-                  v12
+                  v10,
+                  v11
                 ]
               },
               {
@@ -512,6 +506,7 @@ return {
         "concreteType": "Me",
         "plural": false,
         "selections": [
+          v3,
           {
             "kind": "ScalarField",
             "alias": "hasQualifiedCreditCards",
@@ -519,14 +514,12 @@ return {
             "args": null,
             "storageKey": null
           },
-          v6,
-          v3,
-          v10
+          v6
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = 'd98d9bac49c62c2b73eec0cba15eb1c7';
+(node as any).hash = '1354b3087cb33e60c8f600b0da643bcb';
 export default node;


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-465
paired with @bhoggard 

This PR adds a way for unregistered users without credit cards to big and register at the same time. Most of the code is taken from the `Register.tsx` component and there may be a good refactoring opportunity, but in terms of functionality this is good to go.

## Screenshot

![AUCT-465](https://user-images.githubusercontent.com/386234/68884747-cb832800-06e1-11ea-947f-f023b63e3c8f.gif)




