### PR TITLE
[PURCHASE-1610] Allow offer metadata for artworks with min-price

### DIFF
--- a/src/Apps/Artist/Components/__tests__/ArtistMeta.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistMeta.test.tsx
@@ -269,10 +269,10 @@ describe("Meta", () => {
           __typename: "PriceRange",
           maxPrice: {
             major: 1000,
-            currencyCode: "USD",
           },
           minPrice: {
             major: 100,
+            currencyCode: "USD",
           },
         } as const,
       })
@@ -282,6 +282,42 @@ describe("Meta", () => {
         offers: {
           "@type": "AggregateOffer",
           highPrice: 1000,
+          lowPrice: 100,
+        },
+      })
+    })
+
+    it("#productFromArtistArtwork doesn't include a product if price range doesn't have low bound", () => {
+      const modifiedArtist = artistWithArtworkOverrides({
+        listPrice: {
+          __typename: "PriceRange",
+          maxPrice: {
+            major: 1000,
+          },
+          minPrice: null,
+        } as const,
+      })
+      const artwork = modifiedArtist.artworks_connection.edges[0].node
+      const json = productAttributes(modifiedArtist, artwork)
+      expect(json).toBeFalsy()
+    })
+
+    it("#productFromArtistArtwork with a price range includes an AggregateOffer and low bound if price range only has low bound", () => {
+      const modifiedArtist = artistWithArtworkOverrides({
+        listPrice: {
+          __typename: "PriceRange",
+          minPrice: {
+            major: 100,
+            currencyCode: "USD",
+          },
+          maxPrice: null,
+        } as const,
+      })
+      const artwork = modifiedArtist.artworks_connection.edges[0].node
+      const json = productAttributes(modifiedArtist, artwork)
+      expect(json).toMatchObject({
+        offers: {
+          "@type": "AggregateOffer",
           lowPrice: 100,
         },
       })

--- a/src/__generated__/ArtistMeta_artist.graphql.ts
+++ b/src/__generated__/ArtistMeta_artist.graphql.ts
@@ -36,10 +36,10 @@ export type ArtistMeta_artist = {
                     readonly __typename: "PriceRange";
                     readonly minPrice: {
                         readonly major: number;
+                        readonly currencyCode: string;
                     } | null;
                     readonly maxPrice: {
                         readonly major: number;
-                        readonly currencyCode: string;
                     } | null;
                 } | {
                     readonly __typename: "Money";
@@ -378,9 +378,7 @@ return {
                           "args": null,
                           "concreteType": "Money",
                           "plural": false,
-                          "selections": [
-                            (v5/*: any*/)
-                          ]
+                          "selections": (v6/*: any*/)
                         },
                         {
                           "kind": "LinkedField",
@@ -390,7 +388,9 @@ return {
                           "args": null,
                           "concreteType": "Money",
                           "plural": false,
-                          "selections": (v6/*: any*/)
+                          "selections": [
+                            (v5/*: any*/)
+                          ]
                         }
                       ]
                     },
@@ -444,5 +444,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '61fd906cad15ffde99e3d32638becb41';
+(node as any).hash = '658c024a253ef42394b3e4d3317b78d2';
 export default node;

--- a/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
@@ -92,10 +92,10 @@ fragment ArtistMeta_artist on Artist {
           ... on PriceRange {
             minPrice {
               major
+              currencyCode
             }
             maxPrice {
               major
-              currencyCode
             }
           }
           ... on Money {
@@ -517,9 +517,7 @@ return {
                                 "args": null,
                                 "concreteType": "Money",
                                 "plural": false,
-                                "selections": [
-                                  (v7/*: any*/)
-                                ]
+                                "selections": (v8/*: any*/)
                               },
                               {
                                 "kind": "LinkedField",
@@ -529,7 +527,9 @@ return {
                                 "args": null,
                                 "concreteType": "Money",
                                 "plural": false,
-                                "selections": (v8/*: any*/)
+                                "selections": [
+                                  (v7/*: any*/)
+                                ]
                               }
                             ]
                           },
@@ -712,7 +712,7 @@ return {
     "operationKind": "query",
     "name": "routes_ArtistTopLevelQuery",
     "id": null,
-    "text": "query routes_ArtistTopLevelQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  internalID\n  slug\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n            }\n            maxPrice {\n              major\n              currencyCode\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment NavigationTabs_artist on Artist {\n  slug\n  statuses {\n    shows\n    articles\n    cv(minShowCount: 0)\n    auction_lots: auctionLots\n  }\n}\n",
+    "text": "query routes_ArtistTopLevelQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  internalID\n  slug\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment NavigationTabs_artist on Artist {\n  slug\n  statuses {\n    shows\n    articles\n    cv(minShowCount: 0)\n    auction_lots: auctionLots\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Fixes [PURCHASE-1610](https://artsyproduct.atlassian.net/browse/PURCHASE-1610)

Background: only `lowPrice` is required for `AggregateOffer` so we can still produce metadata for artworks with only `minPrice`