### PR TITLE
PaymentForm __id -> id

### DIFF
--- a/src/Components/Payment/PaymentForm.tsx
+++ b/src/Components/Payment/PaymentForm.tsx
@@ -14,7 +14,7 @@ import { ErrorModal } from "Components/Modal/ErrorModal"
 import React, { Component } from "react"
 import { commitMutation, graphql, RelayProp } from "react-relay"
 import { injectStripe, ReactStripeElements } from "react-stripe-elements"
-import { ConnectionHandler } from "relay-runtime"
+import { ConnectionHandler, RecordSourceSelectorProxy } from "relay-runtime"
 import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 import { Responsive } from "Utils/Responsive"
@@ -179,14 +179,18 @@ class PaymentForm extends Component<PaymentFormProps, PaymentFormState> {
     }
   }
 
-  onCreditCardAdded(me, store, data): void {
+  onCreditCardAdded(
+    me: UserSettingsPayments_me,
+    store: RecordSourceSelectorProxy<any>,
+    data: PaymentFormCreateCreditCardMutation["response"]
+  ): void {
     const {
       createCreditCard: { creditCardOrError },
     } = data
 
     // Explicitly update the relay store to be aware of the new credit card
     if (creditCardOrError.creditCardEdge) {
-      const meStore = store.get(me.__id)
+      const meStore = store.get(me.id)
       const connection = ConnectionHandler.getConnection(
         meStore,
         "UserSettingsPayments_creditCards"


### PR DESCRIPTION
further proof, if any were needed, that noImplicitAny is a win.