### PR TITLE
Create gene links view

### DIFF
--- a/src/Components/Gene/GeneRelatedLinks.tsx
+++ b/src/Components/Gene/GeneRelatedLinks.tsx
@@ -1,0 +1,91 @@
+import { Box } from "@artsy/palette"
+import {
+  GeneRelatedLinksQuery,
+  GeneRelatedLinksQueryResponse,
+} from "__generated__/GeneRelatedLinksQuery.graphql"
+import { useSystemContext } from "Artsy"
+import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
+import React from "react"
+import { graphql } from "react-relay"
+
+/**
+ * Used on the Gene page to show related artists and categories.
+ */
+export const GeneRelatedLinks: React.FC<GeneRelatedLinksQueryResponse> = ({
+  gene,
+}) => {
+  return (
+    <>
+      <Box className="related-genes related-links bisected-header-cell-section is-fade-in">
+        <h2>Related Categories</h2>
+        <div className="related-genes-links">
+          {gene.similar.edges.map(({ node: similarGene }, index) => {
+            const separator = index < gene.similar.edges.length - 1 ? ", " : ""
+            return (
+              <>
+                <a href={similarGene.href}>{similarGene.name}</a>
+                {separator}
+              </>
+            )
+          })}
+        </div>
+      </Box>
+      <Box className="related-artists related-links bisected-header-cell-section is-fade-in">
+        <h2>Related Artists</h2>
+        <div className="artists">
+          {gene.artists.edges.map(({ node: artist }, index) => {
+            const separator = index < gene.similar.edges.length - 1 ? ", " : ""
+            return (
+              <>
+                <a href={artist.href}>{artist.name}</a>
+                {separator}
+              </>
+            )
+          })}
+        </div>
+      </Box>
+    </>
+  )
+}
+
+// export const GeneRElatedArtistLinksFragmentContainer
+export interface GeneRelatedLinksQueryRendererProps {
+  geneID: string
+}
+
+export const GeneRelatedLinksQueryRenderer: React.FC<
+  GeneRelatedLinksQueryRendererProps
+> = ({ geneID }) => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <QueryRenderer<GeneRelatedLinksQuery>
+      environment={relayEnvironment}
+      variables={{ geneID }}
+      render={renderWithLoadProgress(GeneRelatedLinks)}
+      query={graphql`
+        query GeneRelatedLinksQuery($geneID: String!) {
+          gene(id: $geneID) {
+            similar(first: 10) {
+              edges {
+                node {
+                  href
+                  name
+                }
+              }
+            }
+            artists: artistsConnection(first: 10) {
+              edges {
+                node {
+                  href
+                  name
+                }
+              }
+            }
+          }
+        }
+      `}
+    />
+  )
+}

--- a/src/Components/Gene/GeneRelatedLinks.tsx
+++ b/src/Components/Gene/GeneRelatedLinks.tsx
@@ -23,10 +23,10 @@ export const GeneRelatedLinks: React.FC<GeneRelatedLinksQueryResponse> = ({
           {gene.similar.edges.map(({ node: similarGene }, index) => {
             const separator = index < gene.similar.edges.length - 1 ? ", " : ""
             return (
-              <>
+              <React.Fragment key={similarGene.name}>
                 <a href={similarGene.href}>{similarGene.name}</a>
                 {separator}
-              </>
+              </React.Fragment>
             )
           })}
         </div>
@@ -37,10 +37,10 @@ export const GeneRelatedLinks: React.FC<GeneRelatedLinksQueryResponse> = ({
           {gene.artists.edges.map(({ node: artist }, index) => {
             const separator = index < gene.similar.edges.length - 1 ? ", " : ""
             return (
-              <>
+              <React.Fragment key={artist.name}>
                 <a href={artist.href}>{artist.name}</a>
                 {separator}
-              </>
+              </React.Fragment>
             )
           })}
         </div>

--- a/src/Components/Gene/GeneRelatedLinks.tsx
+++ b/src/Components/Gene/GeneRelatedLinks.tsx
@@ -17,34 +17,40 @@ export const GeneRelatedLinks: React.FC<GeneRelatedLinksQueryResponse> = ({
 }) => {
   return (
     <>
-      <Box className="related-genes related-links bisected-header-cell-section is-fade-in">
-        <h2>Related Categories</h2>
-        <div className="related-genes-links">
-          {gene.similar.edges.map(({ node: similarGene }, index) => {
-            const separator = index < gene.similar.edges.length - 1 ? ", " : ""
-            return (
-              <React.Fragment key={similarGene.name}>
-                <a href={similarGene.href}>{similarGene.name}</a>
-                {separator}
-              </React.Fragment>
-            )
-          })}
-        </div>
-      </Box>
-      <Box className="related-artists related-links bisected-header-cell-section is-fade-in">
-        <h2>Related Artists</h2>
-        <div className="artists">
-          {gene.artists.edges.map(({ node: artist }, index) => {
-            const separator = index < gene.similar.edges.length - 1 ? ", " : ""
-            return (
-              <React.Fragment key={artist.name}>
-                <a href={artist.href}>{artist.name}</a>
-                {separator}
-              </React.Fragment>
-            )
-          })}
-        </div>
-      </Box>
+      {gene.similar && (
+        <Box className="related-genes related-links bisected-header-cell-section is-fade-in">
+          <h2>Related Categories</h2>
+          <div className="related-genes-links">
+            {gene.similar.edges.map(({ node: similarGene }, index) => {
+              const separator =
+                index < gene.similar.edges.length - 1 ? ", " : ""
+              return (
+                <React.Fragment key={similarGene.name}>
+                  <a href={similarGene.href}>{similarGene.name}</a>
+                  {separator}
+                </React.Fragment>
+              )
+            })}
+          </div>
+        </Box>
+      )}
+      {gene.artists && (
+        <Box className="related-artists related-links bisected-header-cell-section is-fade-in">
+          <h2>Related Artists</h2>
+          <div className="artists">
+            {gene.artists.edges.map(({ node: artist }, index) => {
+              const separator =
+                index < gene.similar.edges.length - 1 ? ", " : ""
+              return (
+                <React.Fragment key={artist.name}>
+                  <a href={artist.href}>{artist.name}</a>
+                  {separator}
+                </React.Fragment>
+              )
+            })}
+          </div>
+        </Box>
+      )}
     </>
   )
 }

--- a/src/Components/Gene/GeneRelatedLinks.tsx
+++ b/src/Components/Gene/GeneRelatedLinks.tsx
@@ -79,7 +79,6 @@ export const GeneRelatedLinksFragmentContainer = createFragmentContainer(
   }
 )
 
-// export const GeneRElatedArtistLinksFragmentContainer
 export interface GeneRelatedLinksQueryRendererProps {
   geneID: string
 }

--- a/src/Components/Gene/__tests__/GeneRelatedLinks.test.tsx
+++ b/src/Components/Gene/__tests__/GeneRelatedLinks.test.tsx
@@ -1,0 +1,78 @@
+import { renderRelayTree } from "DevTools"
+import React from "react"
+import { graphql } from "react-relay"
+import { GeneRelatedLinksFragmentContainer } from "../GeneRelatedLinks"
+
+jest.unmock("react-relay")
+
+const similar = {
+  edges: [
+    {
+      node: {
+        href: "https://www.artsy.net/artwork/david-shrigley-im-dead",
+        name: "meow",
+      },
+    },
+  ],
+}
+
+const artists = {
+  edges: [
+    {
+      node: {
+        href: "https://kawsone.com/",
+        name: "kaws",
+      },
+    },
+  ],
+}
+
+describe("GeneRelatedLinks", () => {
+  const getWrapper = (similarData = similar, artistsData = artists) => {
+    return renderRelayTree({
+      Component: GeneRelatedLinksFragmentContainer,
+      query: graphql`
+        query GeneRelatedLinks_Test_Query @raw_response_type {
+          gene(id: "cats") {
+            ...GeneRelatedLinks_gene
+          }
+        }
+      `,
+      mockData: {
+        gene: {
+          similar: similarData,
+          artists: artistsData,
+        },
+      },
+    })
+  }
+
+  it("should render related genes and related artists", async () => {
+    const wrapper = await getWrapper()
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      `"<div class=\\"related-genes related-links bisected-header-cell-section is-fade-in sc-bdVaJa dVZOZN\\"><h2>Related Categories</h2><div class=\\"related-genes-links\\"><a href=\\"https://www.artsy.net/artwork/david-shrigley-im-dead\\">meow</a></div></div>"`
+    )
+  })
+
+  it("should render related genes even if no related artists", async () => {
+    const wrapper = await getWrapper(similar, null)
+    expect(wrapper.contains(<h2>Related Categories</h2>)).toBeTruthy()
+    expect(wrapper.contains(<h2>Related Artists</h2>)).toBeFalsy()
+  })
+
+  it("should render related artists even if no related genes", async () => {
+    const wrapper = await getWrapper(null, artists)
+    expect(wrapper.contains(<h2>Related Categories</h2>)).toBeFalsy()
+    expect(wrapper.contains(<h2>Related Artists</h2>)).toBeTruthy()
+  })
+
+  it("should comma seperate the list if multiple items are present", async () => {
+    const wrapper = await getWrapper({
+      edges: [
+        { node: { name: "a", href: "" } },
+        { node: { name: "b", href: "" } },
+      ],
+    })
+    expect(wrapper.text().includes("a, b")).toBeTruthy()
+  })
+})

--- a/src/__generated__/GeneRelatedLinksQuery.graphql.ts
+++ b/src/__generated__/GeneRelatedLinksQuery.graphql.ts
@@ -1,0 +1,294 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type GeneRelatedLinksQueryVariables = {
+    geneID: string;
+};
+export type GeneRelatedLinksQueryResponse = {
+    readonly gene: {
+        readonly similar: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly href: string | null;
+                    readonly name: string | null;
+                } | null;
+            } | null> | null;
+        } | null;
+        readonly artists: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly href: string | null;
+                    readonly name: string | null;
+                } | null;
+            } | null> | null;
+        } | null;
+    } | null;
+};
+export type GeneRelatedLinksQuery = {
+    readonly response: GeneRelatedLinksQueryResponse;
+    readonly variables: GeneRelatedLinksQueryVariables;
+};
+
+
+
+/*
+query GeneRelatedLinksQuery(
+  $geneID: String!
+) {
+  gene(id: $geneID) {
+    similar(first: 10) {
+      edges {
+        node {
+          href
+          name
+          id
+        }
+      }
+    }
+    artists: artistsConnection(first: 10) {
+      edges {
+        node {
+          href
+          name
+          id
+        }
+      }
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "geneID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "geneID"
+  }
+],
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  (v3/*: any*/),
+  (v4/*: any*/)
+],
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v7 = [
+  (v3/*: any*/),
+  (v4/*: any*/),
+  (v6/*: any*/)
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "GeneRelatedLinksQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "gene",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Gene",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "similar",
+            "storageKey": "similar(first:10)",
+            "args": (v2/*: any*/),
+            "concreteType": "GeneConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "GeneEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Gene",
+                    "plural": false,
+                    "selections": (v5/*: any*/)
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "artists",
+            "name": "artistsConnection",
+            "storageKey": "artistsConnection(first:10)",
+            "args": (v2/*: any*/),
+            "concreteType": "ArtistConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "plural": false,
+                    "selections": (v5/*: any*/)
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "GeneRelatedLinksQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "gene",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Gene",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "similar",
+            "storageKey": "similar(first:10)",
+            "args": (v2/*: any*/),
+            "concreteType": "GeneConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "GeneEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Gene",
+                    "plural": false,
+                    "selections": (v7/*: any*/)
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "artists",
+            "name": "artistsConnection",
+            "storageKey": "artistsConnection(first:10)",
+            "args": (v2/*: any*/),
+            "concreteType": "ArtistConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "plural": false,
+                    "selections": (v7/*: any*/)
+                  }
+                ]
+              }
+            ]
+          },
+          (v6/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "GeneRelatedLinksQuery",
+    "id": null,
+    "text": "query GeneRelatedLinksQuery(\n  $geneID: String!\n) {\n  gene(id: $geneID) {\n    similar(first: 10) {\n      edges {\n        node {\n          href\n          name\n          id\n        }\n      }\n    }\n    artists: artistsConnection(first: 10) {\n      edges {\n        node {\n          href\n          name\n          id\n        }\n      }\n    }\n    id\n  }\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '1a927d2779cbc7601d0b6626fb8304fe';
+export default node;

--- a/src/__generated__/GeneRelatedLinks_Test_Query.graphql.ts
+++ b/src/__generated__/GeneRelatedLinks_Test_Query.graphql.ts
@@ -2,26 +2,46 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type GeneRelatedLinksQueryVariables = {
-    geneID: string;
-};
-export type GeneRelatedLinksQueryResponse = {
+export type GeneRelatedLinks_Test_QueryVariables = {};
+export type GeneRelatedLinks_Test_QueryResponse = {
     readonly gene: {
         readonly " $fragmentRefs": FragmentRefs<"GeneRelatedLinks_gene">;
     } | null;
 };
-export type GeneRelatedLinksQuery = {
-    readonly response: GeneRelatedLinksQueryResponse;
-    readonly variables: GeneRelatedLinksQueryVariables;
+export type GeneRelatedLinks_Test_QueryRawResponse = {
+    readonly gene: ({
+        readonly similar: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly href: string | null;
+                    readonly name: string | null;
+                    readonly id: string | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
+        readonly artists: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly href: string | null;
+                    readonly name: string | null;
+                    readonly id: string | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type GeneRelatedLinks_Test_Query = {
+    readonly response: GeneRelatedLinks_Test_QueryResponse;
+    readonly variables: GeneRelatedLinks_Test_QueryVariables;
+    readonly rawResponse: GeneRelatedLinks_Test_QueryRawResponse;
 };
 
 
 
 /*
-query GeneRelatedLinksQuery(
-  $geneID: String!
-) {
-  gene(id: $geneID) {
+query GeneRelatedLinks_Test_Query {
+  gene(id: "cats") {
     ...GeneRelatedLinks_gene
     id
   }
@@ -52,34 +72,26 @@ fragment GeneRelatedLinks_gene on Gene {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "kind": "LocalArgument",
-    "name": "geneID",
-    "type": "String!",
-    "defaultValue": null
+    "kind": "Literal",
+    "name": "id",
+    "value": "cats"
   }
 ],
 v1 = [
-  {
-    "kind": "Variable",
-    "name": "id",
-    "variableName": "geneID"
-  }
-],
-v2 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 10
   }
 ],
-v3 = {
+v2 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v4 = [
+v3 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -94,23 +106,23 @@ v4 = [
     "args": null,
     "storageKey": null
   },
-  (v3/*: any*/)
+  (v2/*: any*/)
 ];
 return {
   "kind": "Request",
   "fragment": {
     "kind": "Fragment",
-    "name": "GeneRelatedLinksQuery",
+    "name": "GeneRelatedLinks_Test_Query",
     "type": "Query",
     "metadata": null,
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "selections": [
       {
         "kind": "LinkedField",
         "alias": null,
         "name": "gene",
-        "storageKey": null,
-        "args": (v1/*: any*/),
+        "storageKey": "gene(id:\"cats\")",
+        "args": (v0/*: any*/),
         "concreteType": "Gene",
         "plural": false,
         "selections": [
@@ -125,15 +137,15 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "GeneRelatedLinksQuery",
-    "argumentDefinitions": (v0/*: any*/),
+    "name": "GeneRelatedLinks_Test_Query",
+    "argumentDefinitions": [],
     "selections": [
       {
         "kind": "LinkedField",
         "alias": null,
         "name": "gene",
-        "storageKey": null,
-        "args": (v1/*: any*/),
+        "storageKey": "gene(id:\"cats\")",
+        "args": (v0/*: any*/),
         "concreteType": "Gene",
         "plural": false,
         "selections": [
@@ -142,7 +154,7 @@ return {
             "alias": null,
             "name": "similar",
             "storageKey": "similar(first:10)",
-            "args": (v2/*: any*/),
+            "args": (v1/*: any*/),
             "concreteType": "GeneConnection",
             "plural": false,
             "selections": [
@@ -163,7 +175,7 @@ return {
                     "args": null,
                     "concreteType": "Gene",
                     "plural": false,
-                    "selections": (v4/*: any*/)
+                    "selections": (v3/*: any*/)
                   }
                 ]
               }
@@ -174,7 +186,7 @@ return {
             "alias": "artists",
             "name": "artistsConnection",
             "storageKey": "artistsConnection(first:10)",
-            "args": (v2/*: any*/),
+            "args": (v1/*: any*/),
             "concreteType": "ArtistConnection",
             "plural": false,
             "selections": [
@@ -195,25 +207,25 @@ return {
                     "args": null,
                     "concreteType": "Artist",
                     "plural": false,
-                    "selections": (v4/*: any*/)
+                    "selections": (v3/*: any*/)
                   }
                 ]
               }
             ]
           },
-          (v3/*: any*/)
+          (v2/*: any*/)
         ]
       }
     ]
   },
   "params": {
     "operationKind": "query",
-    "name": "GeneRelatedLinksQuery",
+    "name": "GeneRelatedLinks_Test_Query",
     "id": null,
-    "text": "query GeneRelatedLinksQuery(\n  $geneID: String!\n) {\n  gene(id: $geneID) {\n    ...GeneRelatedLinks_gene\n    id\n  }\n}\n\nfragment GeneRelatedLinks_gene on Gene {\n  similar(first: 10) {\n    edges {\n      node {\n        href\n        name\n        id\n      }\n    }\n  }\n  artists: artistsConnection(first: 10) {\n    edges {\n      node {\n        href\n        name\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query GeneRelatedLinks_Test_Query {\n  gene(id: \"cats\") {\n    ...GeneRelatedLinks_gene\n    id\n  }\n}\n\nfragment GeneRelatedLinks_gene on Gene {\n  similar(first: 10) {\n    edges {\n      node {\n        href\n        name\n        id\n      }\n    }\n  }\n  artists: artistsConnection(first: 10) {\n    edges {\n      node {\n        href\n        name\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '5eed777d3dbca83e395937c6eb8489ae';
+(node as any).hash = '8cb2f41c637fc5a0fe4761ff910f6d02';
 export default node;

--- a/src/__generated__/GeneRelatedLinks_gene.graphql.ts
+++ b/src/__generated__/GeneRelatedLinks_gene.graphql.ts
@@ -1,0 +1,131 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type GeneRelatedLinks_gene = {
+    readonly similar: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly href: string | null;
+                readonly name: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly artists: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly href: string | null;
+                readonly name: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "GeneRelatedLinks_gene";
+};
+export type GeneRelatedLinks_gene$data = GeneRelatedLinks_gene;
+export type GeneRelatedLinks_gene$key = {
+    readonly " $data"?: GeneRelatedLinks_gene$data;
+    readonly " $fragmentRefs": FragmentRefs<"GeneRelatedLinks_gene">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v1 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "href",
+    "args": null,
+    "storageKey": null
+  },
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "name",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Fragment",
+  "name": "GeneRelatedLinks_gene",
+  "type": "Gene",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "similar",
+      "storageKey": "similar(first:10)",
+      "args": (v0/*: any*/),
+      "concreteType": "GeneConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "GeneEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Gene",
+              "plural": false,
+              "selections": (v1/*: any*/)
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "artists",
+      "name": "artistsConnection",
+      "storageKey": "artistsConnection(first:10)",
+      "args": (v0/*: any*/),
+      "concreteType": "ArtistConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtistEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artist",
+              "plural": false,
+              "selections": (v1/*: any*/)
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+})();
+(node as any).hash = '16d8882b604595dcffe85c9f3fdda533';
+export default node;


### PR DESCRIPTION
Adds the related links view from the gene page to reaction. 

<img width="526" alt="image" src="https://user-images.githubusercontent.com/3087225/69171368-c8b17a00-0ac9-11ea-94fc-1f2537e0bdf3.png">

Currently the markup structure is preserved from what exists on the gene page and no additional styling was added. This is largely due to the fact that the gene page isn't in line with our current design system and updating the whole gene page to match feels out of scope for this ticket. 